### PR TITLE
test(integration): add layer 2 veth-leak lifecycle scenarios

### DIFF
--- a/routing_linux.go
+++ b/routing_linux.go
@@ -623,7 +623,23 @@ func (rm *RouteManager) ReconcileVethLeakNetworks(desired []*net.IPNet) error {
 		desiredSet[n.String()] = n
 	}
 
-	// Add missing per-network routes and rules.
+	// Discover current per-network policy rules. Tracked separately from
+	// routes because rules and routes can drift independently — an operator
+	// running `ip rule del ...` removes the rule while the route remains,
+	// and the next reconcile must observe and reinstall just the rule.
+	allRules, ruleListErr := netlink.RuleList(netlink.FAMILY_V4)
+	if ruleListErr != nil {
+		slog.Warn("failed to list policy rules", "error", ruleListErr)
+	}
+	currentRules := make(map[string]bool, len(allRules))
+	for _, r := range allRules {
+		if r.Table != rm.vethLeakTableID || r.Priority != rm.vethLeakRulePriority || r.Src == nil {
+			continue
+		}
+		currentRules[r.Src.String()] = true
+	}
+
+	// Add missing per-network routes.
 	for key, network := range desiredSet {
 		if currentNets[key] {
 			continue
@@ -637,7 +653,16 @@ func (rm *RouteManager) ReconcileVethLeakNetworks(desired []*net.IPNet) error {
 		}); err != nil {
 			return fmt.Errorf("add VRF route for %s: %w", network, err)
 		}
+		slog.Info("veth leak network route added", "network", network)
+	}
 
+	// Add missing per-network policy rules. Decoupled from the route loop
+	// above — when only the rule was deleted, the route already exists and
+	// the route loop is a no-op, but the rule still needs to be re-added.
+	for key, network := range desiredSet {
+		if currentRules[key] {
+			continue
+		}
 		rule := netlink.NewRule()
 		rule.Src = network
 		rule.Table = rm.vethLeakTableID
@@ -647,7 +672,7 @@ func (rm *RouteManager) ReconcileVethLeakNetworks(desired []*net.IPNet) error {
 				return fmt.Errorf("add policy rule for %s: %w", network, err)
 			}
 		}
-		slog.Info("veth leak network added", "network", network)
+		slog.Info("veth leak network rule added", "network", network)
 	}
 
 	// Remove stale per-network routes and rules.

