### PR TITLE
test(integration): drain edge-case scenarios (timeout, no-routers, no-cleanup)

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -14,6 +14,7 @@ test/integration/
   scenarios_helpers_test.go        — shared per-scenario boilerplate (startScenario, readyAgent)
   scenario_fip_test.go             — FIP add/remove, gatewayless gw, multi-router on one chassis
   scenario_failover_test.go        — failover, stale-chassis cleanup, drain & restore-drained
+  scenario_drain_edges_test.go     — drain edge cases (timeout, no local routers, cleanup_on_shutdown=false)
   scenario_network_cidrs_test.go   — manual network_cidr override vs. auto-discovery, empty-filter sweep
   scenario_port_forward_test.go    — DNAT, sticky multi-backend, VIP mgmt, masquerade, hairpin
   testenv/                         — Setup, Teardown, RunAgent, MakeLocalRouter, Assert*, …

--- a/test/integration/scenario_drain_edges_test.go
+++ b/test/integration/scenario_drain_edges_test.go
@@ -1,0 +1,277 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/osism/ovn-network-agent/test/integration/testenv"
+)
+
+// TestScenario_DrainTimeout (#59 scenario 1):
+//
+// With drain_on_shutdown=true and drain_timeout=1s, the agent must give up
+// the drain loop once the context deadline expires (no test-side rebind of
+// the CR Port_Binding means countLocalCRPorts never reaches 0). The agent
+// still proceeds to cleanup, so the kernel /32 route for the LRP must be
+// gone after Stop returns.
+//
+// The drain code emits `"drain: timeout exceeded, proceeding with shutdown"`
+// on the deadline path and returns nil; we assert that line landed in the
+// captured agent log. A future change to the drain metric outcome (#39) will
+// allow asserting via Prometheus instead.
+func TestScenario_DrainTimeout(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "draintmo",
+		LRPNetworks: []string{"198.51.100.11/24"},
+		GatewayChassis: []testenv.GatewayChassisEntry{
+			{ChassisName: testenv.LocalHostname(t), Priority: 5},
+		},
+	})
+	_ = router
+
+	cfg := testenv.Defaults()
+	on := true
+	cfg.DrainOnShutdown = &on
+	cfg.DrainTimeout = "1s"
+	cfg.ReconcileInterval = "2s"
+	a := readyAgent(t, cfg)
+
+	// Wait for the LRP /32 route to land so the post-drain "route is gone"
+	// assertion below is meaningful (not just "never installed").
+	testenv.AssertKernelRoute(t, "198.51.100.11", 15*time.Second)
+
+	// SIGTERM. The drain loop polls SB Port_Binding every 2s; with the
+	// CR Port_Binding still bound to the local chassis, countLocalCRPorts
+	// stays at 1 until the 1s drain_timeout fires. The drain code logs
+	// "drain: timeout exceeded, proceeding with shutdown" and returns nil,
+	// the agent then runs cleanup (CleanupOnShutdown defaults to true), and
+	// Stop unblocks. 15s is plenty for a 1s drain + cleanup pass.
+	if err := a.Stop(15 * time.Second); err != nil {
+		t.Fatalf("agent stop: %v", err)
+	}
+
+	logs := a.LogTail(100000)
+	if !strings.Contains(logs, "drain: timeout exceeded") {
+		t.Errorf("expected drain timeout log line not found; last logs:\n%s", a.LogTail(40))
+	}
+
+	// Cleanup must have run despite the drain timeout: the LRP /32 route
+	// is gone from the bridge device.
+	testenv.AssertNoKernelRoute(t, "198.51.100.11", 5*time.Second)
+}
+
+// TestScenario_DrainWithoutLocalRouters (#59 scenario 2):
+//
+// drain_on_shutdown=true with no local routers must be a fast no-op: the
+// agent finds nothing to drain, logs the no-op, and exits cleanly within a
+// couple of seconds. Pins down that DrainGateways cannot regress into a
+// blocking poll when there is nothing to wait for.
+func TestScenario_DrainWithoutLocalRouters(t *testing.T) {
+	// No MakeLocalRouter call — NB is empty save for whatever ResetOVNState
+	// leaves behind, which contains zero Gateway_Chassis entries.
+	_, cancel, _, _ := startScenario(t)
+	defer cancel()
+
+	cfg := testenv.Defaults()
+	on := true
+	cfg.DrainOnShutdown = &on
+	cfg.DrainTimeout = "30s" // generous; we expect the no-op path
+	cfg.ReconcileInterval = "2s"
+	a := readyAgent(t, cfg)
+
+	stopStart := time.Now()
+	if err := a.Stop(15 * time.Second); err != nil {
+		t.Fatalf("agent stop: %v", err)
+	}
+	elapsed := time.Since(stopStart)
+	// The drain code returns immediately when no Gateway_Chassis entries
+	// match the local chassis; the remaining wall time is dominated by
+	// cleanup and process teardown. 5s leaves headroom for slow CI hosts
+	// while still flagging a regression into the polling loop.
+	if elapsed > 5*time.Second {
+		t.Errorf("Stop took %s with no local routers; expected fast no-op (<5s)", elapsed)
+	}
+
+	logs := a.LogTail(100000)
+	if !strings.Contains(logs, "drain: no gateway chassis entries to drain") {
+		t.Errorf("expected no-op drain log line not found; last logs:\n%s", a.LogTail(40))
+	}
+}
+
+// TestScenario_DrainKeepsRoutesWhenCleanupDisabled (#59 scenario 3):
+//
+// drain_on_shutdown=true with cleanup_on_shutdown=false must drain (NB
+// Gateway_Chassis priority → 0) but leave kernel routes and the nft
+// port-forward table in place. This pins down the operator-facing contract
+// that drain and cleanup are independent toggles — and is the explicit
+// inverse of TestScenario_PortForwardCleanupOnSIGTERM (state remains).
+//
+// We mirror TestScenario_DrainOnShutdown's rebind goroutine so drain
+// completes promptly (instead of timing out), which keeps the test fast.
+func TestScenario_DrainKeepsRoutesWhenCleanupDisabled(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+	testenv.EnsureLoopback1(t)
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "drainkeep",
+		LRPNetworks: []string{"198.51.100.11/24"},
+		GatewayChassis: []testenv.GatewayChassisEntry{
+			{ChassisName: testenv.LocalHostname(t), Priority: 5},
+		},
+	})
+
+	cfg := testenv.Defaults()
+	on := true
+	off := false
+	cfg.DrainOnShutdown = &on
+	cfg.CleanupOnShutdown = &off
+	cfg.ReconcileInterval = "2s"
+
+	// Configure a minimal port-forward VIP so the agent installs its nft
+	// table; the inverse assertion below verifies the table survives a
+	// no-cleanup shutdown.
+	const pfVIP = "198.51.100.88"
+	cfg.PortForwardDev = testenv.PortForwardLoopbackDev
+	cfg.PortForwardCTZone = intPtr(64001)
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+		VIP:       pfVIP,
+		ManageVIP: true,
+		Rules: []testenv.PortForwardRuleFixture{{
+			Proto: "tcp", Port: 80, DestAddr: "10.0.0.88",
+		}},
+	}}
+
+	a := readyAgent(t, cfg)
+	// If the test fatals before Stop runs, the t.Cleanup chain will
+	// SIGKILL the agent — leaving nft / loopback residue. Scrub on exit
+	// to keep the next scenario isolated.
+	t.Cleanup(func() { testenv.ScrubPortForwardResidue(t) })
+
+	// Wait for the LRP /32 route and the nft table to land so the
+	// post-shutdown "state remains" assertions are meaningful.
+	testenv.AssertKernelRoute(t, "198.51.100.11", 15*time.Second)
+	testenv.AssertNftChainExists(t, testenv.DefaultNftTable, "prerouting_dnat", 15*time.Second)
+	testenv.AssertVIPOnLoopback(t, pfVIP, 15*time.Second)
+
+	// Pre-stage a peer chassis so ovn-controller does not complain when
+	// the rebind goroutine moves the Port_Binding mid-drain.
+	peerUUID := testenv.MakeChassis(t, ctx, sb, "drainkeep-peer")
+	gcName := "lrp-" + router.Name + "_" + testenv.LocalHostname(t)
+
+	// Goroutine: when NB shows priority=0 for our local Gateway_Chassis,
+	// rebind the CR Port_Binding to the peer so countLocalCRPorts → 0 and
+	// drain completes without hitting drain_timeout.
+	errCh := make(chan error, 1)
+	pctx, pcancel := context.WithCancel(ctx)
+	defer pcancel()
+	go func() {
+		tick := time.NewTicker(50 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-pctx.Done():
+				return
+			case <-tick.C:
+				var entries []testenv.NBGatewayChassis
+				if err := nb.List(ctx, &entries); err != nil {
+					select {
+					case errCh <- err:
+					default:
+					}
+					return
+				}
+				for _, gc := range entries {
+					if gc.Name != gcName || gc.Priority != 0 {
+						continue
+					}
+					rebind := &testenv.SBPortBinding{UUID: router.CRPortUUID, Chassis: &peerUUID}
+					ops, opErr := sb.Where(rebind).Update(rebind, &rebind.Chassis)
+					if opErr != nil {
+						select {
+						case errCh <- opErr:
+						default:
+						}
+						return
+					}
+					if _, opErr := sb.Transact(ctx, ops...); opErr != nil {
+						select {
+						case errCh <- opErr:
+						default:
+						}
+					}
+					return
+				}
+			}
+		}
+	}()
+
+	if err := a.Stop(45 * time.Second); err != nil {
+		t.Fatalf("agent stop: %v", err)
+	}
+	pcancel()
+	select {
+	case err := <-errCh:
+		t.Fatalf("drain helper goroutine error: %v", err)
+	default:
+	}
+
+	// Drain happened: NB Gateway_Chassis priority is 0.
+	gc, ok := testenv.FindGatewayChassis(t, ctx, nb, gcName)
+	if !ok {
+		t.Fatal("Gateway_Chassis disappeared after drain")
+	}
+	if gc.Priority != 0 {
+		t.Errorf("post-drain Gateway_Chassis priority = %d, want 0", gc.Priority)
+	}
+
+	// Cleanup was skipped: the LRP /32 kernel route, the nft table, and
+	// the managed VIP on loopback1 are still in place. This is the
+	// inverse of TestScenario_PortForwardCleanupOnSIGTERM.
+	out, err := exec.Command("ip", "-4", "route", "show", "198.51.100.11/32", "dev", testenv.DefaultBridgeDev).CombinedOutput()
+	if err != nil {
+		t.Fatalf("ip route show: %v (output: %q)", err, string(out))
+	}
+	if !strings.Contains(string(out), "198.51.100.11") {
+		t.Errorf("LRP /32 route removed despite cleanup_on_shutdown=false; output: %q", strings.TrimSpace(string(out)))
+	}
+	if out, err := exec.Command("nft", "list", "table", "ip", testenv.DefaultNftTable).CombinedOutput(); err != nil {
+		t.Errorf("nft table %s removed despite cleanup_on_shutdown=false: %v (output: %q)",
+			testenv.DefaultNftTable, err, strings.TrimSpace(string(out)))
+	}
+	// Managed VIP must still be on loopback1.
+	testenv.AssertVIPOnLoopback(t, pfVIP, 2*time.Second)
+
+	// And the agent logged the "keeping routes" branch.
+	logs := a.LogTail(100000)
+	if !strings.Contains(logs, "shutting down, keeping routes in place") {
+		t.Errorf("expected keep-routes log line not found; last logs:\n%s", a.LogTail(40))
+	}
+}
+
+// TestScenario_DrainStuckNBWrite (#59 scenario 4, optional):
+//
+// Pausing ovsdb-server (NB) mid-drain to verify drain_timeout is honoured
+// even when NB writes hang would catch a regression where the agent waits
+// for a transaction to complete past the deadline. Implementing this
+// cleanly on Ubuntu requires pausing only the NB DB without taking SB down
+// — ovn-ctl on Ubuntu (`ovn-ctl pause`) toggles both. Without a way to
+// pause NB in isolation the test would be flaky (paused-SB cascades into
+// ovn-controller restarting our chassis row, etc.), so we skip pending a
+// harness primitive that can pause NB alone.
+//
+// Future contributors: do not "fix" this by inserting time.Sleep or a
+// stop-the-world SIGSTOP loop on ovsdb-server. The drain code is supposed
+// to honour drain_timeout regardless of NB write hangs; assert via metrics
+// once the drain outcome label is exposed (#39).
+func TestScenario_DrainStuckNBWrite(t *testing.T) {
+	t.Skip("scenario 4: no clean way to pause NB ovsdb-server alone on the Ubuntu harness")
+}


