### PR TITLE
test(integration): add layer 2 reconciliation scenarios

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -8,11 +8,19 @@ default `go test ./...` run does not pick them up.
 
 ```
 test/integration/
-  README.md          — this file
-  setup.sh           — apt + service bootstrap (run once per host)
-  smoke_test.go      — connect / initial-reconcile / clean-shutdown smoke test
-  testenv/           — Setup, Teardown, RunAgent, AssertKernelRoute, …
+  README.md                        — this file
+  setup.sh                         — apt + service bootstrap (run once per host)
+  smoke_test.go                    — connect / initial-reconcile / clean-shutdown smoke test
+  scenarios_helpers_test.go        — shared per-scenario boilerplate (startScenario, readyAgent)
+  scenario_fip_test.go             — FIP add/remove, gatewayless gw, multi-router on one chassis
+  scenario_failover_test.go        — failover, stale-chassis cleanup, drain & restore-drained
+  testenv/                         — Setup, Teardown, RunAgent, MakeLocalRouter, Assert*, …
 ```
+
+Scenario tests pause `ovn-northd` for the duration of each test (via
+`testenv.PauseOVNNorthd`) so the test driver can write SB Port_Binding rows
+directly without northd garbage-collecting them. `ovn-controller` keeps
+running. `setup.sh` is unchanged from the harness foundation.
 
 ## Local prerequisites
 

--- a/test/integration/scenario_failover_test.go
+++ b/test/integration/scenario_failover_test.go
@@ -1,0 +1,289 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/osism/ovn-network-agent/test/integration/testenv"
+)
+
+// TestScenario_Failover (#42 scenario 4):
+//
+// While the agent is running with a locally-active router, simulate ovn-northd
+// rebinding the chassisredirect Port_Binding to a peer chassis (as would
+// happen if the peer's Gateway_Chassis priority were raised). The agent must
+// notice HasLocalRouters→false and remove the per-IP routes/flows it
+// installed.
+func TestScenario_Failover(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "fover",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+	const fip = "198.51.100.77"
+	testenv.AddFIP(t, ctx, nb, router, fip, "10.0.0.77")
+
+	cfg := testenv.Defaults()
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// Confirm the route is in place before we trigger failover, so the
+	// after-failover assertion really proves removal (not just "never
+	// installed").
+	testenv.AssertKernelRoute(t, fip, 15*time.Second)
+	testenv.AssertFRRRoute(t, fip, 15*time.Second)
+
+	// Insert a peer chassis and rebind the CR Port_Binding to it. This
+	// matches what ovn-northd would do once the peer became higher-priority.
+	peerChassis := testenv.MakeChassis(t, ctx, sb, "peer-host")
+	testenv.SetCRPortChassis(t, ctx, sb, router.CRPortUUID, &peerChassis)
+
+	testenv.AssertNoKernelRoute(t, fip, 20*time.Second)
+	testenv.AssertNoFRRRoute(t, fip, 20*time.Second)
+	// Hairpin flows should also be gone (no local routers => empty map).
+	testenv.AssertNoOVSFlow(t, "0x998", 20*time.Second)
+}
+
+// TestScenario_StaleChassisCleanup (#42 scenario 5):
+//
+// A managed NB static route tagged with the chassis name of a peer that
+// disappears from SB Chassis must be cleaned up by any surviving agent after
+// stale_chassis_grace_period elapses. The grace period is forced down to 2s
+// for this test; jitter is bounded by maxStaleCleanupJitter (≤30s in
+// production) but the test gives a generous 60s deadline to avoid flakes.
+func TestScenario_StaleChassisCleanup(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	// Local router so the agent enters the productive branch every reconcile.
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "stale",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	// Insert the peer chassis and seed a managed route tagged for it. The
+	// route is on a *local* router because CleanupStaleChassisManagedEntries
+	// only walks routes that the local agent can prove ownership of via the
+	// chassis tag, not by router locality.
+	peerName := "ghost-host"
+	peerUUID := testenv.MakeChassis(t, ctx, sb, peerName)
+	staleRouteUUID := testenv.SeedManagedRoute(t, ctx, nb, router,
+		"203.0.113.99/32", "169.254.0.1", peerName)
+
+	// Sanity: route is present before we delete the chassis.
+	if testenv.CountManagedRoutes(t, ctx, nb, peerName) != 1 {
+		t.Fatalf("seeded route not present (uuid=%s)", staleRouteUUID)
+	}
+
+	cfg := testenv.Defaults()
+	staleGrace := "2s"
+	cfg.StaleChassisGracePeriod = staleGrace
+	cfg.ReconcileInterval = "2s" // tighten so the stale check runs quickly
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// While the chassis is alive, the agent must NOT remove the route — even
+	// if a reconcile cycle ran in between.
+	time.Sleep(3 * time.Second)
+	if got := testenv.CountManagedRoutes(t, ctx, nb, peerName); got != 1 {
+		t.Fatalf("agent removed route while chassis is alive (count=%d)", got)
+	}
+
+	// Delete the chassis; after grace + jitter the route must be gone.
+	// Worst-case: 2s grace + 30s jitter + reconcile interval + safety = ~60s.
+	testenv.DeleteChassis(t, ctx, sb, peerUUID)
+	testenv.Eventually(t, func() bool {
+		return testenv.CountManagedRoutes(t, ctx, nb, peerName) == 0
+	}, 60*time.Second, 500*time.Millisecond,
+		"surviving agent must delete managed route tagged for missing chassis")
+}
+
+// TestScenario_DrainOnShutdown (#42 scenario 6):
+//
+// SIGTERM with drain_on_shutdown=true must lower this chassis's
+// Gateway_Chassis priority to 0 BEFORE kernel routes are torn down. The
+// drain loop blocks until SB shows no local CR ports — a goroutine
+// simulates ovn-northd by rebinding the CR Port_Binding once it observes
+// priority=0 in NB, so the agent's drain unblocks promptly.
+//
+// We verify ordering by recording timestamps for both transitions and
+// asserting priority_zero < route_removed.
+func TestScenario_DrainOnShutdown(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "drain",
+		LRPNetworks: []string{"198.51.100.11/24"},
+		GatewayChassis: []testenv.GatewayChassisEntry{
+			{ChassisName: testenv.LocalHostname(t), Priority: 5},
+		},
+	})
+
+	cfg := testenv.Defaults()
+	on := true
+	cfg.DrainOnShutdown = &on
+	cfg.ReconcileInterval = "2s"
+	a := readyAgent(t, cfg)
+
+	// Wait for at least the LRP-network /32 route to land before draining.
+	testenv.AssertKernelRoute(t, "198.51.100.11", 15*time.Second)
+
+	// Pre-stage a peer chassis so ovn-controller does not complain when we
+	// rebind the Port_Binding mid-drain.
+	peerUUID := testenv.MakeChassis(t, ctx, sb, "drain-peer")
+	gcName := "lrp-" + router.Name + "_" + testenv.LocalHostname(t)
+
+	// Goroutine: poll NB for priority==0, record its timestamp, then
+	// rebind the CR port_binding to the peer so countLocalCRPorts returns 0.
+	// We do not call t.Fatalf from this goroutine — testing.T methods are
+	// only safe on the test's own goroutine. Errors are surfaced via errCh.
+	var (
+		priorityZeroAt = make(chan time.Time, 1)
+		errCh          = make(chan error, 1)
+	)
+	pctx, pcancel := context.WithCancel(ctx)
+	defer pcancel()
+	go func() {
+		tick := time.NewTicker(50 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-pctx.Done():
+				return
+			case <-tick.C:
+				var entries []testenv.NBGatewayChassis
+				if err := nb.List(ctx, &entries); err != nil {
+					select {
+					case errCh <- err:
+					default:
+					}
+					return
+				}
+				for _, gc := range entries {
+					if gc.Name != gcName || gc.Priority != 0 {
+						continue
+					}
+					select {
+					case priorityZeroAt <- time.Now():
+					default:
+					}
+					rebind := &testenv.SBPortBinding{UUID: router.CRPortUUID, Chassis: &peerUUID}
+					ops, opErr := sb.Where(rebind).Update(rebind, &rebind.Chassis)
+					if opErr != nil {
+						select {
+						case errCh <- opErr:
+						default:
+						}
+						return
+					}
+					if _, opErr := sb.Transact(ctx, ops...); opErr != nil {
+						select {
+						case errCh <- opErr:
+						default:
+						}
+					}
+					return
+				}
+			}
+		}
+	}()
+
+	if err := a.Stop(45 * time.Second); err != nil {
+		t.Fatalf("agent stop: %v", err)
+	}
+	pcancel()
+	select {
+	case err := <-errCh:
+		t.Fatalf("drain helper goroutine error: %v", err)
+	default:
+	}
+
+	// Capture the moment the kernel route finally disappeared.
+	routeGoneAt := testenv.EventuallyValue(t, func() (time.Time, bool) {
+		out, err := exec.Command("ip", "-4", "route", "show", "198.51.100.11/32", "dev", testenv.DefaultBridgeDev).CombinedOutput()
+		if err == nil && len(out) == 0 {
+			return time.Now(), true
+		}
+		return time.Time{}, false
+	}, 30*time.Second, 50*time.Millisecond, "kernel route for LRP IP must eventually be removed")
+
+	select {
+	case prioAt := <-priorityZeroAt:
+		if !prioAt.Before(routeGoneAt) {
+			t.Fatalf("priority=0 must be observed before route removal: prio=%s route_gone=%s",
+				prioAt.Format(time.StampMilli), routeGoneAt.Format(time.StampMilli))
+		}
+	default:
+		t.Fatal("never observed priority=0 in NB during drain — drain logic regressed")
+	}
+
+	// Final state: NB priority is 0 (drained, not yet restored — agent stopped
+	// without restart).
+	gc, ok := testenv.FindGatewayChassis(t, ctx, nb, gcName)
+	if !ok {
+		t.Fatal("Gateway_Chassis disappeared after drain")
+	}
+	if gc.Priority != 0 {
+		t.Errorf("post-drain Gateway_Chassis priority = %d, want 0", gc.Priority)
+	}
+}
+
+// TestScenario_RestoreDrainedOnStartup (#42 scenario 7):
+//
+// The agent starts with NB Gateway_Chassis already at priority 0 for this
+// chassis (as if a previous shutdown had drained but not restored). On
+// startup the agent must:
+//   - restore the priority to 1 (RestoreDrainedGateways), and then
+//   - boost it to ≥minActivePriority (=2) via EnsureActivePriorityLead so
+//     it strictly outranks any peer that is also at priority 1 after
+//     restore.
+//
+// The test seeds a peer entry at priority 0 too — so once the agent
+// restores and boosts, the local entry sits at 2 against a peer at 0.
+func TestScenario_RestoreDrainedOnStartup(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "restore",
+		LRPNetworks: []string{"198.51.100.11/24"},
+		GatewayChassis: []testenv.GatewayChassisEntry{
+			{ChassisName: testenv.LocalHostname(t), Priority: 0},
+			{ChassisName: "restore-peer", Priority: 0},
+		},
+	})
+
+	gcLocal := "lrp-" + router.Name + "_" + testenv.LocalHostname(t)
+	gcPeer := "lrp-" + router.Name + "_restore-peer"
+
+	cfg := testenv.Defaults()
+	on := true
+	cfg.DrainOnShutdown = &on
+	cfg.ReconcileInterval = "2s"
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// EnsureActivePriorityLead boosts to maxPeer+1 with a floor of
+	// minActivePriority (=2). With peer at 0, expect local priority 2.
+	testenv.Eventually(t, func() bool {
+		gc, ok := testenv.FindGatewayChassis(t, ctx, nb, gcLocal)
+		return ok && gc.Priority >= 2
+	}, 20*time.Second, 200*time.Millisecond,
+		"local Gateway_Chassis must be restored from 0 → ≥2 (1 by RestoreDrainedGateways, then boosted by EnsureActivePriorityLead)")
+
+	// Peer entry must be untouched by RestoreDrainedGateways (different chassis).
+	if peer, ok := testenv.FindGatewayChassis(t, ctx, nb, gcPeer); ok {
+		if peer.Priority != 0 {
+			t.Errorf("peer Gateway_Chassis priority changed: got %d, want 0", peer.Priority)
+		}
+	} else {
+		t.Errorf("peer Gateway_Chassis %s disappeared", gcPeer)
+	}
+}

