### PR TITLE
feat: add OVS hairpin flows for same-chassis cross-router FIP communi…

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -177,12 +177,14 @@ func (a *Agent) reconcile() {
 	// Compute effective network filters for this cycle.
 	a.effectiveFilters = a.computeEffectiveNetworks(state.DiscoveredNetworks)
 
-	// Combine FIPs and SNAT IPs, deduplicate
-	desiredIPs := uniqueIPs(append(state.FIPs, state.SNATIPs...))
+	// hairpinIPs = FIPs + SNATs only; port-forward VIPs are intentionally
+	// excluded because their DNAT is handled by nftables, not OVN.
+	hairpinIPs := uniqueIPs(append(state.FIPs, state.SNATIPs...))
 
-	// Add port forward VIPs to desired IPs — these need kernel routes on
-	// br-ex and FRR static routes for BGP announcement, independent of
-	// whether any OVN routers are locally active.
+	// desiredIPs extends hairpinIPs with port-forward VIPs — these need
+	// kernel routes on br-ex and FRR static routes for BGP announcement,
+	// independent of whether any OVN routers are locally active.
+	desiredIPs := hairpinIPs
 	for _, pf := range a.cfg.PortForwards {
 		desiredIPs = append(desiredIPs, pf.VIP)
 	}
@@ -203,6 +205,14 @@ func (a *Agent) reconcile() {
 		// Ensure OVS MAC-tweak flows are in place (only when active).
 		if err := a.routing.EnsureOVSFlows(); err != nil {
 			slog.Error("failed to ensure OVS flows", "error", err)
+		}
+
+		// Reconcile per-IP hairpin flows for same-chassis cross-router
+		// communication. These reflect FIP/SNAT-IP traffic from OVN back
+		// into OVN's external pipeline instead of sending it to the kernel,
+		// fixing the case where two routers share the same gateway chassis.
+		if err := a.routing.ReconcileOVSHairpinFlows(hairpinIPs); err != nil {
+			slog.Error("failed to reconcile OVS hairpin flows", "error", err)
 		}
 
 		// Ensure OVN default routes and static MAC bindings for local routers.
@@ -240,6 +250,9 @@ func (a *Agent) reconcile() {
 		}
 		if err := a.routing.ReconcileFRRPrefixList(nil); err != nil {
 			slog.Error("failed to clean FRR prefix-list", "error", err)
+		}
+		if err := a.routing.ReconcileOVSHairpinFlows(nil); err != nil {
+			slog.Error("failed to clean OVS hairpin flows", "error", err)
 		}
 	}
 

--- a/ovs.go
+++ b/ovs.go
@@ -3,11 +3,15 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"net"
 	"os/exec"
 	"strings"
 )
 
