### PR TITLE
test(integration): add FRR prefix-list reconcile scenarios

### DIFF
--- a/test/integration/scenario_prefix_list_test.go
+++ b/test/integration/scenario_prefix_list_test.go
@@ -1,0 +1,232 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/osism/ovn-network-agent/test/integration/testenv"
+)
+
+// All scenarios in this file cover #58 — the agent's FRR prefix-list reconcile
+// surface (`ReconcileFRRPrefixList`). The harness's Defaults() leaves
+// frr_prefix_list empty, so until this file existed the entire lifecycle was
+// untested on a real FRR. A regression here is operationally severe: a stale
+// or missing entry directly governs which routes get re-announced over BGP.
+//
+// Each test uses a unique prefix-list name (rather than the production
+// ANNOUNCED-NETWORKS that setup.sh seeds) so the agent's reconcile starts
+// from a known-empty state and t.Cleanup can drop the entire list without
+// disturbing the FRR baseline.
+
+// prefixListCleanup registers a t.Cleanup that drops the named prefix-list.
+// FRR auto-creates the list on first entry, so dropping it on the way out
+// keeps a failed test from poisoning subsequent runs through residual
+// "permit ... ge 32 le 32" entries.
+func prefixListCleanup(t *testing.T, name string) {
+	t.Helper()
+	t.Cleanup(func() {
+		if t.Failed() {
+			testenv.DumpFRRPrefixList(t, name)
+		}
+		testenv.RemoveFRRPrefixList(t, name)
+	})
+}
+
+// TestScenario_PrefixListEntryAdded (#58 scenario 1):
+//
+// Configure a fresh prefix-list and a router with LRP network 198.51.100.11/24.
+// The agent's first reconcile must observe the discovered network
+// (198.51.100.0/24) and install a `permit 198.51.100.0/24 ge 32 le 32` entry.
+// Without this assertion, a regression that broke the LRP→DiscoveredNetworks
+// pipeline or the prefix-list write path would only surface as silent BGP
+// announcement gaps in production.
+func TestScenario_PrefixListEntryAdded(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	const listName = "OVN-AGENT-TEST-58-S1"
+	prefixListCleanup(t, listName)
+
+	testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "plistadd",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	cfg := testenv.Defaults()
+	cfg.FRRPrefixList = listName
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	testenv.AssertFRRPrefixListContains(t, listName, "198.51.100.0/24", 15*time.Second)
+}
+
+// TestScenario_PrefixListStaleEntryPruned (#58 scenario 2):
+//
+// With two locally-active routers on disjoint LRP networks, both networks
+// must show up in the prefix-list. After deleting the second router the
+// agent's reconcile must reap its entry within a couple of ticks, leaving
+// the first router's entry alone. Exercises the "remove stale entries" loop
+// in ReconcileFRRPrefixList (routing.go:351).
+func TestScenario_PrefixListStaleEntryPruned(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	const (
+		listName = "OVN-AGENT-TEST-58-S2"
+		net1     = "198.51.100.0/24"
+		net2     = "203.0.113.0/24"
+	)
+	prefixListCleanup(t, listName)
+
+	testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "plist1",
+		LRPMAC:      "fa:16:3e:11:22:33",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+	r2 := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "plist2",
+		LRPMAC:      "fa:16:3e:11:22:44",
+		LRPNetworks: []string{"203.0.113.11/24"},
+	})
+
+	cfg := testenv.FastDefaults()
+	cfg.FRRPrefixList = listName
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// Both networks land on the first reconcile.
+	testenv.AssertFRRPrefixListContains(t, listName, net1, 15*time.Second)
+	testenv.AssertFRRPrefixListContains(t, listName, net2, 15*time.Second)
+
+	// Drop router 2 — the agent loses 203.0.113.0/24 from DiscoveredNetworks
+	// and must remove the corresponding entry on the next tick.
+	deleteRouter(t, ctx, nb, r2.RouterUUID)
+
+	testenv.AssertNoFRRPrefixListEntry(t, listName, net2, 15*time.Second)
+
+	// net1 must remain — guards against an over-zealous reconciler that
+	// re-emits "remove all" when any single router disappears.
+	testenv.AssertFRRPrefixListContains(t, listName, net1, 1*time.Second)
+}
+
+// TestScenario_PrefixListClearedOnNoLocalRouters (#58 scenario 3):
+//
+// While the agent owns prefix-list entries, simulate ovn-northd rebinding
+// the chassisredirect Port_Binding to a peer chassis (failover-style). The
+// agent observes HasLocalRouters→false and must hit the
+// `ReconcileFRRPrefixList(nil)` branch in agent.reconcile (agent.go:300),
+// clearing every managed entry. Reuses MakeChassis + SetCRPortChassis from
+// the failover scenario.
+func TestScenario_PrefixListClearedOnNoLocalRouters(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	const listName = "OVN-AGENT-TEST-58-S3"
+	prefixListCleanup(t, listName)
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "plistnolr",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	cfg := testenv.FastDefaults()
+	cfg.FRRPrefixList = listName
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// Sanity: confirm the entry is in place before we trigger failover so
+	// the post-failover assertion really proves removal.
+	testenv.AssertFRRPrefixListContains(t, listName, "198.51.100.0/24", 15*time.Second)
+
+	// Insert a peer chassis and rebind the CR Port_Binding to it. After this
+	// commits, the agent's local-router detection sees no locally-active
+	// routers and must clear the prefix-list.
+	peerChassis := testenv.MakeChassis(t, ctx, sb, "plist-peer")
+	testenv.SetCRPortChassis(t, ctx, sb, router.CRPortUUID, &peerChassis)
+
+	testenv.AssertFRRPrefixListEmpty(t, listName, 15*time.Second)
+}
+
+// TestScenario_PrefixListClearedOnShutdown (#58 scenario 4):
+//
+// SIGTERM with cleanup_on_shutdown=true must invoke the
+// `ReconcileFRRPrefixList(nil)` call in agent.cleanup (agent.go:570), which
+// removes every managed entry before the process exits. Mirrors the
+// equivalent veth-leak teardown scenario.
+func TestScenario_PrefixListClearedOnShutdown(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	const listName = "OVN-AGENT-TEST-58-S4"
+	prefixListCleanup(t, listName)
+
+	testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "plistshut",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	cfg := testenv.Defaults()
+	cleanup := true
+	cfg.CleanupOnShutdown = &cleanup
+	cfg.FRRPrefixList = listName
+
+	a := readyAgent(t, cfg)
+	testenv.AssertFRRPrefixListContains(t, listName, "198.51.100.0/24", 15*time.Second)
+
+	// Use manual Stop (rather than WithAgent) so the post-SIGTERM assertion
+	// runs while we are still inside the test, not at t.Cleanup time.
+	if err := a.Stop(20 * time.Second); err != nil {
+		t.Fatalf("agent stop: %v", err)
+	}
+
+	testenv.AssertFRRPrefixListEmpty(t, listName, 5*time.Second)
+}
+
+// TestScenario_PrefixListLeavesUnrelatedEntriesAlone (#58 scenario 5, edge):
+//
+// ListFRRPrefixListEntries only matches lines with the trailing `ge 32 le 32`
+// clause. Anything else — for example a hand-written `permit 10.0.0.0/8`
+// without `ge`/`le` qualifiers — is invisible to the reconciler and must not
+// be touched. We pre-seed such an entry, run the agent through a full
+// reconcile cycle, and verify both: the agent's managed entry shows up AND
+// the seeded entry survives.
+//
+// The seq for the seeded entry deliberately sits below the agent's allocated
+// range (it always picks maxSeq+5 starting from 0), so a reconciler that
+// went rogue and rewrote everything by sequence would be detected.
+func TestScenario_PrefixListLeavesUnrelatedEntriesAlone(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	const listName = "OVN-AGENT-TEST-58-S5"
+	prefixListCleanup(t, listName)
+
+	// Seed a non-managed entry: `permit 10.0.0.0/8` without `ge`/`le` is
+	// outside the agent's reconcile surface (ListFRRPrefixListEntries skips
+	// it) and must survive the agent's lifetime untouched.
+	testenv.SeedFRRPrefixListEntry(t, listName, 100, "permit 10.0.0.0/8")
+
+	testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "plistedge",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	cfg := testenv.FastDefaults()
+	cfg.FRRPrefixList = listName
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// Managed entry lands.
+	testenv.AssertFRRPrefixListContains(t, listName, "198.51.100.0/24", 15*time.Second)
+
+	// Wait at least one reconcile tick (FastDefaults => 2s) to give a buggy
+	// reconciler the chance to wipe the seeded entry. The assertion below
+	// then proves the entry survived through that cycle.
+	time.Sleep(3 * time.Second)
+
+	// Match the raw line because the seeded entry has no `ge`/`le` qualifiers
+	// and is not surfaced as a structured FRRPrefixListEntry by the helpers.
+	testenv.AssertFRRPrefixListLineContains(t, listName, "seq 100 permit 10.0.0.0/8", 1*time.Second)
+}

