### PR TITLE
test(integration): add layer 2 integration test harness foundation

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,36 @@
+name: Integration
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Bootstrap OVN/OVS/FRR/nftables stack
+        run: sudo ./test/integration/setup.sh
+
+      - name: Build agent
+        run: make build
+
+      # The agent needs CAP_NET_ADMIN for netlink operations (see
+      # routing_linux.go). Run as root via sudo, preserving the Go env so
+      # `go test` finds the toolchain installed by setup-go.
+      - name: Run integration tests
+        run: |
+          sudo --preserve-env=PATH,GOROOT,GOPATH,GOTOOLCHAIN \
+            env "OVN_AGENT_BINARY=$PWD/ovn-network-agent" \
+            "$(which go)" test -tags=integration -v -count=1 ./test/integration/...

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION   ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "d
 LDFLAGS   := -s -w -X main.version=$(VERSION)
 GOFLAGS   := -trimpath
 
-.PHONY: all build build-static clean fmt vet test install
+.PHONY: all build build-static clean fmt vet test test-integration install
 
 all: build
 
@@ -22,6 +22,12 @@ vet:
 
 test:
 	go test -v ./...
+
+# Integration tests exercise the agent against a real OVN/OVS/FRR/nftables
+# stack. They require Linux + root (CAP_NET_ADMIN). See test/integration/README.md
+# for local-run prerequisites.
+test-integration: build
+	OVN_AGENT_BINARY=$(CURDIR)/$(BINARY) go test -tags=integration -v -count=1 ./test/integration/...
 
 clean:
 	rm -f $(BINARY)

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,71 @@
+# Integration tests
+
+Integration tests exercise the agent against a real OVN/OVS/FRR/nftables stack
+on a single Linux host. They live behind the `integration` build tag so the
+default `go test ./...` run does not pick them up.
+
+## Layout
+
+```
+test/integration/
+  README.md          — this file
+  setup.sh           — apt + service bootstrap (run once per host)
+  smoke_test.go      — connect / initial-reconcile / clean-shutdown smoke test
+  testenv/           — Setup, Teardown, RunAgent, AssertKernelRoute, …
+```
+
+## Local prerequisites
+
+- Linux host (Ubuntu 24.04 recommended; the harness skips on macOS / Windows).
+- Root privileges (`CAP_NET_ADMIN` is required for netlink operations in
+  `routing_linux.go`).
+- Go toolchain matching `go.mod`.
+- A host you do not mind mutating: `setup.sh` installs packages, creates
+  `br-ex`, configures FRR with a `vrf-provider` VRF, and so on.
+
+## Running locally
+
+```sh
+sudo ./test/integration/setup.sh    # one-time, installs packages and starts services
+make test-integration                # builds the binary and runs the tagged tests
+```
+
+`make test-integration` builds `./ovn-network-agent` first, then exports
+`OVN_AGENT_BINARY=$PWD/ovn-network-agent` and invokes
+`go test -tags=integration -v -count=1 ./test/integration/...`.
+
+To point the harness at a binary built elsewhere:
+
+```sh
+sudo OVN_AGENT_BINARY=/path/to/ovn-network-agent \
+    go test -tags=integration -v -count=1 ./test/integration/...
+```
+
+The tests skip (rather than fail) when:
+
+- not running on Linux, or
+- not running as root, or
+- `br-ex`, `nft`, `ovs-vsctl`, `ovs-ofctl`, or `vtysh` is missing.
+
+Run `setup.sh` if you see skip messages for the bridge or binaries.
+
+## Adding new tests
+
+1. Create a `*_test.go` file in `test/integration/` with the build tag:
+   ```go
+   //go:build integration
+
+   package integration
+   ```
+2. Call `testenv.Setup(t)` first; it registers a cleanup that scrubs leftover
+   nft tables / kernel routes / FRR static routes between tests.
+3. Drive the agent via `testenv.RunAgent(t, cfg)` and verify outcomes with the
+   `Assert*` helpers (`AssertKernelRoute`, `AssertOVSFlow`, `AssertFRRRoute`,
+   `AssertNftRule`).
+4. Always call `proc.Stop(timeout)` — if the test forgets, `t.Cleanup`
+   SIGKILLs the process, but state cleanup may be incomplete.
+
+## CI
+
+`.github/workflows/integration.yml` runs the same flow on `ubuntu-latest`:
+`setup.sh` → `make build` → `go test -tags=integration ...` under sudo.