--- a/test/integration/scenario_vethleak_test.go
+++ b/test/integration/scenario_vethleak_test.go
@@ -1,0 +1,246 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/osism/ovn-network-agent/test/integration/testenv"
+)
+
+// All scenarios in this file cover #56 — the agent's veth-leak lifecycle.
+//
+// Three pieces of state are under test:
+//
+//   - SetupVethLeak: a `veth-default`/`veth-provider` pair created on agent
+//     startup. veth-provider is enslaved to vrf-provider; the leak table
+//     (default 200) holds the default route via veth-default.
+//   - ReconcileVethLeakNetworks: per-network VRF routes (proto 44 in the VRF's
+//     table) and per-network policy rules at the agent's priority (default
+//     2000), reconciled every cycle from the locally-active routers' LRP
+//     networks.
+//   - TeardownVethLeak: on SIGTERM, the agent's cleanup() removes the policy
+//     rules, leak-table default route, per-network VRF routes, and finally
+//     the veth pair itself.
+//
+// Without coverage here, the surface area is only exercised transitively by
+// the FIP and port-forward scenarios, which never assert on the actual
+// netlink state. A regression that, e.g., dropped the proto-44 tag or
+// stopped reconciling stale ip-rules would slip through CI.
+//
+// Each scenario uses testenv.FastDefaults() (2s reconcile) where the test
+// observes drift recovery; otherwise testenv.Defaults() (5s) keeps timing
+// closer to production.
+
+// TestScenario_VethLeakSetup (#56 scenario 1):
+//
+// Cold start: agent connects, runs initial reconcile, becomes ready. By the
+// time WaitReady returns the veth pair must exist, both ends must be up,
+// veth-provider must be enslaved to vrf-provider, and the leak table must
+// hold the agent's default route.
+//
+// SetupVethLeak runs before OVN.Connect (agent.go:90), so this assertion
+// holds regardless of OVN logical state. There is no local router in this
+// scenario, so per-network entries are not expected.
+func TestScenario_VethLeakSetup(t *testing.T) {
+	_, cancel, _, _ := startScenario(t)
+	defer cancel()
+
+	testenv.WithAgent(t, testenv.Defaults())
+
+	testenv.AssertVethPairPresent(t, 5*time.Second)
+	testenv.AssertVethDefaultRouteInLeakTable(t, 5*time.Second)
+}
+
+// TestScenario_VethLeakReconcileNetwork (#56 scenario 2):
+//
+// With one locally-active router carrying LRP 198.51.100.11/24, the agent's
+// next reconcile must install:
+//
+//   - 198.51.100.0/24 via 169.254.0.1 dev veth-provider proto 44 in the VRF
+//     table
+//   - ip rule from 198.51.100.0/24 lookup <leak-table> priority <agent-priority>
+//
+// The router is created before agent start so the startup reconcile observes
+// it; that path also exercises SetupVethLeak's "if len(networkFilters) > 0,
+// run an initial ReconcileVethLeakNetworks" branch (routing_linux.go:471).
+func TestScenario_VethLeakReconcileNetwork(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	const network = "198.51.100.0/24"
+	testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "vethnet",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	testenv.WithAgent(t, testenv.Defaults())
+
+	testenv.AssertVethPairPresent(t, 5*time.Second)
+	testenv.AssertVethRouteInVRF(t, network, 15*time.Second)
+	testenv.AssertIPRuleAtPriority(t, testenv.DefaultVethLeakRulePriority, network, 15*time.Second)
+}
+
+// TestScenario_VethLeakDriftRecovery (#56 scenario 3):
+//
+// With the per-network rule installed, deleting it out of band must be
+// detected by the periodic reconcile and re-installed within at most a
+// couple of ticks. The agent's recovery path is the policy-rule sweep at
+// the end of ReconcileVethLeakNetworks (routing_linux.go:678).
+//
+// FastDefaults ticks at 2s, so we allow up to ~3 ticks before failing —
+// drift recovery is a best-effort property and asserting on a single tick
+// would be flaky on a busy CI runner.
+func TestScenario_VethLeakDriftRecovery(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	const network = "198.51.100.0/24"
+	testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "vethdrift",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	testenv.WithAgent(t, testenv.FastDefaults())
+
+	testenv.AssertIPRuleAtPriority(t, testenv.DefaultVethLeakRulePriority, network, 10*time.Second)
+
+	// Drift: rip the policy rule out from under the agent. The next
+	// reconcile cycle must observe it as missing and reinstall it.
+	testenv.DeleteIPRule(t, testenv.DefaultVethLeakRulePriority, network)
+
+	// Verify the deletion took effect — otherwise the re-add assertion
+	// below would pass trivially. Use a tight inner timeout so we fail fast
+	// if `ip rule del` did not actually remove the rule.
+	testenv.AssertNoIPRuleAtPriority(t, testenv.DefaultVethLeakRulePriority, network, 1*time.Second)
+
+	// Re-appears within reconcile_interval (2s) + processing slack.
+	testenv.AssertIPRuleAtPriority(t, testenv.DefaultVethLeakRulePriority, network, 8*time.Second)
+}
+
+// TestScenario_VethLeakStaleNetworkRemoval (#56 scenario 4):
+//
+// With two locally-active routers carrying distinct LRP networks, both
+// per-network routes and rules must be present. After deleting the second
+// router the agent must reap its entries within a couple of ticks while
+// leaving the first router's state untouched.
+//
+// The reaping path is the "Remove stale per-network routes and rules" loop
+// in ReconcileVethLeakNetworks (routing_linux.go:653). It compares
+// currentNets to desiredSet and deletes anything not in the desired set.
+func TestScenario_VethLeakStaleNetworkRemoval(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	const (
+		net1 = "198.51.100.0/24"
+		net2 = "203.0.113.0/24"
+	)
+	testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "vethstale1",
+		LRPMAC:      "fa:16:3e:11:22:33",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+	r2 := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "vethstale2",
+		LRPMAC:      "fa:16:3e:11:22:44",
+		LRPNetworks: []string{"203.0.113.11/24"},
+	})
+
+	testenv.WithAgent(t, testenv.FastDefaults())
+
+	// Both networks must show up.
+	testenv.AssertVethRouteInVRF(t, net1, 15*time.Second)
+	testenv.AssertVethRouteInVRF(t, net2, 15*time.Second)
+	testenv.AssertIPRuleAtPriority(t, testenv.DefaultVethLeakRulePriority, net1, 5*time.Second)
+	testenv.AssertIPRuleAtPriority(t, testenv.DefaultVethLeakRulePriority, net2, 5*time.Second)
+
+	// Remove the second router. The agent observes net2 as no longer
+	// in the desired set and reaps its route + rule.
+	deleteRouter(t, ctx, nb, r2.RouterUUID)
+
+	testenv.AssertNoVethRouteInVRF(t, net2, 15*time.Second)
+	testenv.AssertNoIPRuleAtPriority(t, testenv.DefaultVethLeakRulePriority, net2, 5*time.Second)
+
+	// net1 must remain — the test fails if the agent over-reaped.
+	testenv.AssertVethRouteInVRF(t, net1, 1*time.Second)
+	testenv.AssertIPRuleAtPriority(t, testenv.DefaultVethLeakRulePriority, net1, 1*time.Second)
+}
+
+// TestScenario_VethLeakTeardownOnSigterm (#56 scenario 5):
+//
+// With cleanup_on_shutdown=true (the agent default) and a per-network entry
+// installed, SIGTERM must cause TeardownVethLeak to:
+//
+//   - remove all policy rules at the agent's priority
+//   - flush proto-44 routes from the VRF table
+//   - delete the veth pair (one end suffices — the kernel removes both)
+//
+// We start a fresh agent so each phase is observable in isolation: install,
+// then SIGTERM, then assert teardown completed. The scenario uses RunAgent
+// + manual Stop rather than WithAgent because WithAgent's t.Cleanup runs
+// after t returns, which is too late for assertions on the post-SIGTERM
+// state.
+func TestScenario_VethLeakTeardownOnSigterm(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	const network = "198.51.100.0/24"
+	testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "vethteardown",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	cfg := testenv.Defaults()
+	cleanup := true
+	cfg.CleanupOnShutdown = &cleanup
+
+	a := readyAgent(t, cfg)
+
+	testenv.AssertVethPairPresent(t, 5*time.Second)
+	testenv.AssertVethRouteInVRF(t, network, 15*time.Second)
+	testenv.AssertIPRuleAtPriority(t, testenv.DefaultVethLeakRulePriority, network, 5*time.Second)
+
+	if err := a.Stop(20 * time.Second); err != nil {
+		t.Fatalf("agent stop: %v", err)
+	}
+
+	// Veth pair gone, per-network route gone, per-network rule gone.
+	testenv.AssertNoVethPair(t, 5*time.Second)
+	testenv.AssertNoVethRouteInVRF(t, network, 5*time.Second)
+	testenv.AssertNoIPRuleAtPriority(t, testenv.DefaultVethLeakRulePriority, network, 5*time.Second)
+}
+
+// TestScenario_VethLeakDisabledSkip (#56 scenario 6 — negative):
+//
+// With veth_leak_enabled=false the agent must skip SetupVethLeak entirely.
+// Counter-asserts scenario #1: even after the agent has been ready long
+// enough that any cold-start setup would have completed, neither end of
+// the veth pair must exist.
+//
+// PortForwardEnabled is left empty because port forwarding requires
+// veth_leak_enabled=true (config.go:430) — config validation would reject
+// this combination.
+func TestScenario_VethLeakDisabledSkip(t *testing.T) {
+	_, cancel, _, _ := startScenario(t)
+	defer cancel()
+
+	cfg := testenv.Defaults()
+	disabled := false
+	cfg.VethLeakEnabled = &disabled
+
+	a := testenv.RunAgent(t, cfg)
+	rctx, rcancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer rcancel()
+	if err := a.WaitReady(rctx); err != nil {
+		t.Fatalf("agent did not become ready: %v", err)
+	}
+	defer a.Stop(15 * time.Second)
+
+	// The agent reached "agent running" without setting up the pair —
+	// hold for a fraction of a reconcile interval to make sure the
+	// negative still holds across the next tick.
+	testenv.AssertNoVethPair(t, 1*time.Second)
+}

