### PR TITLE
test(integration): add harness primitives FastDefaults, WithAgent, du…

### DIFF
--- a/test/integration/scenario_port_forward_test.go
+++ b/test/integration/scenario_port_forward_test.go
@@ -60,6 +60,12 @@ func startPFScenario(t *testing.T) testenv.AgentConfig {
 	// agent up. The Setup-registered Teardown handles the trailing edge.
 	testenv.ScrubPortForwardResidue(t)
 
+	// On failure, dump host-side state for postmortem diagnosis. PF
+	// scenarios that also call startScenario already register the OVN
+	// dump via that helper; calling RegisterFailureDump here covers PF
+	// scenarios that drive only nft/loopback state without OVN clients.
+	testenv.RegisterFailureDump(t)
+
 	return pfDefaults(t)
 }
 

--- a/test/integration/scenarios_helpers_test.go
+++ b/test/integration/scenarios_helpers_test.go
@@ -60,6 +60,17 @@ func startScenario(t *testing.T) (context.Context, context.CancelFunc, client.Cl
 	testenv.ResetOVNState(t, ctx, nb, sb)
 	t.Cleanup(func() { testenv.ResetOVNState(t, context.Background(), nb, sb) })
 
+	// On failure, dump enough state for postmortem diagnosis without an
+	// operator having to ssh in and re-run commands. ctx may be cancelled
+	// by the time cleanup runs (the scenario context has a 90s ceiling),
+	// so use a fresh background context for the OVN dump.
+	t.Cleanup(func() {
+		if t.Failed() {
+			dumpOVNState(t, context.Background(), nb, sb)
+			testenv.DumpHostState(t)
+		}
+	})
+
 	return ctx, cancel, nb, sb
 }
 

--- a/test/integration/testenv/agent.go
+++ b/test/integration/testenv/agent.go
@@ -91,6 +91,16 @@ func Defaults() AgentConfig {
 	}
 }
 
+// FastDefaults is Defaults() with a tightened reconcile interval. Use it for
+// scenarios that need to observe drift recovery, stale-chassis cleanup, or
+// any other periodic behaviour without paying the full 5s production tick.
+// Tests that must mirror production timing should keep using Defaults().
+func FastDefaults() AgentConfig {
+	cfg := Defaults()
+	cfg.ReconcileInterval = "2s"
+	return cfg
+}
+
 // AgentProc is a handle to a running agent subprocess.
 type AgentProc struct {
 	t       *testing.T
@@ -159,6 +169,35 @@ func RunAgent(t *testing.T, cfg AgentConfig) *AgentProc {
 	})
 
 	return p
+}
+
+// WithAgent is the convenience composition of RunAgent + WaitReady + a
+// deferred Stop registered via t.Cleanup. It is the right helper for the
+// common shape of "spin up an agent against this config, run a scenario,
+// let SIGTERM-on-exit do the cleanup".
+//
+// Tests that need to assert on Stop() ordering or timing (drain-on-shutdown,
+// SIGTERM cleanup verification) should keep using RunAgent + manual Stop —
+// WithAgent's cleanup runs after t returns, which is too late for those
+// assertions. The cleanup tolerates a prior manual Stop because AgentProc
+// dedupes on its `stopped` flag.
+func WithAgent(t *testing.T, cfg AgentConfig) *AgentProc {
+	t.Helper()
+	a := RunAgent(t, cfg)
+
+	readyCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := a.WaitReady(readyCtx); err != nil {
+		t.Fatalf("agent did not become ready: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if err := a.Stop(15 * time.Second); err != nil {
+			t.Errorf("agent stop in WithAgent cleanup: %v", err)
+		}
+	})
+
+	return a
 }
 
 // scanStderr forwards agent stderr to t.Log, buffers it for diagnostics,