--- a/test/integration/setup.sh
+++ b/test/integration/setup.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# setup.sh — bootstrap an OVN/OVS/FRR/nftables stack for integration tests.
+#
+# Targets a single Ubuntu host (CI: ubuntu-latest GHA runner, local: a fresh
+# Ubuntu 24.04 VM is recommended). Runs idempotently: re-running on an
+# already-bootstrapped host should be a no-op.
+#
+# Side effects:
+#   * apt-installs openvswitch-switch, ovn-host, ovn-central, frr, nftables
+#   * starts ovsdb-server (NB+SB), ovn-northd, ovn-controller, ovs-vswitchd
+#   * binds OVN NB to tcp:127.0.0.1:6641 and SB to tcp:127.0.0.1:6642
+#   * creates br-ex and br-int with datapath_type=netdev
+#   * configures FRR with a vrf-provider VRF and a dummy BGP peer
+#
+# Requires: root (sudo).
+
+set -euo pipefail
+
+log() { printf '[setup] %s\n' "$*" >&2; }
+
+require_root() {
+    if [[ "$(id -u)" -ne 0 ]]; then
+        echo "setup.sh must run as root (use sudo)" >&2
+        exit 1
+    fi
+}
+
+apt_install() {
+    log "apt update"
+    DEBIAN_FRONTEND=noninteractive apt-get update -y
+    # Ubuntu 24.04 base ships OVN 24.03, but the agent's NB NAT model uses
+    # the `match`/`priority` columns added in OVN 24.09. Pull OVN from the
+    # Ubuntu Cloud Archive flamingo pocket (OpenStack 2025.2 → OVN 25.09).
+    log "enabling cloud-archive:flamingo for current OVN"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        software-properties-common ubuntu-cloud-keyring
+    add-apt-repository -y cloud-archive:flamingo
+    DEBIAN_FRONTEND=noninteractive apt-get update -y
+    log "apt install"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        openvswitch-switch \
+        ovn-host \
+        ovn-central \
+        frr \
+        frr-pythontools \
+        nftables \
+        iproute2
+}
+
+start_ovs() {
+    log "starting openvswitch-switch"
+    systemctl enable --now openvswitch-switch
+    # Wait for ovs-vsctl to respond.
+    for _ in $(seq 1 30); do
+        if ovs-vsctl show >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    echo "openvswitch-switch did not start" >&2
+    exit 1
+}
+
+start_ovn_central() {
+    log "starting ovn-central (NB/SB ovsdb-server + ovn-northd)"
+    systemctl enable --now ovn-central
+    # Bind NB/SB to TCP for the agent.
+    log "configuring NB tcp:6641 and SB tcp:6642 listeners"
+    ovn-nbctl set-connection ptcp:6641:127.0.0.1
+    ovn-sbctl set-connection ptcp:6642:127.0.0.1
+    # Wait for both endpoints to accept connections.
+    for _ in $(seq 1 30); do
+        if ovn-nbctl --db=tcp:127.0.0.1:6641 show >/dev/null 2>&1 \
+            && ovn-sbctl --db=tcp:127.0.0.1:6642 show >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    echo "OVN NB/SB TCP listeners did not become ready" >&2
+    exit 1
+}
+
+start_ovn_host() {
+    log "configuring ovn-controller"
+    local hostname
+    hostname=$(hostname -s)
+    ovs-vsctl set Open_vSwitch . \
+        external_ids:ovn-remote=tcp:127.0.0.1:6642 \
+        external_ids:ovn-encap-type=geneve \
+        external_ids:ovn-encap-ip=127.0.0.1 \
+        external_ids:system-id="${hostname}"
+    systemctl enable --now ovn-host
+    for _ in $(seq 1 30); do
+        if ovs-vsctl br-exists br-int 2>/dev/null; then
+            return 0
+        fi
+        sleep 1
+    done
+    echo "ovn-controller did not create br-int" >&2
+    exit 1
+}
+
+create_bridges() {
+    log "creating br-ex (datapath_type=netdev)"
+    ovs-vsctl --may-exist add-br br-ex -- set bridge br-ex datapath_type=netdev
+    ip link set br-ex up
+    # br-int is created by ovn-controller; ensure datapath_type is consistent
+    # so the smoke stack does not require kernel datapath modules.
+    if ovs-vsctl br-exists br-int 2>/dev/null; then
+        ovs-vsctl set bridge br-int datapath_type=netdev
+    fi
+    # Bridge mapping so that ovn-controller knows br-ex is the provider bridge.
+    ovs-vsctl set Open_vSwitch . external_ids:ovn-bridge-mappings=physnet1:br-ex
+}
+
+configure_frr() {
+    log "configuring FRR (vrf-provider + dummy BGP peer)"
+    # Enable bgpd.
+    if ! grep -q '^bgpd=yes' /etc/frr/daemons; then
+        sed -i 's/^bgpd=no/bgpd=yes/' /etc/frr/daemons
+    fi
+    systemctl enable --now frr
+    # Wait for vtysh to respond.
+    for _ in $(seq 1 30); do
+        if vtysh -c 'show version' >/dev/null 2>&1; then
+            break
+        fi
+        sleep 1
+    done
+
+    # Create the provider VRF as a Linux device so FRR can attach to it.
+    # On the GHA azure-flavoured kernel the vrf module lives in
+    # linux-modules-extra-<uname>, which isn't installed by default; pull it
+    # in (best-effort) before modprobe.
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        "linux-modules-extra-$(uname -r)" || true
+    modprobe vrf
+    if ! ip link show vrf-provider >/dev/null 2>&1; then
+        ip link add vrf-provider type vrf table 100
+        ip link set vrf-provider up
+    fi
+
+    # Push minimal FRR config: vrf-provider + ANNOUNCED-NETWORKS prefix-list +
+    # a dummy BGP peer (192.0.2.1, no real session). Idempotent: re-running
+    # the conf-t block overwrites prior state for these objects.
+    vtysh <<'EOF'
+configure terminal
+ip prefix-list ANNOUNCED-NETWORKS seq 5 permit 0.0.0.0/0 ge 32 le 32
+vrf vrf-provider
+exit-vrf
+router bgp 65000 vrf vrf-provider
+ bgp router-id 127.0.0.1
+ no bgp default ipv4-unicast
+ neighbor 192.0.2.1 remote-as 65001
+ neighbor 192.0.2.1 update-source lo
+ address-family ipv4 unicast
+  redistribute static
+  neighbor 192.0.2.1 activate
+  neighbor 192.0.2.1 prefix-list ANNOUNCED-NETWORKS out
+ exit-address-family
+end
+write memory
+EOF
+}
+
+ensure_nftables() {
+    log "ensuring nftables service is enabled"
+    systemctl enable --now nftables || true
+    # The agent creates its own table; we don't need to pre-populate anything.
+}
+
+main() {
+    require_root
+    apt_install
+    start_ovs
+    start_ovn_central
+    start_ovn_host
+    create_bridges
+    configure_frr
+    ensure_nftables
+    log "setup complete"
+}
+
+main "$@"

