### PR TITLE
feat: add router_masquerade for hairpin NAT fix on instances behind a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The agent monitors the OVN Southbound and Northbound databases and performs targ
    - Ensures `/32` **kernel routes** (with IP rules when using a dedicated routing table) and **FRR static routes** in the VRF for each FIP/SNAT IP
    - If configured, reconciles the **FRR prefix-list** with `permit <network> ge 32 le 32` entries for each discovered provider network
    - If no routers are locally active: removes all managed routes
-5. **Port forwarding (DNAT)** — optionally forwards traffic from anycast VIP addresses (on a loopback interface in the VRF) to internal backends. Supports multiple backends per rule with sticky source-IP hashing (`jhash`) for consistent client-to-backend mapping. Client IPs are preserved using connmark-based return routing through the veth pair. Backends on the same host are handled via dedicated OUTPUT chains (`output_ctzone`, `output_fwmark`) since locally-delivered traffic bypasses the FORWARD/POSTROUTING path. Per-rule `masquerade` control allows mixing local and remote backends on the same VIP. Hairpin masquerade (`hairpin_masquerade: true`) solves the hairpin NAT problem where FIPs on the same node try to connect to a port-forwarded VIP — only source-masquerades traffic from provider networks, leaving external clients unaffected. A `forward_veth_guard` nftables chain restricts the veth return path to legitimate traffic only. Requires `nft` binary and `veth_leak_enabled: true`.
+5. **Port forwarding (DNAT)** — optionally forwards traffic from anycast VIP addresses (on a loopback interface in the VRF) to internal backends. Supports multiple backends per rule with sticky source-IP hashing (`jhash`) for consistent client-to-backend mapping. Client IPs are preserved using connmark-based return routing through the veth pair. Backends on the same host are handled via dedicated OUTPUT chains (`output_ctzone`, `output_fwmark`) since locally-delivered traffic bypasses the FORWARD/POSTROUTING path. Per-rule `masquerade` control allows mixing local and remote backends on the same VIP. Two source-selective hairpin fixes are available: `hairpin_masquerade: true` covers FIPs on the same node (matches the provider CIDR), and `router_masquerade: true` covers instances behind a router without a FIP (matches the specific router SNAT IPs discovered from OVN). Both leave unrelated external clients unaffected and can be combined on the same VIP. A `forward_veth_guard` nftables chain restricts the veth return path to legitimate traffic only. Requires `nft` binary and `veth_leak_enabled: true`.
 6. **Reconciles** periodically as a safety net (default: every 60s)
 7. **Detects stale chassis** — when a node dies without graceful shutdown, surviving agents detect its chassis disappearing from the SB Chassis table and clean up its managed OVN NB entries (static routes and MAC bindings) after a configurable grace period (default: 5m, configurable via `stale_chassis_grace_period`, set to `0` to disable). Random jitter (0-30s) prevents multiple agents from cleaning up simultaneously.
 8. **Drains gateways** on shutdown (SIGINT/SIGTERM) — before cleanup, the agent lowers its `Gateway_Chassis` priority to 0 in OVN NB, causing `ovn-northd` to migrate chassisredirect ports to standby chassis (priority >= 1). On the next startup, drained entries are restored to priority 1 (standby level). The active chassis automatically maintains a minimum priority of 2 (above all possible standby peers) during reconciliation, preventing reverse failover even when a peer restores to priority 1. This eliminates the traffic disruption window between BGP route withdrawal and OVN BFD failover detection (see [Gateway drain mode](#gateway-drain-mode)). Enabled by default (`drain_on_shutdown: true`, `drain_timeout: 60s`).
@@ -471,6 +471,20 @@ ip saddr 5.182.234.0/24 ct original daddr 194.93.78.239 ct status dnat masquerad
 
 Unlike the VIP-level `masquerade: true` (which masquerades ALL traffic), hairpin masquerade is source-selective. It can be combined with per-rule `masquerade` on the same VIP — both rules coexist in `postrouting_snat`. The rules are only generated when provider networks are known; if the agent starts before OVN has delivered network discovery, they appear on the first reconciliation cycle.
 
+**9. Router masquerade (postrouting_snat, optional)** — When `router_masquerade: true` is set on a VIP, SNAT is applied **only to traffic whose source matches a known router SNAT external IP** (discovered dynamically from OVN NB `nat.type=snat` entries on locally-active routers). This solves the hairpin NAT problem for instances **behind a router that do not have a Floating IP**: the router applies SNAT before forwarding, so the source IP arriving at the VIP is the router's OVN-managed external address. Without masquerade, the backend's reply enters OVN's pipeline directly — bypassing this node's conntrack — and the reverse DNAT never fires, so the instance receives a packet from the backend IP instead of the VIP and the connection breaks.
+
+With a single known SNAT IP the rule is emitted as a literal address match; with multiple IPs nft's anonymous set syntax is used so all known router sources are covered by one rule:
+
+```
+# Single SNAT IP
+ip saddr 203.0.113.50 ct original daddr 194.93.78.239 ct status dnat masquerade
+
+# Multiple SNAT IPs
+ip saddr { 203.0.113.50, 203.0.113.51 } ct original daddr 194.93.78.239 ct status dnat masquerade
+```
+
+Unlike `hairpin_masquerade` (which uses the full provider CIDR and would also masquerade unrelated external clients that happen to live in the same subnet), `router_masquerade` is **more surgical**: only the specific router SNAT IPs are rewritten, leaving every other external client IP fully preserved end-to-end. `router_masquerade` and `hairpin_masquerade` can be set together on the same VIP — both rules coexist in `postrouting_snat`, covering FIP-sourced and router-SNAT'd traffic simultaneously. The rule is only emitted once OVN has reported at least one SNAT IP; on a cold start (before the first reconcile delivers SNAT data) the chain is omitted entirely to prevent accidental masquerade.
+
 ### Why conntrack-based fwmark instead of simpler alternatives?
 
 | Approach | Client IP preserved? | Problem |
@@ -480,8 +494,9 @@ Unlike the VIP-level `masquerade: true` (which masquerades ALL traffic), hairpin
 | Conntrack + fwmark | Yes | Only marks packets belonging to DNAT'd connections — surgical, no side effects |
 | Conntrack + fwmark + per-rule masquerade | Depends | Best of both: client IP preserved for local backends, masquerade only where needed (remote backends) |
 | Conntrack + fwmark + hairpin masquerade | Depends | Client IP preserved for external clients; source-selective SNAT fixes hairpin for FIPs on the same node |
+| Conntrack + fwmark + router masquerade | Depends | Client IP preserved for external clients; source-selective SNAT against known router SNAT IPs fixes hairpin for instances behind a router without a FIP |
 
-The conntrack-based approach selectively routes just the DNAT return traffic without affecting any other traffic from the backend. It uses `ct status dnat` and `ct direction` to identify packets belonging to DNAT'd connections and assigns direction-specific fwmarks for policy routing. Per-rule masquerade adds surgical SNAT only for remote backends that need it, while local backends (same host) use the OUTPUT chains for return routing with the original client IP preserved. Hairpin masquerade adds a further refinement: source-selective SNAT only for provider-network traffic, solving the asymmetric routing that occurs when a FIP on the same node connects to the VIP.
+The conntrack-based approach selectively routes just the DNAT return traffic without affecting any other traffic from the backend. It uses `ct status dnat` and `ct direction` to identify packets belonging to DNAT'd connections and assigns direction-specific fwmarks for policy routing. Per-rule masquerade adds surgical SNAT only for remote backends that need it, while local backends (same host) use the OUTPUT chains for return routing with the original client IP preserved. Hairpin masquerade adds a further refinement: source-selective SNAT only for provider-network traffic, solving the asymmetric routing that occurs when a FIP on the same node connects to the VIP. Router masquerade is the no-FIP companion: it targets the specific router SNAT IPs surfaced by OVN, so only those addresses are rewritten and every other external client remains untouched.
 
 ### The `forward_veth_guard` chain
 
@@ -680,6 +695,19 @@ port_forwards:
       - proto: tcp
         port: 443
         dest_addr: "10.0.0.100"
+
+  # VIP that must be reachable from both FIP-equipped VMs and instances
+  # behind a router without a FIP. hairpin_masquerade covers the former,
+  # router_masquerade the latter — both rules coexist in postrouting_snat
+  # and leave every other external client IP untouched.
+  - vip: "198.51.100.30"
+    manage_vip: true
+    hairpin_masquerade: true     # FIPs on the same node
+    router_masquerade: true      # instances behind a router (no FIP)
+    rules:
+      - proto: tcp
+        port: 443
+        dest_addr: "10.0.0.100"
 ```
 
 ### Sticky load balancing (multi-backend)
@@ -709,6 +737,10 @@ ip daddr 198.51.100.10 udp dport 53 dnat to jhash ip saddr mod 3 map { \
 
 ### Hairpin NAT
 
+Two flavors of source-selective masquerade are available to fix hairpin NAT, depending on how the local client reaches the VIP. They can be combined on the same VIP — the resulting rules coexist in `postrouting_snat`.
+
+#### Case 1: instance with a FIP on the same node (`hairpin_masquerade`)
+
 **The problem:** A VM with a Floating IP (FIP) in the provider network (e.g. `5.182.234.153`) tries to reach a port-forwarded VIP (e.g. `194.93.78.239`) on the same node. ICMP to the VIP succeeds because the VIP address is local (`loopback1`) and the kernel responds directly — DNAT is never involved. TCP connections time out because:
 
 1. The VM's packet is DNAT'd: `src=5.182.234.153 dst=194.93.78.239:80` → `dst=backend_ip:80`
@@ -731,6 +763,28 @@ External clients (source outside provider networks) are unaffected — their IPs
 **Difference from `masquerade: true`:** The VIP-level `masquerade` masquerades ALL traffic. Hairpin masquerade only masquerades source IPs within the provider networks, leaving external client IPs intact.
 
 **Note:** Hairpin masquerade rules require the provider networks to be known. On the very first startup (before OVN discovery completes), the rules are absent. They are installed automatically on the first reconciliation cycle once OVN reports the provider network CIDRs.
+
+#### Case 2: instance behind a router without a FIP (`router_masquerade`)
+
+**The problem:** An instance without its own FIP connects to a port-forwarded VIP through an OVN router. The router applies SNAT, so the packet that hits the VIP carries the **router's external IP** as source instead of the instance address. That external IP is OVN-managed — meaning the backend's reply enters OVN's pipeline directly, **bypassing this node's conntrack**. The reverse DNAT never fires, the instance receives a reply from the backend IP instead of the VIP, and the connection fails.
+
+`hairpin_masquerade` does not fix this cleanly: matching the full provider CIDR would also rewrite every unrelated external client living in the same subnet.
+
+**The fix:** Enable `router_masquerade: true` on the VIP. The agent dynamically discovers router SNAT external IPs from OVN NB (rows where `nat.type=snat` on locally-active routers) and emits a source-selective SNAT rule that targets **only those specific addresses**:
+
+```
+# Single SNAT IP
+ip saddr 203.0.113.50 ct original daddr 194.93.78.239 ct status dnat masquerade
+
+# Multiple SNAT IPs (anonymous set)
+ip saddr { 203.0.113.50, 203.0.113.51 } ct original daddr 194.93.78.239 ct status dnat masquerade
+```
+
+With this rule active the backend sees `src=<node-control-plane-IP>`, replies through this node, and conntrack reverses both SNAT and DNAT — the instance receives the reply from the VIP exactly as it expects.
+
+**Difference from `hairpin_masquerade`:** Hairpin masquerade matches a provider-CIDR prefix and therefore also rewrites unrelated external clients that share the subnet. Router masquerade matches the literal set of router SNAT IPs surfaced by OVN, leaving every other client untouched.
+
+**Note:** Router masquerade rules require at least one SNAT IP to be known. If the agent starts before OVN has reported any SNAT entry, the rule (and the entire `postrouting_snat` chain if it would otherwise be empty) is omitted to prevent accidental masquerade during startup. The rule is installed on the first reconciliation cycle that delivers SNAT IP data.
 
 ## Gateway drain mode
 

--- a/agent.go
+++ b/agent.go
@@ -325,7 +325,7 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 
 	// Port forwarding reconciliation runs regardless of local router
 	// presence — DNAT VIPs are managed independently of OVN gateway state.
-	if err := a.routing.ReconcilePortForward(a.effectiveFilters); err != nil {
+	if err := a.routing.ReconcilePortForward(a.effectiveFilters, state.SNATIPs); err != nil {
 		slog.Error("failed to reconcile port forwarding", "error", err)
 	}
 

--- a/config.go
+++ b/config.go
@@ -103,7 +103,8 @@ type PortForwardVIP struct {
 	VIP               string            `yaml:"vip"`                // anycast VIP address
 	ManageVIP         bool              `yaml:"manage_vip"`         // agent adds/removes VIP on port_forward_dev
 	Masquerade        bool              `yaml:"masquerade"`         // SNAT forwarded traffic with outgoing interface IP
-	HairpinMasquerade bool              `yaml:"hairpin_masquerade"` // SNAT only traffic from provider networks (fixes hairpin NAT)
+	HairpinMasquerade bool              `yaml:"hairpin_masquerade"` // SNAT only traffic from provider networks (fixes hairpin NAT for FIPs)
+	RouterMasquerade  bool              `yaml:"router_masquerade"`  // SNAT only traffic from known router SNAT IPs (fixes hairpin NAT for instances behind a router without FIP)
 	Rules             []PortForwardRule `yaml:"rules"`
 }
 

--- a/nftables.go
+++ b/nftables.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"net"
+	"slices"
+	"sort"
 	"strings"
 )
 
@@ -41,9 +43,13 @@ const (
 // the DNAT entry (wrong zone) and the reply is never policy-routed back
 // through the veth pair into the provider VRF.
 //
+// snatIPs contains the router SNAT external IPs discovered from OVN (type=snat
+// NAT entries). These are used by the router_masquerade feature to generate
+// targeted SNAT rules for traffic from instances behind a router without a FIP.
+//
 // Safety: all interpolated values (VIPs, protocols, dest addresses) must be
 // pre-validated by validateConfig before reaching this function.
-func buildNftRuleset(forwards []PortForwardVIP, providerNetworks []*net.IPNet, ctZone int) string {
+func buildNftRuleset(forwards []PortForwardVIP, providerNetworks []*net.IPNet, snatIPs []string, ctZone int) string {
 	// writeCTZoneRules emits conntrack zone assignment rules for both
 	// directions of DNAT'd flows. Used by prerouting_ctzone and
 	// output_ctzone to keep their rule sets in sync.
@@ -120,6 +126,23 @@ func buildNftRuleset(forwards []PortForwardVIP, providerNetworks []*net.IPNet, c
 	for _, pf := range forwards {
 		if pf.HairpinMasquerade {
 			hairpinVIPs = append(hairpinVIPs, pf.VIP)
+		}
+	}
+
+	// Collect VIPs with router_masquerade enabled. Router masquerade applies
+	// SNAT only to traffic whose source is a known router SNAT IP (discovered
+	// from OVN NB NAT entries of type "snat"). This solves the hairpin NAT
+	// problem for instances behind a router that have no Floating IP: the
+	// router SNAT'd source IP is an OVN-managed address, so without masquerade
+	// the backend's reply enters OVN's pipeline directly — bypassing this
+	// node's conntrack — and the reverse DNAT never fires.
+	// Unlike hairpin_masquerade (which uses the full provider CIDR), this is
+	// more surgical: only the specific known SNAT IPs are masqueraded, leaving
+	// all other external clients' IPs fully preserved.
+	var routerMasqVIPs []string
+	for _, pf := range forwards {
+		if pf.RouterMasquerade {
+			routerMasqVIPs = append(routerMasqVIPs, pf.VIP)
 		}
 	}
 
@@ -275,7 +298,7 @@ func buildNftRuleset(forwards []PortForwardVIP, providerNetworks []*net.IPNet, c
 		vethDefaultName, dnatReplyFwmark)
 	b.WriteString("    }\n")
 
-	// Chain: SNAT for two cases:
+	// Chain: SNAT for three cases:
 	//
 	// 1. Per-rule masquerade (masquerade: true on VIP or rule): matches on the
 	//    post-DNAT destination (backend address). Local backends must NOT be
@@ -290,8 +313,18 @@ func buildNftRuleset(forwards []PortForwardVIP, providerNetworks []*net.IPNet, c
 	//    and may route the reply asymmetrically (not back through this node).
 	//    By masquerading only provider-sourced traffic, non-hairpin clients are
 	//    unaffected.
+	//
+	// 3. Router masquerade (router_masquerade: true on VIP): matches on the
+	//    pre-DNAT source address being a known router SNAT IP. Solves the
+	//    hairpin NAT problem for instances without a FIP that reach the VIP
+	//    through a router: the router's external IP is OVN-managed, so the
+	//    backend's reply would normally enter OVN's pipeline directly (bypassing
+	//    this node's conntrack), preventing the reverse DNAT from firing.
+	//    More surgical than hairpin_masquerade: only specific SNAT IPs are
+	//    masqueraded, leaving external clients' IPs fully preserved.
 	hairpinNeeded := len(hairpinVIPs) > 0 && len(providerNetworks) > 0
-	if len(snatEntries) > 0 || hairpinNeeded {
+	routerMasqNeeded := len(routerMasqVIPs) > 0 && len(snatIPs) > 0
+	if len(snatEntries) > 0 || hairpinNeeded || routerMasqNeeded {
 		b.WriteString("    chain postrouting_snat {\n")
 		b.WriteString("        type nat hook postrouting priority srcnat; policy accept;\n")
 		for _, e := range snatEntries {
@@ -310,6 +343,21 @@ func buildNftRuleset(forwards []PortForwardVIP, providerNetworks []*net.IPNet, c
 				srcMatch = "{ " + strings.Join(nets, ", ") + " }"
 			}
 			for _, vip := range hairpinVIPs {
+				fmt.Fprintf(&b, "        ip saddr %s ct original daddr %s ct status dnat masquerade\n",
+					srcMatch, vip)
+			}
+		}
+		if routerMasqNeeded {
+			sortedSNATIPs := append([]string{}, snatIPs...)
+			sort.Strings(sortedSNATIPs)
+			sortedSNATIPs = slices.Compact(sortedSNATIPs)
+			var srcMatch string
+			if len(sortedSNATIPs) == 1 {
+				srcMatch = sortedSNATIPs[0]
+			} else {
+				srcMatch = "{ " + strings.Join(sortedSNATIPs, ", ") + " }"
+			}
+			for _, vip := range routerMasqVIPs {
 				fmt.Fprintf(&b, "        ip saddr %s ct original daddr %s ct status dnat masquerade\n",
 					srcMatch, vip)
 			}

--- a/nftables_linux.go
+++ b/nftables_linux.go
@@ -44,8 +44,8 @@ func (rm *RouteManager) SetupPortForward() error {
 		return fmt.Errorf("manage VIP addresses: %w", err)
 	}
 
-	// 2. Apply nftables ruleset (initial, without provider networks for guard).
-	if err := rm.applyNftRuleset(nil); err != nil {
+	// 2. Apply nftables ruleset (initial, without provider networks or SNAT IPs).
+	if err := rm.applyNftRuleset(nil, nil); err != nil {
 		return fmt.Errorf("apply nftables ruleset: %w", err)
 	}
 
@@ -71,7 +71,9 @@ func (rm *RouteManager) SetupPortForward() error {
 // ReconcilePortForward ensures port forwarding state matches the desired config.
 // providerNetworks are needed for the forward_veth_guard chain (allow existing
 // veth leak return traffic in addition to DNAT return traffic).
-func (rm *RouteManager) ReconcilePortForward(providerNetworks []*net.IPNet) error {
+// snatIPs are the router SNAT external IPs from OVN state, used for
+// router_masquerade rules.
+func (rm *RouteManager) ReconcilePortForward(providerNetworks []*net.IPNet, snatIPs []string) error {
 	if !rm.portForwardEnabled {
 		return nil
 	}
@@ -83,7 +85,7 @@ func (rm *RouteManager) ReconcilePortForward(providerNetworks []*net.IPNet) erro
 	if err := rm.reconcilePortForwardVIPs(); err != nil {
 		return fmt.Errorf("reconcile VIP addresses: %w", err)
 	}
-	if err := rm.applyNftRuleset(providerNetworks); err != nil {
+	if err := rm.applyNftRuleset(providerNetworks, snatIPs); err != nil {
 		return fmt.Errorf("reconcile nftables ruleset: %w", err)
 	}
 	if err := rm.ensureDNATRouting(); err != nil {
@@ -284,8 +286,8 @@ func (rm *RouteManager) reconcilePortForwardVIPs() error {
 // applyNftRuleset atomically replaces the nftables table with the current config.
 // The delete + create is submitted as a single nft -f input to avoid a window
 // where no rules exist.
-func (rm *RouteManager) applyNftRuleset(providerNetworks []*net.IPNet) error {
-	ruleset := buildNftRuleset(rm.portForwards, providerNetworks, rm.portForwardCTZone)
+func (rm *RouteManager) applyNftRuleset(providerNetworks []*net.IPNet, snatIPs []string) error {
+	ruleset := buildNftRuleset(rm.portForwards, providerNetworks, snatIPs, rm.portForwardCTZone)
 
 	// Combine delete (if exists) and create into a single atomic nft load.
 	// The delete may fail on first run (table doesn't exist yet), so we

--- a/nftables_notlinux.go
+++ b/nftables_notlinux.go
@@ -19,7 +19,7 @@ func (rm *RouteManager) SetupPortForward() error {
 	return fmt.Errorf("port forwarding is only supported on Linux")
 }
 
-func (rm *RouteManager) ReconcilePortForward(providerNetworks []*net.IPNet) error {
+func (rm *RouteManager) ReconcilePortForward(providerNetworks []*net.IPNet, snatIPs []string) error {
 	if !rm.portForwardEnabled {
 		return nil
 	}

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -21,7 +21,7 @@ func TestBuildNftRuleset(t *testing.T) {
 	}
 	_, provNet, _ := net.ParseCIDR("198.51.100.0/24")
 
-	result := buildNftRuleset(forwards, []*net.IPNet{provNet}, dnatCTZoneDefault)
+	result := buildNftRuleset(forwards, []*net.IPNet{provNet}, nil, dnatCTZoneDefault)
 
 	// Verify table structure
 	if !strings.Contains(result, "table ip ovn-network-agent {") {
@@ -118,7 +118,7 @@ func TestBuildNftRulesetMultipleVIPs(t *testing.T) {
 		},
 	}
 
-	result := buildNftRuleset(forwards, nil, dnatCTZoneDefault)
+	result := buildNftRuleset(forwards, nil, nil, dnatCTZoneDefault)
 
 	if !strings.Contains(result, "ip daddr 198.51.100.10 tcp dport 80") {
 		t.Error("missing DNAT rule for first VIP")
@@ -171,7 +171,7 @@ func TestBuildNftRulesetNoProviderNetworks(t *testing.T) {
 		},
 	}
 
-	result := buildNftRuleset(forwards, nil, dnatCTZoneDefault)
+	result := buildNftRuleset(forwards, nil, nil, dnatCTZoneDefault)
 
 	// Guard chain should not have provider network allow rule
 	if strings.Contains(result, "ip saddr {") {
@@ -194,7 +194,7 @@ func TestBuildNftRulesetDestPortDefault(t *testing.T) {
 		},
 	}
 
-	result := buildNftRuleset(forwards, nil, dnatCTZoneDefault)
+	result := buildNftRuleset(forwards, nil, nil, dnatCTZoneDefault)
 
 	// dest_port=0 should use port as default
 	if !strings.Contains(result, "dnat to 10.0.0.100:80") {
@@ -213,7 +213,7 @@ func TestBuildNftRulesetSamePortDifferentProto(t *testing.T) {
 		},
 	}
 
-	result := buildNftRuleset(forwards, nil, dnatCTZoneDefault)
+	result := buildNftRuleset(forwards, nil, nil, dnatCTZoneDefault)
 
 	if !strings.Contains(result, "tcp dport 53 dnat to 10.0.0.200:1053") {
 		t.Error("missing TCP DNAT rule for port 53")
@@ -233,7 +233,7 @@ func TestBuildNftRulesetMultipleProviderNetworks(t *testing.T) {
 	_, net1, _ := net.ParseCIDR("198.51.100.0/24")
 	_, net2, _ := net.ParseCIDR("203.0.113.0/24")
 
-	result := buildNftRuleset(forwards, []*net.IPNet{net1, net2}, dnatCTZoneDefault)
+	result := buildNftRuleset(forwards, []*net.IPNet{net1, net2}, nil, dnatCTZoneDefault)
 
 	if !strings.Contains(result, "198.51.100.0/24, 203.0.113.0/24") {
 		t.Errorf("guard chain should contain both provider networks, got:\n%s", result)
@@ -248,7 +248,7 @@ func TestBuildNftRulesetMaxPort(t *testing.T) {
 		},
 	}
 
-	result := buildNftRuleset(forwards, nil, dnatCTZoneDefault)
+	result := buildNftRuleset(forwards, nil, nil, dnatCTZoneDefault)
 
 	if !strings.Contains(result, "tcp dport 65535 dnat to 10.0.0.100:65535") {
 		t.Error("missing rule for max port 65535")
@@ -272,7 +272,7 @@ func TestBuildNftRulesetMasquerade(t *testing.T) {
 		},
 	}
 
-	result := buildNftRuleset(forwards, nil, dnatCTZoneDefault)
+	result := buildNftRuleset(forwards, nil, nil, dnatCTZoneDefault)
 
 	// Should have postrouting SNAT chain (VIP-level masquerade inherits to rules)
 	if !strings.Contains(result, "chain postrouting_snat") {
@@ -318,7 +318,7 @@ func TestBuildNftRulesetPerRuleMasquerade(t *testing.T) {
 		},
 	}
 
-	result := buildNftRuleset(forwards, nil, dnatCTZoneDefault)
+	result := buildNftRuleset(forwards, nil, nil, dnatCTZoneDefault)
 	snat := extractChain(result, "postrouting_snat")
 	if snat == "" {
 		t.Fatal("missing postrouting_snat chain")
@@ -367,7 +367,7 @@ func TestBuildNftRulesetNoMasquerade(t *testing.T) {
 		},
 	}
 
-	result := buildNftRuleset(forwards, nil, dnatCTZoneDefault)
+	result := buildNftRuleset(forwards, nil, nil, dnatCTZoneDefault)
 
 	// Should NOT have postrouting SNAT chain
 	if strings.Contains(result, "postrouting_snat") {
@@ -385,7 +385,7 @@ func TestBuildNftRulesetMultiBackend(t *testing.T) {
 		},
 	}
 
-	result := buildNftRuleset(forwards, nil, dnatCTZoneDefault)
+	result := buildNftRuleset(forwards, nil, nil, dnatCTZoneDefault)
 
 	// Verify jhash-based DNAT rule. nft requires the concat operator
 	// (`addr . port`) inside a verdict map; the inline `addr:port` form
@@ -414,7 +414,7 @@ func TestBuildNftRulesetMultiBackendTwoBackends(t *testing.T) {
 		},
 	}
 
-	result := buildNftRuleset(forwards, nil, dnatCTZoneDefault)
+	result := buildNftRuleset(forwards, nil, nil, dnatCTZoneDefault)
 
 	// With two backends, jhash mod 2. Map values use the concat operator
 	// (`addr . port`); see TestBuildNftRulesetMultiBackend for context.
@@ -435,7 +435,7 @@ func TestBuildNftRulesetSingleElementDestAddrs(t *testing.T) {
 		},
 	}
 
-	result := buildNftRuleset(forwards, nil, dnatCTZoneDefault)
+	result := buildNftRuleset(forwards, nil, nil, dnatCTZoneDefault)
 
 	if !strings.Contains(result, "ip daddr 198.51.100.10 tcp dport 80 dnat to 10.0.0.100:80") {
 		t.Error("single-element dest_addrs should produce direct DNAT")
@@ -458,7 +458,7 @@ func TestBuildNftRulesetMixedSingleAndMultiBackend(t *testing.T) {
 		},
 	}
 
-	result := buildNftRuleset(forwards, nil, dnatCTZoneDefault)
+	result := buildNftRuleset(forwards, nil, nil, dnatCTZoneDefault)
 
 	// Single backend → direct DNAT
 	if !strings.Contains(result, "ip daddr 198.51.100.10 tcp dport 443 dnat to 10.0.0.100:443") {
@@ -485,7 +485,7 @@ func TestBuildNftRulesetHairpinMasquerade(t *testing.T) {
 		},
 	}
 
-	result := buildNftRuleset(forwards, []*net.IPNet{provNet}, dnatCTZoneDefault)
+	result := buildNftRuleset(forwards, []*net.IPNet{provNet}, nil, dnatCTZoneDefault)
 
 	snat := extractChain(result, "postrouting_snat")
 	if snat == "" {
@@ -515,7 +515,7 @@ func TestBuildNftRulesetHairpinMasqueradeMultipleProviderNets(t *testing.T) {
 		},
 	}
 
-	result := buildNftRuleset(forwards, []*net.IPNet{net1, net2}, dnatCTZoneDefault)
+	result := buildNftRuleset(forwards, []*net.IPNet{net1, net2}, nil, dnatCTZoneDefault)
 
 	snat := extractChain(result, "postrouting_snat")
 	if snat == "" {
@@ -539,7 +539,7 @@ func TestBuildNftRulesetHairpinMasqueradeWithoutProviderNets(t *testing.T) {
 		},
 	}
 
-	result := buildNftRuleset(forwards, nil, dnatCTZoneDefault)
+	result := buildNftRuleset(forwards, nil, nil, dnatCTZoneDefault)
 
 	if strings.Contains(result, "postrouting_snat") {
 		t.Error("postrouting_snat must not be emitted when provider networks are unknown")
@@ -561,7 +561,7 @@ func TestBuildNftRulesetHairpinAndPerRuleMasqueradeCombined(t *testing.T) {
 		},
 	}
 
-	result := buildNftRuleset(forwards, []*net.IPNet{provNet}, dnatCTZoneDefault)
+	result := buildNftRuleset(forwards, []*net.IPNet{provNet}, nil, dnatCTZoneDefault)
 
 	snat := extractChain(result, "postrouting_snat")
 	if snat == "" {
@@ -576,6 +576,178 @@ func TestBuildNftRulesetHairpinAndPerRuleMasqueradeCombined(t *testing.T) {
 	// Hairpin masquerade rule (hairpin_masquerade: true on VIP)
 	if !strings.Contains(snat, "ip saddr 5.182.234.0/24 ct original daddr 194.93.78.239 ct status dnat masquerade") {
 		t.Errorf("missing hairpin masquerade rule, got:\n%s", snat)
+	}
+}
+
+func TestBuildNftRulesetRouterMasquerade(t *testing.T) {
+	// Instance behind a router (no FIP) connects to a VIP on the same node.
+	// The router SNAT'd source IP is an OVN-managed address; without masquerade
+	// the backend's reply enters OVN's pipeline and the reverse DNAT never fires.
+	// router_masquerade generates a SNAT rule targeted at the specific SNAT IPs.
+	snatIPs := []string{"203.0.113.50"}
+	forwards := []PortForwardVIP{
+		{
+			VIP:              "194.93.78.239",
+			RouterMasquerade: true,
+			Rules:            []PortForwardRule{{Proto: "tcp", Port: 80, DestAddr: "10.1.8.226"}},
+		},
+	}
+
+	result := buildNftRuleset(forwards, nil, snatIPs, dnatCTZoneDefault)
+
+	snat := extractChain(result, "postrouting_snat")
+	if snat == "" {
+		t.Fatal("missing postrouting_snat chain (needed for router masquerade)")
+	}
+
+	expected := "ip saddr 203.0.113.50 ct original daddr 194.93.78.239 ct status dnat masquerade"
+	if !strings.Contains(snat, expected) {
+		t.Errorf("missing router masquerade rule.\nwant: %s\ngot:\n%s", expected, snat)
+	}
+
+	// Must NOT masquerade all traffic (no per-backend rules since masquerade: false)
+	if strings.Contains(snat, "ip daddr 10.1.8.226") {
+		t.Errorf("router_masquerade must not emit per-backend rules, got:\n%s", snat)
+	}
+}
+
+func TestBuildNftRulesetRouterMasqueradeMultipleSNATIPs(t *testing.T) {
+	// Multiple router SNAT IPs: nftables set syntax { ip1, ip2 }.
+	// IPs must be sorted for deterministic output.
+	snatIPs := []string{"203.0.113.51", "203.0.113.50"} // intentionally unsorted
+	forwards := []PortForwardVIP{
+		{
+			VIP:              "194.93.78.239",
+			RouterMasquerade: true,
+			Rules:            []PortForwardRule{{Proto: "tcp", Port: 80, DestAddr: "10.1.8.226"}},
+		},
+	}
+
+	result := buildNftRuleset(forwards, nil, snatIPs, dnatCTZoneDefault)
+
+	snat := extractChain(result, "postrouting_snat")
+	if snat == "" {
+		t.Fatal("missing postrouting_snat chain")
+	}
+
+	expected := "ip saddr { 203.0.113.50, 203.0.113.51 } ct original daddr 194.93.78.239 ct status dnat masquerade"
+	if !strings.Contains(snat, expected) {
+		t.Errorf("missing router masquerade rule with set syntax.\nwant: %s\ngot:\n%s", expected, snat)
+	}
+}
+
+func TestBuildNftRulesetRouterMasqueradeDuplicateSNATIPs(t *testing.T) {
+	// OVN may return the same external IP for multiple NAT entries (e.g. two
+	// routers sharing a SNAT address). Duplicates must be removed before
+	// building the nftables set — { ip, ip } is invalid syntax.
+	snatIPs := []string{"203.0.113.50", "203.0.113.50"} // intentional duplicate
+	forwards := []PortForwardVIP{
+		{
+			VIP:              "194.93.78.239",
+			RouterMasquerade: true,
+			Rules:            []PortForwardRule{{Proto: "tcp", Port: 80, DestAddr: "10.1.8.226"}},
+		},
+	}
+
+	result := buildNftRuleset(forwards, nil, snatIPs, dnatCTZoneDefault)
+
+	snat := extractChain(result, "postrouting_snat")
+	if snat == "" {
+		t.Fatal("missing postrouting_snat chain")
+	}
+
+	// Deduplicated: single IP, no set syntax.
+	expected := "ip saddr 203.0.113.50 ct original daddr 194.93.78.239 ct status dnat masquerade"
+	if !strings.Contains(snat, expected) {
+		t.Errorf("duplicate SNAT IPs must be deduplicated to single-IP form.\nwant: %s\ngot:\n%s", expected, snat)
+	}
+
+	// Set syntax must not appear (would be invalid nftables).
+	if strings.Contains(snat, "{ 203.0.113.50, 203.0.113.50 }") {
+		t.Error("duplicate SNAT IPs produced invalid nftables set syntax")
+	}
+}
+
+func TestBuildNftRulesetRouterMasqueradeWithoutSNATIPs(t *testing.T) {
+	// router_masquerade: true but no SNAT IPs known yet (no routers discovered).
+	// The SNAT chain must NOT be emitted to avoid accidental masquerade.
+	forwards := []PortForwardVIP{
+		{
+			VIP:              "194.93.78.239",
+			RouterMasquerade: true,
+			Rules:            []PortForwardRule{{Proto: "tcp", Port: 80, DestAddr: "10.1.8.226"}},
+		},
+	}
+
+	result := buildNftRuleset(forwards, nil, nil, dnatCTZoneDefault)
+
+	if strings.Contains(result, "postrouting_snat") {
+		t.Error("postrouting_snat must not be emitted when no SNAT IPs are known")
+	}
+}
+
+func TestBuildNftRulesetRouterAndHairpinMasqueradeCombined(t *testing.T) {
+	// VIP with both router_masquerade and hairpin_masquerade.
+	// Both rules should coexist in postrouting_snat.
+	_, provNet, _ := net.ParseCIDR("203.0.113.0/24")
+	snatIPs := []string{"203.0.113.50"}
+	forwards := []PortForwardVIP{
+		{
+			VIP:               "194.93.78.239",
+			HairpinMasquerade: true,
+			RouterMasquerade:  true,
+			Rules:             []PortForwardRule{{Proto: "tcp", Port: 80, DestAddr: "10.1.8.226"}},
+		},
+	}
+
+	result := buildNftRuleset(forwards, []*net.IPNet{provNet}, snatIPs, dnatCTZoneDefault)
+
+	snat := extractChain(result, "postrouting_snat")
+	if snat == "" {
+		t.Fatal("missing postrouting_snat chain")
+	}
+
+	// Hairpin masquerade rule (CIDR-based)
+	if !strings.Contains(snat, "ip saddr 203.0.113.0/24 ct original daddr 194.93.78.239 ct status dnat masquerade") {
+		t.Errorf("missing hairpin masquerade rule, got:\n%s", snat)
+	}
+
+	// Router masquerade rule (IP-based)
+	if !strings.Contains(snat, "ip saddr 203.0.113.50 ct original daddr 194.93.78.239 ct status dnat masquerade") {
+		t.Errorf("missing router masquerade rule, got:\n%s", snat)
+	}
+}
+
+func TestBuildNftRulesetRouterMasqueradeDoesNotAffectOtherVIPs(t *testing.T) {
+	// router_masquerade on one VIP must not generate rules for other VIPs.
+	snatIPs := []string{"203.0.113.50"}
+	forwards := []PortForwardVIP{
+		{
+			VIP:              "194.93.78.239",
+			RouterMasquerade: true,
+			Rules:            []PortForwardRule{{Proto: "tcp", Port: 80, DestAddr: "10.1.8.226"}},
+		},
+		{
+			VIP:   "194.93.78.240",
+			Rules: []PortForwardRule{{Proto: "tcp", Port: 80, DestAddr: "10.1.8.227"}},
+		},
+	}
+
+	result := buildNftRuleset(forwards, nil, snatIPs, dnatCTZoneDefault)
+
+	snat := extractChain(result, "postrouting_snat")
+	if snat == "" {
+		t.Fatal("missing postrouting_snat chain")
+	}
+
+	// Rule for the router_masquerade VIP
+	if !strings.Contains(snat, "ct original daddr 194.93.78.239 ct status dnat masquerade") {
+		t.Errorf("missing router masquerade rule for VIP .239, got:\n%s", snat)
+	}
+
+	// No rule for the other VIP
+	if strings.Contains(snat, "ct original daddr 194.93.78.240") {
+		t.Errorf("router masquerade rule must not be emitted for VIP .240 (no router_masquerade), got:\n%s", snat)
 	}
 }
 

--- a/ovn-network-agent.yaml.sample
+++ b/ovn-network-agent.yaml.sample
@@ -187,3 +187,32 @@ ovn_nb_remote: "tcp:10.10.0.1:6641,tcp:10.10.0.2:6641,tcp:10.10.0.3:6641"
 #       - proto: tcp
 #         port: 443
 #         dest_addr: "10.0.0.100"
+#
+# Hairpin NAT options (per VIP):
+#
+#   hairpin_masquerade: true
+#     SNAT traffic from provider network CIDRs to the VIP. Fixes hairpin NAT
+#     for instances that have a Floating IP on the same network node: without
+#     this, the backend sees the FIP as source and may reply asymmetrically,
+#     bypassing this node's conntrack and breaking reverse DNAT.
+#     Uses the full provider CIDR (e.g. 203.0.113.0/24).
+#
+#   router_masquerade: true
+#     SNAT traffic from known router SNAT IPs to the VIP. Fixes hairpin NAT
+#     for instances behind a router that have no Floating IP: the router's
+#     external IP is OVN-managed, so the backend's reply would normally enter
+#     OVN's pipeline directly — bypassing this node's conntrack — and the
+#     reverse DNAT would never fire. Unlike hairpin_masquerade, this is more
+#     surgical: only the specific SNAT IPs (discovered dynamically from OVN NB
+#     NAT entries of type "snat") are masqueraded, leaving all other external
+#     clients' IPs fully preserved.
+#
+#   Example — VIP accessible from both FIPs and router-NAT'd instances:
+#   - vip: "198.51.100.30"
+#     manage_vip: true
+#     hairpin_masquerade: true  # covers FIPs on the same node
+#     router_masquerade: true   # covers instances behind a router (no FIP)
+#     rules:
+#       - proto: tcp
+#         port: 443
+#         dest_addr: "10.0.0.100"

--- a/routing_test.go
+++ b/routing_test.go
@@ -393,7 +393,7 @@ func TestDryRunPortForward(t *testing.T) {
 	}
 
 	_, cidr, _ := net.ParseCIDR("198.51.100.0/24")
-	if err := rm.ReconcilePortForward([]*net.IPNet{cidr}); err != nil {
+	if err := rm.ReconcilePortForward([]*net.IPNet{cidr}, nil); err != nil {
 		t.Errorf("ReconcilePortForward() dry-run error: %v", err)
 	}
 
@@ -414,7 +414,7 @@ func TestDisabledPortForward(t *testing.T) {
 	if err := rm.SetupPortForward(); err != nil {
 		t.Errorf("SetupPortForward() disabled error: %v", err)
 	}
-	if err := rm.ReconcilePortForward(nil); err != nil {
+	if err := rm.ReconcilePortForward(nil, nil); err != nil {
 		t.Errorf("ReconcilePortForward() disabled error: %v", err)
 	}
 	if err := rm.TeardownPortForward(); err != nil {

--- a/test/integration/scenario_port_forward_test.go
+++ b/test/integration/scenario_port_forward_test.go
@@ -478,6 +478,65 @@ func TestScenario_PortForwardHairpinMasquerade(t *testing.T) {
 		30*time.Second, "hairpin masquerade rule for VIP "+vip+" with provider 198.51.100.0/24")
 }
 
+// TestScenario_PortForwardRouterMasquerade (PR #15).
+//
+// router_masquerade:true plus a router with a `snat`-type NAT entry should
+// produce a postrouting_snat rule of the form:
+//
+//	ip saddr <router-snat-ip> ct original daddr <vip> ct status dnat masquerade
+//
+// The agent's OVN reconcile populates state.SNATIPs from NB NAT rows of
+// type=snat on locally-active routers; that slice is then handed to
+// ReconcilePortForward, which buildNftRuleset turns into the literal-IP
+// masquerade rule. Unlike hairpin masquerade (provider-CIDR match) the source
+// match here is a single IP, so we assert with HasMatch rather than
+// HasMatchPrefix.
+func TestScenario_PortForwardRouterMasquerade(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+	testenv.EnsureLoopback1(t)
+
+	// Local router with LRP in 198.51.100.0/24. The agent's network-filter
+	// fallback uses discovered LRP networks, so the SNAT external IP we add
+	// below must fall inside this prefix to survive the filter in
+	// ovn.go's NAT-collection step.
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "rmasqr",
+		LRPMAC:      "fa:16:3e:7a:00:01",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	const (
+		vip     = "198.51.100.41"
+		snatIP  = "198.51.100.50"
+		snatNet = "10.0.0.0/24"
+	)
+	testenv.AddSNATEntry(t, ctx, nb, router, snatIP, snatNet)
+
+	cfg := pfDefaults(t)
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+		VIP:              vip,
+		RouterMasquerade: true,
+		Rules: []testenv.PortForwardRuleFixture{{
+			Proto: "tcp", Port: 80, DestAddr: "10.0.0.100",
+		}},
+	}}
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// The rule only appears once OVN has reported at least one SNAT IP, so
+	// give reconcile time to run. saddr literal + masquerade uniquely
+	// identifies the router-masquerade rule — no other rule in
+	// postrouting_snat carries a literal-IP saddr match.
+	testenv.AssertNftRuleInChain(t, pfTable, "postrouting_snat",
+		func(r testenv.NftRule) bool {
+			return r.HasMatch("ip", "saddr", snatIP) &&
+				r.HasMasquerade()
+		},
+		30*time.Second, "router masquerade rule for VIP "+vip+" with SNAT IP "+snatIP)
+}
+
 // TestScenario_PortForwardL3mdevSysctls (#43 scenario 6).
 //
 // port_forward_l3mdev_accept:true must set udp_l3mdev_accept=1 and

--- a/test/integration/testenv/agent.go
+++ b/test/integration/testenv/agent.go
@@ -73,6 +73,7 @@ type PortForwardVIPFixture struct {
 	ManageVIP         bool                     `yaml:"manage_vip,omitempty"`
 	Masquerade        bool                     `yaml:"masquerade,omitempty"`
 	HairpinMasquerade bool                     `yaml:"hairpin_masquerade,omitempty"`
+	RouterMasquerade  bool                     `yaml:"router_masquerade,omitempty"`
 	Rules             []PortForwardRuleFixture `yaml:"rules"`
 }
 


### PR DESCRIPTION
… router without FIP

Adds a new per-VIP option router_masquerade: true that solves the hairpin NAT problem for instances that reach a port-forwarded VIP through a router without having their own Floating IP.

When an instance without a FIP connects to a VIP on the same network node, the OVN router applies SNAT so the traffic arrives with the router's external IP as source. This external IP is OVN-managed, meaning the backend's reply enters OVN's pipeline directly — bypassing this node's conntrack — and the reverse DNAT never fires. The instance receives a reply from the backend IP instead of the VIP, causing the connection to fail.

The fix adds a source-selective SNAT rule in postrouting_snat that masquerades only traffic whose source matches a known router SNAT IP (dynamically discovered from OVN NB NAT entries of type "snat"):

  ip saddr <snat-ip> ct original daddr <vip> ct status dnat masquerade

With multiple SNAT IPs the nftables set syntax is used:

  ip saddr { snat-ip1, snat-ip2 } ct original daddr <vip> ct status dnat masquerade

Unlike hairpin_masquerade (which uses the full provider CIDR and thus masquerades any client in the provider subnet), router_masquerade is more surgical: only the specific known SNAT IPs are masqueraded, leaving all other external clients' IPs fully preserved end-to-end.

Rules are only generated when OVN has reported SNAT IPs; the chain is omitted entirely until the first reconciliation cycle delivers SNAT IP data, preventing accidental masquerade during startup.

router_masquerade and hairpin_masquerade can be combined on the same VIP to cover both FIP-sourced and router-SNAT'd traffic simultaneously.

AI-assisted: Claude Code