--- a/test/integration/scenarios_helpers_test.go
+++ b/test/integration/scenarios_helpers_test.go
@@ -74,6 +74,22 @@ func startScenario(t *testing.T) (context.Context, context.CancelFunc, client.Cl
 	return ctx, cancel, nb, sb
 }
 
+// deleteRouter removes a Logical_Router by UUID. OVSDB referential integrity
+// cascades to the LRP, NAT, Gateway_Chassis, and static_route children the
+// router owned, which is what the agent's local-router detection observes
+// when LRPs disappear from NB. Any SB chassisredirect Port_Binding /
+// Datapath_Binding seeded by MakeLocalRouter is left in place — it now
+// points at a non-existent LRP, so localLRPUUIDs[portUUID] in ovn.go no
+// longer includes it. End-of-test ResetOVNState scrubs the SB residue.
+func deleteRouter(t *testing.T, ctx context.Context, nb client.Client, routerUUID string) {
+	t.Helper()
+	ops, err := nb.Where(&testenv.NBLogicalRouter{UUID: routerUUID}).Delete()
+	if err != nil {
+		t.Fatalf("delete router op: %v", err)
+	}
+	testenv.Transact(t, ctx, nb, ops)
+}
+
 // readyAgent starts an agent with cfg and waits for the "agent running" log
 // line. The agent is stopped at test cleanup if the test forgot to do so.
 func readyAgent(t *testing.T, cfg testenv.AgentConfig) *testenv.AgentProc {

--- a/test/integration/testenv/assert.go
+++ b/test/integration/testenv/assert.go
@@ -304,4 +304,10 @@ func scrubLocalState(t *testing.T) {
 	// Port-forward residue: managed VIPs on loopback1, fwmark ip rules,
 	// the port-forward reply table. Calls into portforward.go.
 	scrubPortForwardState(t)
+
+	// Veth-leak residue: per-network policy rules at the agent's priority,
+	// the leak table, and the veth pair itself. SIGKILL'd agents (the test
+	// crashed before WithAgent's Stop ran) skip the agent's TeardownVethLeak,
+	// so without this scrub the next scenario inherits an enslaved veth pair.
+	scrubVethLeakState(t)
 }

--- a/test/integration/testenv/testenv.go
+++ b/test/integration/testenv/testenv.go
@@ -152,6 +152,13 @@ func Teardown(t *testing.T) {
 	// Idempotent — port-forward scenarios that did not run pay only the
 	// cost of a few quick "no such process" exits.
 	scrubPortForwardState(t)
+
+	// Veth-leak residue: per-network policy rules at the agent's priority,
+	// leak-table routes, and the veth pair itself. The agent recreates the
+	// pair on every startup, so smoke-style tests that don't go through
+	// startScenario / ResetOVNState still rely on this safety net to keep
+	// the next run from inheriting an enslaved veth pair.
+	scrubVethLeakState(t)
 }
 
 // frrStaticRoutes returns the /32 static routes currently present in the

--- a/test/integration/testenv/vethleak.go
+++ b/test/integration/testenv/vethleak.go
@@ -1,0 +1,466 @@
+//go:build integration
+
+package testenv
+
+import (
+	"encoding/json"
+	"net"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Veth-leak-related constants. They mirror the agent's defaults
+// (vethDefaultName/vethProviderName from routing.go and the table/priority
+// defaults from config.go) so scenario tests can refer to a single source of
+// truth instead of duplicating literals across files.
+const (
+	// VethDefaultName is the default-VRF side of the veth pair created by
+	// SetupVethLeak.
+	VethDefaultName = "veth-default"
+
+	// VethProviderName is the provider-VRF side of the veth pair. It is
+	// enslaved to vrf-provider on agent startup.
+	VethProviderName = "veth-provider"
+
+	// DefaultVethNexthop matches the agent's default veth_nexthop and is
+	// also what testenv.Defaults() configures: the address assigned to
+	// veth-default and the gateway for per-network VRF routes installed by
+	// ReconcileVethLeakNetworks.
+	DefaultVethNexthop = "169.254.0.1"
+
+	// DefaultVethProviderIP is the address assigned to veth-provider — the
+	// agent computes it as veth_nexthop + 1 when veth_provider_ip is unset.
+	DefaultVethProviderIP = "169.254.0.2"
+
+	// DefaultVethLeakTableID matches the agent's default veth_leak_table_id.
+	// The default route via veth-default lives in this table.
+	DefaultVethLeakTableID = 200
+
+	// DefaultVethLeakRulePriority matches the agent's default
+	// veth_leak_rule_priority. Per-network policy rules installed by
+	// ReconcileVethLeakNetworks live at this priority.
+	DefaultVethLeakRulePriority = 2000
+
+	// VethLeakRouteProtocol mirrors rtProtoOVNNetworkAgent in routing_linux.go
+	// — the custom rtproto the agent tags its per-network VRF routes with so
+	// they can be distinguished from FRR-installed entries.
+	VethLeakRouteProtocol = 44
+)
+
+// linkInfo is the subset of `ip -j -d link show` we care about. The
+// `linkinfo.info_data.table` path is how the kernel exposes a VRF device's
+// associated routing-table id. `master` reports the device a slave is
+// enslaved to.
+type linkInfo struct {
+	IfName    string `json:"ifname"`
+	Master    string `json:"master,omitempty"`
+	OperState string `json:"operstate,omitempty"`
+	Flags     []string
+	LinkInfo  struct {
+		InfoKind string `json:"info_kind,omitempty"`
+		InfoData struct {
+			Table int `json:"table,omitempty"`
+		} `json:"info_data,omitempty"`
+	} `json:"linkinfo,omitempty"`
+}
+
+// routeInfo is the subset of `ip -j route show` fields used by veth-leak
+// assertions. `Protocol` is rendered as either an int or a string by iproute2
+// depending on whether a name is registered for the protocol number; we
+// accept both via json.RawMessage and parse defensively.
+type routeInfo struct {
+	Dst      string          `json:"dst"`
+	Gateway  string          `json:"gateway,omitempty"`
+	Dev      string          `json:"dev,omitempty"`
+	Protocol json.RawMessage `json:"protocol,omitempty"`
+}
+
+// ruleInfo is the subset of `ip -j rule show` fields relevant to veth-leak
+// per-network rules: priority, source IP + prefix length, and the destination
+// table. iproute2 splits the CIDR across two fields (`src` is the bare IP,
+// `srclen` is the prefix bits) — srcCIDR reassembles them. When there is no
+// source match, iproute2 emits `"src":"all"` and omits srclen.
+type ruleInfo struct {
+	Priority int             `json:"priority"`
+	Src      string          `json:"src,omitempty"`
+	Srclen   int             `json:"srclen,omitempty"`
+	Table    json.RawMessage `json:"table,omitempty"`
+}
+
+// srcCIDR rebuilds the rule's source CIDR from src + srclen. Returns "" when
+// the rule has no source filter (iproute2 reports "all"). Tests can compare
+// the result directly to a `net.ParseCIDR`-shaped string.
+func (r ruleInfo) srcCIDR() string {
+	if r.Src == "" || r.Src == "all" {
+		return ""
+	}
+	return r.Src + "/" + strconv.Itoa(r.Srclen)
+}
+
+// readLink invokes `ip -j -d link show <name>` and decodes the first entry.
+// Returns false if the link does not exist.
+func readLink(t *testing.T, name string) (linkInfo, bool) {
+	t.Helper()
+	out, err := exec.Command("ip", "-j", "-d", "link", "show", name).CombinedOutput()
+	if err != nil {
+		// "Device not found" exits non-zero; treat that as absent, not an error.
+		return linkInfo{}, false
+	}
+	var arr []linkInfo
+	if err := json.Unmarshal(out, &arr); err != nil {
+		t.Fatalf("parse link json for %s: %v (raw: %q)", name, err, string(out))
+	}
+	if len(arr) == 0 {
+		return linkInfo{}, false
+	}
+	return arr[0], true
+}
+
+// VRFTableID looks up the routing table id associated with a VRF device.
+// Mirrors the agent's getVRFTableID helper in routing_linux.go.
+func VRFTableID(t *testing.T, vrf string) int {
+	t.Helper()
+	li, ok := readLink(t, vrf)
+	if !ok {
+		t.Fatalf("VRFTableID: VRF device %s not found", vrf)
+	}
+	if li.LinkInfo.InfoKind != "vrf" {
+		t.Fatalf("VRFTableID: %s is not a VRF (kind=%q)", vrf, li.LinkInfo.InfoKind)
+	}
+	if li.LinkInfo.InfoData.Table == 0 {
+		t.Fatalf("VRFTableID: %s has no associated table", vrf)
+	}
+	return li.LinkInfo.InfoData.Table
+}
+
+// AssertVethPairPresent fails the test if the veth pair created by
+// SetupVethLeak is not wired up correctly: both ends must exist and be up,
+// and veth-provider must be enslaved to vrf-provider.
+func AssertVethPairPresent(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		def, defOK := readLink(t, VethDefaultName)
+		prov, provOK := readLink(t, VethProviderName)
+		if defOK && provOK {
+			// Both ends must be UP. iproute2 sets operstate=UP once the
+			// kernel has finished bringing the interface up.
+			defUp := def.OperState == "UP" || hasFlag(def.Flags, "UP")
+			provUp := prov.OperState == "UP" || hasFlag(prov.Flags, "UP")
+			if defUp && provUp && prov.Master == DefaultVRFName {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("veth pair not fully present after %s: default=%+v provider=%+v",
+				timeout, def, prov)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// AssertNoVethPair fails the test if either side of the veth pair is still
+// present past timeout. Used by teardown scenarios.
+func AssertNoVethPair(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		_, defOK := readLink(t, VethDefaultName)
+		_, provOK := readLink(t, VethProviderName)
+		if !defOK && !provOK {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("veth pair still present after %s (default=%v, provider=%v)",
+				timeout, defOK, provOK)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// AssertVethRouteInVRF fails the test if no per-network VRF route exists for
+// cidr — gateway DefaultVethNexthop, dev veth-provider, proto
+// VethLeakRouteProtocol, in the VRF's table. Polls up to timeout.
+func AssertVethRouteInVRF(t *testing.T, cidr string, timeout time.Duration) {
+	t.Helper()
+	if _, _, err := net.ParseCIDR(cidr); err != nil {
+		t.Fatalf("AssertVethRouteInVRF: invalid CIDR %q: %v", cidr, err)
+	}
+	tableID := VRFTableID(t, DefaultVRFName)
+	deadline := time.Now().Add(timeout)
+	var lastOut string
+	for {
+		out, err := exec.Command("ip", "-j", "route", "show", "table", strconv.Itoa(tableID)).CombinedOutput()
+		lastOut = string(out)
+		if err == nil {
+			var routes []routeInfo
+			if err := json.Unmarshal(out, &routes); err == nil {
+				for _, r := range routes {
+					if r.Dst == cidr &&
+						r.Gateway == DefaultVethNexthop &&
+						r.Dev == VethProviderName &&
+						protocolMatches(r.Protocol, VethLeakRouteProtocol) {
+						return
+					}
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("veth-leak VRF route %s via %s dev %s proto %d table %d not found after %s (last: %q)",
+				cidr, DefaultVethNexthop, VethProviderName, VethLeakRouteProtocol, tableID, timeout,
+				strings.TrimSpace(lastOut))
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+}
+
+// AssertNoVethRouteInVRF fails the test if a per-network VRF route for cidr
+// (matching the agent's gateway/dev/protocol fingerprint) still exists past
+// timeout.
+func AssertNoVethRouteInVRF(t *testing.T, cidr string, timeout time.Duration) {
+	t.Helper()
+	if _, _, err := net.ParseCIDR(cidr); err != nil {
+		t.Fatalf("AssertNoVethRouteInVRF: invalid CIDR %q: %v", cidr, err)
+	}
+	tableID := VRFTableID(t, DefaultVRFName)
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := exec.Command("ip", "-j", "route", "show", "table", strconv.Itoa(tableID)).CombinedOutput()
+		if err == nil {
+			var routes []routeInfo
+			if err := json.Unmarshal(out, &routes); err == nil {
+				present := false
+				for _, r := range routes {
+					if r.Dst == cidr &&
+						r.Gateway == DefaultVethNexthop &&
+						r.Dev == VethProviderName &&
+						protocolMatches(r.Protocol, VethLeakRouteProtocol) {
+						present = true
+						break
+					}
+				}
+				if !present {
+					return
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("veth-leak VRF route %s in table %d still present after %s (out: %q)",
+				cidr, tableID, timeout, strings.TrimSpace(string(out)))
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+}
+
+// AssertVethDefaultRouteInLeakTable fails the test if the leak-table default
+// route SetupVethLeak installs is missing. Format:
+//
+//	default via <DefaultVethProviderIP> dev veth-default table <DefaultVethLeakTableID>
+func AssertVethDefaultRouteInLeakTable(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastOut string
+	for {
+		out, err := exec.Command("ip", "-j", "route", "show", "table", strconv.Itoa(DefaultVethLeakTableID)).CombinedOutput()
+		lastOut = string(out)
+		if err == nil {
+			var routes []routeInfo
+			if err := json.Unmarshal(out, &routes); err == nil {
+				for _, r := range routes {
+					if r.Dst == "default" &&
+						r.Gateway == DefaultVethProviderIP &&
+						r.Dev == VethDefaultName {
+						return
+					}
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("veth-leak default route in table %d not found after %s (last: %q)",
+				DefaultVethLeakTableID, timeout, strings.TrimSpace(lastOut))
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+}
+
+// AssertIPRuleAtPriority fails the test if no policy rule with the given
+// priority and source CIDR pointing to DefaultVethLeakTableID exists. Polls
+// up to timeout to give the agent time to install rules after a state change.
+func AssertIPRuleAtPriority(t *testing.T, priority int, src string, timeout time.Duration) {
+	t.Helper()
+	if _, _, err := net.ParseCIDR(src); err != nil {
+		t.Fatalf("AssertIPRuleAtPriority: invalid CIDR %q: %v", src, err)
+	}
+	deadline := time.Now().Add(timeout)
+	var lastOut string
+	for {
+		out, err := exec.Command("ip", "-j", "rule", "show").CombinedOutput()
+		lastOut = string(out)
+		if err == nil {
+			var rules []ruleInfo
+			if err := json.Unmarshal(out, &rules); err == nil {
+				for _, r := range rules {
+					if r.Priority == priority &&
+						r.srcCIDR() == src &&
+						tableMatches(r.Table, DefaultVethLeakTableID) {
+						return
+					}
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("ip rule priority %d from %s table %d not present after %s (last: %q)",
+				priority, src, DefaultVethLeakTableID, timeout, strings.TrimSpace(lastOut))
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+}
+
+// AssertNoIPRuleAtPriority fails the test if any policy rule with the given
+// priority and source CIDR remains past timeout. The mirror of
+// AssertIPRuleAtPriority for cleanup checks.
+func AssertNoIPRuleAtPriority(t *testing.T, priority int, src string, timeout time.Duration) {
+	t.Helper()
+	if _, _, err := net.ParseCIDR(src); err != nil {
+		t.Fatalf("AssertNoIPRuleAtPriority: invalid CIDR %q: %v", src, err)
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := exec.Command("ip", "-j", "rule", "show").CombinedOutput()
+		if err == nil {
+			var rules []ruleInfo
+			if err := json.Unmarshal(out, &rules); err == nil {
+				present := false
+				for _, r := range rules {
+					if r.Priority == priority && r.srcCIDR() == src {
+						present = true
+						break
+					}
+				}
+				if !present {
+					return
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("ip rule priority %d from %s still present after %s (out: %q)",
+				priority, src, timeout, strings.TrimSpace(string(out)))
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+}
+
+// DeleteIPRule removes a policy rule matching priority + src CIDR. Used by
+// the drift-recovery scenario to simulate an out-of-band operator action.
+// Errors are surfaced via t.Fatalf — if the test cannot mutate state it
+// cannot validate recovery.
+func DeleteIPRule(t *testing.T, priority int, src string) {
+	t.Helper()
+	out, err := exec.Command("ip", "rule", "del", "priority", strconv.Itoa(priority), "from", src).CombinedOutput()
+	if err != nil {
+		t.Fatalf("ip rule del priority %d from %s: %v (%s)", priority, src, err, strings.TrimSpace(string(out)))
+	}
+}
+
+// hasFlag reports whether flag appears in flags. Used to fall back to UP
+// detection when iproute2 omits operstate (rare, but seen on some kernels
+// with veth devices that have no carrier).
+func hasFlag(flags []string, flag string) bool {
+	for _, f := range flags {
+		if f == flag {
+			return true
+		}
+	}
+	return false
+}
+
+// protocolMatches reports whether a route's protocol field (rendered by
+// iproute2 as either an int or a string) corresponds to want. iproute2
+// prints the numeric form unless the protocol has a name in
+// /etc/iproute2/rt_protos.d/, so the agent's custom proto 44 normally
+// renders as "44".
+func protocolMatches(raw json.RawMessage, want int) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	// Try int first.
+	var asInt int
+	if err := json.Unmarshal(raw, &asInt); err == nil {
+		return asInt == want
+	}
+	// Fall back to string. iproute2 may emit the int as a JSON string on some
+	// versions ("44"), or a registered name. We compare to the int form only.
+	var asStr string
+	if err := json.Unmarshal(raw, &asStr); err == nil {
+		if n, err := strconv.Atoi(asStr); err == nil && n == want {
+			return true
+		}
+	}
+	return false
+}
+
+// tableMatches reports whether a rule's table field matches want. iproute2
+// renders the table as either an int or a registered name string ("main",
+// "local", "default") — for the agent's custom table id 200 it is normally
+// the int form.
+func tableMatches(raw json.RawMessage, want int) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var asInt int
+	if err := json.Unmarshal(raw, &asInt); err == nil {
+		return asInt == want
+	}
+	var asStr string
+	if err := json.Unmarshal(raw, &asStr); err == nil {
+		if n, err := strconv.Atoi(asStr); err == nil && n == want {
+			return true
+		}
+	}
+	return false
+}
+
+// scrubVethLeakState removes any veth-leak residue this test (or a previous
+// failing test) may have left behind. Best-effort, idempotent — between
+// scenarios this guarantees no stale veth pair, leak-table routes, or
+// per-network policy rules can poison the next case.
+//
+// Acceptance criterion #3 of issue #56 is that no test leaks veth devices.
+// scrubLocalState calls this so it runs before every scenario, regardless of
+// whether the previous one tested veth-leak directly.
+func scrubVethLeakState(t *testing.T) {
+	t.Helper()
+
+	// Drop policy rules we might have planted at the agent's priorities.
+	// Both default and any custom priority a future test may inject get
+	// flushed; missing rules cause `ip rule del` to exit non-zero with
+	// "RTNETLINK answers: No such file or directory" — ignore.
+	if out, err := exec.Command("ip", "-j", "rule", "show").CombinedOutput(); err == nil {
+		var rules []ruleInfo
+		if err := json.Unmarshal(out, &rules); err == nil {
+			for _, r := range rules {
+				if r.Priority != DefaultVethLeakRulePriority {
+					continue
+				}
+				cidr := r.srcCIDR()
+				if cidr == "" {
+					continue
+				}
+				_ = exec.Command("ip", "rule", "del",
+					"priority", strconv.Itoa(r.Priority),
+					"from", cidr,
+				).Run()
+			}
+		}
+	}
+
+	// Flush the agent's leak table (default route + anything else that
+	// might have been added) and delete the veth pair. Deleting one end
+	// removes both, which also drops any remaining proto-44 routes the
+	// kernel had pinned to the link.
+	_ = exec.Command("ip", "route", "flush", "table", strconv.Itoa(DefaultVethLeakTableID)).Run()
+	_ = exec.Command("ip", "link", "del", VethDefaultName).Run()
+}


### PR DESCRIPTION
Cover SetupVethLeak, ReconcileVethLeakNetworks, and TeardownVethLeak — previously only exercised transitively by FIP and port-forward tests with no assertions on the actual netlink state. Six scenarios assert against `ip -j` JSON (filtering on proto 44 to avoid colliding with FRR-installed routes): cold-start setup, per-network reconciliation, drift recovery, stale-network removal, SIGTERM teardown, and the veth_leak_enabled=false negative path.

Adds testenv helpers (AssertVethPairPresent, AssertVethRouteInVRF, AssertIPRuleAtPriority + Not* variants, AssertVethDefaultRouteInLeakTable, DeleteIPRule, VRFTableID) and a between-test scrub so SIGKILL'd agents cannot leak an enslaved veth pair into the next scenario.

Closes #56

AI-assisted: Claude Code