--- a/test/integration/testenv/dump.go
+++ b/test/integration/testenv/dump.go
@@ -1,0 +1,63 @@
+//go:build integration
+
+package testenv
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// DumpHostState logs the host-side state most relevant to diagnosing a
+// scenario failure: the agent's nft ruleset, /4 and /6 routes on the test
+// bridge, OVS flows tagged with the agent's cookies, and FRR static routes
+// in the test VRF for both address families.
+//
+// Output goes to t.Logf so it never compounds an existing failure into a
+// fresh one. Best-effort — commands that fail (binary missing, no rules
+// installed, etc.) log the error alongside the empty-or-error output.
+func DumpHostState(t *testing.T) {
+	t.Helper()
+
+	runs := []struct {
+		name string
+		argv []string
+	}{
+		{"nft list ruleset", []string{"nft", "list", "ruleset"}},
+		{"ip -4 route show dev " + DefaultBridgeDev, []string{"ip", "-4", "route", "show", "dev", DefaultBridgeDev}},
+		{"ip -6 route show dev " + DefaultBridgeDev, []string{"ip", "-6", "route", "show", "dev", DefaultBridgeDev}},
+		{"ovs-ofctl dump-flows " + DefaultBridgeDev + " cookie=0x999/-1", []string{"ovs-ofctl", "dump-flows", DefaultBridgeDev, "cookie=0x999/-1"}},
+		{"ovs-ofctl dump-flows " + DefaultBridgeDev + " cookie=0x998/-1", []string{"ovs-ofctl", "dump-flows", DefaultBridgeDev, "cookie=0x998/-1"}},
+		{"vtysh show ip route vrf " + DefaultVRFName + " static", []string{"vtysh", "-c", "show ip route vrf " + DefaultVRFName + " static"}},
+		{"vtysh show ipv6 route vrf " + DefaultVRFName + " static", []string{"vtysh", "-c", "show ipv6 route vrf " + DefaultVRFName + " static"}},
+	}
+
+	t.Logf("=== host state dump ===")
+	for _, r := range runs {
+		out, err := exec.Command(r.argv[0], r.argv[1:]...).CombinedOutput()
+		text := strings.TrimRight(string(out), "\n")
+		switch {
+		case err != nil:
+			t.Logf("--- %s --- (err: %v)\n%s", r.name, err, text)
+		case strings.TrimSpace(text) == "":
+			t.Logf("--- %s --- (empty)", r.name)
+		default:
+			t.Logf("--- %s ---\n%s", r.name, text)
+		}
+	}
+	t.Logf("=== end host state dump ===")
+}
+
+// RegisterFailureDump registers a t.Cleanup that calls DumpHostState only
+// when the test has failed by the time the cleanup runs. Tests that pass pay
+// nothing; failing tests get a single self-contained snapshot in their log
+// output instead of forcing an operator to ssh in and re-run commands by
+// hand.
+func RegisterFailureDump(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		if t.Failed() {
+			DumpHostState(t)
+		}
+	})
+}

--- a/test/integration/testenv/testenv.go
+++ b/test/integration/testenv/testenv.go
@@ -8,6 +8,32 @@
 // ovn-controller, FRR, nftables, br-ex) has already been provisioned by
 // test/integration/setup.sh. Setup verifies the prerequisites and records
 // initial state; Teardown best-effort restores it.
+//
+// # Lifecycle of a scenario test
+//
+// Every test should follow this shape so cleanup is reliable even when the
+// test fails:
+//
+//  1. Call testenv.Setup(t) first. It performs prerequisite checks (Linux,
+//     root, br-ex, required binaries) and registers a t.Cleanup that runs
+//     Teardown. Tests that need OVN should also call PauseOVNNorthd /
+//     PauseOVNController via the higher-level startScenario helper in the
+//     test package.
+//  2. Drive desired state — write to NB/SB via the libovsdb clients, configure
+//     the agent via AgentConfig, run it via RunAgent or WithAgent.
+//  3. Assert outcomes via the Assert* helpers (AssertKernelRoute,
+//     AssertOVSFlow, AssertFRRRoute, AssertNftRuleInChain). Prefer the
+//     polling forms — these tests race against an event-driven daemon.
+//  4. On exit, the Teardown registered in step 1 runs scrubLocalState +
+//     scrubPortForwardState, undoing whatever the agent installed. The
+//     dump-on-fail hook in startScenario logs the surviving state if the
+//     test failed, so the failure log is self-contained.
+//
+// All cleanup is best-effort and idempotent: between tests the harness flushes
+// the agent's nft table, kernel /32 routes on br-ex, FRR static routes in the
+// VRF, OVS flows tagged with the agent's cookies, and port-forward residue
+// (loopback addresses, fwmark ip rules, the reply table). One failing test
+// must not poison the next.
 package testenv
 
 import (


### PR DESCRIPTION
…mp-on-fail

Tightens the integration harness without migrating any existing scenarios:

- FastDefaults() returns Defaults() with a 2s reconcile interval, so future drift-recovery and stale-chassis tests don't pay the production 5s tick.
- WithAgent(t, cfg) composes RunAgent + WaitReady + deferred Stop. Tests that need to time SIGTERM (drain, cleanup-on-shutdown) keep using RunAgent.
- DumpHostState / RegisterFailureDump log nft, br-ex routes (v4/v6), agent OVS cookies, and FRR static routes when t.Failed(). startScenario also dumps the OVN side via dumpOVNState, making failure logs self-contained.
- Lifecycle doc block in testenv.go for new contributors.

Items 4-7 from #65 (Eventually-with-diff, FreeTCPPort, family-parameterised FRR helpers, central priority constants) intentionally left for follow-up PRs per the issue's acceptance criteria.

Part of #65

AI-assisted: Claud Code