--- a/test/integration/scenario_fip_test.go
+++ b/test/integration/scenario_fip_test.go
@@ -1,0 +1,157 @@
+//go:build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/osism/ovn-network-agent/test/integration/testenv"
+)
+
+// TestScenario_FIPAddRemove (#42 scenario 1):
+//
+// Inserting a NAT entry into NB causes the agent to install:
+//   - kernel /32 route on br-ex
+//   - FRR static route in vrf-provider
+//   - OVS MAC-tweak flow on br-ex (cookie 0x999)
+//
+// Removing the NAT entry removes all of the above. The MAC-tweak flow stays
+// while any local router is active (it is a per-bridge flow, not per-IP), so
+// the FIP-removal half of the test only verifies the per-IP routes are gone.
+func TestScenario_FIPAddRemove(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "fipr1",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	cfg := testenv.Defaults()
+	a := readyAgent(t, cfg)
+
+	// Adding a NAT entry should install routes for the external IP.
+	const fipExternal = "198.51.100.42"
+	natUUID := testenv.AddFIP(t, ctx, nb, router, fipExternal, "10.0.0.42")
+
+	testenv.AssertKernelRoute(t, fipExternal, 10*time.Second)
+	testenv.AssertFRRRoute(t, fipExternal, 10*time.Second)
+	testenv.AssertOVSFlow(t, "0x999", 10*time.Second)
+
+	// Removing the NAT entry should withdraw both routes.
+	testenv.RemoveFIP(t, ctx, nb, router, natUUID)
+	testenv.AssertNoKernelRoute(t, fipExternal, 15*time.Second)
+	testenv.AssertNoFRRRoute(t, fipExternal, 15*time.Second)
+
+	if err := a.Stop(15 * time.Second); err != nil {
+		t.Fatalf("agent stop: %v", err)
+	}
+}
+
+// TestScenario_GatewaylessVirtualGateway (#42 scenario 2):
+//
+// A provider net without a real gateway (no pre-existing default route in NB)
+// should cause the agent to:
+//   - insert a 0.0.0.0/0 default route in NB pointing at the last usable host
+//     IP of the LRP network (.254 for a /24)
+//   - insert a Static_MAC_Binding for that virtual gateway IP, with MAC =
+//     br-ex MAC
+func TestScenario_GatewaylessVirtualGateway(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "gwless",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	cfg := testenv.Defaults()
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// Last usable host IP of 198.51.100.0/24 is .254 (broadcast minus 1).
+	const vgw = "198.51.100.254"
+
+	testenv.Eventually(t, func() bool {
+		_, ok := testenv.FindStaticRoute(t, ctx, nb, router.RouterUUID, "0.0.0.0/0")
+		return ok
+	}, 15*time.Second, 200*time.Millisecond, "agent must insert managed default route")
+
+	route, _ := testenv.FindStaticRoute(t, ctx, nb, router.RouterUUID, "0.0.0.0/0")
+	if route.Nexthop != vgw {
+		t.Errorf("default route nexthop = %q, want %q", route.Nexthop, vgw)
+	}
+	if route.ExternalIDs["ovn-network-agent"] != "managed" {
+		t.Errorf("default route is not tagged managed: %+v", route.ExternalIDs)
+	}
+
+	// MAC binding: lrp-gwless → 198.51.100.254 → bridge MAC.
+	binding := testenv.EventuallyValue(t, func() (testenv.NBStaticMACBinding, bool) {
+		return testenv.FindMACBinding(t, ctx, nb, router.LRPName, vgw)
+	}, 15*time.Second, 200*time.Millisecond, "agent must insert static MAC binding for virtual gateway")
+	if binding.MAC == "" {
+		t.Fatalf("MAC binding has empty MAC")
+	}
+
+	// Verify the MAC matches br-ex's actual MAC.
+	bridgeMAC := readBridgeMAC(t)
+	if !strings.EqualFold(binding.MAC, bridgeMAC) {
+		t.Errorf("MAC binding mac = %q, want bridge MAC %q", binding.MAC, bridgeMAC)
+	}
+}
+
+// TestScenario_MultiRouterOnOneChassis (#42 scenario 3):
+//
+// Two routers active locally:
+//   - both routers' FIPs end up as kernel + FRR routes
+//   - the per-IP hairpin flow (cookie 0x998) is installed on br-ex for each
+//     FIP, with mod_dl_dst set to the corresponding router-port MAC so OVN's
+//     L2 lookup delivers the reflected packet to the right router
+func TestScenario_MultiRouterOnOneChassis(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	r1 := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "multia",
+		LRPMAC:      "fa:16:3e:aa:00:01",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+	r2 := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "multib",
+		LRPMAC:      "fa:16:3e:bb:00:02",
+		LRPNetworks: []string{"203.0.113.11/24"},
+	})
+
+	cfg := testenv.Defaults()
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	const (
+		fipA = "198.51.100.55"
+		fipB = "203.0.113.66"
+	)
+	testenv.AddFIP(t, ctx, nb, r1, fipA, "10.0.0.55")
+	testenv.AddFIP(t, ctx, nb, r2, fipB, "10.0.1.66")
+
+	// Both FIPs land in kernel + FRR.
+	testenv.AssertKernelRoute(t, fipA, 15*time.Second)
+	testenv.AssertKernelRoute(t, fipB, 15*time.Second)
+	testenv.AssertFRRRoute(t, fipA, 15*time.Second)
+	testenv.AssertFRRRoute(t, fipB, 15*time.Second)
+
+	// Hairpin flow (cookie 0x998) installed for each FIP with mod_dl_dst
+	// set to the *owning* router-port MAC. We assert by string-matching the
+	// dump-flows output for the (nw_dst, mod_dl_dst) pair. ovs-ofctl
+	// dump-flows reports IP-destination matches using the classic
+	// `nw_dst=...` notation, not OpenFlow's `ip_dst=...`.
+	testenv.AssertOVSFlowMatches(t, "0x998",
+		func(line string) bool {
+			return strings.Contains(line, "nw_dst="+fipA) && strings.Contains(line, "mod_dl_dst:"+r1.LRPMAC)
+		}, 15*time.Second, "hairpin flow for FIP A → router A MAC")
+	testenv.AssertOVSFlowMatches(t, "0x998",
+		func(line string) bool {
+			return strings.Contains(line, "nw_dst="+fipB) && strings.Contains(line, "mod_dl_dst:"+r2.LRPMAC)
+		}, 15*time.Second, "hairpin flow for FIP B → router B MAC")
+}