--- a/test/integration/smoke_test.go
+++ b/test/integration/smoke_test.go
@@ -1,0 +1,33 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/osism/ovn-network-agent/test/integration/testenv"
+)
+
+// TestSmoke verifies the agent can connect to OVN, complete the initial
+// reconcile, and exit cleanly on SIGTERM. No OVN logical state is
+// configured — there are no local routers, so the reconcile is essentially
+// a no-op. The point is to exercise the connect/shutdown lifecycle end to
+// end against a real OVSDB.
+func TestSmoke(t *testing.T) {
+	testenv.Setup(t)
+
+	cfg := testenv.Defaults()
+	agent := testenv.RunAgent(t, cfg)
+
+	readyCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := agent.WaitReady(readyCtx); err != nil {
+		t.Fatalf("agent did not become ready: %v", err)
+	}
+
+	if err := agent.Stop(15 * time.Second); err != nil {
+		t.Fatalf("agent did not stop cleanly: %v", err)
+	}
+}

--- a/test/integration/testenv/agent.go
+++ b/test/integration/testenv/agent.go
@@ -1,0 +1,251 @@
+//go:build integration
+
+package testenv
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// AgentConfig captures the config-file fields the integration harness uses
+// to run the agent. Zero-valued fields fall back to AgentConfig defaults
+// applied by Defaults().
+type AgentConfig struct {
+	OVNNBRemote   string `yaml:"ovn_nb_remote"`
+	OVNSBRemote   string `yaml:"ovn_sb_remote"`
+	BridgeDev     string `yaml:"bridge_dev"`
+	VRFName       string `yaml:"vrf_name"`
+	VethNexthop   string `yaml:"veth_nexthop"`
+	FRRPrefixList string `yaml:"frr_prefix_list"`
+	LogLevel      string `yaml:"log_level"`
+
+	// Pointers so we can distinguish "unset" from "explicit false".
+	DryRun            *bool `yaml:"dry_run,omitempty"`
+	CleanupOnShutdown *bool `yaml:"cleanup_on_shutdown,omitempty"`
+	DrainOnShutdown   *bool `yaml:"drain_on_shutdown,omitempty"`
+	VethLeakEnabled   *bool `yaml:"veth_leak_enabled,omitempty"`
+
+	ReconcileInterval string `yaml:"reconcile_interval,omitempty"`
+}
+
+// Defaults returns an AgentConfig wired for the local test stack:
+// TCP NB on 6641, TCP SB on 6642, FRR prefix-list disabled to avoid
+// touching FRR config that may not exist.
+func Defaults() AgentConfig {
+	off := false
+	return AgentConfig{
+		OVNNBRemote:       "tcp:127.0.0.1:6641",
+		OVNSBRemote:       "tcp:127.0.0.1:6642",
+		BridgeDev:         DefaultBridgeDev,
+		VRFName:           DefaultVRFName,
+		VethNexthop:       "169.254.0.1",
+		FRRPrefixList:     "",
+		LogLevel:          "debug",
+		DrainOnShutdown:   &off,
+		ReconcileInterval: "5s",
+	}
+}
+
+// AgentProc is a handle to a running agent subprocess.
+type AgentProc struct {
+	t       *testing.T
+	cmd     *exec.Cmd
+	stderr  io.ReadCloser
+	configF string
+
+	// readyCh is closed when "agent running" appears on stderr.
+	readyCh chan struct{}
+	// exitCh receives the process exit error once cmd.Wait() returns.
+	exitCh chan error
+
+	mu      sync.Mutex
+	logBuf  strings.Builder
+	stopped bool
+}
+
+// RunAgent writes cfg to a temp YAML file, execs the agent binary, and
+// returns a handle. The process is killed on test cleanup if Stop has
+// not already been called.
+func RunAgent(t *testing.T, cfg AgentConfig) *AgentProc {
+	t.Helper()
+
+	configPath := writeTempConfig(t, cfg)
+
+	bin := AgentBinary(t)
+	cmd := exec.Command(bin, "--config", configPath)
+	cmd.Env = append(os.Environ(), "GOTRACEBACK=all")
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		t.Fatalf("StderrPipe: %v", err)
+	}
+	cmd.Stdout = os.Stdout
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start agent: %v", err)
+	}
+	t.Logf("agent started pid=%d binary=%s config=%s", cmd.Process.Pid, bin, configPath)
+
+	p := &AgentProc{
+		t:       t,
+		cmd:     cmd,
+		stderr:  stderr,
+		configF: configPath,
+		readyCh: make(chan struct{}),
+		exitCh:  make(chan error, 1),
+	}
+
+	go p.scanStderr()
+
+	go func() {
+		p.exitCh <- cmd.Wait()
+	}()
+
+	t.Cleanup(func() {
+		// Best-effort kill if the test forgot to call Stop. We don't
+		// fail the cleanup — that masks the real test failure.
+		p.mu.Lock()
+		stopped := p.stopped
+		p.mu.Unlock()
+		if !stopped {
+			_ = p.cmd.Process.Signal(syscall.SIGKILL)
+			<-p.exitCh
+		}
+	})
+
+	return p
+}
+
+// scanStderr forwards agent stderr to t.Log, buffers it for diagnostics,
+// and signals readyCh when the "agent running" line appears.
+func (p *AgentProc) scanStderr() {
+	scanner := bufio.NewScanner(p.stderr)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	readyClosed := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		p.t.Logf("agent: %s", line)
+		p.mu.Lock()
+		p.logBuf.WriteString(line)
+		p.logBuf.WriteByte('\n')
+		p.mu.Unlock()
+		if !readyClosed && strings.Contains(line, "agent running") {
+			close(p.readyCh)
+			readyClosed = true
+		}
+	}
+	if !readyClosed {
+		// stderr closed before we ever saw "agent running" — unblock
+		// any WaitReady caller so they don't hang on a dead process.
+		close(p.readyCh)
+	}
+}
+
+// WaitReady blocks until the agent logs "agent running" (which fires
+// after Connect + initial reconcile) or ctx is cancelled.
+func (p *AgentProc) WaitReady(ctx context.Context) error {
+	select {
+	case <-p.readyCh:
+		// readyCh may close because the process died early; surface that.
+		select {
+		case err := <-p.exitCh:
+			p.exitCh <- err
+			return fmt.Errorf("agent exited before becoming ready: %w (logs: %s)", err, p.LogTail(20))
+		default:
+			return nil
+		}
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Stop sends SIGTERM and waits up to timeout for clean exit. If the
+// process does not exit in time, it is killed with SIGKILL.
+func (p *AgentProc) Stop(timeout time.Duration) error {
+	p.mu.Lock()
+	if p.stopped {
+		p.mu.Unlock()
+		return nil
+	}
+	p.stopped = true
+	p.mu.Unlock()
+
+	if err := p.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("signal SIGTERM: %w", err)
+	}
+
+	select {
+	case err := <-p.exitCh:
+		if err != nil {
+			// Exit due to signal-induced shutdown is fine; the agent
+			// returns nil from Run() when ctx is cancelled, so a
+			// graceful SIGTERM yields exit code 0.
+			return fmt.Errorf("agent exited with error: %w", err)
+		}
+		return nil
+	case <-time.After(timeout):
+		_ = p.cmd.Process.Signal(syscall.SIGKILL)
+		<-p.exitCh
+		return fmt.Errorf("agent did not exit within %s, killed", timeout)
+	}
+}
+
+// LogTail returns the last n lines of agent stderr captured so far.
+func (p *AgentProc) LogTail(n int) string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	lines := strings.Split(strings.TrimRight(p.logBuf.String(), "\n"), "\n")
+	if len(lines) <= n {
+		return strings.Join(lines, "\n")
+	}
+	return strings.Join(lines[len(lines)-n:], "\n")
+}
+
+// writeTempConfig serialises cfg to a temp YAML file in t.TempDir().
+// Pointer fields are emitted only when set, so the agent's own defaults
+// apply for everything else.
+func writeTempConfig(t *testing.T, cfg AgentConfig) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.yaml")
+
+	var b strings.Builder
+	w := func(k, v string) {
+		if v != "" {
+			fmt.Fprintf(&b, "%s: %q\n", k, v)
+		}
+	}
+	wb := func(k string, v *bool) {
+		if v != nil {
+			fmt.Fprintf(&b, "%s: %t\n", k, *v)
+		}
+	}
+	w("ovn_nb_remote", cfg.OVNNBRemote)
+	w("ovn_sb_remote", cfg.OVNSBRemote)
+	w("bridge_dev", cfg.BridgeDev)
+	w("vrf_name", cfg.VRFName)
+	w("veth_nexthop", cfg.VethNexthop)
+	// frr_prefix_list intentionally allows empty string to disable.
+	fmt.Fprintf(&b, "frr_prefix_list: %q\n", cfg.FRRPrefixList)
+	w("log_level", cfg.LogLevel)
+	w("reconcile_interval", cfg.ReconcileInterval)
+	wb("dry_run", cfg.DryRun)
+	wb("cleanup_on_shutdown", cfg.CleanupOnShutdown)
+	wb("drain_on_shutdown", cfg.DrainOnShutdown)
+	wb("veth_leak_enabled", cfg.VethLeakEnabled)
+
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}