--- a/test/integration/testenv/dump.go
+++ b/test/integration/testenv/dump.go
@@ -61,3 +61,24 @@ func RegisterFailureDump(t *testing.T) {
 		}
 	})
 }
+
+// DumpFRRPrefixList logs `vtysh -c "show ip prefix-list <name>"` to the test
+// log. Used by scenario tests that exercise FRRPrefixList reconcile so a
+// failure message includes the FRR-side state without an operator having to
+// ssh in. Best-effort: silently no-ops if vtysh is missing.
+func DumpFRRPrefixList(t *testing.T, name string) {
+	t.Helper()
+	if _, err := exec.LookPath("vtysh"); err != nil {
+		return
+	}
+	out, err := exec.Command("vtysh", "-c", "show ip prefix-list "+name).CombinedOutput()
+	text := strings.TrimRight(string(out), "\n")
+	switch {
+	case err != nil:
+		t.Logf("--- vtysh show ip prefix-list %s --- (err: %v)\n%s", name, err, text)
+	case strings.TrimSpace(text) == "":
+		t.Logf("--- vtysh show ip prefix-list %s --- (empty)", name)
+	default:
+		t.Logf("--- vtysh show ip prefix-list %s ---\n%s", name, text)
+	}
+}

--- a/test/integration/testenv/frr_prefix_list.go
+++ b/test/integration/testenv/frr_prefix_list.go
@@ -1,0 +1,233 @@
+//go:build integration
+
+package testenv
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// FRRPrefixListEntry mirrors a single line in `vtysh -c "show ip prefix-list <name>"`
+// output: `seq <N> permit <network> [ge X] [le Y]`.
+type FRRPrefixListEntry struct {
+	Seq    int
+	Permit bool   // true for "permit", false for "deny"
+	Prefix string // e.g. "198.51.100.0/24"
+	Suffix string // everything after the prefix (e.g. "ge 32 le 32"), empty if none
+	Raw    string // original trimmed line
+}
+
+// fetchFRRPrefixListEntries shells out to vtysh and parses the entries of a
+// prefix-list. Returns nil entries (without erroring) if the list does not
+// exist yet — FRR auto-creates lists on first entry, so a non-existent list
+// is simply "empty" from the test's perspective.
+func fetchFRRPrefixListEntries(name string) ([]FRRPrefixListEntry, string, error) {
+	out, err := exec.Command("vtysh",
+		"-c", "show ip prefix-list "+name,
+	).CombinedOutput()
+	raw := string(out)
+	if err != nil {
+		return nil, raw, fmt.Errorf("vtysh show ip prefix-list %s: %w (%s)",
+			name, err, strings.TrimSpace(raw))
+	}
+	if strings.Contains(raw, "Can't find") || strings.TrimSpace(raw) == "" {
+		return nil, raw, nil
+	}
+
+	var entries []FRRPrefixListEntry
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		fields := strings.Fields(line)
+		// Need at least: seq <N> permit|deny <prefix>
+		if len(fields) < 4 || fields[0] != "seq" {
+			continue
+		}
+		seq, serr := strconv.Atoi(fields[1])
+		if serr != nil {
+			continue
+		}
+		var permit bool
+		switch fields[2] {
+		case "permit":
+			permit = true
+		case "deny":
+			permit = false
+		default:
+			continue
+		}
+		entry := FRRPrefixListEntry{
+			Seq:    seq,
+			Permit: permit,
+			Prefix: fields[3],
+			Suffix: strings.Join(fields[4:], " "),
+			Raw:    line,
+		}
+		entries = append(entries, entry)
+	}
+	return entries, raw, nil
+}
+
+// requireVtysh skips the test if vtysh is not on PATH. Setup() already gates
+// on this for scenario tests, but this defensive check keeps the helpers
+// reusable from contexts that did not go through Setup().
+func requireVtysh(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("vtysh"); err != nil {
+		t.Skipf("vtysh not in PATH (run test/integration/setup.sh first): %v", err)
+	}
+}
+
+// AssertFRRPrefixListContains polls `vtysh -c "show ip prefix-list <name>"` until
+// it contains a `permit <cidr> ge 32 le 32` entry (the format the agent installs
+// for discovered networks). Fails the test if the entry never appears.
+func AssertFRRPrefixListContains(t *testing.T, name, cidr string, timeout time.Duration) {
+	t.Helper()
+	requireVtysh(t)
+	deadline := time.Now().Add(timeout)
+	var lastRaw string
+	var lastErr error
+	for {
+		entries, raw, err := fetchFRRPrefixListEntries(name)
+		lastRaw = raw
+		lastErr = err
+		if err == nil {
+			for _, e := range entries {
+				if e.Permit && e.Prefix == cidr && e.Suffix == "ge 32 le 32" {
+					return
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("FRR prefix-list %q does not contain `permit %s ge 32 le 32` after %s (last output: %q, err: %v)",
+				name, cidr, timeout, strings.TrimSpace(lastRaw), lastErr)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// AssertNoFRRPrefixListEntry polls until the prefix-list <name> no longer
+// contains a `permit <cidr> ge 32 le 32` entry. Used to verify removal.
+func AssertNoFRRPrefixListEntry(t *testing.T, name, cidr string, timeout time.Duration) {
+	t.Helper()
+	requireVtysh(t)
+	deadline := time.Now().Add(timeout)
+	var lastRaw string
+	for {
+		entries, raw, err := fetchFRRPrefixListEntries(name)
+		lastRaw = raw
+		if err == nil {
+			present := false
+			for _, e := range entries {
+				if e.Permit && e.Prefix == cidr && e.Suffix == "ge 32 le 32" {
+					present = true
+					break
+				}
+			}
+			if !present {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("FRR prefix-list %q still contains `permit %s ge 32 le 32` after %s (last output: %q)",
+				name, cidr, timeout, strings.TrimSpace(lastRaw))
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// AssertFRRPrefixListEmpty polls until the prefix-list <name> contains no
+// managed entries (`permit ... ge 32 le 32`). Non-managed entries (different
+// mask/length specifiers, or deny entries) are ignored — they are outside the
+// agent's reconciliation surface. Used to verify scenarios 3 and 4 where the
+// agent must clear out everything it owns.
+func AssertFRRPrefixListEmpty(t *testing.T, name string, timeout time.Duration) {
+	t.Helper()
+	requireVtysh(t)
+	deadline := time.Now().Add(timeout)
+	var lastRaw string
+	for {
+		entries, raw, err := fetchFRRPrefixListEntries(name)
+		lastRaw = raw
+		if err == nil {
+			managed := 0
+			for _, e := range entries {
+				if e.Permit && e.Suffix == "ge 32 le 32" {
+					managed++
+				}
+			}
+			if managed == 0 {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("FRR prefix-list %q still has managed entries after %s (last output: %q)",
+				name, timeout, strings.TrimSpace(lastRaw))
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// AssertFRRPrefixListLineContains fails if no line in the prefix-list contains
+// the given substring after timeout. Used by scenario 5 to verify a manually-
+// seeded entry survives across the agent's reconcile cycles.
+func AssertFRRPrefixListLineContains(t *testing.T, name, substring string, timeout time.Duration) {
+	t.Helper()
+	requireVtysh(t)
+	deadline := time.Now().Add(timeout)
+	var lastRaw string
+	for {
+		_, raw, err := fetchFRRPrefixListEntries(name)
+		lastRaw = raw
+		if err == nil && strings.Contains(raw, substring) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("FRR prefix-list %q does not contain %q after %s (last output: %q)",
+				name, substring, timeout, strings.TrimSpace(lastRaw))
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// SeedFRRPrefixListEntry adds a raw `ip prefix-list <name> seq <seq> <expr>`
+// line via vtysh. expr is everything after the seq number — typically
+// `permit 10.0.0.0/8` (no `ge`/`le` clauses, so the agent's reconciler
+// ignores it). Fails the test if vtysh returns an error.
+func SeedFRRPrefixListEntry(t *testing.T, name string, seq int, expr string) {
+	t.Helper()
+	requireVtysh(t)
+	args := []string{
+		"-c", "conf t",
+		"-c", fmt.Sprintf("ip prefix-list %s seq %d %s", name, seq, expr),
+		"-c", "end",
+	}
+	if out, err := exec.Command("vtysh", args...).CombinedOutput(); err != nil {
+		t.Fatalf("vtysh seed prefix-list entry %q seq %d %q: %v (%s)",
+			name, seq, expr, err, strings.TrimSpace(string(out)))
+	}
+}
+
+// RemoveFRRPrefixList removes every entry in the named prefix-list, then drops
+// the list itself via `no ip prefix-list <name>`. Best-effort and idempotent —
+// safe to call from t.Cleanup even if the list never came into existence.
+func RemoveFRRPrefixList(t *testing.T, name string) {
+	t.Helper()
+	if _, err := exec.LookPath("vtysh"); err != nil {
+		return
+	}
+	// `no ip prefix-list <name>` removes the entire list with all entries in
+	// one shot. FRR is permissive: the command succeeds even if the list does
+	// not exist. Best-effort; we only log on failure.
+	args := []string{
+		"-c", "conf t",
+		"-c", "no ip prefix-list " + name,
+		"-c", "end",
+	}
+	if out, err := exec.Command("vtysh", args...).CombinedOutput(); err != nil {
+		t.Logf("RemoveFRRPrefixList %q: %v (%s)", name, err, strings.TrimSpace(string(out)))
+	}
+}


### PR DESCRIPTION
Cover the ReconcileFRRPrefixList lifecycle with five scenarios — entry add on activation, stale-entry pruning, no-local-routers clear, cleanup on shutdown, and the unrelated-entry edge — plus the testenv helpers they need (Assert*FRRPrefixList*, SeedFRRPrefixListEntry, RemoveFRRPrefixList, DumpFRRPrefixList).

Each scenario uses a unique prefix-list name so the agent reconciles from a known-empty state rather than racing the ANNOUNCED-NETWORKS seq-5 baseline that setup.sh seeds.

Closes #58

AI-assisted: Claude Code