### PR DESCRIPTION
Implements #59.

Covers the three drain edge cases the existing happy-path tests
(`TestScenario_DrainOnShutdown`, `TestScenario_RestoreDrainedOnStartup`)
do not exercise. Scenario 4 is registered as `t.Skip` with a comment
documenting the Ubuntu `ovn-ctl` harness limitation that blocks a
deterministic implementation.

## Summary
- `TestScenario_DrainTimeout` (#59 scenario 1): `drain_timeout=1s`, no
  rebind. Asserts the `drain: timeout exceeded` log line lands and the
  LRP /32 kernel route is still removed by the cleanup pass after the
  drain gave up.
- `TestScenario_DrainWithoutLocalRouters` (#59 scenario 2): SIGTERM with
  `drain_on_shutdown=true` on an empty NB exits within seconds and logs
  the no-op (`drain: no gateway chassis entries to drain`). Pins down
  that a future change to `DrainGateways` cannot regress into a blocking
  poll when there is nothing to drain.
- `TestScenario_DrainKeepsRoutesWhenCleanupDisabled` (#59 scenario 3):
  `drain_on_shutdown=true` + `cleanup_on_shutdown=false`. Mirrors the
  rebind goroutine from `TestScenario_DrainOnShutdown` so drain
  completes, then asserts the inverse of
  `TestScenario_PortForwardCleanupOnSIGTERM`: NB Gateway_Chassis
  priority is 0, but the LRP /32 kernel route, the nft port-forward
  table, and the managed VIP on `loopback1` are all still in place.
- `TestScenario_DrainStuckNBWrite` (#59 scenario 4): `t.Skip` with a
  comment explaining the Ubuntu `ovn-ctl` limitation (pausing NB alone
  is not possible without also taking SB down).

## Test plan
- [ ] `go vet -tags=integration ./...` — passes
- [ ] `go build ./... && go test ./...` — passes
- [ ] `go test -tags=integration -count=1 -run '^$' ./test/integration/...` (compile-check) — passes
- [ ] Run the three new scenarios on a Linux host with the OVN harness:
      `sudo OVN_AGENT_BINARY=\$PWD/ovn-network-agent go test -tags=integration -v -run 'TestScenario_Drain(Timeout|WithoutLocalRouters|KeepsRoutesWhenCleanupDisabled)' ./test/integration/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)