--- a/test/integration/testenv/assert.go
+++ b/test/integration/testenv/assert.go
@@ -1,0 +1,107 @@
+//go:build integration
+
+package testenv
+
+import (
+	"fmt"
+	"net"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// AssertKernelRoute fails the test if no /32 route for ip exists on the
+// default bridge device. Polls for up to timeout to give the agent time
+// to install the route after a state change.
+func AssertKernelRoute(t *testing.T, ip string, timeout time.Duration) {
+	t.Helper()
+	if net.ParseIP(ip) == nil {
+		t.Fatalf("AssertKernelRoute: invalid IP %q", ip)
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := exec.Command("ip", "-4", "route", "show", ip+"/32", "dev", DefaultBridgeDev).CombinedOutput()
+		if err == nil && strings.Contains(string(out), ip) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("kernel route %s/32 on %s not present after %s (last output: %q, err: %v)",
+				ip, DefaultBridgeDev, timeout, strings.TrimSpace(string(out)), err)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// AssertOVSFlow fails the test if no flow with the given cookie exists on
+// br-ex. Cookie format mirrors ovs-ofctl: e.g. "0x999".
+func AssertOVSFlow(t *testing.T, cookie string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := exec.Command("ovs-ofctl", "dump-flows", DefaultBridgeDev,
+			fmt.Sprintf("cookie=%s/-1", cookie)).CombinedOutput()
+		if err == nil {
+			// dump-flows always prints a header line; a match means
+			// at least one additional line containing "cookie=".
+			lines := 0
+			for _, line := range strings.Split(string(out), "\n") {
+				if strings.Contains(line, "cookie=") {
+					lines++
+				}
+			}
+			if lines > 0 {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("OVS flow with cookie %s on %s not present after %s (last output: %q, err: %v)",
+				cookie, DefaultBridgeDev, timeout, strings.TrimSpace(string(out)), err)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// AssertFRRRoute fails the test if no static /32 route for ip exists in
+// the default VRF.
+func AssertFRRRoute(t *testing.T, ip string, timeout time.Duration) {
+	t.Helper()
+	if net.ParseIP(ip) == nil {
+		t.Fatalf("AssertFRRRoute: invalid IP %q", ip)
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		routes, err := frrStaticRoutes(DefaultVRFName)
+		if err == nil {
+			for _, r := range routes {
+				if r == ip {
+					return
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("FRR static route %s/32 in vrf %s not present after %s (current: %v, err: %v)",
+				ip, DefaultVRFName, timeout, routes, err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// AssertNftRule fails the test if `nft list table ip <DefaultNftTable>`
+// does not contain substring. The substring must be specific enough to
+// uniquely identify the rule (e.g. a VIP address combined with a port).
+func AssertNftRule(t *testing.T, substring string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := exec.Command("nft", "list", "table", "ip", DefaultNftTable).CombinedOutput()
+		if err == nil && strings.Contains(string(out), substring) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("nft table %s does not contain %q after %s (err: %v, output: %q)",
+				DefaultNftTable, substring, timeout, err, strings.TrimSpace(string(out)))
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}

--- a/test/integration/testenv/testenv.go
+++ b/test/integration/testenv/testenv.go
@@ -1,0 +1,199 @@
+//go:build integration
+
+// Package testenv provides bootstrap, teardown, and assertion helpers for
+// integration tests that exercise the agent against a real OVN/OVS/FRR/nftables
+// stack on Linux.
+//
+// The package assumes the surrounding stack (ovsdb-server, ovn-northd,
+// ovn-controller, FRR, nftables, br-ex) has already been provisioned by
+// test/integration/setup.sh. Setup verifies the prerequisites and records
+// initial state; Teardown best-effort restores it.
+package testenv
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// DefaultBridgeDev is the bridge name the agent defaults to and which
+// setup.sh provisions. testenv assertions target this device.
+const DefaultBridgeDev = "br-ex"
+
+// DefaultVRFName is the FRR VRF name the agent defaults to.
+const DefaultVRFName = "vrf-provider"
+
+// DefaultNftTable is the nftables table name the agent uses for port
+// forwarding (mirrors nftTableName in nftables.go).
+const DefaultNftTable = "ovn-network-agent"
+
+// requiredBinaries are external commands the harness shells out to.
+// Setup fails fast if any are missing.
+var requiredBinaries = []string{
+	"ip",
+	"nft",
+	"ovs-vsctl",
+	"ovs-ofctl",
+	"vtysh",
+}
+
+// Setup verifies the host has the prerequisites for integration tests:
+//   - running as root (CAP_NET_ADMIN required for netlink ops)
+//   - br-ex bridge present and up
+//   - required CLI binaries on PATH
+//   - OVN NB/SB reachable via TCP
+//
+// It registers a t.Cleanup that warns on leaked state. Sub-tests that mutate
+// state should still call helpers like ResetAgentState directly.
+func Setup(t *testing.T) {
+	t.Helper()
+
+	if runtime.GOOS != "linux" {
+		t.Skipf("integration tests require Linux (current: %s)", runtime.GOOS)
+	}
+
+	if os.Geteuid() != 0 {
+		t.Skip("integration tests require root (CAP_NET_ADMIN); rerun with sudo")
+	}
+
+	for _, bin := range requiredBinaries {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("required binary %q not found in PATH: %v", bin, err)
+		}
+	}
+
+	if _, err := net.InterfaceByName(DefaultBridgeDev); err != nil {
+		t.Skipf("bridge %s not present (run test/integration/setup.sh first): %v",
+			DefaultBridgeDev, err)
+	}
+
+	t.Cleanup(func() { Teardown(t) })
+}
+
+// Teardown best-effort cleans residue the agent might have left behind:
+//   - removes the agent's nftables table if present
+//   - flushes /32 routes from br-ex installed by the agent (rtproto 44)
+//   - removes static /32 routes from the FRR VRF
+//
+// The agent's own CleanupOnShutdown should handle this on SIGTERM, so
+// Teardown is a safety net that prevents one failing test from poisoning
+// the next.
+func Teardown(t *testing.T) {
+	t.Helper()
+
+	// nftables table.
+	if out, err := exec.Command("nft", "list", "table", "ip", DefaultNftTable).CombinedOutput(); err == nil && len(out) > 0 {
+		if err := exec.Command("nft", "delete", "table", "ip", DefaultNftTable).Run(); err != nil {
+			t.Logf("teardown: failed to delete nft table %s: %v", DefaultNftTable, err)
+		}
+	}
+
+	// Kernel routes installed by the agent on br-ex are tagged with rtproto 44.
+	// Flush by protocol so we don't touch system routes.
+	if err := exec.Command("ip", "route", "flush", "proto", "44", "dev", DefaultBridgeDev).Run(); err != nil {
+		// Likely "no such process" if there are no matching routes — ignore.
+		if !strings.Contains(err.Error(), "exit status") {
+			t.Logf("teardown: flush kernel routes on %s: %v", DefaultBridgeDev, err)
+		}
+	}
+
+	// Strip leftover /32 static routes from the FRR VRF. We only attempt
+	// this if vtysh succeeds — FRR may have been torn down by the host.
+	routes, err := frrStaticRoutes(DefaultVRFName)
+	if err == nil {
+		for _, ip := range routes {
+			args := []string{
+				"-c", "conf t",
+				"-c", "vrf " + DefaultVRFName,
+				"-c", "no ip route " + ip + "/32",
+				"-c", "exit-vrf",
+				"-c", "end",
+			}
+			if err := exec.Command("vtysh", args...).Run(); err != nil {
+				t.Logf("teardown: remove FRR route %s/32: %v", ip, err)
+			}
+		}
+	}
+}
+
+// frrStaticRoutes returns the /32 static routes currently present in the
+// given FRR VRF, parsed from "show ip route vrf <vrf> static".
+func frrStaticRoutes(vrf string) ([]string, error) {
+	out, err := exec.Command("vtysh",
+		"-c", "show ip route vrf "+vrf+" static",
+	).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("vtysh: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	var ips []string
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "S") {
+			continue
+		}
+		for _, f := range strings.Fields(line) {
+			if !strings.Contains(f, "/32") {
+				continue
+			}
+			ip, _, err := net.ParseCIDR(f)
+			if err == nil {
+				ips = append(ips, ip.String())
+			}
+			break
+		}
+	}
+	return ips, nil
+}
+
+// RepoRoot returns the repository root by walking up from the directory
+// containing this source file until it finds go.mod.
+func RepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not locate repo root (no go.mod found)")
+		}
+		dir = parent
+	}
+}
+
+// AgentBinary returns the absolute path to the agent binary the harness
+// should exec. It honours the OVN_AGENT_BINARY env var; otherwise it
+// defaults to <repo>/ovn-network-agent. The binary must already exist —
+// the Makefile target builds it before running integration tests.
+func AgentBinary(t *testing.T) string {
+	t.Helper()
+	if p := os.Getenv("OVN_AGENT_BINARY"); p != "" {
+		if !filepath.IsAbs(p) {
+			abs, err := filepath.Abs(p)
+			if err != nil {
+				t.Fatalf("resolve OVN_AGENT_BINARY=%q: %v", p, err)
+			}
+			p = abs
+		}
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("OVN_AGENT_BINARY=%q not found: %v", p, err)
+		}
+		return p
+	}
+	bin := filepath.Join(RepoRoot(t), "ovn-network-agent")
+	if _, err := os.Stat(bin); errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("agent binary not found at %s; run `make build` or set OVN_AGENT_BINARY", bin)
+	}
+	return bin
+}


### PR DESCRIPTION
Establishes test/integration/ behind //go:build integration with a testenv package (Setup/Teardown, RunAgent, AssertKernelRoute / AssertOVSFlow / AssertFRRRoute / AssertNftRule), a single connect / initial-reconcile / clean-shutdown smoke test, an apt+systemd bootstrap script, a make test-integration target, and a GHA workflow that runs the suite as root on ubuntu-latest. Closes #41.

Closes #41

AI-assisted: Claude Code