--- a/test/integration/scenarios_helpers_test.go
+++ b/test/integration/scenarios_helpers_test.go
@@ -1,0 +1,114 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/ovn-kubernetes/libovsdb/client"
+
+	"github.com/osism/ovn-network-agent/test/integration/testenv"
+)
+
+// readBridgeMAC returns the MAC of the test bridge interface. Used by
+// scenarios that compare an OVN-side MAC binding to the host-side bridge MAC.
+func readBridgeMAC(t *testing.T) string {
+	t.Helper()
+	link, err := net.InterfaceByName(testenv.DefaultBridgeDev)
+	if err != nil {
+		t.Fatalf("lookup %s: %v", testenv.DefaultBridgeDev, err)
+	}
+	mac := link.HardwareAddr.String()
+	if mac == "" {
+		t.Fatalf("bridge %s has no MAC", testenv.DefaultBridgeDev)
+	}
+	return mac
+}
+
+// scenarioCtx is a per-test context with a hard 90s ceiling. All scenarios
+// in this suite are sub-3-minute by design, so they should never need more.
+func scenarioCtx(t *testing.T) (context.Context, context.CancelFunc) {
+	t.Helper()
+	return context.WithTimeout(context.Background(), 90*time.Second)
+}
+
+// startScenario performs the boilerplate every reconciliation test shares:
+//
+//   - testenv.Setup (host preconditions)
+//   - PauseOVNNorthd so direct SB writes survive
+//   - PauseOVNController so it doesn't unbind our hand-set chassisredirect
+//     port (it would otherwise clear Port_Binding.chassis because there are
+//     no SB Gateway_Chassis records to back the binding without northd)
+//   - connect NB and SB clients
+//   - reset state from any previous test
+//
+// Returns the per-test context, the NB client, and the SB client. The caller
+// is responsible for spawning the agent and asserting the scenario.
+func startScenario(t *testing.T) (context.Context, context.CancelFunc, client.Client, client.Client) {
+	t.Helper()
+	testenv.Setup(t)
+	testenv.PauseOVNNorthd(t)
+	testenv.PauseOVNController(t)
+	testenv.EnsureBridgePatchPort(t)
+
+	ctx, cancel := scenarioCtx(t)
+	nb := testenv.NewNBClient(t, ctx)
+	sb := testenv.NewSBClient(t, ctx)
+	testenv.ResetOVNState(t, ctx, nb, sb)
+	t.Cleanup(func() { testenv.ResetOVNState(t, context.Background(), nb, sb) })
+
+	return ctx, cancel, nb, sb
+}
+
+// readyAgent starts an agent with cfg and waits for the "agent running" log
+// line. The agent is stopped at test cleanup if the test forgot to do so.
+func readyAgent(t *testing.T, cfg testenv.AgentConfig) *testenv.AgentProc {
+	t.Helper()
+	a := testenv.RunAgent(t, cfg)
+	rctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := a.WaitReady(rctx); err != nil {
+		t.Fatalf("agent did not become ready: %v", err)
+	}
+	return a
+}
+
+// dumpOVNState writes the current state of the relevant SB and NB tables to
+// the test log. Call this when a scenario fails in confusing ways and you
+// want to see what the agent's view of the world should look like.
+func dumpOVNState(t *testing.T, ctx context.Context, nb, sb client.Client) {
+	t.Helper()
+	t.Logf("--- OVN STATE DUMP ---")
+	t.Logf("LocalHostname=%s", testenv.LocalHostname(t))
+	for _, ch := range testenv.MustList[testenv.SBChassis](t, ctx, sb) {
+		t.Logf("SB Chassis: uuid=%s name=%s hostname=%s", ch.UUID, ch.Name, ch.Hostname)
+	}
+	for _, pb := range testenv.MustList[testenv.SBPortBinding](t, ctx, sb) {
+		chassis := "<nil>"
+		if pb.Chassis != nil {
+			chassis = *pb.Chassis
+		}
+		t.Logf("SB PortBinding: uuid=%s logical_port=%s type=%s chassis=%s datapath=%s",
+			pb.UUID, pb.LogicalPort, pb.Type, chassis, pb.Datapath)
+	}
+	for _, lrp := range testenv.MustList[testenv.NBLogicalRouterPort](t, ctx, nb) {
+		t.Logf("NB LRP: uuid=%s name=%s mac=%s networks=%v",
+			lrp.UUID, lrp.Name, lrp.MAC, lrp.Networks)
+	}
+	for _, lr := range testenv.MustList[testenv.NBLogicalRouter](t, ctx, nb) {
+		t.Logf("NB LR: uuid=%s name=%s ports=%v nat=%v static_routes=%v",
+			lr.UUID, lr.Name, lr.Ports, lr.Nat, lr.StaticRoutes)
+	}
+	for _, gc := range testenv.MustList[testenv.NBGatewayChassis](t, ctx, nb) {
+		t.Logf("NB GC: uuid=%s name=%s chassis_name=%s priority=%d",
+			gc.UUID, gc.Name, gc.ChassisName, gc.Priority)
+	}
+	for _, n := range testenv.MustList[testenv.NBNAT](t, ctx, nb) {
+		t.Logf("NB NAT: uuid=%s type=%s external_ip=%s logical_ip=%s",
+			n.UUID, n.Type, n.ExternalIP, n.LogicalIP)
+	}
+	t.Logf("--- END OVN STATE DUMP ---")
+}

