### PR TITLE
test(integration): add layer 2 port-forward scenarios

### DIFF
--- a/nftables.go
+++ b/nftables.go
@@ -173,13 +173,19 @@ func buildNftRuleset(forwards []PortForwardVIP, providerNetworks []*net.IPNet, c
 			} else {
 				// jhash: consistent source-IP hashing distributes clients
 				// across backends. Same client IP → same backend (sticky).
+				//
+				// nft note: inside a verdict map for `dnat to`, the
+				// (addr, port) target must use the concat operator
+				// (`addr . port`), not the inline `addr:port` form. The
+				// inline form is only valid for a single non-mapped
+				// dnat target.
 				fmt.Fprintf(&b, "        ip daddr %s %s dport %d dnat to jhash ip saddr mod %d map { ",
 					pf.VIP, r.Proto, r.Port, len(addrs))
 				for i, addr := range addrs {
 					if i > 0 {
 						b.WriteString(", ")
 					}
-					fmt.Fprintf(&b, "%d : %s:%d", i, addr, destPort)
+					fmt.Fprintf(&b, "%d : %s . %d", i, addr, destPort)
 				}
 				b.WriteString(" }\n")
 			}
@@ -204,10 +210,15 @@ func buildNftRuleset(forwards []PortForwardVIP, providerNetworks []*net.IPNet, c
 		fmt.Fprintf(&b, "        ct direction reply ct status dnat ct original daddr %s meta mark set 0x%x\n",
 			allVIPs[0], dnatReplyFwmark)
 	} else {
+		// nft note: for a single bare-IP literal, `ct original daddr`
+		// can infer the address family. For an anonymous set with
+		// multiple values it cannot, and rejects with "specify either
+		// ip or ip6 for address matching". The explicit `ip daddr`
+		// pins the family so the set parses.
 		vipSet := strings.Join(allVIPs, ", ")
-		fmt.Fprintf(&b, "        ct direction original ct status dnat ct original daddr { %s } meta mark set 0x%x\n",
+		fmt.Fprintf(&b, "        ct direction original ct status dnat ct original ip daddr { %s } meta mark set 0x%x\n",
 			vipSet, dnatFwmark)
-		fmt.Fprintf(&b, "        ct direction reply ct status dnat ct original daddr { %s } meta mark set 0x%x\n",
+		fmt.Fprintf(&b, "        ct direction reply ct status dnat ct original ip daddr { %s } meta mark set 0x%x\n",
 			vipSet, dnatReplyFwmark)
 	}
 	b.WriteString("    }\n")
@@ -224,8 +235,11 @@ func buildNftRuleset(forwards []PortForwardVIP, providerNetworks []*net.IPNet, c
 		fmt.Fprintf(&b, "        ct direction reply ct status dnat ct original daddr %s meta mark set 0x%x\n",
 			allVIPs[0], dnatReplyFwmark)
 	} else {
+		// Same family-inference issue as prerouting_fwmark — see
+		// the comment there. The explicit `ip daddr` pins the family
+		// so the multi-element set parses.
 		vipSet := strings.Join(allVIPs, ", ")
-		fmt.Fprintf(&b, "        ct direction reply ct status dnat ct original daddr { %s } meta mark set 0x%x\n",
+		fmt.Fprintf(&b, "        ct direction reply ct status dnat ct original ip daddr { %s } meta mark set 0x%x\n",
 			vipSet, dnatReplyFwmark)
 	}
 	b.WriteString("    }\n")

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -131,10 +131,10 @@ func TestBuildNftRulesetMultipleVIPs(t *testing.T) {
 	}
 
 	// Verify fwmark chain uses set syntax for multiple VIPs (both directions)
-	if !strings.Contains(result, "ct direction original ct status dnat ct original daddr { 198.51.100.10, 198.51.100.20 } meta mark set 0x100") {
+	if !strings.Contains(result, "ct direction original ct status dnat ct original ip daddr { 198.51.100.10, 198.51.100.20 } meta mark set 0x100") {
 		t.Errorf("forward fwmark should use set syntax for multiple VIPs, got:\n%s", result)
 	}
-	if !strings.Contains(result, "ct direction reply ct status dnat ct original daddr { 198.51.100.10, 198.51.100.20 } meta mark set 0x200") {
+	if !strings.Contains(result, "ct direction reply ct status dnat ct original ip daddr { 198.51.100.10, 198.51.100.20 } meta mark set 0x200") {
 		t.Errorf("reply fwmark should use set syntax for multiple VIPs, got:\n%s", result)
 	}
 
@@ -144,7 +144,7 @@ func TestBuildNftRulesetMultipleVIPs(t *testing.T) {
 	}
 	// Extract output_fwmark chain content and verify set syntax
 	outputFwmark := extractChain(result, "output_fwmark")
-	if !strings.Contains(outputFwmark, "ct direction reply ct status dnat ct original daddr { 198.51.100.10, 198.51.100.20 } meta mark set 0x200") {
+	if !strings.Contains(outputFwmark, "ct direction reply ct status dnat ct original ip daddr { 198.51.100.10, 198.51.100.20 } meta mark set 0x200") {
 		t.Errorf("output_fwmark should use set syntax for multiple VIPs, got:\n%s", outputFwmark)
 	}
 
@@ -387,8 +387,10 @@ func TestBuildNftRulesetMultiBackend(t *testing.T) {
 
 	result := buildNftRuleset(forwards, nil, dnatCTZoneDefault)
 
-	// Verify jhash-based DNAT rule
-	expected := "ip daddr 198.51.100.10 udp dport 53 dnat to jhash ip saddr mod 3 map { 0 : 10.0.0.200:1053, 1 : 10.0.0.201:1053, 2 : 10.0.0.202:1053 }"
+	// Verify jhash-based DNAT rule. nft requires the concat operator
+	// (`addr . port`) inside a verdict map; the inline `addr:port` form
+	// is only valid for non-mapped dnat targets.
+	expected := "ip daddr 198.51.100.10 udp dport 53 dnat to jhash ip saddr mod 3 map { 0 : 10.0.0.200 . 1053, 1 : 10.0.0.201 . 1053, 2 : 10.0.0.202 . 1053 }"
 	if !strings.Contains(result, expected) {
 		t.Errorf("missing jhash DNAT rule.\nwant: %s\ngot:\n%s", expected, result)
 	}
@@ -414,8 +416,9 @@ func TestBuildNftRulesetMultiBackendTwoBackends(t *testing.T) {
 
 	result := buildNftRuleset(forwards, nil, dnatCTZoneDefault)
 
-	// With two backends, jhash mod 2
-	expected := "ip daddr 198.51.100.10 tcp dport 443 dnat to jhash ip saddr mod 2 map { 0 : 10.0.0.100:443, 1 : 10.0.0.101:443 }"
+	// With two backends, jhash mod 2. Map values use the concat operator
+	// (`addr . port`); see TestBuildNftRulesetMultiBackend for context.
+	expected := "ip daddr 198.51.100.10 tcp dport 443 dnat to jhash ip saddr mod 2 map { 0 : 10.0.0.100 . 443, 1 : 10.0.0.101 . 443 }"
 	if !strings.Contains(result, expected) {
 		t.Errorf("missing jhash DNAT rule for 2 backends.\nwant: %s\ngot:\n%s", expected, result)
 	}

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -14,8 +14,17 @@ test/integration/
   scenarios_helpers_test.go        — shared per-scenario boilerplate (startScenario, readyAgent)
   scenario_fip_test.go             — FIP add/remove, gatewayless gw, multi-router on one chassis
   scenario_failover_test.go        — failover, stale-chassis cleanup, drain & restore-drained
+  scenario_port_forward_test.go    — DNAT, sticky multi-backend, VIP mgmt, masquerade, hairpin
   testenv/                         — Setup, Teardown, RunAgent, MakeLocalRouter, Assert*, …
 ```
+
+Port-forward scenarios additionally rely on:
+
+- a `loopback1` dummy device enslaved to `vrf-provider` (created by setup.sh)
+- the `nft -j list ruleset` JSON output for stable, structured assertions
+  (parsers live in `testenv/nftjson.go`)
+- save/restore of the global `udp_l3mdev_accept` / `tcp_l3mdev_accept`
+  sysctls when a scenario sets `port_forward_l3mdev_accept: true`
 
 Scenario tests pause `ovn-northd` for the duration of each test (via
 `testenv.PauseOVNNorthd`) so the test driver can write SB Port_Binding rows

--- a/test/integration/scenario_port_forward_test.go
+++ b/test/integration/scenario_port_forward_test.go
@@ -1,0 +1,426 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/osism/ovn-network-agent/test/integration/testenv"
+)
+
+// All scenarios in this file cover #43 — port-forward (DNAT, conntrack zones,
+// hairpin masquerade) integration tests. Each scenario configures the agent
+// with a specific port_forwards block, asserts the resulting nft ruleset and
+// kernel state via JSON-parsed `nft -j list ruleset` (not regex on text), and
+// relies on the harness's scrubLocalState to delete leaked state between runs.
+//
+// The agent's port-forward feature requires veth_leak_enabled=true (handled
+// by the harness defaults) and a loopback1 device in vrf-provider (provisioned
+// by setup.sh — EnsureLoopback1 short-circuits the test if it's missing).
+
+const (
+	pfTable = testenv.DefaultNftTable
+)
+
+// boolPtr returns a pointer to b — used for *bool fields in fixtures.
+func boolPtr(b bool) *bool { return &b }
+
+// intPtr returns a pointer to i — used for *int fields in AgentConfig.
+func intPtr(i int) *int { return &i }
+
+// pfDefaults returns a Defaults() AgentConfig augmented with the port-forward
+// fields tests need. Caller appends to PortForwards.
+func pfDefaults(t *testing.T) testenv.AgentConfig {
+	t.Helper()
+	cfg := testenv.Defaults()
+	cfg.PortForwardDev = testenv.PortForwardLoopbackDev
+	// Use a non-default ct zone so collisions with anything OVN might use
+	// surface as test failures rather than silent crosstalk.
+	cfg.PortForwardCTZone = intPtr(64000)
+	return cfg
+}
+
+// startPFScenario is the port-forward analogue of startScenario. It performs
+// the same OVN bring-up plus EnsureLoopback1, so scenarios that don't drive
+// any NB/SB state still have the device they need. It also issues a defensive
+// scrub of port-forward residue at the start so a previous failed test cannot
+// pollute the current one (the registered Cleanup also scrubs at the end via
+// Teardown).
+func startPFScenario(t *testing.T) testenv.AgentConfig {
+	t.Helper()
+	testenv.Setup(t)
+	testenv.EnsureLoopback1(t)
+	// We don't need ovn-northd paused for port-forward scenarios that don't
+	// inject SB Port_Bindings, but we do need a clean slate.
+	testenv.PauseOVNNorthd(t)
+	testenv.PauseOVNController(t)
+	// Defensive scrub: drop any nft table / loopback addresses / fwmark
+	// rules left behind by a prior failing scenario before we bring the
+	// agent up. The Setup-registered Teardown handles the trailing edge.
+	testenv.ScrubPortForwardResidue(t)
+
+	return pfDefaults(t)
+}
+
+// TestScenario_PortForwardSingleBackendDNAT (#43 scenario 1).
+//
+// A VIP with a single rule and one backend should produce:
+//   - prerouting_dnat:    ip daddr <VIP> tcp dport 80 dnat to <backend>:80
+//   - prerouting_ctzone:  ip daddr <VIP> tcp dport 80 ct zone set <zone>
+//     ip saddr <backend> tcp sport 80 ct zone set <zone>
+//   - prerouting_fwmark:  meta mark set 0x100 / 0x200 (for original/reply)
+func TestScenario_PortForwardSingleBackendDNAT(t *testing.T) {
+	cfg := startPFScenario(t)
+
+	const (
+		vip     = "198.51.100.10"
+		backend = "10.0.0.100"
+	)
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+		VIP: vip,
+		Rules: []testenv.PortForwardRuleFixture{{
+			Proto: "tcp", Port: 80, DestAddr: backend,
+		}},
+	}}
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// DNAT rule.
+	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_dnat",
+		func(r testenv.NftRule) bool {
+			return r.HasMatch("ip", "daddr", vip) &&
+				r.HasMatch("tcp", "dport", 80) &&
+				r.HasDNATTo(backend, 80)
+		},
+		15*time.Second, "single-backend DNAT rule for "+vip+":80")
+
+	// Conntrack zone: original direction (VIP daddr).
+	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_ctzone",
+		func(r testenv.NftRule) bool {
+			return r.HasMatch("ip", "daddr", vip) &&
+				r.HasMatch("tcp", "dport", 80) &&
+				r.HasCTZoneSet(*cfg.PortForwardCTZone)
+		},
+		10*time.Second, "ctzone original-direction rule for "+vip)
+
+	// Conntrack zone: reply direction (backend saddr).
+	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_ctzone",
+		func(r testenv.NftRule) bool {
+			return r.HasMatch("ip", "saddr", backend) &&
+				r.HasMatch("tcp", "sport", 80) &&
+				r.HasCTZoneSet(*cfg.PortForwardCTZone)
+		},
+		10*time.Second, "ctzone reply-direction rule for backend "+backend)
+
+	// Fwmark: original (0x100) and reply (0x200).
+	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_fwmark",
+		func(r testenv.NftRule) bool { return r.HasMarkSet(0x100) },
+		10*time.Second, "prerouting_fwmark sets 0x100 on original direction")
+	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_fwmark",
+		func(r testenv.NftRule) bool { return r.HasMarkSet(0x200) },
+		10*time.Second, "prerouting_fwmark sets 0x200 on reply direction")
+}
+
+// TestScenario_PortForwardMultiBackendStickyHashing (#43 scenario 2).
+//
+// A 3-backend rule should generate a single DNAT statement using nft's jhash
+// expression: `dnat to jhash ip saddr mod 3 map { 0:..., 1:..., 2:... }`.
+// The map keys are 0-indexed; values pair (addr, port).
+func TestScenario_PortForwardMultiBackendStickyHashing(t *testing.T) {
+	cfg := startPFScenario(t)
+
+	const vip = "198.51.100.20"
+	backends := []string{"10.0.0.100", "10.0.0.101", "10.0.0.102"}
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+		VIP: vip,
+		Rules: []testenv.PortForwardRuleFixture{{
+			Proto: "tcp", Port: 8080, DestAddrs: backends,
+		}},
+	}}
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	expected := []testenv.NftBackend{
+		{Addr: backends[0], Port: 8080},
+		{Addr: backends[1], Port: 8080},
+		{Addr: backends[2], Port: 8080},
+	}
+	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_dnat",
+		func(r testenv.NftRule) bool {
+			return r.HasMatch("ip", "daddr", vip) &&
+				r.HasMatch("tcp", "dport", 8080) &&
+				r.HasDNATMap(expected)
+		},
+		15*time.Second, "jhash sticky DNAT map across 3 backends")
+}
+
+// TestScenario_PortForwardManageVIP (#43 scenario 3).
+//
+// manage_vip:true should add the VIP/32 to loopback1; manage_vip:false (the
+// default) should leave it absent. Verified via `ip -j addr show dev loopback1`.
+func TestScenario_PortForwardManageVIP(t *testing.T) {
+	cfg := startPFScenario(t)
+
+	const (
+		managedVIP   = "198.51.100.10"
+		unmanagedVIP = "198.51.100.11"
+	)
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{
+		{
+			VIP:       managedVIP,
+			ManageVIP: true,
+			Rules: []testenv.PortForwardRuleFixture{{
+				Proto: "tcp", Port: 80, DestAddr: "10.0.0.100",
+			}},
+		},
+		{
+			VIP:       unmanagedVIP,
+			ManageVIP: false,
+			Rules: []testenv.PortForwardRuleFixture{{
+				Proto: "tcp", Port: 81, DestAddr: "10.0.0.101",
+			}},
+		},
+	}
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	testenv.AssertVIPOnLoopback(t, managedVIP, 15*time.Second)
+	// The unmanaged VIP must stay off the device. Use a short timeout —
+	// the agent never adds it, so a wait of a few seconds is enough to
+	// rule out a race with the initial reconcile.
+	testenv.AssertVIPNotOnLoopback(t, unmanagedVIP, 3*time.Second)
+}
+
+// TestScenario_PortForwardPerRuleMasquerade (#43 scenario 4).
+//
+// VIP-level masquerade:true with one rule overridden to masquerade:false
+// should produce a postrouting_snat chain with exactly the inheriting rule's
+// backend (and no entry for the overridden rule).
+func TestScenario_PortForwardPerRuleMasquerade(t *testing.T) {
+	cfg := startPFScenario(t)
+
+	const (
+		vip             = "198.51.100.30"
+		inheritBackend  = "10.1.0.50"  // remote — should be masqueraded
+		overrideBackend = "10.0.0.100" // local — masquerade:false override
+	)
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+		VIP:        vip,
+		Masquerade: true,
+		Rules: []testenv.PortForwardRuleFixture{
+			{
+				Proto: "tcp", Port: 443, DestAddr: inheritBackend,
+				// Inherits VIP-level masquerade=true.
+			},
+			{
+				Proto: "udp", Port: 53, DestAddr: overrideBackend,
+				Masquerade: boolPtr(false),
+			},
+		},
+	}}
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// Inheriting rule appears in postrouting_snat.
+	testenv.AssertNftRuleInChain(t, pfTable, "postrouting_snat",
+		func(r testenv.NftRule) bool {
+			return r.HasMatch("ip", "daddr", inheritBackend) &&
+				r.HasMatch("tcp", "dport", 443) &&
+				r.HasMasquerade()
+		},
+		15*time.Second, "inheriting rule must appear in postrouting_snat")
+
+	// Overridden rule must NOT appear. Read the dump once and assert
+	// directly — Eventually-style waits on absence are slow and we already
+	// know the chain converged from the previous assertion.
+	dump := testenv.DumpNftRuleset(t)
+	for _, r := range dump.RulesIn(pfTable, "postrouting_snat") {
+		if r.HasMatch("ip", "daddr", overrideBackend) {
+			t.Errorf("overridden backend %s should not be masqueraded but appears in postrouting_snat: %s",
+				overrideBackend, string(r.Raw))
+		}
+	}
+}
+
+// TestScenario_PortForwardHairpinMasquerade (#43 scenario 5).
+//
+// hairpin_masquerade:true plus a discovered provider network should produce
+// a postrouting_snat rule of the form:
+//
+//	ip saddr <provider-net> ct original daddr <vip> ct status dnat masquerade
+//
+// To make the agent discover a provider network we insert a local router
+// whose LRP networks fall in 198.51.100.0/24 — the agent's reconcile picks
+// these up and feeds them to ReconcilePortForward as the providerNetworks
+// arg, which buildNftRuleset uses to materialise the hairpin rule.
+func TestScenario_PortForwardHairpinMasquerade(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+	testenv.EnsureLoopback1(t)
+
+	// Provider network 198.51.100.0/24 — the LRP network the agent will
+	// discover and pass into the hairpin rule.
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "hairpinr",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+	_ = router
+
+	const vip = "198.51.100.40"
+	cfg := pfDefaults(t)
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+		VIP:               vip,
+		HairpinMasquerade: true,
+		Rules: []testenv.PortForwardRuleFixture{{
+			Proto: "tcp", Port: 80, DestAddr: "10.0.0.100",
+		}},
+	}}
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// Wait for the reconcile that populates providerNetworks. The agent
+	// emits the hairpin rule only on Reconcile (not Setup), so a longer
+	// timeout is appropriate.
+	testenv.AssertNftRuleInChain(t, pfTable, "postrouting_snat",
+		func(r testenv.NftRule) bool {
+			// Hairpin rule matches `ip saddr <provider-cidr>` (a
+			// prefix expression in nft JSON) plus a masquerade
+			// statement. The accompanying ct-expression matches
+			// (`ct original daddr <vip>`, `ct status dnat`) are
+			// not asserted here — saddr-prefix + masquerade
+			// uniquely identify the hairpin rule because no other
+			// rule in postrouting_snat carries a CIDR match.
+			return r.HasMatchPrefix("ip", "saddr", "198.51.100.0/24") &&
+				r.HasMasquerade()
+		},
+		30*time.Second, "hairpin masquerade rule for VIP "+vip+" with provider 198.51.100.0/24")
+}
+
+// TestScenario_PortForwardL3mdevSysctls (#43 scenario 6).
+//
+// port_forward_l3mdev_accept:true must set udp_l3mdev_accept=1 and
+// tcp_l3mdev_accept=1 in /proc/sys/net/ipv4/. These are GLOBAL sysctls — the
+// test saves and restores them via SaveSysctl so the host is left as it was
+// found.
+func TestScenario_PortForwardL3mdevSysctls(t *testing.T) {
+	cfg := startPFScenario(t)
+
+	// Capture original values so the t.Cleanup restores them after the
+	// test, regardless of pass/fail.
+	testenv.SaveSysctl(t, testenv.SysctlUDPL3mdevAccept)
+	testenv.SaveSysctl(t, testenv.SysctlTCPL3mdevAccept)
+
+	cfg.PortForwardL3mdevAccept = boolPtr(true)
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+		VIP: "198.51.100.50",
+		Rules: []testenv.PortForwardRuleFixture{{
+			Proto: "tcp", Port: 80, DestAddr: "10.0.0.100",
+		}},
+	}}
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	testenv.AssertSysctl(t, testenv.SysctlUDPL3mdevAccept, "1", 10*time.Second)
+	testenv.AssertSysctl(t, testenv.SysctlTCPL3mdevAccept, "1", 10*time.Second)
+}
+
+// TestScenario_PortForwardOutputChains (#43 scenario 7).
+//
+// A local-backend rule with masquerade:false should leave both output_ctzone
+// (zone assignment for locally-generated reply traffic) and output_fwmark
+// (mark 0x200 with type=route to trigger reroute) chains in place, with rules
+// mirroring their prerouting counterparts. The agent always emits these
+// chains, but the rules inside them must include the local-backend's port —
+// otherwise the same-host reply path is broken.
+func TestScenario_PortForwardOutputChains(t *testing.T) {
+	cfg := startPFScenario(t)
+
+	const (
+		vip          = "198.51.100.60"
+		localBackend = "127.0.0.10"
+	)
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+		VIP:        vip,
+		Masquerade: false, // local backend, no SNAT
+		Rules: []testenv.PortForwardRuleFixture{{
+			Proto: "tcp", Port: 8443, DestAddr: localBackend,
+			Masquerade: boolPtr(false),
+		}},
+	}}
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// output_ctzone exists and mirrors the original-direction zone rule.
+	testenv.AssertNftChainExists(t, pfTable, "output_ctzone", 15*time.Second)
+	testenv.AssertNftRuleInChain(t, pfTable, "output_ctzone",
+		func(r testenv.NftRule) bool {
+			return r.HasMatch("ip", "daddr", vip) &&
+				r.HasMatch("tcp", "dport", 8443) &&
+				r.HasCTZoneSet(*cfg.PortForwardCTZone)
+		},
+		10*time.Second, "output_ctzone mirrors VIP daddr rule")
+	testenv.AssertNftRuleInChain(t, pfTable, "output_ctzone",
+		func(r testenv.NftRule) bool {
+			return r.HasMatch("ip", "saddr", localBackend) &&
+				r.HasMatch("tcp", "sport", 8443) &&
+				r.HasCTZoneSet(*cfg.PortForwardCTZone)
+		},
+		10*time.Second, "output_ctzone mirrors backend saddr rule")
+
+	// output_fwmark exists and sets 0x200 on the reply direction.
+	testenv.AssertNftChainExists(t, pfTable, "output_fwmark", 15*time.Second)
+	testenv.AssertNftRuleInChain(t, pfTable, "output_fwmark",
+		func(r testenv.NftRule) bool { return r.HasMarkSet(0x200) },
+		10*time.Second, "output_fwmark sets 0x200 on locally-generated reply")
+
+	// Verify the chain header is `type route` (not `type filter`) — the
+	// route hook is required to trigger routing re-evaluation when the
+	// mark changes. Without it the reply never re-enters the provider VRF.
+	chain, ok := testenv.DumpNftRuleset(t).Chain(pfTable, "output_fwmark")
+	if !ok {
+		t.Fatal("output_fwmark chain missing in second dump")
+	}
+	if chain.Type != "route" {
+		t.Errorf("output_fwmark chain type = %q, want %q", chain.Type, "route")
+	}
+}
+
+// TestScenario_PortForwardCleanupOnSIGTERM (#43 scenario 8).
+//
+// SIGTERM with cleanup_on_shutdown=true (the harness default) must remove
+// the agent's nft table and all VIP addresses managed by manage_vip:true.
+// We start the agent, verify the desired state landed, send SIGTERM via
+// AgentProc.Stop, and assert both the table and the VIP are gone.
+func TestScenario_PortForwardCleanupOnSIGTERM(t *testing.T) {
+	cfg := startPFScenario(t)
+
+	const vip = "198.51.100.99"
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+		VIP:       vip,
+		ManageVIP: true,
+		Rules: []testenv.PortForwardRuleFixture{{
+			Proto: "tcp", Port: 80, DestAddr: "10.0.0.99",
+		}},
+	}}
+
+	a := readyAgent(t, cfg)
+
+	// Confirm we have something to clean up before signalling SIGTERM.
+	testenv.AssertNftChainExists(t, pfTable, "prerouting_dnat", 15*time.Second)
+	testenv.AssertVIPOnLoopback(t, vip, 15*time.Second)
+
+	if err := a.Stop(15 * time.Second); err != nil {
+		t.Fatalf("agent stop: %v", err)
+	}
+
+	testenv.AssertNftTableAbsent(t, pfTable, 10*time.Second)
+	testenv.AssertVIPNotOnLoopback(t, vip, 10*time.Second)
+}

--- a/test/integration/setup.sh
+++ b/test/integration/setup.sh
@@ -176,6 +176,20 @@ ensure_nftables() {
     # The agent creates its own table; we don't need to pre-populate anything.
 }
 
+create_loopback1() {
+    # The agent's port-forward feature attaches managed VIP /32 addresses to a
+    # loopback device inside the provider VRF. Production hosts provision
+    # `loopback1` via systemd-networkd or similar; the agent never creates it.
+    # The integration harness needs the same surface, so we materialise it as
+    # a dummy device enslaved to vrf-provider.
+    log "creating loopback1 dummy device in vrf-provider"
+    if ! ip link show loopback1 >/dev/null 2>&1; then
+        ip link add loopback1 type dummy
+    fi
+    ip link set loopback1 master vrf-provider
+    ip link set loopback1 up
+}
+
 main() {
     require_root
     apt_install
@@ -184,6 +198,7 @@ main() {
     start_ovn_host
     create_bridges
     configure_frr
+    create_loopback1
     ensure_nftables
     log "setup complete"
 }

--- a/test/integration/testenv/agent.go
+++ b/test/integration/testenv/agent.go
@@ -15,6 +15,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 // AgentConfig captures the config-file fields the integration harness uses
@@ -38,6 +40,37 @@ type AgentConfig struct {
 	ReconcileInterval       string `yaml:"reconcile_interval,omitempty"`
 	StaleChassisGracePeriod string `yaml:"stale_chassis_grace_period,omitempty"`
 	DrainTimeout            string `yaml:"drain_timeout,omitempty"`
+
+	// Port forwarding (DNAT). PortForwards is the list of VIPs and rules; the
+	// agent infers PortForwardEnabled from len > 0. PortForwardL3mdevAccept
+	// flips a *global* sysctl when true — scenario tests that set it must use
+	// SaveSysctl/RestoreSysctl to avoid leaking state.
+	PortForwardDev          string                  `yaml:"port_forward_dev,omitempty"`
+	PortForwardL3mdevAccept *bool                   `yaml:"port_forward_l3mdev_accept,omitempty"`
+	PortForwardCTZone       *int                    `yaml:"port_forward_ct_zone,omitempty"`
+	PortForwards            []PortForwardVIPFixture `yaml:"port_forwards,omitempty"`
+}
+
+// PortForwardVIPFixture mirrors the agent's PortForwardVIP for scenario
+// fixtures. It cannot import from main, so the YAML keys must stay in lock
+// step with config.go's PortForwardVIP / PortForwardRule.
+type PortForwardVIPFixture struct {
+	VIP               string                   `yaml:"vip"`
+	ManageVIP         bool                     `yaml:"manage_vip,omitempty"`
+	Masquerade        bool                     `yaml:"masquerade,omitempty"`
+	HairpinMasquerade bool                     `yaml:"hairpin_masquerade,omitempty"`
+	Rules             []PortForwardRuleFixture `yaml:"rules"`
+}
+
+// PortForwardRuleFixture mirrors the agent's PortForwardRule. Masquerade is a
+// pointer to distinguish "inherit from VIP" (nil) from explicit true/false.
+type PortForwardRuleFixture struct {
+	Proto      string   `yaml:"proto"`
+	Port       int      `yaml:"port"`
+	DestAddr   string   `yaml:"dest_addr,omitempty"`
+	DestAddrs  []string `yaml:"dest_addrs,omitempty"`
+	DestPort   int      `yaml:"dest_port,omitempty"`
+	Masquerade *bool    `yaml:"masquerade,omitempty"`
 }
 
 // Defaults returns an AgentConfig wired for the local test stack:
@@ -213,42 +246,62 @@ func (p *AgentProc) LogTail(n int) string {
 	return strings.Join(lines[len(lines)-n:], "\n")
 }
 
-// writeTempConfig serialises cfg to a temp YAML file in t.TempDir().
-// Pointer fields are emitted only when set, so the agent's own defaults
-// apply for everything else.
+// writeTempConfig serialises cfg to a temp YAML file in t.TempDir(). It uses
+// yaml.v3 with explicit handling for fields whose semantics differ between
+// "unset" and "empty string". In particular, frr_prefix_list always emits a
+// quoted value (the agent treats an absent key as "use the default
+// ANNOUNCED-NETWORKS prefix list", but tests usually want to disable it
+// outright by passing an empty string).
 func writeTempConfig(t *testing.T, cfg AgentConfig) string {
 	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "agent.yaml")
 
-	var b strings.Builder
-	w := func(k, v string) {
+	doc := map[string]any{}
+	put := func(k, v string) {
 		if v != "" {
-			fmt.Fprintf(&b, "%s: %q\n", k, v)
+			doc[k] = v
 		}
 	}
-	wb := func(k string, v *bool) {
+	putBool := func(k string, v *bool) {
 		if v != nil {
-			fmt.Fprintf(&b, "%s: %t\n", k, *v)
+			doc[k] = *v
 		}
 	}
-	w("ovn_nb_remote", cfg.OVNNBRemote)
-	w("ovn_sb_remote", cfg.OVNSBRemote)
-	w("bridge_dev", cfg.BridgeDev)
-	w("vrf_name", cfg.VRFName)
-	w("veth_nexthop", cfg.VethNexthop)
-	// frr_prefix_list intentionally allows empty string to disable.
-	fmt.Fprintf(&b, "frr_prefix_list: %q\n", cfg.FRRPrefixList)
-	w("log_level", cfg.LogLevel)
-	w("reconcile_interval", cfg.ReconcileInterval)
-	w("stale_chassis_grace_period", cfg.StaleChassisGracePeriod)
-	w("drain_timeout", cfg.DrainTimeout)
-	wb("dry_run", cfg.DryRun)
-	wb("cleanup_on_shutdown", cfg.CleanupOnShutdown)
-	wb("drain_on_shutdown", cfg.DrainOnShutdown)
-	wb("veth_leak_enabled", cfg.VethLeakEnabled)
+	putInt := func(k string, v *int) {
+		if v != nil {
+			doc[k] = *v
+		}
+	}
 
-	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+	put("ovn_nb_remote", cfg.OVNNBRemote)
+	put("ovn_sb_remote", cfg.OVNSBRemote)
+	put("bridge_dev", cfg.BridgeDev)
+	put("vrf_name", cfg.VRFName)
+	put("veth_nexthop", cfg.VethNexthop)
+	// frr_prefix_list intentionally always emits, allowing "" to disable.
+	doc["frr_prefix_list"] = cfg.FRRPrefixList
+	put("log_level", cfg.LogLevel)
+	put("reconcile_interval", cfg.ReconcileInterval)
+	put("stale_chassis_grace_period", cfg.StaleChassisGracePeriod)
+	put("drain_timeout", cfg.DrainTimeout)
+	putBool("dry_run", cfg.DryRun)
+	putBool("cleanup_on_shutdown", cfg.CleanupOnShutdown)
+	putBool("drain_on_shutdown", cfg.DrainOnShutdown)
+	putBool("veth_leak_enabled", cfg.VethLeakEnabled)
+
+	put("port_forward_dev", cfg.PortForwardDev)
+	putBool("port_forward_l3mdev_accept", cfg.PortForwardL3mdevAccept)
+	putInt("port_forward_ct_zone", cfg.PortForwardCTZone)
+	if len(cfg.PortForwards) > 0 {
+		doc["port_forwards"] = cfg.PortForwards
+	}
+
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(path, out, 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 	return path

--- a/test/integration/testenv/assert.go
+++ b/test/integration/testenv/assert.go
@@ -266,4 +266,8 @@ func scrubLocalState(t *testing.T) {
 		_ = exec.Command("ovs-ofctl", "del-flows", DefaultBridgeDev,
 			fmt.Sprintf("cookie=%s/-1", cookie)).Run()
 	}
+
+	// Port-forward residue: managed VIPs on loopback1, fwmark ip rules,
+	// the port-forward reply table. Calls into portforward.go.
+	scrubPortForwardState(t)
 }

--- a/test/integration/testenv/nftjson.go
+++ b/test/integration/testenv/nftjson.go
@@ -1,0 +1,508 @@
+//go:build integration
+
+package testenv
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// NftRule is a parsed `nft -j list ruleset` rule with the expression list
+// preserved as raw JSON-decoded values. Tests compose matchers over Expr
+// rather than regex-matching the textual rule output.
+type NftRule struct {
+	Family string
+	Table  string
+	Chain  string
+	Handle int
+	Expr   []map[string]any
+	Raw    json.RawMessage // the entire {"rule":{...}} object
+}
+
+// NftChain is a parsed chain header (one per `chain` element in the JSON
+// output). Anonymous (unhooked) chains are not used by the agent, but Hook
+// may be empty for them.
+type NftChain struct {
+	Family string
+	Table  string
+	Name   string
+	Type   string
+	Hook   string
+	Prio   any // number or string, depending on nft version
+	Policy string
+}
+
+// NftDump is the full parsed ruleset.
+type NftDump struct {
+	Tables []string
+	Chains []NftChain
+	Rules  []NftRule
+}
+
+// DumpNftRuleset shells out to `nft -j list ruleset` and parses the result.
+// Fails the test on parse errors. Empty ruleset is not an error — the dump is
+// returned with zero-length slices.
+func DumpNftRuleset(t *testing.T) NftDump {
+	t.Helper()
+	out, err := exec.Command("nft", "-j", "list", "ruleset").CombinedOutput()
+	if err != nil {
+		t.Fatalf("nft -j list ruleset: %v (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	dump, err := parseNftDump(out)
+	if err != nil {
+		t.Fatalf("parse nft json: %v (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	return dump
+}
+
+// parseNftDump is split out from DumpNftRuleset so unit tests (if added later)
+// can exercise the parser without needing nft on the host.
+func parseNftDump(data []byte) (NftDump, error) {
+	var top struct {
+		Nftables []map[string]json.RawMessage `json:"nftables"`
+	}
+	if err := json.Unmarshal(data, &top); err != nil {
+		return NftDump{}, fmt.Errorf("decode top-level: %w", err)
+	}
+	var dump NftDump
+	for _, item := range top.Nftables {
+		// Each element has exactly one key (table, chain, rule, set, …).
+		for kind, raw := range item {
+			switch kind {
+			case "table":
+				var t struct {
+					Family string `json:"family"`
+					Name   string `json:"name"`
+				}
+				if err := json.Unmarshal(raw, &t); err != nil {
+					return NftDump{}, fmt.Errorf("decode table: %w", err)
+				}
+				dump.Tables = append(dump.Tables, t.Family+":"+t.Name)
+			case "chain":
+				var c struct {
+					Family string `json:"family"`
+					Table  string `json:"table"`
+					Name   string `json:"name"`
+					Type   string `json:"type"`
+					Hook   string `json:"hook"`
+					Prio   any    `json:"prio"`
+					Policy string `json:"policy"`
+				}
+				if err := json.Unmarshal(raw, &c); err != nil {
+					return NftDump{}, fmt.Errorf("decode chain: %w", err)
+				}
+				dump.Chains = append(dump.Chains, NftChain{
+					Family: c.Family, Table: c.Table, Name: c.Name,
+					Type: c.Type, Hook: c.Hook, Prio: c.Prio, Policy: c.Policy,
+				})
+			case "rule":
+				var r struct {
+					Family string           `json:"family"`
+					Table  string           `json:"table"`
+					Chain  string           `json:"chain"`
+					Handle int              `json:"handle"`
+					Expr   []map[string]any `json:"expr"`
+				}
+				if err := json.Unmarshal(raw, &r); err != nil {
+					return NftDump{}, fmt.Errorf("decode rule: %w", err)
+				}
+				dump.Rules = append(dump.Rules, NftRule{
+					Family: r.Family, Table: r.Table, Chain: r.Chain,
+					Handle: r.Handle, Expr: r.Expr, Raw: raw,
+				})
+			}
+		}
+	}
+	return dump, nil
+}
+
+// HasTable returns true if the dump contains an `ip`-family table named name.
+func (d NftDump) HasTable(name string) bool {
+	for _, t := range d.Tables {
+		if t == "ip:"+name {
+			return true
+		}
+	}
+	return false
+}
+
+// Chain returns the named (table, chain) header. ok=false if missing.
+func (d NftDump) Chain(table, name string) (NftChain, bool) {
+	for _, c := range d.Chains {
+		if c.Table == table && c.Name == name {
+			return c, true
+		}
+	}
+	return NftChain{}, false
+}
+
+// RulesIn returns rules in the (table, chain), in their nft load order.
+func (d NftDump) RulesIn(table, chain string) []NftRule {
+	var out []NftRule
+	for _, r := range d.Rules {
+		if r.Table == table && r.Chain == chain {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// =============================================================================
+// Rule-level matchers — composed over the parsed expression tree.
+// All numeric values from the JSON arrive as float64 (encoding/json default);
+// the matchers normalise both sides before comparing.
+// =============================================================================
+
+// HasMatch returns true iff the rule contains a {"match": {"op": "==",
+// "left": {"payload": {"protocol": <protocol>, "field": <field>}},
+// "right": <value>}} expression.
+func (r NftRule) HasMatch(protocol, field string, value any) bool {
+	for _, stmt := range r.Expr {
+		m, ok := stmt["match"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if op, _ := m["op"].(string); op != "==" {
+			continue
+		}
+		left, _ := m["left"].(map[string]any)
+		payload, _ := left["payload"].(map[string]any)
+		if p, _ := payload["protocol"].(string); p != protocol {
+			continue
+		}
+		if f, _ := payload["field"].(string); f != field {
+			continue
+		}
+		if jsonEq(m["right"], value) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasMatchPrefix asserts the rule has an `ip saddr <addr>/<len>`-style match
+// where the right-hand side is a CIDR. nft renders these as {"match": {"op":
+// "==", "left": {"payload": {...}}, "right": {"prefix": {"addr": addr,
+// "len": len}}}}.
+func (r NftRule) HasMatchPrefix(protocol, field, cidr string) bool {
+	addr, prefixLen, ok := splitCIDR(cidr)
+	if !ok {
+		return false
+	}
+	for _, stmt := range r.Expr {
+		m, ok := stmt["match"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if op, _ := m["op"].(string); op != "==" {
+			continue
+		}
+		left, _ := m["left"].(map[string]any)
+		payload, _ := left["payload"].(map[string]any)
+		if p, _ := payload["protocol"].(string); p != protocol {
+			continue
+		}
+		if f, _ := payload["field"].(string); f != field {
+			continue
+		}
+		right, _ := m["right"].(map[string]any)
+		prefix, _ := right["prefix"].(map[string]any)
+		if a, _ := prefix["addr"].(string); a != addr {
+			continue
+		}
+		if !jsonEq(prefix["len"], prefixLen) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// HasDNATTo asserts the rule has a single-target {"dnat": {"addr": addr,
+// "port": port, "family": "ip"}} statement. Pass port=0 to skip the port check.
+func (r NftRule) HasDNATTo(addr string, port int) bool {
+	for _, stmt := range r.Expr {
+		d, ok := stmt["dnat"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if a, _ := d["addr"].(string); a != addr {
+			continue
+		}
+		if port != 0 {
+			if !jsonEq(d["port"], port) {
+				continue
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// HasDNATMap asserts the rule has a jhash-based DNAT map containing exactly
+// the given backends (ordered, indexed 0..n-1). Implementation note: nft
+// renders multi-backend rules as `dnat to jhash ip saddr mod N map { ... }`,
+// which decodes as a {"dnat":{"addr":{"map":{"key":{"jhash":...},"data":{"set":[...]}}}}}
+// expression. We walk the structure and verify the `set` payload pairs
+// `[index, [addr, port]]` against the expected list.
+func (r NftRule) HasDNATMap(backends []NftBackend) bool {
+	for _, stmt := range r.Expr {
+		d, ok := stmt["dnat"].(map[string]any)
+		if !ok {
+			continue
+		}
+		addr, ok := d["addr"].(map[string]any)
+		if !ok {
+			continue
+		}
+		mp, ok := addr["map"].(map[string]any)
+		if !ok {
+			continue
+		}
+		// data is `{"set": [[idx, [addr, port]], ...]}`.
+		data, ok := mp["data"].(map[string]any)
+		if !ok {
+			continue
+		}
+		set, ok := data["set"].([]any)
+		if !ok || len(set) != len(backends) {
+			continue
+		}
+		ok = true
+		for i, entry := range set {
+			pair, _ := entry.([]any)
+			if len(pair) != 2 {
+				ok = false
+				break
+			}
+			if !jsonEq(pair[0], i) {
+				ok = false
+				break
+			}
+			target, _ := pair[1].(map[string]any)
+			concat, _ := target["concat"].([]any)
+			if len(concat) != 2 {
+				ok = false
+				break
+			}
+			if a, _ := concat[0].(string); a != backends[i].Addr {
+				ok = false
+				break
+			}
+			if !jsonEq(concat[1], backends[i].Port) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+// NftBackend is one entry in a multi-backend DNAT map.
+type NftBackend struct {
+	Addr string
+	Port int
+}
+
+// HasCTZoneSet asserts the rule has a {"mangle": {"key": {"ct": {"key":
+// "zone"}}, "value": <zone>}} statement (nft renders `ct zone set N` as a
+// mangle on the ct zone key).
+func (r NftRule) HasCTZoneSet(zone int) bool {
+	for _, stmt := range r.Expr {
+		m, ok := stmt["mangle"].(map[string]any)
+		if !ok {
+			continue
+		}
+		key, _ := m["key"].(map[string]any)
+		ct, _ := key["ct"].(map[string]any)
+		if k, _ := ct["key"].(string); k != "zone" {
+			continue
+		}
+		if jsonEq(m["value"], zone) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasMarkSet asserts the rule has a {"mangle": {"key": {"meta": {"key":
+// "mark"}}, "value": <mark>}} statement (nft renders `meta mark set N` as a
+// mangle on meta mark).
+func (r NftRule) HasMarkSet(mark int) bool {
+	for _, stmt := range r.Expr {
+		m, ok := stmt["mangle"].(map[string]any)
+		if !ok {
+			continue
+		}
+		key, _ := m["key"].(map[string]any)
+		meta, _ := key["meta"].(map[string]any)
+		if k, _ := meta["key"].(string); k != "mark" {
+			continue
+		}
+		if jsonEq(m["value"], mark) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasMasquerade asserts the rule contains a {"masquerade": null} (or empty
+// map) statement.
+func (r NftRule) HasMasquerade() bool {
+	for _, stmt := range r.Expr {
+		if _, ok := stmt["masquerade"]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// HasCTStatusDNAT asserts the rule matches `ct status dnat`. nft renders this
+// as {"match": {"op": "in", "left": {"ct": {"key": "status"}}, "right": "dnat"}}.
+func (r NftRule) HasCTStatusDNAT() bool {
+	for _, stmt := range r.Expr {
+		m, ok := stmt["match"].(map[string]any)
+		if !ok {
+			continue
+		}
+		left, _ := m["left"].(map[string]any)
+		ct, _ := left["ct"].(map[string]any)
+		if k, _ := ct["key"].(string); k != "status" {
+			continue
+		}
+		if right, _ := m["right"].(string); right == "dnat" {
+			return true
+		}
+	}
+	return false
+}
+
+// =============================================================================
+// Polling wrappers
+// =============================================================================
+
+// EventuallyNft polls DumpNftRuleset every 200ms until predicate returns
+// true or timeout expires. msg is included in the failure message.
+func EventuallyNft(t *testing.T, predicate func(NftDump) bool, timeout time.Duration, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		// Allow nft to be empty-ruleset transient — that's not an error.
+		out, err := exec.Command("nft", "-j", "list", "ruleset").CombinedOutput()
+		if err == nil {
+			if dump, perr := parseNftDump(out); perr == nil && predicate(dump) {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("EventuallyNft timed out after %s: %s", timeout, msg)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// AssertNftTableAbsent fails the test if the named ip-family table persists
+// past timeout. Used to verify cleanup on SIGTERM.
+func AssertNftTableAbsent(t *testing.T, table string, timeout time.Duration) {
+	t.Helper()
+	EventuallyNft(t, func(d NftDump) bool { return !d.HasTable(table) }, timeout,
+		fmt.Sprintf("table ip %s should be absent", table))
+}
+
+// AssertNftRuleInChain fails the test if no rule in (table, chain) satisfies
+// match within timeout. msg is included in the failure message.
+func AssertNftRuleInChain(t *testing.T, table, chain string, match func(NftRule) bool, timeout time.Duration, msg string) {
+	t.Helper()
+	EventuallyNft(t, func(d NftDump) bool {
+		for _, r := range d.RulesIn(table, chain) {
+			if match(r) {
+				return true
+			}
+		}
+		return false
+	}, timeout, fmt.Sprintf("chain %s/%s: %s", table, chain, msg))
+}
+
+// AssertNftChainExists fails the test if the named chain is missing within
+// timeout. The chain is identified by (table, name).
+func AssertNftChainExists(t *testing.T, table, chain string, timeout time.Duration) {
+	t.Helper()
+	EventuallyNft(t, func(d NftDump) bool {
+		_, ok := d.Chain(table, chain)
+		return ok
+	}, timeout, fmt.Sprintf("chain %s/%s should exist", table, chain))
+}
+
+// =============================================================================
+// JSON value comparison helpers
+// =============================================================================
+
+// jsonEq compares a JSON-decoded value (typically float64 for numbers) against
+// a Go literal. It treats numeric types as equal if they have the same value.
+func jsonEq(decoded, expected any) bool {
+	if decoded == nil {
+		return expected == nil
+	}
+	// Numeric: encoding/json decodes JSON numbers to float64, but tests
+	// pass int/int64 literals.
+	if df, ok := numeric(decoded); ok {
+		if ef, ok := numeric(expected); ok {
+			return df == ef
+		}
+	}
+	// Strings, bools, slices, maps fall through to deep equality.
+	return fmt.Sprintf("%v", decoded) == fmt.Sprintf("%v", expected)
+}
+
+func numeric(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	}
+	return 0, false
+}
+
+// splitCIDR parses "addr/len" into its components without bringing in net.
+// Returns false on a malformed CIDR; tests catch this as a "no match" rather
+// than a hard fail because matchers are designed to be composable.
+func splitCIDR(cidr string) (string, int, bool) {
+	for i := len(cidr) - 1; i >= 0; i-- {
+		if cidr[i] == '/' {
+			n, err := parsePositiveInt(cidr[i+1:])
+			if err != nil {
+				return "", 0, false
+			}
+			return cidr[:i], n, true
+		}
+	}
+	return "", 0, false
+}
+
+func parsePositiveInt(s string) (int, error) {
+	if s == "" {
+		return 0, fmt.Errorf("empty")
+	}
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, fmt.Errorf("non-digit")
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n, nil
+}

--- a/test/integration/testenv/portforward.go
+++ b/test/integration/testenv/portforward.go
@@ -1,0 +1,194 @@
+//go:build integration
+
+package testenv
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// PortForwardLoopbackDev is the device name the agent's port_forward_dev
+// defaults to, and which setup.sh provisions inside vrf-provider.
+const PortForwardLoopbackDev = "loopback1"
+
+// Sysctl paths the agent's port-forward feature mutates on a global basis
+// (per-device sysctls go away with the veth pair so we don't track them
+// here). Tests that flip these must save/restore via SaveSysctl.
+const (
+	SysctlUDPL3mdevAccept = "/proc/sys/net/ipv4/udp_l3mdev_accept"
+	SysctlTCPL3mdevAccept = "/proc/sys/net/ipv4/tcp_l3mdev_accept"
+)
+
+// EnsureLoopback1 checks that the loopback1 dummy device exists and is
+// enslaved to vrf-provider. It does *not* create the device — that is
+// setup.sh's job and a missing device means the host was not bootstrapped.
+// Tests skip rather than fail in that case, mirroring how Setup() handles
+// missing prerequisites.
+func EnsureLoopback1(t *testing.T) {
+	t.Helper()
+	if _, err := net.InterfaceByName(PortForwardLoopbackDev); err != nil {
+		t.Skipf("device %s not present (run test/integration/setup.sh first): %v",
+			PortForwardLoopbackDev, err)
+	}
+	// Best-effort verify it is enslaved to vrf-provider; not all kernels
+	// expose this in /proc, so a failure here is informational only.
+	out, err := exec.Command("ip", "-d", "link", "show", PortForwardLoopbackDev).CombinedOutput()
+	if err == nil && !strings.Contains(string(out), "vrf-provider") {
+		t.Logf("warning: %s does not appear to be in vrf-provider (output: %s)",
+			PortForwardLoopbackDev, strings.TrimSpace(string(out)))
+	}
+}
+
+// AssertVIPOnLoopback fails the test if `ip -j addr show dev loopback1` does
+// not list vip/32 within timeout.
+func AssertVIPOnLoopback(t *testing.T, vip string, timeout time.Duration) {
+	t.Helper()
+	if net.ParseIP(vip) == nil {
+		t.Fatalf("AssertVIPOnLoopback: invalid IP %q", vip)
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		if vipPresentOnLoopback(t, vip) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("VIP %s/32 not present on %s after %s",
+				vip, PortForwardLoopbackDev, timeout)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// AssertVIPNotOnLoopback fails the test if vip persists on loopback1 past
+// timeout. Used to verify manage_vip:false leaves the device alone and that
+// teardown removes managed VIPs.
+func AssertVIPNotOnLoopback(t *testing.T, vip string, timeout time.Duration) {
+	t.Helper()
+	if net.ParseIP(vip) == nil {
+		t.Fatalf("AssertVIPNotOnLoopback: invalid IP %q", vip)
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		if !vipPresentOnLoopback(t, vip) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("VIP %s/32 still present on %s after %s",
+				vip, PortForwardLoopbackDev, timeout)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func vipPresentOnLoopback(t *testing.T, vip string) bool {
+	t.Helper()
+	out, err := exec.Command("ip", "-j", "-4", "addr", "show", "dev", PortForwardLoopbackDev).CombinedOutput()
+	if err != nil {
+		return false
+	}
+	type addrInfo struct {
+		Local     string `json:"local"`
+		Prefixlen int    `json:"prefixlen"`
+	}
+	var entries []struct {
+		AddrInfo []addrInfo `json:"addr_info"`
+	}
+	if err := json.Unmarshal(out, &entries); err != nil {
+		return false
+	}
+	for _, e := range entries {
+		for _, a := range e.AddrInfo {
+			if a.Local == vip && a.Prefixlen == 32 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// SaveSysctl reads the current value of path and registers a t.Cleanup that
+// writes it back. Returns the saved value. Used for global sysctls like
+// udp_l3mdev_accept where a leak would silently change kernel behaviour for
+// every subsequent test on the host.
+func SaveSysctl(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read sysctl %s: %v", path, err)
+	}
+	original := strings.TrimSpace(string(data))
+	t.Cleanup(func() {
+		if err := os.WriteFile(path, []byte(original+"\n"), 0o644); err != nil {
+			t.Logf("restore sysctl %s=%s: %v", path, original, err)
+		}
+	})
+	return original
+}
+
+// AssertSysctl reads path and fails the test if the trimmed contents do not
+// equal want within timeout.
+func AssertSysctl(t *testing.T, path, want string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last string
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			last = strings.TrimSpace(string(data))
+			if last == want {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("sysctl %s = %q, want %q (after %s)", path, last, want, timeout)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// ScrubPortForwardResidue is the exported entry point for tests that want to
+// scrub port-forward state without going through the full Setup/Teardown
+// pair. Internally it just delegates to scrubPortForwardState.
+func ScrubPortForwardResidue(t *testing.T) {
+	t.Helper()
+	scrubPortForwardState(t)
+}
+
+// scrubPortForwardState removes all per-test residue of the agent's
+// port-forward feature: managed addresses on loopback1, fwmark ip rules at
+// priorities 150/151, the entire port-forward routing table (default 201),
+// and the agent's nft table. Best-effort — used between scenarios so a
+// failed test does not poison the next.
+func scrubPortForwardState(t *testing.T) {
+	t.Helper()
+
+	// Flush all addresses on loopback1. The device itself stays in place
+	// (setup.sh created it and tests share it).
+	if _, err := net.InterfaceByName(PortForwardLoopbackDev); err == nil {
+		_ = exec.Command("ip", "addr", "flush", "dev", PortForwardLoopbackDev).Run()
+	}
+
+	// Remove DNAT fwmark policy rules. RuleDel via netlink would require
+	// importing the agent's package; the `ip rule del` form by priority is
+	// idempotent enough for cleanup.
+	for _, prio := range []string{"150", "151"} {
+		_ = exec.Command("ip", "rule", "del", "priority", prio).Run()
+	}
+
+	// Flush the port-forward reply table (default 201). If the test used a
+	// non-default table we don't know it here — but the default-table flush
+	// is the safe path for the harness's typical Defaults() config.
+	_ = exec.Command("ip", "route", "flush", "table", "201").Run()
+
+	// Drop the agent's nft table. Already covered by scrubLocalState, but
+	// repeating it here makes scrubPortForwardState self-contained for
+	// callers that need just port-forward cleanup.
+	if out, err := exec.Command("nft", "list", "table", "ip", DefaultNftTable).CombinedOutput(); err == nil && len(out) > 0 {
+		_ = exec.Command("nft", "delete", "table", "ip", DefaultNftTable).Run()
+	}
+}

--- a/test/integration/testenv/testenv.go
+++ b/test/integration/testenv/testenv.go
@@ -120,6 +120,12 @@ func Teardown(t *testing.T) {
 			}
 		}
 	}
+
+	// Port-forward residue: managed VIPs on loopback1, fwmark ip rules at
+	// priorities 150/151, and the port-forward reply table (default 201).
+	// Idempotent — port-forward scenarios that did not run pay only the
+	// cost of a few quick "no such process" exits.
+	scrubPortForwardState(t)
 }
 
 // frrStaticRoutes returns the /32 static routes currently present in the


### PR DESCRIPTION
Adds the eight scenarios from #43 covering DNAT, sticky multi-backend hashing, VIP management, per-rule and hairpin masquerade, l3mdev sysctls, output chains, and SIGTERM cleanup. Assertions parse `nft -j list ruleset` JSON via typed matchers (no regex on text), and Teardown plus a defensive start-of-scenario scrub keep state from leaking between tests.

Closes #43

AI-assisted: Claude Code