-const ovsCookieMACTweak = "0x999"
+const (
+	ovsCookieMACTweak = "0x999"
+	ovsCookieHairpin  = "0x998"
+)
 
 // MACTweakFlow returns the OpenFlow rule string for a MAC-tweak flow.
 func MACTweakFlow(cookie, ofport, mac string, ipv6 bool) string {
@@ -84,6 +88,74 @@ func (rm *RouteManager) EnsureOVSFlows() error {
 	return nil
 }
 
+// HairpinFlow returns the OpenFlow rule string for a same-chassis hairpin flow.
+// The flow intercepts packets from OVN (via the patch port) destined for a
+// locally-managed IP and sends them back through the same patch port using
+// output:in_port. OVN then processes the packet as incoming on the external
+// logical switch, allowing correct DNAT/ICMP handling without leaving the host.
+//
+// Priority 910 ensures hairpin fires before the MAC-tweak flow (priority 900),
+// so locally-managed IPs are reflected into OVN while all other traffic
+// (destined for remote IPs) still falls through to MAC-tweak and exits to the
+// physical network normally.
+func HairpinFlow(cookie, ofport, ip string, ipv6 bool) string {
+	if ipv6 {
+		return fmt.Sprintf("cookie=%s,priority=910,ipv6,in_port=%s,ipv6_dst=%s/128,actions=output:in_port",
+			cookie, ofport, ip)
+	}
+	return fmt.Sprintf("cookie=%s,priority=910,ip,in_port=%s,ip_dst=%s/32,actions=output:in_port",
+		cookie, ofport, ip)
+}
+
+// ReconcileOVSHairpinFlows installs per-IP hairpin flows on the bridge device.
+//
+// Without these flows, same-chassis traffic between FIPs on different OVN
+// routers is mishandled: OVN sends it via the localnet port to br-ex, the
+// MAC-tweak flow delivers it to the kernel, but the kernel has no "local"
+// address for the destination FIP and either drops or loops the packet.
+// From a different chassis the same traffic arrives via the physical network
+// and OVN processes it correctly — explaining the asymmetric failure.
+//
+// EnsureOVSFlows must be called before this method so that cachedOfport is
+// populated. If cachedOfport is empty this method is a no-op.
+//
+// Pass nil or an empty slice to remove all hairpin flows (e.g. when no
+// locally-active routers remain).
+func (rm *RouteManager) ReconcileOVSHairpinFlows(localIPs []string) error {
+	if rm.dryRun {
+		slog.Info("[dry-run] would reconcile OVS hairpin flows", "count", len(localIPs))
+		return nil
+	}
+	if rm.cachedOfport == "" {
+		// Patch port not yet discovered; EnsureOVSFlows must run first.
+		slog.Warn("skipping OVS hairpin flow reconcile: patch port ofport not yet cached")
+		return nil
+	}
+
+	// Full replace: delete all current hairpin flows then reinstall.
+	// The replacement window is sub-millisecond and tolerable.
+	delCmd := rm.ovsCmd("ovs-ofctl", "del-flows", rm.bridgeDev,
+		fmt.Sprintf("cookie=%s/-1", ovsCookieHairpin))
+	if out, err := delCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("del hairpin OVS flows on %s: %w (output: %s)", rm.bridgeDev, err, strings.TrimSpace(string(out)))
+	}
+
+	for _, ip := range localIPs {
+		parsed := net.ParseIP(ip)
+		if parsed == nil {
+			return fmt.Errorf("invalid IP %q", ip)
+		}
+		isIPv6 := parsed.To4() == nil
+		flow := HairpinFlow(ovsCookieHairpin, rm.cachedOfport, ip, isIPv6)
+		if err := rm.addOVSFlow(flow); err != nil {
+			return fmt.Errorf("add hairpin flow for %s: %w", ip, err)
+		}
+	}
+
+	slog.Debug("OVS hairpin flows reconciled", "count", len(localIPs))
+	return nil
+}
+
 // RemoveOVSFlows removes all agent-managed OVS flows from the bridge device.
 func (rm *RouteManager) RemoveOVSFlows() error {
 	if rm.dryRun {
@@ -97,6 +169,14 @@ func (rm *RouteManager) RemoveOVSFlows() error {
 		return fmt.Errorf("del OVS flows on %s: %w (output: %s)", rm.bridgeDev, err, strings.TrimSpace(string(out)))
 	}
 	slog.Info("OVS MAC-tweak flows removed", "dev", rm.bridgeDev)
+
+	hairpinCmd := rm.ovsCmd("ovs-ofctl", "del-flows", rm.bridgeDev,
+		fmt.Sprintf("cookie=%s/-1", ovsCookieHairpin))
+	if hout, herr := hairpinCmd.CombinedOutput(); herr != nil {
+		return fmt.Errorf("del hairpin OVS flows on %s: %w (output: %s)", rm.bridgeDev, herr, strings.TrimSpace(string(hout)))
+	}
+	slog.Info("OVS hairpin flows removed", "dev", rm.bridgeDev)
+
 	return nil
 }
 

--- a/ovs_test.go
+++ b/ovs_test.go
@@ -4,6 +4,52 @@ import (
 	"testing"
 )
 
+func TestHairpinFlow(t *testing.T) {
+	tests := []struct {
+		name   string
+		cookie string
+		ofport string
+		ip     string
+		ipv6   bool
+		want   string
+	}{
+		{
+			"basic IPv4 hairpin flow",
+			"0x998", "42", "5.182.234.199", false,
+			"cookie=0x998,priority=910,ip,in_port=42,ip_dst=5.182.234.199/32,actions=output:in_port",
+		},
+		{
+			"different IPv4 IP and ofport",
+			"0x998", "7", "192.0.2.1", false,
+			"cookie=0x998,priority=910,ip,in_port=7,ip_dst=192.0.2.1/32,actions=output:in_port",
+		},
+		{
+			"SNAT router external IP",
+			"0x998", "3", "5.182.234.128", false,
+			"cookie=0x998,priority=910,ip,in_port=3,ip_dst=5.182.234.128/32,actions=output:in_port",
+		},
+		{
+			"IPv6 FIP",
+			"0x998", "42", "2001:db8::1", true,
+			"cookie=0x998,priority=910,ipv6,in_port=42,ipv6_dst=2001:db8::1/128,actions=output:in_port",
+		},
+		{
+			"IPv6 SNAT",
+			"0x998", "5", "2001:db8:cafe::1", true,
+			"cookie=0x998,priority=910,ipv6,in_port=5,ipv6_dst=2001:db8:cafe::1/128,actions=output:in_port",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HairpinFlow(tt.cookie, tt.ofport, tt.ip, tt.ipv6)
+			if got != tt.want {
+				t.Errorf("HairpinFlow() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMACTweakFlow(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
…cation

When two OVN gateway routers share the same chassis, traffic between their FIPs and external IPs fails: OVN sends packets via the localnet port to br-ex, the MAC-tweak flow delivers them to the kernel, but the kernel has no local address for the destination FIP and drops or loops the packet. From a different chassis the same traffic arrives via the physical network and OVN handles it correctly, explaining the asymmetric failure.

Fix by installing a per-IP OVS hairpin flow (cookie 0x998, priority 910) for each locally-managed FIP and SNAT IP. The flow matches packets from OVN via the patch port and reflects them back using output:in_port, causing OVN to process the packet as incoming on the external logical switch. This enables correct DNAT and ICMP handling entirely within OVN without kernel involvement.

Priority 910 ensures hairpin fires before MAC-tweak (900), so only locally- managed IPs are reflected; traffic to remote IPs falls through to MAC-tweak and exits to the physical network normally. Cross-chassis routing is unaffected because the destination IP is not locally managed on the sending node.

Port-forward VIPs are intentionally excluded: their DNAT is handled by nftables on the host, not by OVN, so they must not be reflected back into OVN's pipeline.

IPv6 FIPs and SNAT IPs are handled via ipv6/ipv6_dst=.../128 flows, matching the existing MAC-tweak flow pattern.

Delete failures in ReconcileOVSHairpinFlows and RemoveOVSFlows are now propagated as errors rather than silently logged, preventing stale flows from persisting undetected.

The redundant uniqueIPs(FIPs+SNATs) computation in reconcile() is eliminated by deriving hairpinIPs before port-forward VIPs are appended to desiredIPs.

AI-assisted: Claude Code