--- a/test/integration/setup.sh
+++ b/test/integration/setup.sh
@@ -84,11 +84,18 @@ start_ovn_host() {
     log "configuring ovn-controller"
     local hostname
     hostname=$(hostname -s)
+    # Pin both system-id (becomes Chassis.name) AND external_ids:hostname
+    # (becomes Chassis.hostname). Without external_ids:hostname,
+    # ovn-controller falls back to gethostname(2), which on some runners
+    # returns the FQDN, breaking the agent's local-router detection
+    # (it compares Chassis.hostname against the short form of its own
+    # hostname).
     ovs-vsctl set Open_vSwitch . \
         external_ids:ovn-remote=tcp:127.0.0.1:6642 \
         external_ids:ovn-encap-type=geneve \
         external_ids:ovn-encap-ip=127.0.0.1 \
-        external_ids:system-id="${hostname}"
+        external_ids:system-id="${hostname}" \
+        external_ids:hostname="${hostname}"
     systemctl enable --now ovn-host
     for _ in $(seq 1 30); do
         if ovs-vsctl br-exists br-int 2>/dev/null; then

--- a/test/integration/testenv/agent.go
+++ b/test/integration/testenv/agent.go
@@ -35,7 +35,9 @@ type AgentConfig struct {
 	DrainOnShutdown   *bool `yaml:"drain_on_shutdown,omitempty"`
 	VethLeakEnabled   *bool `yaml:"veth_leak_enabled,omitempty"`
 
-	ReconcileInterval string `yaml:"reconcile_interval,omitempty"`
+	ReconcileInterval       string `yaml:"reconcile_interval,omitempty"`
+	StaleChassisGracePeriod string `yaml:"stale_chassis_grace_period,omitempty"`
+	DrainTimeout            string `yaml:"drain_timeout,omitempty"`
 }
 
 // Defaults returns an AgentConfig wired for the local test stack:
@@ -239,6 +241,8 @@ func writeTempConfig(t *testing.T, cfg AgentConfig) string {
 	fmt.Fprintf(&b, "frr_prefix_list: %q\n", cfg.FRRPrefixList)
 	w("log_level", cfg.LogLevel)
 	w("reconcile_interval", cfg.ReconcileInterval)
+	w("stale_chassis_grace_period", cfg.StaleChassisGracePeriod)
+	w("drain_timeout", cfg.DrainTimeout)
 	wb("dry_run", cfg.DryRun)
 	wb("cleanup_on_shutdown", cfg.CleanupOnShutdown)
 	wb("drain_on_shutdown", cfg.DrainOnShutdown)

--- a/test/integration/testenv/assert.go
+++ b/test/integration/testenv/assert.go
@@ -20,14 +20,39 @@ func AssertKernelRoute(t *testing.T, ip string, timeout time.Duration) {
 		t.Fatalf("AssertKernelRoute: invalid IP %q", ip)
 	}
 	deadline := time.Now().Add(timeout)
+	var lastOut string
+	var lastErr error
 	for {
 		out, err := exec.Command("ip", "-4", "route", "show", ip+"/32", "dev", DefaultBridgeDev).CombinedOutput()
+		lastOut = strings.TrimSpace(string(out))
+		lastErr = err
 		if err == nil && strings.Contains(string(out), ip) {
 			return
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("kernel route %s/32 on %s not present after %s (last output: %q, err: %v)",
-				ip, DefaultBridgeDev, timeout, strings.TrimSpace(string(out)), err)
+				ip, DefaultBridgeDev, timeout, lastOut, lastErr)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// AssertNoKernelRoute fails the test if a /32 route for ip persists on the
+// bridge device past timeout. Mirrors AssertKernelRoute for the negative case.
+func AssertNoKernelRoute(t *testing.T, ip string, timeout time.Duration) {
+	t.Helper()
+	if net.ParseIP(ip) == nil {
+		t.Fatalf("AssertNoKernelRoute: invalid IP %q", ip)
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := exec.Command("ip", "-4", "route", "show", ip+"/32", "dev", DefaultBridgeDev).CombinedOutput()
+		if err == nil && !strings.Contains(string(out), ip) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("kernel route %s/32 on %s still present after %s (last output: %q)",
+				ip, DefaultBridgeDev, timeout, strings.TrimSpace(string(out)))
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
@@ -42,8 +67,6 @@ func AssertOVSFlow(t *testing.T, cookie string, timeout time.Duration) {
 		out, err := exec.Command("ovs-ofctl", "dump-flows", DefaultBridgeDev,
 			fmt.Sprintf("cookie=%s/-1", cookie)).CombinedOutput()
 		if err == nil {
-			// dump-flows always prints a header line; a match means
-			// at least one additional line containing "cookie=".
 			lines := 0
 			for _, line := range strings.Split(string(out), "\n") {
 				if strings.Contains(line, "cookie=") {
@@ -62,6 +85,61 @@ func AssertOVSFlow(t *testing.T, cookie string, timeout time.Duration) {
 	}
 }
 
+// AssertNoOVSFlow fails the test if any flow with the given cookie persists
+// on the bridge device past timeout. Used to verify cleanup paths.
+func AssertNoOVSFlow(t *testing.T, cookie string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := exec.Command("ovs-ofctl", "dump-flows", DefaultBridgeDev,
+			fmt.Sprintf("cookie=%s/-1", cookie)).CombinedOutput()
+		if err == nil {
+			lines := 0
+			for _, line := range strings.Split(string(out), "\n") {
+				if strings.Contains(line, "cookie=") {
+					lines++
+				}
+			}
+			if lines == 0 {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("OVS flows with cookie %s on %s still present after %s (last output: %q)",
+				cookie, DefaultBridgeDev, timeout, strings.TrimSpace(string(out)))
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// AssertOVSFlowMatches polls dump-flows for the cookie and runs match against
+// each line containing "cookie=". Useful when several flows share a cookie
+// (e.g. hairpin flows for several IPs) and the test wants to check a specific
+// IP/MAC combination.
+func AssertOVSFlowMatches(t *testing.T, cookie string, match func(line string) bool, timeout time.Duration, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := exec.Command("ovs-ofctl", "dump-flows", DefaultBridgeDev,
+			fmt.Sprintf("cookie=%s/-1", cookie)).CombinedOutput()
+		if err == nil {
+			for _, line := range strings.Split(string(out), "\n") {
+				if !strings.Contains(line, "cookie=") {
+					continue
+				}
+				if match(line) {
+					return
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no OVS flow with cookie %s matching %s after %s (last output: %q)",
+				cookie, msg, timeout, strings.TrimSpace(string(out)))
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
 // AssertFRRRoute fails the test if no static /32 route for ip exists in
 // the default VRF.
 func AssertFRRRoute(t *testing.T, ip string, timeout time.Duration) {
@@ -70,8 +148,10 @@ func AssertFRRRoute(t *testing.T, ip string, timeout time.Duration) {
 		t.Fatalf("AssertFRRRoute: invalid IP %q", ip)
 	}
 	deadline := time.Now().Add(timeout)
+	var routes []string
+	var err error
 	for {
-		routes, err := frrStaticRoutes(DefaultVRFName)
+		routes, err = frrStaticRoutes(DefaultVRFName)
 		if err == nil {
 			for _, r := range routes {
 				if r == ip {
@@ -82,6 +162,36 @@ func AssertFRRRoute(t *testing.T, ip string, timeout time.Duration) {
 		if time.Now().After(deadline) {
 			t.Fatalf("FRR static route %s/32 in vrf %s not present after %s (current: %v, err: %v)",
 				ip, DefaultVRFName, timeout, routes, err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// AssertNoFRRRoute fails the test if the static /32 route for ip persists in
+// the VRF past timeout.
+func AssertNoFRRRoute(t *testing.T, ip string, timeout time.Duration) {
+	t.Helper()
+	if net.ParseIP(ip) == nil {
+		t.Fatalf("AssertNoFRRRoute: invalid IP %q", ip)
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		routes, err := frrStaticRoutes(DefaultVRFName)
+		if err == nil {
+			present := false
+			for _, r := range routes {
+				if r == ip {
+					present = true
+					break
+				}
+			}
+			if !present {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("FRR static route %s/32 in vrf %s still present after %s",
+				ip, DefaultVRFName, timeout)
 		}
 		time.Sleep(200 * time.Millisecond)
 	}
@@ -103,5 +213,57 @@ func AssertNftRule(t *testing.T, substring string, timeout time.Duration) {
 				DefaultNftTable, substring, timeout, err, strings.TrimSpace(string(out)))
 		}
 		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// scrubLocalState removes everything the agent might have installed on this
+// host: nft table, /32 routes on br-ex, FRR static routes, and OVS flows
+// matching the agent's cookies. Best-effort — used between tests so a single
+// failed test does not poison the next.
+func scrubLocalState(t *testing.T) {
+	t.Helper()
+
+	if out, err := exec.Command("nft", "list", "table", "ip", DefaultNftTable).CombinedOutput(); err == nil && len(out) > 0 {
+		_ = exec.Command("nft", "delete", "table", "ip", DefaultNftTable).Run()
+	}
+
+	// Flush all /32 routes on br-ex (regardless of protocol) since the agent
+	// adds them with the kernel default protocol when no route_table_id is
+	// configured. This is heavier-handed than Teardown but safer between
+	// scenario tests.
+	out, err := exec.Command("ip", "-4", "route", "show", "dev", DefaultBridgeDev).CombinedOutput()
+	if err == nil {
+		for _, line := range strings.Split(string(out), "\n") {
+			line = strings.TrimSpace(line)
+			fields := strings.Fields(line)
+			if len(fields) == 0 {
+				continue
+			}
+			dst := fields[0]
+			if !strings.HasSuffix(dst, "/32") {
+				continue
+			}
+			_ = exec.Command("ip", "route", "del", dst, "dev", DefaultBridgeDev).Run()
+		}
+	}
+
+	// FRR static /32 routes in the test VRF.
+	if routes, err := frrStaticRoutes(DefaultVRFName); err == nil {
+		for _, ip := range routes {
+			args := []string{
+				"-c", "conf t",
+				"-c", "vrf " + DefaultVRFName,
+				"-c", "no ip route " + ip + "/32",
+				"-c", "exit-vrf",
+				"-c", "end",
+			}
+			_ = exec.Command("vtysh", args...).Run()
+		}
+	}
+
+	// OVS flows tagged with the agent's cookies.
+	for _, cookie := range []string{"0x999", "0x998"} {
+		_ = exec.Command("ovs-ofctl", "del-flows", DefaultBridgeDev,
+			fmt.Sprintf("cookie=%s/-1", cookie)).Run()
 	}
 }

--- a/test/integration/testenv/eventually.go
+++ b/test/integration/testenv/eventually.go
@@ -1,0 +1,45 @@
+//go:build integration
+
+package testenv
+
+import (
+	"testing"
+	"time"
+)
+
+// Eventually polls condition every tick until it returns true or the timeout
+// expires. On timeout the test is failed with msg. It is the integration
+// harness's standard polling primitive — prefer it to ad-hoc time.After loops.
+func Eventually(t *testing.T, condition func() bool, timeout, tick time.Duration, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if condition() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Eventually timed out after %s: %s", timeout, msg)
+		}
+		time.Sleep(tick)
+	}
+}
+
+// EventuallyValue polls fn every tick until it returns (value, true) or the
+// timeout expires. The captured value is returned to the caller. Useful when
+// the test needs to record *when* a condition first held (e.g. drain ordering).
+func EventuallyValue[T any](t *testing.T, fn func() (T, bool), timeout, tick time.Duration, msg string) T {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var zero T
+	for {
+		v, ok := fn()
+		if ok {
+			return v
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("EventuallyValue timed out after %s: %s", timeout, msg)
+			return zero
+		}
+		time.Sleep(tick)
+	}
+}

--- a/test/integration/testenv/fixtures.go
+++ b/test/integration/testenv/fixtures.go
@@ -1,0 +1,517 @@
+//go:build integration
+
+package testenv
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ovn-kubernetes/libovsdb/client"
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+)
+
+// LocalHostname mirrors the agent's hostname normalisation in ovn.go's
+// getHostname (short-form, no domain). All scenario state that pretends to
+// belong to "this host" must use this value.
+func LocalHostname(t *testing.T) string {
+	t.Helper()
+	h, err := os.Hostname()
+	if err != nil {
+		t.Fatalf("hostname: %v", err)
+	}
+	if idx := strings.IndexByte(h, '.'); idx != -1 {
+		h = h[:idx]
+	}
+	return h
+}
+
+// LocalChassisUUID returns the SB Chassis UUID that ovn-controller registered
+// for the local host. The test fails if no matching chassis appears within a
+// short polling window — that means setup.sh did not finish wiring
+// ovn-controller, or it crashed mid-run.
+//
+// We match on Chassis.name (which equals the OVS system-id, set explicitly by
+// setup.sh to `hostname -s`) rather than Chassis.hostname, because OVN
+// derives Chassis.hostname from gethostname(2) and on some hosts that
+// returns an FQDN that differs from LocalHostname's short form.
+//
+// Polling tolerates a benign startup race: if ResetOVNState ran while
+// ovn-controller had momentarily lost its chassis row (e.g. just after we
+// paused northd or cleared SB state), ovn-controller re-registers within a
+// reconciliation tick.
+func LocalChassisUUID(t *testing.T, ctx context.Context, sb client.Client) string {
+	t.Helper()
+	hostname := LocalHostname(t)
+
+	deadline := time.Now().Add(15 * time.Second)
+	var lastCount int
+	for {
+		var chassis []SBChassis
+		if err := sb.List(ctx, &chassis); err != nil {
+			t.Fatalf("list SB chassis: %v", err)
+		}
+		lastCount = len(chassis)
+		for _, ch := range chassis {
+			if ch.Name == hostname || ch.Hostname == hostname {
+				return ch.UUID
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no SB chassis matching name/hostname %q after 15s (have %d entries)",
+				hostname, lastCount)
+			return ""
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("LocalChassisUUID: context cancelled while waiting for chassis: %v", ctx.Err())
+			return ""
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+}
+
+// tunnelKeyAllocator hands out monotonically-increasing tunnel keys so each
+// fixture inserts unique Datapath_Binding / Port_Binding rows. Scoped to
+// process lifetime; tests that need deterministic keys should set them
+// explicitly.
+var tunnelKeyAllocator atomic.Int32
+
+// nextTunnelKey returns a tunnel_key value safely above the OVN_internal range
+// so it cannot collide with anything ovn-controller might create on its own.
+func nextTunnelKey() int {
+	v := tunnelKeyAllocator.Add(1)
+	return 16384 + int(v)
+}
+
+// RouterRef is the handle returned by MakeLocalRouter — it captures the UUIDs
+// the test needs to reference later (e.g. to attach NAT entries or query
+// Gateway_Chassis state).
+type RouterRef struct {
+	Name        string // logical router name
+	RouterUUID  string
+	LRPName     string // e.g. "lrp-router1"
+	LRPUUID     string
+	LRPMAC      string // MAC of the LRP
+	LRPNetworks []string
+	CRPort      string // "cr-lrp-router1"
+	CRPortUUID  string
+	DatapathID  string // SB Datapath_Binding UUID
+}
+
+// LocalRouterOpts configures MakeLocalRouter. ChassisUUID defaults to the
+// local SB chassis. GatewayChassisHostnames lets the test seed peer entries
+// (used by failover and restore-drained scenarios).
+type LocalRouterOpts struct {
+	Name        string
+	LRPMAC      string
+	LRPNetworks []string
+
+	// ChassisUUID is the SB Chassis UUID to bind the chassisredirect
+	// Port_Binding to. Defaults to the local chassis.
+	ChassisUUID string
+
+	// GatewayChassis is a list of (chassis_name, priority) entries to insert
+	// into NB Gateway_Chassis. If nil, a single entry is created for the
+	// local hostname at priority DefaultLocalPriority.
+	GatewayChassis []GatewayChassisEntry
+}
+
+// GatewayChassisEntry is one row in NB Gateway_Chassis seeded by MakeLocalRouter.
+type GatewayChassisEntry struct {
+	ChassisName string
+	Priority    int
+}
+
+// DefaultLocalPriority is the Gateway_Chassis priority assigned to the local
+// chassis when LocalRouterOpts.GatewayChassis is unset. Matches the agent's
+// minActivePriority floor so EnsureActivePriorityLead is a no-op for plain
+// "single active router" scenarios.
+const DefaultLocalPriority = 2
+
+// MakeLocalRouter inserts a Logical_Router + Logical_Router_Port + matching
+// SB Datapath_Binding + chassisredirect Port_Binding so the agent treats the
+// router as locally-active. Returns the inserted UUIDs.
+//
+// Caller must have called PauseOVNNorthd(t) first; otherwise ovn-northd will
+// garbage-collect the SB rows shortly after they are inserted.
+func MakeLocalRouter(t *testing.T, ctx context.Context, nb, sb client.Client, opts LocalRouterOpts) RouterRef {
+	t.Helper()
+	if opts.Name == "" {
+		t.Fatal("MakeLocalRouter: opts.Name required")
+	}
+	if opts.LRPMAC == "" {
+		opts.LRPMAC = "fa:16:3e:11:22:33"
+	}
+	if len(opts.LRPNetworks) == 0 {
+		opts.LRPNetworks = []string{"198.51.100.11/24"}
+	}
+	if opts.ChassisUUID == "" {
+		opts.ChassisUUID = LocalChassisUUID(t, ctx, sb)
+	}
+	if len(opts.GatewayChassis) == 0 {
+		opts.GatewayChassis = []GatewayChassisEntry{{
+			ChassisName: LocalHostname(t),
+			Priority:    DefaultLocalPriority,
+		}}
+	}
+
+	lrpName := "lrp-" + opts.Name
+
+	// --- NB: insert Gateway_Chassis + LRP + Logical_Router in ONE tx -----
+	// Logical_Router_Port and Gateway_Chassis are non-root tables in the
+	// OVN_Northbound schema, so the OVSDB engine deletes any unreferenced
+	// row at commit time. Splitting into multiple transactions would
+	// orphan the LRP (no LR points at it yet) and the Gateway_Chassis
+	// entries (no LRP gateway_chassis points at them yet). All three
+	// inserts must happen atomically with named-UUID cross-references.
+	const lrpUUIDName = "lrp_named"
+	const lrUUIDName = "lr_named"
+
+	var ops []ovsdb.Operation
+	gcRefs := make([]any, 0, len(opts.GatewayChassis))
+	for i, e := range opts.GatewayChassis {
+		gcUUIDName := fmt.Sprintf("gc_%d", i)
+		ops = append(ops, ovsdb.Operation{
+			Op:       ovsdb.OperationInsert,
+			Table:    "Gateway_Chassis",
+			UUIDName: gcUUIDName,
+			Row: ovsdb.Row{
+				"name":         lrpName + "_" + e.ChassisName,
+				"chassis_name": e.ChassisName,
+				"priority":     e.Priority,
+			},
+		})
+		gcRefs = append(gcRefs, nameUUID(gcUUIDName))
+	}
+
+	lrpNetworks := make([]any, len(opts.LRPNetworks))
+	for i, n := range opts.LRPNetworks {
+		lrpNetworks[i] = n
+	}
+	lrpRow := ovsdb.Row{
+		"name":     lrpName,
+		"mac":      opts.LRPMAC,
+		"networks": ovsdb.OvsSet{GoSet: lrpNetworks},
+	}
+	if len(gcRefs) > 0 {
+		lrpRow["gateway_chassis"] = ovsdb.OvsSet{GoSet: gcRefs}
+	}
+	ops = append(ops, ovsdb.Operation{
+		Op:       ovsdb.OperationInsert,
+		Table:    "Logical_Router_Port",
+		UUIDName: lrpUUIDName,
+		Row:      lrpRow,
+	})
+
+	ops = append(ops, ovsdb.Operation{
+		Op:       ovsdb.OperationInsert,
+		Table:    "Logical_Router",
+		UUIDName: lrUUIDName,
+		Row: ovsdb.Row{
+			"name":  opts.Name,
+			"ports": ovsdb.OvsSet{GoSet: []any{nameUUID(lrpUUIDName)}},
+		},
+	})
+
+	results := Transact(t, ctx, nb, ops)
+	// Layout: [Gateway_Chassis...] [LRP] [LR]
+	lrpUUID := results[len(opts.GatewayChassis)].UUID.GoUUID
+	lrUUID := results[len(opts.GatewayChassis)+1].UUID.GoUUID
+
+	// --- SB: insert Datapath_Binding then chassisredirect Port_Binding ---
+	dpKey := nextTunnelKey()
+	dpRow := &SBDatapathBinding{
+		UUID:        "dp_named",
+		TunnelKey:   dpKey,
+		ExternalIDs: map[string]string{"name": opts.Name, "name2": opts.Name},
+	}
+	dpOps, err := sb.Create(dpRow)
+	if err != nil {
+		t.Fatalf("create datapath op: %v", err)
+	}
+	dpResults := Transact(t, ctx, sb, dpOps)
+	dpUUID := dpResults[0].UUID.GoUUID
+
+	pbKey := nextTunnelKey()
+	crPortName := "cr-" + lrpName
+	// Build the Port_Binding insert as a raw OVSDB op rather than going
+	// through libovsdb's Create. With Create, the *string Chassis field
+	// (declared as min=0,max=1 UUID ref in the schema) silently round-trips
+	// to NULL — the resulting row has chassis=<nil> even when we pass a real
+	// UUID. Raw ops with an explicit ovsdb.UUID{} value bypass that quirk
+	// and produce a row with chassis correctly set, which is what the
+	// agent's local-router detection requires.
+	pbInsertOp := ovsdb.Operation{
+		Op:       ovsdb.OperationInsert,
+		Table:    "Port_Binding",
+		UUIDName: "pb_named",
+		Row: ovsdb.Row{
+			"datapath":     realUUID(dpUUID),
+			"tunnel_key":   pbKey,
+			"logical_port": crPortName,
+			"type":         "chassisredirect",
+			"chassis":      realUUID(opts.ChassisUUID),
+			// Raw ops require explicit OVSDB types: a plain Go map
+			// serialises as JSON object, but the wire format for
+			// OVSDB map columns is `["map", [[k,v]...]]`. OvsMap does
+			// that wrapping. (libovsdb's Create handles this for us;
+			// raw Operation.Row does not.)
+			"options": ovsdb.OvsMap{GoMap: map[any]any{"distributed-port": lrpName}},
+		},
+	}
+	pbResults := Transact(t, ctx, sb, []ovsdb.Operation{pbInsertOp})
+	pbUUID := pbResults[0].UUID.GoUUID
+
+	return RouterRef{
+		Name:        opts.Name,
+		RouterUUID:  lrUUID,
+		LRPName:     lrpName,
+		LRPUUID:     lrpUUID,
+		LRPMAC:      opts.LRPMAC,
+		LRPNetworks: opts.LRPNetworks,
+		CRPort:      crPortName,
+		CRPortUUID:  pbUUID,
+		DatapathID:  dpUUID,
+	}
+}
+
+// AddFIP inserts a dnat_and_snat NAT entry on the given router for externalIP
+// and returns the new NAT UUID.
+func AddFIP(t *testing.T, ctx context.Context, nb client.Client, router RouterRef, externalIP, logicalIP string) string {
+	t.Helper()
+	natRow := &NBNAT{
+		UUID:       "nat_named",
+		Type:       "dnat_and_snat",
+		ExternalIP: externalIP,
+		LogicalIP:  logicalIP,
+	}
+	natOps, err := nb.Create(natRow)
+	if err != nil {
+		t.Fatalf("create nat op: %v", err)
+	}
+	mutateOp := ovsdb.Operation{
+		Op:    "mutate",
+		Table: "Logical_Router",
+		Where: []ovsdb.Condition{{
+			Column:   "_uuid",
+			Function: ovsdb.ConditionEqual,
+			Value:    realUUID(router.RouterUUID),
+		}},
+		Mutations: []ovsdb.Mutation{{
+			Column:  "nat",
+			Mutator: ovsdb.MutateOperationInsert,
+			Value:   ovsdb.OvsSet{GoSet: []any{nameUUID("nat_named")}},
+		}},
+	}
+	results := Transact(t, ctx, nb, append(natOps, mutateOp))
+	return results[0].UUID.GoUUID
+}
+
+// RemoveFIP deletes a NAT entry by UUID and removes it from any router's
+// nat column. Best-effort if the entry has already been removed.
+func RemoveFIP(t *testing.T, ctx context.Context, nb client.Client, router RouterRef, natUUID string) {
+	t.Helper()
+	mutateOp := ovsdb.Operation{
+		Op:    "mutate",
+		Table: "Logical_Router",
+		Where: []ovsdb.Condition{{
+			Column:   "_uuid",
+			Function: ovsdb.ConditionEqual,
+			Value:    realUUID(router.RouterUUID),
+		}},
+		Mutations: []ovsdb.Mutation{{
+			Column:  "nat",
+			Mutator: ovsdb.MutateOperationDelete,
+			Value:   ovsdb.OvsSet{GoSet: []any{realUUID(natUUID)}},
+		}},
+	}
+	deleteOps, err := nb.Where(&NBNAT{UUID: natUUID}).Delete()
+	if err != nil {
+		t.Fatalf("delete nat op: %v", err)
+	}
+	Transact(t, ctx, nb, append([]ovsdb.Operation{mutateOp}, deleteOps...))
+}
+
+// peerEncapIPCounter hands out unique loopback IPs for peer-chassis Encap
+// rows. SB Encap has a unique index on (type, ip), and ovn-controller's
+// local chassis already owns (geneve, 127.0.0.1) — so every additional
+// peer chassis must use a distinct IP or the insert fails the index
+// constraint.
+var peerEncapIPCounter atomic.Int32
+
+// MakeChassis inserts an SB Chassis row representing a peer host. Used by the
+// stale-chassis cleanup scenario.
+//
+// SB Chassis.encaps has a min=1 constraint in the schema, so we also insert
+// a minimal Encap row in the same transaction and reference it via a named
+// UUID. Encap is non-root in SB and gets cascade-GC'd when the owning
+// Chassis is deleted.
+func MakeChassis(t *testing.T, ctx context.Context, sb client.Client, hostname string) string {
+	t.Helper()
+	const encapUUIDName = "encap_named"
+	const chassisUUIDName = "ch_named"
+	// Allocate a unique 127.0.0.X IP. The local chassis sits on .1, so we
+	// start at .2 and increment per call. Wraps at .254 (more than enough
+	// for any single test run).
+	idx := peerEncapIPCounter.Add(1)
+	encapIP := fmt.Sprintf("127.0.0.%d", 2+(idx%253))
+	ops := []ovsdb.Operation{
+		{
+			Op:       ovsdb.OperationInsert,
+			Table:    "Encap",
+			UUIDName: encapUUIDName,
+			Row: ovsdb.Row{
+				"type":         "geneve",
+				"ip":           encapIP,
+				"chassis_name": hostname,
+			},
+		},
+		{
+			Op:       ovsdb.OperationInsert,
+			Table:    "Chassis",
+			UUIDName: chassisUUIDName,
+			Row: ovsdb.Row{
+				"name":     hostname, // production code matches by both name and hostname
+				"hostname": hostname,
+				"encaps":   ovsdb.OvsSet{GoSet: []any{nameUUID(encapUUIDName)}},
+			},
+		},
+	}
+	results := Transact(t, ctx, sb, ops)
+	// Layout: [Encap, Chassis]
+	return results[1].UUID.GoUUID
+}
+
+// DeleteChassis removes an SB Chassis by UUID.
+func DeleteChassis(t *testing.T, ctx context.Context, sb client.Client, uuid string) {
+	t.Helper()
+	ops, err := sb.Where(&SBChassis{UUID: uuid}).Delete()
+	if err != nil {
+		t.Fatalf("delete chassis op: %v", err)
+	}
+	Transact(t, ctx, sb, ops)
+}
+
+// FindGatewayChassis returns the Gateway_Chassis row whose Name matches.
+// Returns the zero value and false if not present.
+func FindGatewayChassis(t *testing.T, ctx context.Context, nb client.Client, name string) (NBGatewayChassis, bool) {
+	t.Helper()
+	for _, gc := range MustList[NBGatewayChassis](t, ctx, nb) {
+		if gc.Name == name {
+			return gc, true
+		}
+	}
+	return NBGatewayChassis{}, false
+}
+
+// SetCRPortChassis rebinds an existing chassisredirect Port_Binding to a new
+// chassis UUID. Used by the failover scenario to simulate ovn-northd moving
+// the gateway after Gateway_Chassis priorities change.
+func SetCRPortChassis(t *testing.T, ctx context.Context, sb client.Client, pbUUID string, newChassisUUID *string) {
+	t.Helper()
+	pb := &SBPortBinding{UUID: pbUUID, Chassis: newChassisUUID}
+	ops, err := sb.Where(pb).Update(pb, &pb.Chassis)
+	if err != nil {
+		t.Fatalf("build update op: %v", err)
+	}
+	Transact(t, ctx, sb, ops)
+}
+
+// CountManagedRoutes returns the number of NB Logical_Router_Static_Route rows
+// tagged as agent-managed for the given chassis, or any chassis if "" is passed.
+func CountManagedRoutes(t *testing.T, ctx context.Context, nb client.Client, chassis string) int {
+	t.Helper()
+	count := 0
+	for _, r := range MustList[NBLogicalRouterStaticRoute](t, ctx, nb) {
+		if r.ExternalIDs["ovn-network-agent"] != "managed" {
+			continue
+		}
+		if chassis != "" && r.ExternalIDs["ovn-network-agent-chassis"] != chassis {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+// FindMACBinding returns the Static_MAC_Binding for (lrp, ip), or false.
+func FindMACBinding(t *testing.T, ctx context.Context, nb client.Client, lrp, ip string) (NBStaticMACBinding, bool) {
+	t.Helper()
+	for _, b := range MustList[NBStaticMACBinding](t, ctx, nb) {
+		if b.LogicalPort == lrp && b.IP == ip {
+			return b, true
+		}
+	}
+	return NBStaticMACBinding{}, false
+}
+
+// FindStaticRoute returns the matching managed default route on router (or any
+// router if routerUUID is ""), and true if present.
+func FindStaticRoute(t *testing.T, ctx context.Context, nb client.Client, routerUUID, prefix string) (NBLogicalRouterStaticRoute, bool) {
+	t.Helper()
+	owners := make(map[string]string)
+	if routerUUID != "" {
+		for _, lr := range MustList[NBLogicalRouter](t, ctx, nb) {
+			if lr.UUID != routerUUID {
+				continue
+			}
+			for _, ru := range lr.StaticRoutes {
+				owners[ru] = lr.UUID
+			}
+		}
+	}
+	for _, r := range MustList[NBLogicalRouterStaticRoute](t, ctx, nb) {
+		if r.IPPrefix != prefix {
+			continue
+		}
+		if routerUUID != "" {
+			if _, ok := owners[r.UUID]; !ok {
+				continue
+			}
+		}
+		return r, true
+	}
+	return NBLogicalRouterStaticRoute{}, false
+}
+
+// SeedManagedRoute inserts a Logical_Router_Static_Route tagged for chassis
+// owner — used by stale-chassis cleanup tests to plant entries that look like
+// they were left behind by another agent.
+func SeedManagedRoute(t *testing.T, ctx context.Context, nb client.Client, router RouterRef, prefix, nexthop, chassis string) string {
+	t.Helper()
+	rRow := &NBLogicalRouterStaticRoute{
+		UUID:       "rt_named",
+		IPPrefix:   prefix,
+		Nexthop:    nexthop,
+		OutputPort: strRef(router.LRPName),
+		ExternalIDs: map[string]string{
+			"ovn-network-agent":         "managed",
+			"ovn-network-agent-chassis": chassis,
+		},
+	}
+	rOps, err := nb.Create(rRow)
+	if err != nil {
+		t.Fatalf("create route op: %v", err)
+	}
+	mutateOp := ovsdb.Operation{
+		Op:    "mutate",
+		Table: "Logical_Router",
+		Where: []ovsdb.Condition{{
+			Column:   "_uuid",
+			Function: ovsdb.ConditionEqual,
+			Value:    realUUID(router.RouterUUID),
+		}},
+		Mutations: []ovsdb.Mutation{{
+			Column:  "static_routes",
+			Mutator: ovsdb.MutateOperationInsert,
+			Value:   ovsdb.OvsSet{GoSet: []any{nameUUID("rt_named")}},
+		}},
+	}
+	results := Transact(t, ctx, nb, append(rOps, mutateOp))
+	return results[0].UUID.GoUUID
+}

--- a/test/integration/testenv/ovsdb.go
+++ b/test/integration/testenv/ovsdb.go
@@ -1,0 +1,365 @@
+//go:build integration
+
+package testenv
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ovn-kubernetes/libovsdb/client"
+	"github.com/ovn-kubernetes/libovsdb/model"
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+)
+
+// Default OVN endpoints provisioned by setup.sh.
+const (
+	NBRemote = "tcp:127.0.0.1:6641"
+	SBRemote = "tcp:127.0.0.1:6642"
+)
+
+// =============================================================================
+// NB models — mirrors of the production types in ovn.go (the integration
+// package cannot import from `main`). Field tags must match the OVSDB schema.
+// =============================================================================
+
+type NBNAT struct {
+	UUID              string            `ovsdb:"_uuid"`
+	Type              string            `ovsdb:"type"`
+	ExternalIP        string            `ovsdb:"external_ip"`
+	ExternalMAC       *string           `ovsdb:"external_mac"`
+	ExternalPortRange string            `ovsdb:"external_port_range"`
+	LogicalIP         string            `ovsdb:"logical_ip"`
+	LogicalPort       *string           `ovsdb:"logical_port"`
+	GatewayPort       *string           `ovsdb:"gateway_port"`
+	Match             string            `ovsdb:"match"`
+	Priority          int               `ovsdb:"priority"`
+	Options           map[string]string `ovsdb:"options"`
+	AllowedExtIPs     *string           `ovsdb:"allowed_ext_ips"`
+	ExemptedExtIPs    *string           `ovsdb:"exempted_ext_ips"`
+	ExternalIDs       map[string]string `ovsdb:"external_ids"`
+}
+
+type NBLogicalRouter struct {
+	UUID         string            `ovsdb:"_uuid"`
+	Name         string            `ovsdb:"name"`
+	Ports        []string          `ovsdb:"ports"`
+	Nat          []string          `ovsdb:"nat"`
+	StaticRoutes []string          `ovsdb:"static_routes"`
+	ExternalIDs  map[string]string `ovsdb:"external_ids"`
+}
+
+type NBLogicalRouterPort struct {
+	UUID     string   `ovsdb:"_uuid"`
+	Name     string   `ovsdb:"name"`
+	MAC      string   `ovsdb:"mac"`
+	Networks []string `ovsdb:"networks"`
+}
+
+type NBLogicalRouterStaticRoute struct {
+	UUID        string            `ovsdb:"_uuid"`
+	IPPrefix    string            `ovsdb:"ip_prefix"`
+	Nexthop     string            `ovsdb:"nexthop"`
+	OutputPort  *string           `ovsdb:"output_port"`
+	Policy      *string           `ovsdb:"policy"`
+	Options     map[string]string `ovsdb:"options"`
+	ExternalIDs map[string]string `ovsdb:"external_ids"`
+}
+
+type NBStaticMACBinding struct {
+	UUID        string `ovsdb:"_uuid"`
+	LogicalPort string `ovsdb:"logical_port"`
+	IP          string `ovsdb:"ip"`
+	MAC         string `ovsdb:"mac"`
+}
+
+type NBGatewayChassis struct {
+	UUID        string            `ovsdb:"_uuid"`
+	ChassisName string            `ovsdb:"chassis_name"`
+	Name        string            `ovsdb:"name"`
+	Priority    int               `ovsdb:"priority"`
+	ExternalIDs map[string]string `ovsdb:"external_ids"`
+	Options     map[string]string `ovsdb:"options"`
+}
+
+// =============================================================================
+// SB models — mirrors of the production types in ovn.go plus SBDatapathBinding,
+// which the production agent does not need but the integration harness does in
+// order to insert chassisredirect Port_Bindings without ovn-northd.
+// =============================================================================
+
+type SBPortBinding struct {
+	UUID                       string            `ovsdb:"_uuid"`
+	Datapath                   string            `ovsdb:"datapath"`
+	TunnelKey                  int               `ovsdb:"tunnel_key"`
+	LogicalPort                string            `ovsdb:"logical_port"`
+	Type                       string            `ovsdb:"type"`
+	Chassis                    *string           `ovsdb:"chassis"`
+	AdditionalChassis          []string          `ovsdb:"additional_chassis"`
+	Encap                      *string           `ovsdb:"encap"`
+	AdditionalEncap            []string          `ovsdb:"additional_encap"`
+	Options                    map[string]string `ovsdb:"options"`
+	ParentPort                 *string           `ovsdb:"parent_port"`
+	Tag                        *int              `ovsdb:"tag"`
+	Mac                        []string          `ovsdb:"mac"`
+	NatAddresses               []string          `ovsdb:"nat_addresses"`
+	Up                         *bool             `ovsdb:"up"`
+	ExternalIDs                map[string]string `ovsdb:"external_ids"`
+	GatewayChassis             []string          `ovsdb:"gateway_chassis"`
+	HaChassisGroup             *string           `ovsdb:"ha_chassis_group"`
+	VirtualParent              *string           `ovsdb:"virtual_parent"`
+	RequestedChassis           *string           `ovsdb:"requested_chassis"`
+	RequestedAdditionalChassis []string          `ovsdb:"requested_additional_chassis"`
+	MirrorRules                []string          `ovsdb:"mirror_rules"`
+}
+
+type SBChassis struct {
+	UUID        string            `ovsdb:"_uuid"`
+	Name        string            `ovsdb:"name"`
+	Hostname    string            `ovsdb:"hostname"`
+	ExternalIDs map[string]string `ovsdb:"external_ids"`
+}
+
+type SBDatapathBinding struct {
+	UUID          string            `ovsdb:"_uuid"`
+	TunnelKey     int               `ovsdb:"tunnel_key"`
+	LoadBalancers []string          `ovsdb:"load_balancers"`
+	ExternalIDs   map[string]string `ovsdb:"external_ids"`
+}
+
+// =============================================================================
+// Database models
+// =============================================================================
+
+func nbDatabaseModel(t *testing.T) model.ClientDBModel {
+	t.Helper()
+	dbm, err := model.NewClientDBModel("OVN_Northbound", map[string]model.Model{
+		"NAT":                         &NBNAT{},
+		"Logical_Router":              &NBLogicalRouter{},
+		"Logical_Router_Port":         &NBLogicalRouterPort{},
+		"Logical_Router_Static_Route": &NBLogicalRouterStaticRoute{},
+		"Static_MAC_Binding":          &NBStaticMACBinding{},
+		"Gateway_Chassis":             &NBGatewayChassis{},
+	})
+	if err != nil {
+		t.Fatalf("nbDatabaseModel: %v", err)
+	}
+	return dbm
+}
+
+func sbDatabaseModel(t *testing.T) model.ClientDBModel {
+	t.Helper()
+	dbm, err := model.NewClientDBModel("OVN_Southbound", map[string]model.Model{
+		"Port_Binding":     &SBPortBinding{},
+		"Chassis":          &SBChassis{},
+		"Datapath_Binding": &SBDatapathBinding{},
+	})
+	if err != nil {
+		t.Fatalf("sbDatabaseModel: %v", err)
+	}
+	return dbm
+}
+
+// =============================================================================
+// Connected client helpers
+// =============================================================================
+
+// NewNBClient returns a libovsdb client connected to the local NB DB with all
+// monitored tables already populated. The client is closed on test cleanup.
+func NewNBClient(t *testing.T, ctx context.Context) client.Client {
+	t.Helper()
+	c, err := client.NewOVSDBClient(nbDatabaseModel(t), client.WithEndpoint(NBRemote))
+	if err != nil {
+		t.Fatalf("create NB client: %v", err)
+	}
+	connectCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := c.Connect(connectCtx); err != nil {
+		t.Fatalf("connect NB: %v", err)
+	}
+	mon := c.NewMonitor(
+		client.WithTable(&NBNAT{}),
+		client.WithTable(&NBLogicalRouter{}),
+		client.WithTable(&NBLogicalRouterPort{}),
+		client.WithTable(&NBLogicalRouterStaticRoute{}),
+		client.WithTable(&NBStaticMACBinding{}),
+		client.WithTable(&NBGatewayChassis{}),
+	)
+	if _, err := c.Monitor(connectCtx, mon); err != nil {
+		c.Close()
+		t.Fatalf("monitor NB: %v", err)
+	}
+	t.Cleanup(c.Close)
+	return c
+}
+
+// NewSBClient returns a libovsdb client connected to the local SB DB.
+func NewSBClient(t *testing.T, ctx context.Context) client.Client {
+	t.Helper()
+	c, err := client.NewOVSDBClient(sbDatabaseModel(t), client.WithEndpoint(SBRemote))
+	if err != nil {
+		t.Fatalf("create SB client: %v", err)
+	}
+	connectCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := c.Connect(connectCtx); err != nil {
+		t.Fatalf("connect SB: %v", err)
+	}
+	mon := c.NewMonitor(
+		client.WithTable(&SBPortBinding{}),
+		client.WithTable(&SBChassis{}),
+		client.WithTable(&SBDatapathBinding{}),
+	)
+	if _, err := c.Monitor(connectCtx, mon); err != nil {
+		c.Close()
+		t.Fatalf("monitor SB: %v", err)
+	}
+	t.Cleanup(c.Close)
+	return c
+}
+
+// Transact runs ops and asserts that no per-op errors occurred. Tests should
+// almost always use this rather than calling client.Transact directly so that
+// constraint violations surface as test failures with context.
+func Transact(t *testing.T, ctx context.Context, c client.Client, ops []ovsdb.Operation) []ovsdb.OperationResult {
+	t.Helper()
+	if len(ops) == 0 {
+		return nil
+	}
+	results, err := c.Transact(ctx, ops...)
+	if err != nil {
+		t.Fatalf("transact: %v (ops=%+v)", err, ops)
+	}
+	if opErrs, err := ovsdb.CheckOperationResults(results, ops); err != nil {
+		t.Fatalf("transact op errors: %v (per-op=%+v ops=%+v)", err, opErrs, ops)
+	}
+	return results
+}
+
+// MustList runs c.List and fails the test on error. Returns the populated slice.
+func MustList[T any](t *testing.T, ctx context.Context, c client.Client) []T {
+	t.Helper()
+	var out []T
+	if err := c.List(ctx, &out); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	return out
+}
+
+// =============================================================================
+// State scrub between tests
+// =============================================================================
+
+// ResetOVNState removes all rows from the NB and SB tables the integration
+// harness writes to, plus any agent-installed kernel/OVS/FRR state. Call at
+// the start of each scenario so cases do not leak into one another.
+func ResetOVNState(t *testing.T, ctx context.Context, nb, sb client.Client) {
+	t.Helper()
+
+	// Best-effort cleanup of agent residue first so that NB deletes do not
+	// race with the agent (no agent should be running at this point).
+	scrubLocalState(t)
+
+	// NB ----------------------------------------------------------------
+	// Delete the root tables first; OVSDB's referential-integrity GC then
+	// removes the non-root rows that the root tables held references to.
+	// Specifically, deleting a Logical_Router cascade-frees its NAT,
+	// Logical_Router_Port, Gateway_Chassis (via LRP), and
+	// Logical_Router_Static_Route children.
+	//
+	// Doing it in the other order — deleting NAT/static-routes/LRP first —
+	// fails with "cannot delete X because of N remaining reference(s)" as
+	// long as the parent Logical_Router still references them.
+	for _, lr := range MustList[NBLogicalRouter](t, ctx, nb) {
+		ops, err := nb.Where(&NBLogicalRouter{UUID: lr.UUID}).Delete()
+		if err != nil {
+			t.Fatalf("delete router op: %v", err)
+		}
+		Transact(t, ctx, nb, ops)
+	}
+	// Static_MAC_Binding is a root table on its own — nothing references it
+	// from the test fixtures, but a previous run may have left rows.
+	for _, mb := range MustList[NBStaticMACBinding](t, ctx, nb) {
+		ops, err := nb.Where(&NBStaticMACBinding{UUID: mb.UUID}).Delete()
+		if err != nil {
+			t.Fatalf("delete static mac binding op: %v", err)
+		}
+		Transact(t, ctx, nb, ops)
+	}
+	// Defensive sweep of non-root tables in case the cache is briefly stale
+	// or a future fixture inserts rows without an owning router. List+delete
+	// is idempotent — an already-GC'd row simply isn't returned.
+	for _, sr := range MustList[NBLogicalRouterStaticRoute](t, ctx, nb) {
+		ops, err := nb.Where(&NBLogicalRouterStaticRoute{UUID: sr.UUID}).Delete()
+		if err != nil {
+			t.Fatalf("delete static route op: %v", err)
+		}
+		Transact(t, ctx, nb, ops)
+	}
+	for _, n := range MustList[NBNAT](t, ctx, nb) {
+		ops, err := nb.Where(&NBNAT{UUID: n.UUID}).Delete()
+		if err != nil {
+			t.Fatalf("delete nat op: %v", err)
+		}
+		Transact(t, ctx, nb, ops)
+	}
+	for _, lrp := range MustList[NBLogicalRouterPort](t, ctx, nb) {
+		ops, err := nb.Where(&NBLogicalRouterPort{UUID: lrp.UUID}).Delete()
+		if err != nil {
+			t.Fatalf("delete lrp op: %v", err)
+		}
+		Transact(t, ctx, nb, ops)
+	}
+	for _, gc := range MustList[NBGatewayChassis](t, ctx, nb) {
+		ops, err := nb.Where(&NBGatewayChassis{UUID: gc.UUID}).Delete()
+		if err != nil {
+			t.Fatalf("delete gw chassis op: %v", err)
+		}
+		Transact(t, ctx, nb, ops)
+	}
+
+	// SB ----------------------------------------------------------------
+	// Port_Bindings before Datapath_Bindings (FK).
+	for _, pb := range MustList[SBPortBinding](t, ctx, sb) {
+		ops, err := sb.Where(&SBPortBinding{UUID: pb.UUID}).Delete()
+		if err != nil {
+			t.Fatalf("delete port binding op: %v", err)
+		}
+		Transact(t, ctx, sb, ops)
+	}
+	for _, dp := range MustList[SBDatapathBinding](t, ctx, sb) {
+		ops, err := sb.Where(&SBDatapathBinding{UUID: dp.UUID}).Delete()
+		if err != nil {
+			t.Fatalf("delete datapath op: %v", err)
+		}
+		Transact(t, ctx, sb, ops)
+	}
+	// Chassis: leave the local one alone (auto-created by ovn-controller),
+	// remove any extras inserted by previous tests. Match by Name OR Hostname
+	// because OVN derives Chassis.hostname from gethostname(2), which on some
+	// hosts returns an FQDN that LocalHostname (short form) won't match. The
+	// Name column is set by setup.sh from the OVS external_ids:system-id and
+	// is guaranteed to equal the short hostname.
+	localName := LocalHostname(t)
+	for _, ch := range MustList[SBChassis](t, ctx, sb) {
+		if ch.Name == localName || ch.Hostname == localName {
+			continue
+		}
+		ops, err := sb.Where(&SBChassis{UUID: ch.UUID}).Delete()
+		if err != nil {
+			t.Fatalf("delete chassis op: %v", err)
+		}
+		Transact(t, ctx, sb, ops)
+	}
+}
+
+// nameUUID returns an ovsdb-named UUID handle suitable for building cross-row
+// references inside a single transaction (e.g. inserting a Logical_Router and
+// pointing its ports column at a freshly-inserted LRP).
+func nameUUID(name string) ovsdb.UUID { return ovsdb.UUID{GoUUID: name} }
+
+// realUUID returns an ovsdb.UUID that references an already-existing row.
+func realUUID(uuid string) ovsdb.UUID { return ovsdb.UUID{GoUUID: uuid} }
+
+// strRef returns a pointer to the given string.
+func strRef(s string) *string { return &s }

--- a/test/integration/testenv/services.go
+++ b/test/integration/testenv/services.go
@@ -1,0 +1,136 @@
+//go:build integration
+
+package testenv
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// patch port names used by EnsureBridgePatchPort. Long enough to be visibly
+// "from the test harness" in any leftover diagnostic output.
+const (
+	testenvPatchOnBrEx  = "patch-testenv-brex"
+	testenvPatchOnBrInt = "patch-testenv-brint"
+)
+
+// EnsureBridgePatchPort creates a patch-port pair between br-int and br-ex so
+// the agent's discoverPatchPort can find a type=patch port to bind its OVS
+// MAC-tweak / hairpin flows to. Idempotent — re-running is a no-op.
+//
+// Without this, scenarios that bypass ovn-northd never have a patch port on
+// br-ex (because ovn-controller only creates them in response to logical
+// switch state in SB). Tests that assert OVS flows depend on it.
+func EnsureBridgePatchPort(t *testing.T) {
+	t.Helper()
+
+	addPort := func(bridge, port, peer string) {
+		// `--may-exist add-port` is idempotent for the port row but not for
+		// the interface options; set them explicitly each time.
+		out, err := exec.Command("ovs-vsctl",
+			"--may-exist", "add-port", bridge, port, "--",
+			"set", "Interface", port, "type=patch", "options:peer="+peer,
+		).CombinedOutput()
+		if err != nil {
+			t.Fatalf("create patch port %s on %s: %v (output: %s)",
+				port, bridge, err, strings.TrimSpace(string(out)))
+		}
+	}
+	addPort(DefaultBridgeDev, testenvPatchOnBrEx, testenvPatchOnBrInt)
+	addPort("br-int", testenvPatchOnBrInt, testenvPatchOnBrEx)
+}
+
+// PauseOVNNorthd suspends the ovn-northd processing loop for the duration of
+// the test, registering a Cleanup that resumes it.
+//
+// Scenario tests that drive SB Port_Binding entries directly need ovn-northd
+// out of the picture: northd treats SB as a pure projection of NB and would
+// otherwise garbage-collect manually-inserted Port_Binding/Datapath_Binding
+// rows within seconds.
+//
+// We use OVN's built-in `ovn-appctl -t ovn-northd pause/resume` rather than
+// stopping the systemd unit. On Ubuntu the `ovn-northd.service` unit is a
+// thin wrapper around `ovn-ctl start_northd`/`stop_northd`, which manages
+// the NB ovsdb-server, SB ovsdb-server, AND the northd daemon together —
+// so a `systemctl stop ovn-northd` would also take down the databases the
+// test needs to talk to.
+func PauseOVNNorthd(t *testing.T) {
+	t.Helper()
+
+	if _, err := exec.LookPath("ovn-appctl"); err != nil {
+		t.Skipf("ovn-appctl not found in PATH: %v", err)
+	}
+
+	// `ovn-appctl -t ovn-northd pause` is idempotent; re-running it on an
+	// already-paused daemon returns success.
+	t.Logf("pausing ovn-northd processing for the duration of the test")
+	if out, err := exec.Command("ovn-appctl", "-t", "ovn-northd", "pause").CombinedOutput(); err != nil {
+		// If northd is not running at all, there is nothing to pause and
+		// nothing to garbage-collect SB rows we insert — treat it as a
+		// successful no-op rather than failing the test.
+		txt := strings.TrimSpace(string(out))
+		if isNorthdUnreachable(txt) {
+			t.Logf("PauseOVNNorthd: ovn-northd not reachable via appctl (%s); assuming not running", txt)
+			return
+		}
+		t.Fatalf("pause ovn-northd: %v (output: %s)", err, txt)
+	}
+
+	t.Cleanup(func() {
+		if out, err := exec.Command("ovn-appctl", "-t", "ovn-northd", "resume").CombinedOutput(); err != nil {
+			t.Logf("resume ovn-northd after test: %v (output: %s)", err, strings.TrimSpace(string(out)))
+		}
+	})
+}
+
+// isNorthdUnreachable distinguishes "ovn-northd is not running / its control
+// socket does not exist" from "the pause command itself failed". The former
+// is harmless for tests; the latter must surface as a failure.
+func isNorthdUnreachable(out string) bool {
+	out = strings.ToLower(out)
+	return strings.Contains(out, "no such file") ||
+		strings.Contains(out, "connection refused") ||
+		strings.Contains(out, "cannot connect")
+}
+
+// PauseOVNController suspends ovn-controller's main processing loop for the
+// duration of the test, registering a Cleanup that resumes it.
+//
+// Scenario tests that drive SB Port_Binding entries directly need
+// ovn-controller out of the picture too: ovn-controller continuously
+// reclaims chassisredirect Port_Bindings based on SB Gateway_Chassis
+// records, and with northd paused those records don't exist. Left to its
+// own devices, ovn-controller decides our hand-set Port_Binding.chassis
+// shouldn't be bound here and clears the field within milliseconds —
+// which is exactly the column the agent's local-router detection reads.
+//
+// Unlike ovn-northd, ovn-controller has no `pause`/`resume` appctl, so we
+// suspend it at the process level with SIGSTOP and resume it with SIGCONT
+// at test cleanup. The process keeps its OVSDB connections (just doesn't
+// drive them) and the local Chassis/Encap rows it registered remain
+// intact.
+func PauseOVNController(t *testing.T) {
+	t.Helper()
+
+	if _, err := exec.LookPath("pkill"); err != nil {
+		t.Skipf("pkill not found in PATH: %v", err)
+	}
+
+	t.Logf("suspending ovn-controller (SIGSTOP) for the duration of the test")
+	if out, err := exec.Command("pkill", "-STOP", "-x", "ovn-controller").CombinedOutput(); err != nil {
+		// pkill exits 1 when no processes matched. That's fine — there's
+		// nothing to stop, so nothing will reclaim our Port_Bindings.
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			t.Logf("PauseOVNController: no ovn-controller process found; nothing to suspend")
+			return
+		}
+		t.Fatalf("SIGSTOP ovn-controller: %v (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+
+	t.Cleanup(func() {
+		if out, err := exec.Command("pkill", "-CONT", "-x", "ovn-controller").CombinedOutput(); err != nil {
+			t.Logf("SIGCONT ovn-controller after test: %v (output: %s)", err, strings.TrimSpace(string(out)))
+		}
+	})
+}


### PR DESCRIPTION
Implements the seven scenarios from #42 against the harness from #41: FIP add/remove, gatewayless virtual gateway, multi-router on one chassis, failover, stale-chassis cleanup, drain on shutdown, and restore-drained on startup.

Adds testenv primitives (NB/SB libovsdb clients with state-reset, polling helpers, MakeLocalRouter / AddFIP / MakeChassis fixtures, PauseOVNNorthd, EnsureBridgePatchPort) so scenarios can drive NB/SB writes directly with ovn-northd paused, then assert kernel routes, FRR routes, OVS flows by cookie, and NB writes the agent emits in response.

Closes #42

AI-assisted: Claude Code