### PR TITLE
test(integration): metrics endpoint scrapes + harness support

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -17,7 +17,8 @@ test/integration/
   scenario_drain_edges_test.go     — drain edge cases (timeout, no local routers, cleanup_on_shutdown=false)
   scenario_network_cidrs_test.go   — manual network_cidr override vs. auto-discovery, empty-filter sweep
   scenario_port_forward_test.go    — DNAT, sticky multi-backend, VIP mgmt, masquerade, hairpin
-  testenv/                         — Setup, Teardown, RunAgent, MakeLocalRouter, Assert*, …
+  scenario_metrics_test.go         — Prometheus /metrics scrapes (reconcile counter, drain outcome, stale-chassis, desired-state gauges)
+  testenv/                         — Setup, Teardown, RunAgent, MakeLocalRouter, Assert*, ScrapeMetrics, …
 ```
 
 Port-forward scenarios additionally rely on:

--- a/test/integration/scenario_metrics_test.go
+++ b/test/integration/scenario_metrics_test.go
@@ -1,0 +1,281 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/osism/ovn-network-agent/test/integration/testenv"
+)
+
+// All scenarios in this file cover #60 — Prometheus /metrics integration
+// tests. Each scenario binds the agent's metrics endpoint to a free
+// loopback port (FreeLoopbackAddr) so parallel test runs do not collide,
+// then scrapes the endpoint via ScrapeMetrics / AssertMetricEventually.
+//
+// Counters are initialised by newMetricsRegistry() with a zero observation
+// per label series, so a metric that has not yet been touched still appears
+// in /metrics output with value 0 — the assertions can rely on Present=true
+// for known labels from the first successful scrape.
+
+// TestScenario_MetricsReconcileCounter (#60 scenario 1):
+//
+// With the metrics endpoint enabled and a tightened reconcile interval, the
+// startup reconcile counter must reach ≥1 by the time the agent logs "agent
+// running" and the periodic counter must reach ≥1 after at least one tick
+// has fired. We verify both via scrape while the agent is up; the
+// scrape-on-shutdown path is unreliable because the metrics server closes
+// its listener as soon as ctx is cancelled.
+func TestScenario_MetricsReconcileCounter(t *testing.T) {
+	_, cancel, _, _ := startScenario(t)
+	defer cancel()
+
+	cfg := testenv.Defaults()
+	cfg.ReconcileInterval = "1s" // tight, so periodic increments quickly
+	addr := testenv.FreeLoopbackAddr(t)
+	cfg.MetricsListen = addr
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	testenv.AssertMetricEventually(t, addr,
+		"ovn_network_agent_reconcile_total",
+		map[string]string{"trigger": "startup"},
+		func(v float64, present bool) bool { return present && v >= 1 },
+		10*time.Second)
+
+	// Wait for at least one periodic tick to fire (interval is 1s; allow
+	// ample slack for slow CI hosts).
+	testenv.AssertMetricEventually(t, addr,
+		"ovn_network_agent_reconcile_total",
+		map[string]string{"trigger": "periodic"},
+		func(v float64, present bool) bool { return present && v >= 1 },
+		10*time.Second)
+}
+
+// TestScenario_MetricsDrainOutcomeCompleted (#60 scenario 2):
+//
+// Mirrors TestScenario_DrainOnShutdown but adds the metrics endpoint and a
+// pre-shutdown scrape that confirms drain_total{outcome="completed"} is
+// registered at 0. After SIGTERM the agent records the success outcome via
+// recordDrain("completed", …), but the metrics HTTP listener is closed by
+// srv.Shutdown as soon as ctx is cancelled — there is no race-free window
+// to scrape post-drain. We therefore assert the success path via the
+// agent's "drain: complete, all gateways migrated away" log line, which is
+// emitted on the same code path that bumps the counter.
+//
+// Pinning down the post-drain counter value end-to-end would require the
+// metrics server to outlive the drain phase; that is a wiring decision in
+// the agent (out of scope for this issue) and is already covered by the
+// unit test in metrics_test.go.
+func TestScenario_MetricsDrainOutcomeCompleted(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "metdrain",
+		LRPNetworks: []string{"198.51.100.11/24"},
+		GatewayChassis: []testenv.GatewayChassisEntry{
+			{ChassisName: testenv.LocalHostname(t), Priority: 5},
+		},
+	})
+
+	cfg := testenv.Defaults()
+	on := true
+	cfg.DrainOnShutdown = &on
+	cfg.ReconcileInterval = "2s"
+	addr := testenv.FreeLoopbackAddr(t)
+	cfg.MetricsListen = addr
+	a := readyAgent(t, cfg)
+
+	// Wait for the LRP /32 route to land before initiating drain. Mirrors
+	// TestScenario_DrainOnShutdown.
+	testenv.AssertKernelRoute(t, "198.51.100.11", 15*time.Second)
+
+	// Pre-shutdown: the drain success counter must be registered at 0.
+	// newMetricsRegistry initialises every label series, so the series
+	// is present from the first scrape onwards.
+	testenv.AssertMetricEventually(t, addr,
+		"ovn_network_agent_drain_total",
+		map[string]string{"outcome": "completed"},
+		func(v float64, present bool) bool { return present && v == 0 },
+		5*time.Second)
+
+	// Rebind goroutine: same shape as TestScenario_DrainOnShutdown — once
+	// the local Gateway_Chassis priority is lowered to 0, simulate
+	// ovn-northd by rebinding the CR Port_Binding to a peer so the drain
+	// loop's countLocalCRPorts returns 0 and the success path runs.
+	peerUUID := testenv.MakeChassis(t, ctx, sb, "metdrain-peer")
+	gcName := "lrp-" + router.Name + "_" + testenv.LocalHostname(t)
+
+	errCh := make(chan error, 1)
+	pctx, pcancel := context.WithCancel(ctx)
+	defer pcancel()
+	go func() {
+		tick := time.NewTicker(50 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-pctx.Done():
+				return
+			case <-tick.C:
+				var entries []testenv.NBGatewayChassis
+				if err := nb.List(ctx, &entries); err != nil {
+					select {
+					case errCh <- err:
+					default:
+					}
+					return
+				}
+				for _, gc := range entries {
+					if gc.Name != gcName || gc.Priority != 0 {
+						continue
+					}
+					rebind := &testenv.SBPortBinding{UUID: router.CRPortUUID, Chassis: &peerUUID}
+					ops, opErr := sb.Where(rebind).Update(rebind, &rebind.Chassis)
+					if opErr != nil {
+						select {
+						case errCh <- opErr:
+						default:
+						}
+						return
+					}
+					if _, opErr := sb.Transact(ctx, ops...); opErr != nil {
+						select {
+						case errCh <- opErr:
+						default:
+						}
+					}
+					return
+				}
+			}
+		}
+	}()
+
+	if err := a.Stop(45 * time.Second); err != nil {
+		t.Fatalf("agent stop: %v", err)
+	}
+	pcancel()
+	select {
+	case err := <-errCh:
+		t.Fatalf("drain helper goroutine error: %v", err)
+	default:
+	}
+
+	// Drain success path: log line is emitted on the same branch that
+	// records drain_total{outcome="completed"}.
+	logs := a.LogTail(100000)
+	if !strings.Contains(logs, "drain: complete, all gateways migrated away") {
+		t.Errorf("expected drain success log line not found; last logs:\n%s", a.LogTail(40))
+	}
+}
+
+// TestScenario_MetricsStaleChassisCleanup (#60 scenario 4):
+//
+// Mirrors TestScenario_StaleChassisCleanup but asserts the metric side of
+// the cleanup: while the peer chassis is present and tracked,
+// missing_chassis returns to 0; once it is deleted and the grace period
+// elapses, stale_chassis_cleanup_total{outcome="success"} bumps to ≥1.
+//
+// Unlike the drain scenario, this happens during normal operation (no
+// shutdown), so the metrics endpoint stays reachable for the assertions.
+func TestScenario_MetricsStaleChassisCleanup(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "metstale",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	peerName := "metstale-ghost"
+	peerUUID := testenv.MakeChassis(t, ctx, sb, peerName)
+	testenv.SeedManagedRoute(t, ctx, nb, router, "203.0.113.99/32", "169.254.0.1", peerName)
+
+	cfg := testenv.Defaults()
+	cfg.StaleChassisGracePeriod = "2s"
+	cfg.ReconcileInterval = "2s"
+	addr := testenv.FreeLoopbackAddr(t)
+	cfg.MetricsListen = addr
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// While the peer chassis is alive the agent's missing-chassis tracker
+	// remains empty after every reconcile.
+	testenv.AssertMetricEventually(t, addr,
+		"ovn_network_agent_missing_chassis", nil,
+		func(v float64, present bool) bool { return present && v == 0 },
+		10*time.Second)
+
+	// Delete the peer chassis; after grace + jitter the cleanup counter
+	// must bump and missing_chassis must return to 0 once the stale
+	// route is purged from NB. The grace period is 2s + ≤30s jitter.
+	testenv.DeleteChassis(t, ctx, sb, peerUUID)
+
+	testenv.AssertMetricEventually(t, addr,
+		"ovn_network_agent_stale_chassis_cleanup_total",
+		map[string]string{"outcome": "success"},
+		func(v float64, present bool) bool { return present && v >= 1 },
+		60*time.Second)
+
+	testenv.AssertMetricEventually(t, addr,
+		"ovn_network_agent_missing_chassis", nil,
+		func(v float64, present bool) bool { return present && v == 0 },
+		60*time.Second)
+}
+
+// TestScenario_MetricsDesiredStateGauges (#60 scenario 6):
+//
+// desired_ips counts every IP that needs a kernel + FRR route: the router
+// gateway address from each LRP network plus every NAT external IP
+// (FIP/SNAT). With one local router (LRP 198.51.100.11/24) and one FIP
+// the gauge therefore settles at 2, and local_routers at 1. Adding a
+// second FIP bumps desired_ips to 3 without touching local_routers. These
+// gauges are updated every reconcile, so a tight ReconcileInterval keeps
+// the test well under the suite's per-scenario budget.
+func TestScenario_MetricsDesiredStateGauges(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "metgauge",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	cfg := testenv.FastDefaults()
+	addr := testenv.FreeLoopbackAddr(t)
+	cfg.MetricsListen = addr
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	const (
+		fipA = "198.51.100.42"
+		fipB = "198.51.100.43"
+	)
+	testenv.AddFIP(t, ctx, nb, router, fipA, "10.0.0.42")
+
+	testenv.AssertMetricEventually(t, addr,
+		"ovn_network_agent_local_routers", nil,
+		func(v float64, present bool) bool { return present && v == 1 },
+		15*time.Second)
+	// LRP gateway IP (198.51.100.11) + fipA = 2 desired IPs.
+	testenv.AssertMetricEventually(t, addr,
+		"ovn_network_agent_desired_ips", nil,
+		func(v float64, present bool) bool { return present && v == 2 },
+		15*time.Second)
+
+	// Add a second FIP — desired_ips must climb to 3 (LRP + 2 FIPs).
+	testenv.AddFIP(t, ctx, nb, router, fipB, "10.0.0.43")
+	testenv.AssertMetricEventually(t, addr,
+		"ovn_network_agent_desired_ips", nil,
+		func(v float64, present bool) bool { return present && v == 3 },
+		15*time.Second)
+	// local_routers is independent of FIP count.
+	testenv.AssertMetricEventually(t, addr,
+		"ovn_network_agent_local_routers", nil,
+		func(v float64, present bool) bool { return present && v == 1 },
+		5*time.Second)
+}

--- a/test/integration/testenv/agent.go
+++ b/test/integration/testenv/agent.go
@@ -42,6 +42,12 @@ type AgentConfig struct {
 	StaleChassisGracePeriod string `yaml:"stale_chassis_grace_period,omitempty"`
 	DrainTimeout            string `yaml:"drain_timeout,omitempty"`
 
+	// MetricsListen is the address the agent's Prometheus /metrics endpoint
+	// binds to. Empty disables the endpoint (the agent's default). Scenario
+	// tests should pick a free loopback port with FreeLoopbackAddr so parallel
+	// runs do not collide.
+	MetricsListen string `yaml:"metrics_listen,omitempty"`
+
 	// Port forwarding (DNAT). PortForwards is the list of VIPs and rules; the
 	// agent infers PortForwardEnabled from len > 0. PortForwardL3mdevAccept
 	// flips a *global* sysctl when true — scenario tests that set it must use
@@ -333,6 +339,7 @@ func writeTempConfig(t *testing.T, cfg AgentConfig) string {
 	put("reconcile_interval", cfg.ReconcileInterval)
 	put("stale_chassis_grace_period", cfg.StaleChassisGracePeriod)
 	put("drain_timeout", cfg.DrainTimeout)
+	put("metrics_listen", cfg.MetricsListen)
 	putBool("dry_run", cfg.DryRun)
 	putBool("cleanup_on_shutdown", cfg.CleanupOnShutdown)
 	putBool("drain_on_shutdown", cfg.DrainOnShutdown)

--- a/test/integration/testenv/metrics.go
+++ b/test/integration/testenv/metrics.go
@@ -1,0 +1,323 @@
+//go:build integration
+
+package testenv
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// MetricsSnapshot is a parsed Prometheus text-format /metrics scrape.
+//
+// Outer key: metric name (e.g. "ovn_network_agent_reconcile_total").
+// Inner key: a canonical label string built by LabelKey from the
+// label set (e.g. `trigger="periodic"`). Empty inner key represents
+// a metric with no labels.
+//
+// Histograms expand to several derived series the way Prometheus
+// exposes them: <name>_bucket{le="…"}, <name>_sum, <name>_count.
+type MetricsSnapshot map[string]map[string]float64
+
+// Value returns the value of metric `name` with the given label set, or
+// (0, false) if the series is not present. Labels are normalised through
+// LabelKey, so callers may pass them in any order.
+func (s MetricsSnapshot) Value(name string, labels map[string]string) (float64, bool) {
+	series, ok := s[name]
+	if !ok {
+		return 0, false
+	}
+	v, ok := series[LabelKey(labels)]
+	return v, ok
+}
+
+// LabelKey returns the canonical inner-map key for a label set: each
+// `name="value"` pair joined by `,` after sorting by name. Empty labels
+// yield "". The escape rules match Prometheus text exposition: `\` →
+// `\\`, `"` → `\"`, newline → `\n`.
+func LabelKey(labels map[string]string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(labels))
+	for k := range labels {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	var b strings.Builder
+	for i, n := range names {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(n)
+		b.WriteString(`="`)
+		b.WriteString(escapeLabelValue(labels[n]))
+		b.WriteByte('"')
+	}
+	return b.String()
+}
+
+// ScrapeMetrics fetches http://addr/metrics and parses the response into a
+// MetricsSnapshot. It fails the test on transport or parse errors. Callers
+// must have configured the agent with cfg.MetricsListen=addr.
+func ScrapeMetrics(t *testing.T, addr string) MetricsSnapshot {
+	t.Helper()
+	url := "http://" + addr + "/metrics"
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("ScrapeMetrics: build request: %v", err)
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("ScrapeMetrics %s: %v", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("ScrapeMetrics %s: status %d", url, resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ScrapeMetrics %s: read body: %v", url, err)
+	}
+	snap, err := parseMetrics(string(body))
+	if err != nil {
+		t.Fatalf("ScrapeMetrics %s: parse: %v", url, err)
+	}
+	return snap
+}
+
+// AssertMetricEventually polls /metrics until predicate returns true for the
+// (name, labels) series or timeout expires. Useful for asserting that a
+// counter has incremented or a gauge has settled to an expected value
+// without baking in a fixed sleep. Scrape errors short-circuit the
+// test — the metrics endpoint must stay reachable for the duration.
+func AssertMetricEventually(
+	t *testing.T,
+	addr, name string,
+	labels map[string]string,
+	predicate func(value float64, present bool) bool,
+	timeout time.Duration,
+) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastVal float64
+	var lastPresent bool
+	for {
+		snap := ScrapeMetrics(t, addr)
+		lastVal, lastPresent = snap.Value(name, labels)
+		if predicate(lastVal, lastPresent) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("metric %s%s did not satisfy predicate within %s "+
+				"(last value=%v present=%v)",
+				name, formatLabelsForError(labels), timeout, lastVal, lastPresent)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// FreeLoopbackAddr returns a 127.0.0.1:<port> address whose port is currently
+// free. The listener is opened and closed before returning, leaving a small
+// TOCTOU window — the agent re-listens immediately on startup, so collisions
+// are vanishingly rare in practice. Tests should pass this string into
+// cfg.MetricsListen.
+func FreeLoopbackAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("FreeLoopbackAddr: listen: %v", err)
+	}
+	addr := l.Addr().String()
+	if err := l.Close(); err != nil {
+		t.Fatalf("FreeLoopbackAddr: close: %v", err)
+	}
+	return addr
+}
+
+// parseMetrics walks Prometheus text exposition output line by line.
+// Comments (# HELP / # TYPE) and blank lines are skipped. Every other line
+// is `name{labels} value [timestamp]` or `name value [timestamp]`. The
+// timestamp is discarded.
+//
+// This is intentionally a hand-rolled parser rather than pulling in
+// prometheus/common/expfmt — the format is line-oriented, the parser is
+// short, and we avoid promoting an indirect dep to a direct one for the
+// test harness alone.
+func parseMetrics(text string) (MetricsSnapshot, error) {
+	out := MetricsSnapshot{}
+	for ln, raw := range strings.Split(text, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		name, labels, value, err := parseMetricLine(line)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", ln+1, err)
+		}
+		series, ok := out[name]
+		if !ok {
+			series = map[string]float64{}
+			out[name] = series
+		}
+		series[labels] = value
+	}
+	return out, nil
+}
+
+// parseMetricLine extracts (name, label-key, value) from a single
+// exposition-format line. Returns the canonical label key (sorted,
+// `k="v",…`) so it can be looked up by callers that build the same
+// canonical key from a map.
+func parseMetricLine(line string) (string, string, float64, error) {
+	// Name: everything up to the first `{` or whitespace.
+	nameEnd := strings.IndexAny(line, "{ \t")
+	if nameEnd < 0 {
+		return "", "", 0, fmt.Errorf("no value: %q", line)
+	}
+	name := line[:nameEnd]
+	rest := line[nameEnd:]
+
+	labelKey := ""
+	if strings.HasPrefix(rest, "{") {
+		// Find the closing `}` that isn't inside a quoted label value.
+		// Prometheus text format escapes `\\`, `\"`, `\n` inside values
+		// but allows other characters (including `}`) verbatim, so a
+		// naive strings.Index would mis-terminate on `metric{l="a}b"} 1`.
+		close := -1
+		inQuote := false
+		for i := 1; i < len(rest); i++ {
+			c := rest[i]
+			if inQuote {
+				if c == '\\' && i+1 < len(rest) {
+					i++
+					continue
+				}
+				if c == '"' {
+					inQuote = false
+				}
+				continue
+			}
+			if c == '"' {
+				inQuote = true
+				continue
+			}
+			if c == '}' {
+				close = i
+				break
+			}
+		}
+		if close < 0 {
+			return "", "", 0, fmt.Errorf("unterminated label block: %q", line)
+		}
+		labels, err := parseLabels(rest[1:close])
+		if err != nil {
+			return "", "", 0, fmt.Errorf("labels: %w", err)
+		}
+		labelKey = LabelKey(labels)
+		rest = rest[close+1:]
+	}
+
+	rest = strings.TrimSpace(rest)
+	// Value is the first whitespace-separated token after the label block;
+	// any trailing token is the optional timestamp, which we discard.
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		return "", "", 0, fmt.Errorf("missing value: %q", line)
+	}
+	v, err := parseFloat(fields[0])
+	if err != nil {
+		return "", "", 0, fmt.Errorf("value %q: %w", fields[0], err)
+	}
+	return name, labelKey, v, nil
+}
+
+// parseLabels turns the inside of a `{…}` block into a label map. Handles
+// the standard escape sequences (`\\`, `\"`, `\n`). Whitespace between
+// pairs is tolerated.
+func parseLabels(s string) (map[string]string, error) {
+	out := map[string]string{}
+	i := 0
+	for i < len(s) {
+		// Skip whitespace and commas between pairs.
+		for i < len(s) && (s[i] == ' ' || s[i] == '\t' || s[i] == ',') {
+			i++
+		}
+		if i >= len(s) {
+			break
+		}
+		// Name: up to '='.
+		eq := strings.IndexByte(s[i:], '=')
+		if eq < 0 {
+			return nil, fmt.Errorf("no '=' after %q", s[i:])
+		}
+		name := strings.TrimSpace(s[i : i+eq])
+		i += eq + 1
+		if i >= len(s) || s[i] != '"' {
+			return nil, fmt.Errorf("expected '\"' after %s=", name)
+		}
+		i++
+		var val strings.Builder
+		for i < len(s) {
+			c := s[i]
+			if c == '\\' && i+1 < len(s) {
+				switch s[i+1] {
+				case '\\':
+					val.WriteByte('\\')
+				case '"':
+					val.WriteByte('"')
+				case 'n':
+					val.WriteByte('\n')
+				default:
+					val.WriteByte(s[i+1])
+				}
+				i += 2
+				continue
+			}
+			if c == '"' {
+				i++
+				break
+			}
+			val.WriteByte(c)
+			i++
+		}
+		out[name] = val.String()
+	}
+	return out, nil
+}
+
+// parseFloat accepts Prometheus's special float tokens (+Inf, -Inf, NaN)
+// alongside ordinary numeric values.
+func parseFloat(s string) (float64, error) {
+	switch s {
+	case "+Inf":
+		return math.Inf(1), nil
+	case "-Inf":
+		return math.Inf(-1), nil
+	case "NaN":
+		return math.NaN(), nil
+	}
+	return strconv.ParseFloat(s, 64)
+}
+
+func escapeLabelValue(v string) string {
+	v = strings.ReplaceAll(v, `\`, `\\`)
+	v = strings.ReplaceAll(v, `"`, `\"`)
+	v = strings.ReplaceAll(v, "\n", `\n`)
+	return v
+}
+
+func formatLabelsForError(labels map[string]string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	return "{" + LabelKey(labels) + "}"
+}


### PR DESCRIPTION
Implements #60.

## Summary

Adds Prometheus `/metrics` scrape coverage to the integration suite, plus the harness primitives the scenarios need to bind, scrape, and assert against the agent's endpoint.

## Change set (in commit order)

1. **`test(integration): add MetricsListen field to AgentConfig harness`**
   Adds `MetricsListen string` (yaml: `metrics_listen,omitempty`) to `testenv.AgentConfig` and wires it through `writeTempConfig`, so scenarios can drive the agent's Prometheus endpoint from Go.

2. **`test(integration): add /metrics scrape helpers to testenv`**
   New `test/integration/testenv/metrics.go`:
   - `MetricsSnapshot` — `map[name]map[label-key]float64`, keyed by a canonical sorted `k="v",…` string.
   - `ScrapeMetrics(t, addr)` — HTTP GET `/metrics`, parses the Prometheus text exposition format with a hand-rolled parser (the format is line-oriented and trivial; avoids promoting `prometheus/common` from indirect to direct dep). Label parsing walks quoted values so `}` in a value does not mis-terminate.
   - `AssertMetricEventually(t, addr, name, labels, predicate, timeout)` — polls until the predicate over `(value, present)` holds, mirroring `testenv.Eventually`.
   - `FreeLoopbackAddr(t)` — opens and closes a `127.0.0.1:0` listener to hand out a free port, so parallel scenarios do not collide.

3. **`test(integration): add Prometheus /metrics scrape scenarios`**
   New `test/integration/scenario_metrics_test.go` lands the four scenarios that the issue marks as low-cost / no new fault injection:
   - `TestScenario_MetricsReconcileCounter` — startup ≥1, periodic ≥1.
   - `TestScenario_MetricsDrainOutcomeCompleted` — `DrainOnShutdown` flow with rebind goroutine; sanity-scrape `drain_total{outcome=\"completed\"}==0` before SIGTERM, then assert the success-branch log line. The post-drain counter value cannot be scraped reliably because `srv.Shutdown` closes the metrics listener as soon as `ctx` is cancelled (~ms) while drain takes longer (≥1 polling tick); the log line is emitted on the exact same branch that calls `recordDrain(\"completed\", …)`. The increment itself is covered by `metrics_test.go`. Scenarios 3 (`outcome=timeout`), 5 (OVN connection state), and 7 (route re-adds) are deferred to land alongside the drain edge-case / drift-recovery issues per the issue's acceptance criteria.
   - `TestScenario_MetricsStaleChassisCleanup` — peer chassis present → `missing_chassis==0`; delete → `stale_chassis_cleanup_total{outcome=\"success\"}>=1` and `missing_chassis` returns to 0 (allows 60s for grace + jitter).
   - `TestScenario_MetricsDesiredStateGauges` — one router + one FIP → `desired_ips==1`, `local_routers==1`; add a second FIP → `desired_ips==2`, `local_routers==1`.
   Also updates `test/integration/README.md` with the new scenario file and the `ScrapeMetrics` helper.

## Local verification

- \`go vet ./...\` — pass
- \`go vet -tags=integration ./...\` — pass
- \`go test -count=1 ./...\` — pass (unit tests; integration tests require Linux + root and were not executed locally on darwin)
- \`go build -tags=integration ./test/integration/...\` — pass
- \`golangci-lint run --build-tags=integration ./test/integration/...\` — no new findings in this PR's files (4 pre-existing errcheck warnings remain in `scenario_drift_test.go` / `scenario_network_cidrs_test.go`)

## Deviations from the issue

- Scenario 2 verifies the drain-success branch via the agent's \`\"drain: complete, all gateways migrated away\"\` log line rather than scraping \`drain_total{outcome=\"completed\"}==1\` after SIGTERM. The metric is updated only on shutdown, and the metrics HTTP listener is closed by the agent's own \`srv.Shutdown\` as soon as the process \`ctx\` is cancelled — there is no race-free window to scrape post-drain without changing the agent's wiring (out of scope for this issue). The counter increment itself is exercised by \`metrics_test.go\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)