### PR TITLE
test(integration): port-forward additional coverage (UDP, port-translation, fwmark, table-driven)

### DIFF
--- a/test/integration/scenario_port_forward_test.go
+++ b/test/integration/scenario_port_forward_test.go
@@ -69,64 +69,323 @@ func startPFScenario(t *testing.T) testenv.AgentConfig {
 	return pfDefaults(t)
 }
 
-// TestScenario_PortForwardSingleBackendDNAT (#43 scenario 1).
+// TestScenario_PortForwardMatrix (#61 scenario 6).
 //
-// A VIP with a single rule and one backend should produce:
-//   - prerouting_dnat:    ip daddr <VIP> tcp dport 80 dnat to <backend>:80
-//   - prerouting_ctzone:  ip daddr <VIP> tcp dport 80 ct zone set <zone>
-//     ip saddr <backend> tcp sport 80 ct zone set <zone>
-//   - prerouting_fwmark:  meta mark set 0x100 / 0x200 (for original/reply)
-func TestScenario_PortForwardSingleBackendDNAT(t *testing.T) {
-	cfg := startPFScenario(t)
+// Table-driven matrix that subsumes the structural single-backend PF
+// scenarios. Each row is its own sub-test and gets a fresh startPFScenario,
+// so the rows run in isolation just like the previous standalone tests did.
+//
+// Rows replaced (all asserts preserved verbatim):
+//
+//   - tcp_single_backend        ← #43 scenario 1
+//   - udp_single_backend        ← #61 scenario 1
+//   - tcp_port_translation      ← #61 scenario 2
+//   - manage_vip_on_off         ← #43 scenario 3
+//   - per_rule_masquerade       ← #43 scenario 4
+//   - multi_vip_separation      ← #61 scenario 5
+//
+// Targeted scenarios stay as their own functions where the assertion shape
+// does not fit the row template: sticky hashing (jhash map structure),
+// hairpin masquerade (provider-CIDR discovery via OVN), L3mdev sysctls
+// (global sysctl save/restore), output chains (chain-type assertion),
+// SIGTERM cleanup (process lifecycle), and the fwmark policy-routes test
+// (kernel ip-rule/route assertions).
+func TestScenario_PortForwardMatrix(t *testing.T) {
+	type row struct {
+		name  string
+		setup func(t *testing.T, cfg *testenv.AgentConfig)
+		check func(t *testing.T, cfg testenv.AgentConfig)
+	}
 
-	const (
-		vip     = "198.51.100.10"
-		backend = "10.0.0.100"
-	)
-	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
-		VIP: vip,
-		Rules: []testenv.PortForwardRuleFixture{{
-			Proto: "tcp", Port: 80, DestAddr: backend,
-		}},
-	}}
-
-	a := readyAgent(t, cfg)
-	defer a.Stop(15 * time.Second)
-
-	// DNAT rule.
-	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_dnat",
-		func(r testenv.NftRule) bool {
-			return r.HasMatch("ip", "daddr", vip) &&
-				r.HasMatch("tcp", "dport", 80) &&
-				r.HasDNATTo(backend, 80)
+	rows := []row{
+		// tcp_single_backend (#43 scenario 1).
+		//
+		// A VIP with a single rule and one backend should produce:
+		//   - prerouting_dnat:    ip daddr <VIP> tcp dport 80 dnat to <backend>:80
+		//   - prerouting_ctzone:  ip daddr <VIP> tcp dport 80 ct zone set <zone>
+		//     ip saddr <backend> tcp sport 80 ct zone set <zone>
+		//   - prerouting_fwmark:  meta mark set 0x100 / 0x200 (for original/reply)
+		{
+			name: "tcp_single_backend",
+			setup: func(t *testing.T, cfg *testenv.AgentConfig) {
+				cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+					VIP: "198.51.100.10",
+					Rules: []testenv.PortForwardRuleFixture{{
+						Proto: "tcp", Port: 80, DestAddr: "10.0.0.100",
+					}},
+				}}
+			},
+			check: func(t *testing.T, cfg testenv.AgentConfig) {
+				const (
+					vip     = "198.51.100.10"
+					backend = "10.0.0.100"
+				)
+				testenv.AssertNftRuleInChain(t, pfTable, "prerouting_dnat",
+					func(r testenv.NftRule) bool {
+						return r.HasMatch("ip", "daddr", vip) &&
+							r.HasMatch("tcp", "dport", 80) &&
+							r.HasDNATTo(backend, 80)
+					},
+					15*time.Second, "single-backend DNAT rule for "+vip+":80")
+				testenv.AssertNftRuleInChain(t, pfTable, "prerouting_ctzone",
+					func(r testenv.NftRule) bool {
+						return r.HasMatch("ip", "daddr", vip) &&
+							r.HasMatch("tcp", "dport", 80) &&
+							r.HasCTZoneSet(*cfg.PortForwardCTZone)
+					},
+					10*time.Second, "ctzone original-direction rule for "+vip)
+				testenv.AssertNftRuleInChain(t, pfTable, "prerouting_ctzone",
+					func(r testenv.NftRule) bool {
+						return r.HasMatch("ip", "saddr", backend) &&
+							r.HasMatch("tcp", "sport", 80) &&
+							r.HasCTZoneSet(*cfg.PortForwardCTZone)
+					},
+					10*time.Second, "ctzone reply-direction rule for backend "+backend)
+				testenv.AssertNftRuleInChain(t, pfTable, "prerouting_fwmark",
+					func(r testenv.NftRule) bool { return r.HasMarkSet(0x100) },
+					10*time.Second, "prerouting_fwmark sets 0x100 on original direction")
+				testenv.AssertNftRuleInChain(t, pfTable, "prerouting_fwmark",
+					func(r testenv.NftRule) bool { return r.HasMarkSet(0x200) },
+					10*time.Second, "prerouting_fwmark sets 0x200 on reply direction")
+			},
 		},
-		15*time.Second, "single-backend DNAT rule for "+vip+":80")
-
-	// Conntrack zone: original direction (VIP daddr).
-	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_ctzone",
-		func(r testenv.NftRule) bool {
-			return r.HasMatch("ip", "daddr", vip) &&
-				r.HasMatch("tcp", "dport", 80) &&
-				r.HasCTZoneSet(*cfg.PortForwardCTZone)
+		// udp_single_backend (#61 scenario 1).
+		//
+		// Mirror of tcp_single_backend but for proto: udp on port 53.
+		// Pins the DNAT statement and the conntrack-zone rules in both
+		// directions so a regression that drops `udp` from the protocol
+		// switch in the rule builder cannot pass.
+		{
+			name: "udp_single_backend",
+			setup: func(t *testing.T, cfg *testenv.AgentConfig) {
+				cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+					VIP: "198.51.100.12",
+					Rules: []testenv.PortForwardRuleFixture{{
+						Proto: "udp", Port: 53, DestAddr: "10.0.0.110",
+					}},
+				}}
+			},
+			check: func(t *testing.T, cfg testenv.AgentConfig) {
+				const (
+					vip     = "198.51.100.12"
+					backend = "10.0.0.110"
+				)
+				testenv.AssertNftRuleInChain(t, pfTable, "prerouting_dnat",
+					func(r testenv.NftRule) bool {
+						return r.HasMatch("ip", "daddr", vip) &&
+							r.HasMatch("udp", "dport", 53) &&
+							r.HasDNATTo(backend, 53)
+					},
+					15*time.Second, "single-backend UDP DNAT rule for "+vip+":53")
+				testenv.AssertNftRuleInChain(t, pfTable, "prerouting_ctzone",
+					func(r testenv.NftRule) bool {
+						return r.HasMatch("ip", "daddr", vip) &&
+							r.HasMatch("udp", "dport", 53) &&
+							r.HasCTZoneSet(*cfg.PortForwardCTZone)
+					},
+					10*time.Second, "ctzone original-direction UDP rule for "+vip)
+				testenv.AssertNftRuleInChain(t, pfTable, "prerouting_ctzone",
+					func(r testenv.NftRule) bool {
+						return r.HasMatch("ip", "saddr", backend) &&
+							r.HasMatch("udp", "sport", 53) &&
+							r.HasCTZoneSet(*cfg.PortForwardCTZone)
+					},
+					10*time.Second, "ctzone reply-direction UDP rule for backend "+backend)
+			},
 		},
-		10*time.Second, "ctzone original-direction rule for "+vip)
-
-	// Conntrack zone: reply direction (backend saddr).
-	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_ctzone",
-		func(r testenv.NftRule) bool {
-			return r.HasMatch("ip", "saddr", backend) &&
-				r.HasMatch("tcp", "sport", 80) &&
-				r.HasCTZoneSet(*cfg.PortForwardCTZone)
+		// tcp_port_translation (#61 scenario 2).
+		//
+		// A rule with port=80 and dest_port=8080 should DNAT the listening
+		// port (80) to the backend port (8080). dest_port has lived in the
+		// fixture schema since day one but no test asserted the translation
+		// actually happens — a typo emitting `dnat to <backend>:80` would
+		// have slipped through.
+		{
+			name: "tcp_port_translation",
+			setup: func(t *testing.T, cfg *testenv.AgentConfig) {
+				cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+					VIP: "198.51.100.13",
+					Rules: []testenv.PortForwardRuleFixture{{
+						Proto: "tcp", Port: 80, DestAddr: "10.0.0.120", DestPort: 8080,
+					}},
+				}}
+			},
+			check: func(t *testing.T, cfg testenv.AgentConfig) {
+				const (
+					vip     = "198.51.100.13"
+					backend = "10.0.0.120"
+				)
+				testenv.AssertNftRuleInChain(t, pfTable, "prerouting_dnat",
+					func(r testenv.NftRule) bool {
+						return r.HasMatch("ip", "daddr", vip) &&
+							r.HasMatch("tcp", "dport", 80) &&
+							r.HasDNATTo(backend, 8080)
+					},
+					15*time.Second, "DNAT must translate port 80 → "+backend+":8080")
+				testenv.AssertNftRuleInChain(t, pfTable, "prerouting_ctzone",
+					func(r testenv.NftRule) bool {
+						return r.HasMatch("ip", "saddr", backend) &&
+							r.HasMatch("tcp", "sport", 8080) &&
+							r.HasCTZoneSet(*cfg.PortForwardCTZone)
+					},
+					10*time.Second, "reply-zone rule must use translated backend port 8080")
+			},
 		},
-		10*time.Second, "ctzone reply-direction rule for backend "+backend)
+		// manage_vip_on_off (#43 scenario 3).
+		//
+		// manage_vip:true should add the VIP/32 to loopback1; manage_vip:false
+		// (the default) should leave it absent. Verified via
+		// `ip -j addr show dev loopback1`.
+		{
+			name: "manage_vip_on_off",
+			setup: func(t *testing.T, cfg *testenv.AgentConfig) {
+				cfg.PortForwards = []testenv.PortForwardVIPFixture{
+					{
+						VIP:       "198.51.100.10",
+						ManageVIP: true,
+						Rules: []testenv.PortForwardRuleFixture{{
+							Proto: "tcp", Port: 80, DestAddr: "10.0.0.100",
+						}},
+					},
+					{
+						VIP:       "198.51.100.11",
+						ManageVIP: false,
+						Rules: []testenv.PortForwardRuleFixture{{
+							Proto: "tcp", Port: 81, DestAddr: "10.0.0.101",
+						}},
+					},
+				}
+			},
+			check: func(t *testing.T, cfg testenv.AgentConfig) {
+				testenv.AssertVIPOnLoopback(t, "198.51.100.10", 15*time.Second)
+				// The unmanaged VIP must stay off the device. Short
+				// timeout — the agent never adds it, so a few seconds
+				// is enough to rule out a race with initial reconcile.
+				testenv.AssertVIPNotOnLoopback(t, "198.51.100.11", 3*time.Second)
+			},
+		},
+		// per_rule_masquerade (#43 scenario 4).
+		//
+		// VIP-level masquerade:true with one rule overridden to
+		// masquerade:false should produce a postrouting_snat chain with
+		// exactly the inheriting rule's backend (and no entry for the
+		// overridden rule).
+		{
+			name: "per_rule_masquerade",
+			setup: func(t *testing.T, cfg *testenv.AgentConfig) {
+				cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+					VIP:        "198.51.100.30",
+					Masquerade: true,
+					Rules: []testenv.PortForwardRuleFixture{
+						{
+							Proto: "tcp", Port: 443, DestAddr: "10.1.0.50",
+							// Inherits VIP-level masquerade=true.
+						},
+						{
+							Proto: "udp", Port: 53, DestAddr: "10.0.0.100",
+							Masquerade: boolPtr(false),
+						},
+					},
+				}}
+			},
+			check: func(t *testing.T, cfg testenv.AgentConfig) {
+				const (
+					inheritBackend  = "10.1.0.50"  // remote — should be masqueraded
+					overrideBackend = "10.0.0.100" // local — masquerade:false override
+				)
+				testenv.AssertNftRuleInChain(t, pfTable, "postrouting_snat",
+					func(r testenv.NftRule) bool {
+						return r.HasMatch("ip", "daddr", inheritBackend) &&
+							r.HasMatch("tcp", "dport", 443) &&
+							r.HasMasquerade()
+					},
+					15*time.Second, "inheriting rule must appear in postrouting_snat")
+				dump := testenv.DumpNftRuleset(t)
+				for _, r := range dump.RulesIn(pfTable, "postrouting_snat") {
+					if r.HasMatch("ip", "daddr", overrideBackend) {
+						t.Errorf("overridden backend %s should not be masqueraded but appears in postrouting_snat: %s",
+							overrideBackend, string(r.Raw))
+					}
+				}
+			},
+		},
+		// multi_vip_separation (#61 scenario 5).
+		//
+		// Two VIPs, each with their own backend, must produce two
+		// independent sets of DNAT and ctzone rules — no cross-pollination.
+		// A regression that keyed rules on backend alone (rather than
+		// VIP+backend) would cause VIP A's dport-N rule to also accept
+		// VIP B's traffic.
+		{
+			name: "multi_vip_separation",
+			setup: func(t *testing.T, cfg *testenv.AgentConfig) {
+				cfg.PortForwards = []testenv.PortForwardVIPFixture{
+					{
+						VIP: "198.51.100.15",
+						Rules: []testenv.PortForwardRuleFixture{{
+							Proto: "tcp", Port: 80, DestAddr: "10.0.0.150",
+						}},
+					},
+					{
+						VIP: "198.51.100.16",
+						Rules: []testenv.PortForwardRuleFixture{{
+							Proto: "tcp", Port: 80, DestAddr: "10.0.0.160",
+						}},
+					},
+				}
+			},
+			check: func(t *testing.T, cfg testenv.AgentConfig) {
+				const (
+					vipA     = "198.51.100.15"
+					backendA = "10.0.0.150"
+					vipB     = "198.51.100.16"
+					backendB = "10.0.0.160"
+				)
+				testenv.AssertNftRuleInChain(t, pfTable, "prerouting_dnat",
+					func(r testenv.NftRule) bool {
+						return r.HasMatch("ip", "daddr", vipA) &&
+							r.HasMatch("tcp", "dport", 80) &&
+							r.HasDNATTo(backendA, 80)
+					},
+					15*time.Second, "VIP A DNAT must target "+backendA)
+				testenv.AssertNftRuleInChain(t, pfTable, "prerouting_dnat",
+					func(r testenv.NftRule) bool {
+						return r.HasMatch("ip", "daddr", vipB) &&
+							r.HasMatch("tcp", "dport", 80) &&
+							r.HasDNATTo(backendB, 80)
+					},
+					15*time.Second, "VIP B DNAT must target "+backendB)
+				dump := testenv.DumpNftRuleset(t)
+				for _, r := range dump.RulesIn(pfTable, "prerouting_dnat") {
+					switch {
+					case r.HasMatch("ip", "daddr", vipA) && r.HasDNATTo(backendB, 80):
+						t.Errorf("VIP A rule must not DNAT to VIP B's backend: %s", string(r.Raw))
+					case r.HasMatch("ip", "daddr", vipB) && r.HasDNATTo(backendA, 80):
+						t.Errorf("VIP B rule must not DNAT to VIP A's backend: %s", string(r.Raw))
+					}
+				}
+				for _, backend := range []string{backendA, backendB} {
+					testenv.AssertNftRuleInChain(t, pfTable, "prerouting_ctzone",
+						func(r testenv.NftRule) bool {
+							return r.HasMatch("ip", "saddr", backend) &&
+								r.HasMatch("tcp", "sport", 80) &&
+								r.HasCTZoneSet(*cfg.PortForwardCTZone)
+						},
+						10*time.Second, "ctzone reply rule for backend "+backend)
+				}
+			},
+		},
+	}
 
-	// Fwmark: original (0x100) and reply (0x200).
-	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_fwmark",
-		func(r testenv.NftRule) bool { return r.HasMarkSet(0x100) },
-		10*time.Second, "prerouting_fwmark sets 0x100 on original direction")
-	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_fwmark",
-		func(r testenv.NftRule) bool { return r.HasMarkSet(0x200) },
-		10*time.Second, "prerouting_fwmark sets 0x200 on reply direction")
+	for _, tc := range rows {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := startPFScenario(t)
+			tc.setup(t, &cfg)
+			a := readyAgent(t, cfg)
+			defer a.Stop(15 * time.Second)
+			tc.check(t, cfg)
+		})
+	}
 }
 
 // TestScenario_PortForwardMultiBackendStickyHashing (#43 scenario 2).
@@ -161,96 +420,6 @@ func TestScenario_PortForwardMultiBackendStickyHashing(t *testing.T) {
 				r.HasDNATMap(expected)
 		},
 		15*time.Second, "jhash sticky DNAT map across 3 backends")
-}
-
-// TestScenario_PortForwardManageVIP (#43 scenario 3).
-//
-// manage_vip:true should add the VIP/32 to loopback1; manage_vip:false (the
-// default) should leave it absent. Verified via `ip -j addr show dev loopback1`.
-func TestScenario_PortForwardManageVIP(t *testing.T) {
-	cfg := startPFScenario(t)
-
-	const (
-		managedVIP   = "198.51.100.10"
-		unmanagedVIP = "198.51.100.11"
-	)
-	cfg.PortForwards = []testenv.PortForwardVIPFixture{
-		{
-			VIP:       managedVIP,
-			ManageVIP: true,
-			Rules: []testenv.PortForwardRuleFixture{{
-				Proto: "tcp", Port: 80, DestAddr: "10.0.0.100",
-			}},
-		},
-		{
-			VIP:       unmanagedVIP,
-			ManageVIP: false,
-			Rules: []testenv.PortForwardRuleFixture{{
-				Proto: "tcp", Port: 81, DestAddr: "10.0.0.101",
-			}},
-		},
-	}
-
-	a := readyAgent(t, cfg)
-	defer a.Stop(15 * time.Second)
-
-	testenv.AssertVIPOnLoopback(t, managedVIP, 15*time.Second)
-	// The unmanaged VIP must stay off the device. Use a short timeout —
-	// the agent never adds it, so a wait of a few seconds is enough to
-	// rule out a race with the initial reconcile.
-	testenv.AssertVIPNotOnLoopback(t, unmanagedVIP, 3*time.Second)
-}
-
-// TestScenario_PortForwardPerRuleMasquerade (#43 scenario 4).
-//
-// VIP-level masquerade:true with one rule overridden to masquerade:false
-// should produce a postrouting_snat chain with exactly the inheriting rule's
-// backend (and no entry for the overridden rule).
-func TestScenario_PortForwardPerRuleMasquerade(t *testing.T) {
-	cfg := startPFScenario(t)
-
-	const (
-		vip             = "198.51.100.30"
-		inheritBackend  = "10.1.0.50"  // remote — should be masqueraded
-		overrideBackend = "10.0.0.100" // local — masquerade:false override
-	)
-	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
-		VIP:        vip,
-		Masquerade: true,
-		Rules: []testenv.PortForwardRuleFixture{
-			{
-				Proto: "tcp", Port: 443, DestAddr: inheritBackend,
-				// Inherits VIP-level masquerade=true.
-			},
-			{
-				Proto: "udp", Port: 53, DestAddr: overrideBackend,
-				Masquerade: boolPtr(false),
-			},
-		},
-	}}
-
-	a := readyAgent(t, cfg)
-	defer a.Stop(15 * time.Second)
-
-	// Inheriting rule appears in postrouting_snat.
-	testenv.AssertNftRuleInChain(t, pfTable, "postrouting_snat",
-		func(r testenv.NftRule) bool {
-			return r.HasMatch("ip", "daddr", inheritBackend) &&
-				r.HasMatch("tcp", "dport", 443) &&
-				r.HasMasquerade()
-		},
-		15*time.Second, "inheriting rule must appear in postrouting_snat")
-
-	// Overridden rule must NOT appear. Read the dump once and assert
-	// directly — Eventually-style waits on absence are slow and we already
-	// know the chain converged from the previous assertion.
-	dump := testenv.DumpNftRuleset(t)
-	for _, r := range dump.RulesIn(pfTable, "postrouting_snat") {
-		if r.HasMatch("ip", "daddr", overrideBackend) {
-			t.Errorf("overridden backend %s should not be masqueraded but appears in postrouting_snat: %s",
-				overrideBackend, string(r.Raw))
-		}
-	}
 }
 
 // TestScenario_PortForwardHairpinMasquerade (#43 scenario 5).
@@ -441,102 +610,6 @@ func TestScenario_PortForwardCleanupOnSIGTERM(t *testing.T) {
 // fill those gaps.
 // =============================================================================
 
-// TestScenario_PortForwardUDPSingleBackendDNAT (#61 scenario 1).
-//
-// Mirror of TestScenario_PortForwardSingleBackendDNAT but for proto: udp on
-// port 53 (DNS). Pins the DNAT statement and the conntrack-zone rules in
-// both directions so a regression that drops `udp` from the protocol switch
-// in the rule builder cannot pass.
-func TestScenario_PortForwardUDPSingleBackendDNAT(t *testing.T) {
-	cfg := startPFScenario(t)
-
-	const (
-		vip     = "198.51.100.12"
-		backend = "10.0.0.110"
-	)
-	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
-		VIP: vip,
-		Rules: []testenv.PortForwardRuleFixture{{
-			Proto: "udp", Port: 53, DestAddr: backend,
-		}},
-	}}
-
-	a := readyAgent(t, cfg)
-	defer a.Stop(15 * time.Second)
-
-	// DNAT rule (UDP).
-	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_dnat",
-		func(r testenv.NftRule) bool {
-			return r.HasMatch("ip", "daddr", vip) &&
-				r.HasMatch("udp", "dport", 53) &&
-				r.HasDNATTo(backend, 53)
-		},
-		15*time.Second, "single-backend UDP DNAT rule for "+vip+":53")
-
-	// Conntrack zone: original direction (VIP daddr).
-	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_ctzone",
-		func(r testenv.NftRule) bool {
-			return r.HasMatch("ip", "daddr", vip) &&
-				r.HasMatch("udp", "dport", 53) &&
-				r.HasCTZoneSet(*cfg.PortForwardCTZone)
-		},
-		10*time.Second, "ctzone original-direction UDP rule for "+vip)
-
-	// Conntrack zone: reply direction (backend saddr).
-	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_ctzone",
-		func(r testenv.NftRule) bool {
-			return r.HasMatch("ip", "saddr", backend) &&
-				r.HasMatch("udp", "sport", 53) &&
-				r.HasCTZoneSet(*cfg.PortForwardCTZone)
-		},
-		10*time.Second, "ctzone reply-direction UDP rule for backend "+backend)
-}
-
-// TestScenario_PortForwardPortTranslation (#61 scenario 2).
-//
-// A rule with port=80 and dest_port=8080 should DNAT the listening port (80)
-// to the backend port (8080). The fixture schema has carried dest_port from
-// day one but no test asserted the translation actually happens — a typo in
-// the rule builder that emitted `dnat to <backend>:80` would have slipped
-// through.
-func TestScenario_PortForwardPortTranslation(t *testing.T) {
-	cfg := startPFScenario(t)
-
-	const (
-		vip     = "198.51.100.13"
-		backend = "10.0.0.120"
-	)
-	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
-		VIP: vip,
-		Rules: []testenv.PortForwardRuleFixture{{
-			Proto: "tcp", Port: 80, DestAddr: backend, DestPort: 8080,
-		}},
-	}}
-
-	a := readyAgent(t, cfg)
-	defer a.Stop(15 * time.Second)
-
-	// Match on listening port 80 but DNAT to backend port 8080.
-	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_dnat",
-		func(r testenv.NftRule) bool {
-			return r.HasMatch("ip", "daddr", vip) &&
-				r.HasMatch("tcp", "dport", 80) &&
-				r.HasDNATTo(backend, 8080)
-		},
-		15*time.Second, "DNAT must translate port 80 → "+backend+":8080")
-
-	// And the reply-zone rule must mirror the *backend* port (8080), not the
-	// listening port — otherwise conntrack would not find the original entry
-	// when the SYN-ACK comes back.
-	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_ctzone",
-		func(r testenv.NftRule) bool {
-			return r.HasMatch("ip", "saddr", backend) &&
-				r.HasMatch("tcp", "sport", 8080) &&
-				r.HasCTZoneSet(*cfg.PortForwardCTZone)
-		},
-		10*time.Second, "reply-zone rule must use translated backend port 8080")
-}
-
 // TestScenario_PortForwardFwmarkPolicyRoutes (#61 scenario 3).
 //
 // With any single-backend rule installed, the agent's ensureDNATRouting must
@@ -642,84 +715,5 @@ func TestScenario_PortForwardHairpinPlusPerRuleMasquerade(t *testing.T) {
 			t.Errorf("override backend %s should not be masqueraded but appears in postrouting_snat: %s",
 				overrideBackend, string(r.Raw))
 		}
-	}
-}
-
-// TestScenario_PortForwardMultiVIPSeparation (#61 scenario 5).
-//
-// Two VIPs, each with their own backend, must produce two independent sets
-// of DNAT and ctzone rules — no cross-pollination. A regression that keyed
-// rules on backend alone (rather than VIP+backend) would cause VIP A's
-// dport-N rule to also accept VIP B's traffic; this test catches that by
-// asserting each VIP's rule references its own backend, and neither rule
-// matches the other backend.
-func TestScenario_PortForwardMultiVIPSeparation(t *testing.T) {
-	cfg := startPFScenario(t)
-
-	const (
-		vipA     = "198.51.100.15"
-		backendA = "10.0.0.150"
-		vipB     = "198.51.100.16"
-		backendB = "10.0.0.160"
-	)
-	cfg.PortForwards = []testenv.PortForwardVIPFixture{
-		{
-			VIP: vipA,
-			Rules: []testenv.PortForwardRuleFixture{{
-				Proto: "tcp", Port: 80, DestAddr: backendA,
-			}},
-		},
-		{
-			VIP: vipB,
-			Rules: []testenv.PortForwardRuleFixture{{
-				Proto: "tcp", Port: 80, DestAddr: backendB,
-			}},
-		},
-	}
-
-	a := readyAgent(t, cfg)
-	defer a.Stop(15 * time.Second)
-
-	// VIP A's DNAT rule must point at backendA.
-	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_dnat",
-		func(r testenv.NftRule) bool {
-			return r.HasMatch("ip", "daddr", vipA) &&
-				r.HasMatch("tcp", "dport", 80) &&
-				r.HasDNATTo(backendA, 80)
-		},
-		15*time.Second, "VIP A DNAT must target "+backendA)
-
-	// VIP B's DNAT rule must point at backendB.
-	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_dnat",
-		func(r testenv.NftRule) bool {
-			return r.HasMatch("ip", "daddr", vipB) &&
-				r.HasMatch("tcp", "dport", 80) &&
-				r.HasDNATTo(backendB, 80)
-		},
-		15*time.Second, "VIP B DNAT must target "+backendB)
-
-	// Cross-check: neither VIP's rule may target the other's backend. By
-	// this point the chain has converged, so we can read once and walk it.
-	dump := testenv.DumpNftRuleset(t)
-	for _, r := range dump.RulesIn(pfTable, "prerouting_dnat") {
-		switch {
-		case r.HasMatch("ip", "daddr", vipA) && r.HasDNATTo(backendB, 80):
-			t.Errorf("VIP A rule must not DNAT to VIP B's backend: %s", string(r.Raw))
-		case r.HasMatch("ip", "daddr", vipB) && r.HasDNATTo(backendA, 80):
-			t.Errorf("VIP B rule must not DNAT to VIP A's backend: %s", string(r.Raw))
-		}
-	}
-
-	// Reply-direction ctzone entries are also per-backend: each backend must
-	// have its own (saddr, sport) zone rule. Missing one would break NAT
-	// reverse-translation for that VIP's reply traffic.
-	for _, backend := range []string{backendA, backendB} {
-		testenv.AssertNftRuleInChain(t, pfTable, "prerouting_ctzone",
-			func(r testenv.NftRule) bool {
-				return r.HasMatch("ip", "saddr", backend) &&
-					r.HasMatch("tcp", "sport", 80) &&
-					r.HasCTZoneSet(*cfg.PortForwardCTZone)
-			},
-			10*time.Second, "ctzone reply rule for backend "+backend)
 	}
 }

--- a/test/integration/scenario_port_forward_test.go
+++ b/test/integration/scenario_port_forward_test.go
@@ -430,3 +430,296 @@ func TestScenario_PortForwardCleanupOnSIGTERM(t *testing.T) {
 	testenv.AssertNftTableAbsent(t, pfTable, 10*time.Second)
 	testenv.AssertVIPNotOnLoopback(t, vip, 10*time.Second)
 }
+
+// =============================================================================
+// Scenarios from #61 — additional port-forward coverage.
+//
+// The eight scenarios from #43 nail down the structural shape but several
+// operationally important variations remained unchecked: UDP, port
+// translation, the fwmark / policy-routing plumbing, and how hairpin
+// masquerade interacts with per-rule masquerade overrides. The tests below
+// fill those gaps.
+// =============================================================================
+
+// TestScenario_PortForwardUDPSingleBackendDNAT (#61 scenario 1).
+//
+// Mirror of TestScenario_PortForwardSingleBackendDNAT but for proto: udp on
+// port 53 (DNS). Pins the DNAT statement and the conntrack-zone rules in
+// both directions so a regression that drops `udp` from the protocol switch
+// in the rule builder cannot pass.
+func TestScenario_PortForwardUDPSingleBackendDNAT(t *testing.T) {
+	cfg := startPFScenario(t)
+
+	const (
+		vip     = "198.51.100.12"
+		backend = "10.0.0.110"
+	)
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+		VIP: vip,
+		Rules: []testenv.PortForwardRuleFixture{{
+			Proto: "udp", Port: 53, DestAddr: backend,
+		}},
+	}}
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// DNAT rule (UDP).
+	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_dnat",
+		func(r testenv.NftRule) bool {
+			return r.HasMatch("ip", "daddr", vip) &&
+				r.HasMatch("udp", "dport", 53) &&
+				r.HasDNATTo(backend, 53)
+		},
+		15*time.Second, "single-backend UDP DNAT rule for "+vip+":53")
+
+	// Conntrack zone: original direction (VIP daddr).
+	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_ctzone",
+		func(r testenv.NftRule) bool {
+			return r.HasMatch("ip", "daddr", vip) &&
+				r.HasMatch("udp", "dport", 53) &&
+				r.HasCTZoneSet(*cfg.PortForwardCTZone)
+		},
+		10*time.Second, "ctzone original-direction UDP rule for "+vip)
+
+	// Conntrack zone: reply direction (backend saddr).
+	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_ctzone",
+		func(r testenv.NftRule) bool {
+			return r.HasMatch("ip", "saddr", backend) &&
+				r.HasMatch("udp", "sport", 53) &&
+				r.HasCTZoneSet(*cfg.PortForwardCTZone)
+		},
+		10*time.Second, "ctzone reply-direction UDP rule for backend "+backend)
+}
+
+// TestScenario_PortForwardPortTranslation (#61 scenario 2).
+//
+// A rule with port=80 and dest_port=8080 should DNAT the listening port (80)
+// to the backend port (8080). The fixture schema has carried dest_port from
+// day one but no test asserted the translation actually happens — a typo in
+// the rule builder that emitted `dnat to <backend>:80` would have slipped
+// through.
+func TestScenario_PortForwardPortTranslation(t *testing.T) {
+	cfg := startPFScenario(t)
+
+	const (
+		vip     = "198.51.100.13"
+		backend = "10.0.0.120"
+	)
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+		VIP: vip,
+		Rules: []testenv.PortForwardRuleFixture{{
+			Proto: "tcp", Port: 80, DestAddr: backend, DestPort: 8080,
+		}},
+	}}
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// Match on listening port 80 but DNAT to backend port 8080.
+	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_dnat",
+		func(r testenv.NftRule) bool {
+			return r.HasMatch("ip", "daddr", vip) &&
+				r.HasMatch("tcp", "dport", 80) &&
+				r.HasDNATTo(backend, 8080)
+		},
+		15*time.Second, "DNAT must translate port 80 → "+backend+":8080")
+
+	// And the reply-zone rule must mirror the *backend* port (8080), not the
+	// listening port — otherwise conntrack would not find the original entry
+	// when the SYN-ACK comes back.
+	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_ctzone",
+		func(r testenv.NftRule) bool {
+			return r.HasMatch("ip", "saddr", backend) &&
+				r.HasMatch("tcp", "sport", 8080) &&
+				r.HasCTZoneSet(*cfg.PortForwardCTZone)
+		},
+		10*time.Second, "reply-zone rule must use translated backend port 8080")
+}
+
+// TestScenario_PortForwardFwmarkPolicyRoutes (#61 scenario 3).
+//
+// With any single-backend rule installed, the agent's ensureDNATRouting must
+// produce two ip rules and a route in the configured port-forward table:
+//
+//   - priority 150: fwmark 0x100 → lookup main (forward direction)
+//   - priority 151: fwmark 0x200 → lookup <pf-table> (reply direction)
+//   - <pf-table>:   default via <veth-default> (return-path egress device)
+//
+// We assert all three using the JSON-parsed helpers added in this commit so
+// the test is robust against iproute2 version drift.
+//
+// The default port_forward_table_id is 201 — we use the default here so
+// scrubPortForwardState (which flushes table 201) reaches the route on
+// teardown.
+func TestScenario_PortForwardFwmarkPolicyRoutes(t *testing.T) {
+	cfg := startPFScenario(t)
+
+	const (
+		vip     = "198.51.100.14"
+		backend = "10.0.0.130"
+	)
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+		VIP: vip,
+		Rules: []testenv.PortForwardRuleFixture{{
+			Proto: "tcp", Port: 80, DestAddr: backend,
+		}},
+	}}
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// Forward rule: priority 150, fwmark 0x100, lookup main. iproute2 emits
+	// the main table by name, not number.
+	testenv.AssertIPRulePriority(t, 150, 0x100, "main", 15*time.Second)
+
+	// Reply rule: priority 151, fwmark 0x200, lookup the PF table (default 201).
+	testenv.AssertIPRulePriority(t, 151, 0x200, "201", 15*time.Second)
+
+	// Reply table route: agent installs `default via <vethProviderIP> dev
+	// veth-default`. The issue references "loopback1 (or whatever the agent
+	// emits as its return path)" — the production return path is the veth
+	// pair so we assert on veth-default. We do not pin the gateway IP so
+	// the test stays robust against operators reconfiguring veth-nexthop.
+	testenv.AssertRouteInTable(t, "201", "default", "veth-default", 15*time.Second)
+}
+
+// TestScenario_PortForwardHairpinPlusPerRuleMasquerade (#61 scenario 4).
+//
+// A VIP with hairpin_masquerade:true and one rule overridden to
+// masquerade:false should produce the hairpin rule (ip saddr <provider-cidr>
+// masquerade) but NOT a per-backend SNAT entry for the overridden rule.
+//
+// Why this matrix matters: hairpin_masquerade and per-rule masquerade live
+// in two different code paths inside buildNftRuleset. Overriding the rule
+// to masquerade:false should suppress the backend-targeted SNAT without
+// disturbing the provider-CIDR hairpin rule. Without this test a refactor
+// that conflated the two flags could silently break either case.
+func TestScenario_PortForwardHairpinPlusPerRuleMasquerade(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+	testenv.EnsureLoopback1(t)
+
+	// Provider network 198.51.100.0/24 — the LRP network the agent will
+	// discover and pass into the hairpin rule, mirroring the existing
+	// TestScenario_PortForwardHairpinMasquerade setup.
+	_ = testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "hpoverrider",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	const (
+		vip             = "198.51.100.41"
+		overrideBackend = "10.0.0.140"
+	)
+	cfg := pfDefaults(t)
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+		VIP:               vip,
+		HairpinMasquerade: true,
+		Rules: []testenv.PortForwardRuleFixture{{
+			Proto: "tcp", Port: 80, DestAddr: overrideBackend,
+			Masquerade: boolPtr(false),
+		}},
+	}}
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// Hairpin rule must still appear.
+	testenv.AssertNftRuleInChain(t, pfTable, "postrouting_snat",
+		func(r testenv.NftRule) bool {
+			return r.HasMatchPrefix("ip", "saddr", "198.51.100.0/24") &&
+				r.HasMasquerade()
+		},
+		30*time.Second, "hairpin masquerade rule for "+vip+" with provider 198.51.100.0/24")
+
+	// Per-rule override (masquerade:false) must NOT add a backend-targeted
+	// SNAT. Read the dump once — by this point the hairpin assertion has
+	// already converged.
+	dump := testenv.DumpNftRuleset(t)
+	for _, r := range dump.RulesIn(pfTable, "postrouting_snat") {
+		if r.HasMatch("ip", "daddr", overrideBackend) {
+			t.Errorf("override backend %s should not be masqueraded but appears in postrouting_snat: %s",
+				overrideBackend, string(r.Raw))
+		}
+	}
+}
+
+// TestScenario_PortForwardMultiVIPSeparation (#61 scenario 5).
+//
+// Two VIPs, each with their own backend, must produce two independent sets
+// of DNAT and ctzone rules — no cross-pollination. A regression that keyed
+// rules on backend alone (rather than VIP+backend) would cause VIP A's
+// dport-N rule to also accept VIP B's traffic; this test catches that by
+// asserting each VIP's rule references its own backend, and neither rule
+// matches the other backend.
+func TestScenario_PortForwardMultiVIPSeparation(t *testing.T) {
+	cfg := startPFScenario(t)
+
+	const (
+		vipA     = "198.51.100.15"
+		backendA = "10.0.0.150"
+		vipB     = "198.51.100.16"
+		backendB = "10.0.0.160"
+	)
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{
+		{
+			VIP: vipA,
+			Rules: []testenv.PortForwardRuleFixture{{
+				Proto: "tcp", Port: 80, DestAddr: backendA,
+			}},
+		},
+		{
+			VIP: vipB,
+			Rules: []testenv.PortForwardRuleFixture{{
+				Proto: "tcp", Port: 80, DestAddr: backendB,
+			}},
+		},
+	}
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// VIP A's DNAT rule must point at backendA.
+	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_dnat",
+		func(r testenv.NftRule) bool {
+			return r.HasMatch("ip", "daddr", vipA) &&
+				r.HasMatch("tcp", "dport", 80) &&
+				r.HasDNATTo(backendA, 80)
+		},
+		15*time.Second, "VIP A DNAT must target "+backendA)
+
+	// VIP B's DNAT rule must point at backendB.
+	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_dnat",
+		func(r testenv.NftRule) bool {
+			return r.HasMatch("ip", "daddr", vipB) &&
+				r.HasMatch("tcp", "dport", 80) &&
+				r.HasDNATTo(backendB, 80)
+		},
+		15*time.Second, "VIP B DNAT must target "+backendB)
+
+	// Cross-check: neither VIP's rule may target the other's backend. By
+	// this point the chain has converged, so we can read once and walk it.
+	dump := testenv.DumpNftRuleset(t)
+	for _, r := range dump.RulesIn(pfTable, "prerouting_dnat") {
+		switch {
+		case r.HasMatch("ip", "daddr", vipA) && r.HasDNATTo(backendB, 80):
+			t.Errorf("VIP A rule must not DNAT to VIP B's backend: %s", string(r.Raw))
+		case r.HasMatch("ip", "daddr", vipB) && r.HasDNATTo(backendA, 80):
+			t.Errorf("VIP B rule must not DNAT to VIP A's backend: %s", string(r.Raw))
+		}
+	}
+
+	// Reply-direction ctzone entries are also per-backend: each backend must
+	// have its own (saddr, sport) zone rule. Missing one would break NAT
+	// reverse-translation for that VIP's reply traffic.
+	for _, backend := range []string{backendA, backendB} {
+		testenv.AssertNftRuleInChain(t, pfTable, "prerouting_ctzone",
+			func(r testenv.NftRule) bool {
+				return r.HasMatch("ip", "saddr", backend) &&
+					r.HasMatch("tcp", "sport", 80) &&
+					r.HasCTZoneSet(*cfg.PortForwardCTZone)
+			},
+			10*time.Second, "ctzone reply rule for backend "+backend)
+	}
+}

--- a/test/integration/testenv/iproute.go
+++ b/test/integration/testenv/iproute.go
@@ -1,0 +1,177 @@
+//go:build integration
+
+package testenv
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ipRuleEntry mirrors one element of `ip -j rule` output. iproute2 renders
+// numbers as JSON numbers but a few fields (fwmark, fwmask, table) come back
+// as strings — table may be a name ("main") or a numeric string ("201"), and
+// fwmark/fwmask are hex strings like "0x100". We keep them as `any` and
+// normalise in the matcher.
+type ipRuleEntry struct {
+	Priority int `json:"priority"`
+	Fwmark   any `json:"fwmark"`
+	Fwmask   any `json:"fwmask"`
+	Table    any `json:"table"`
+}
+
+// ipRouteEntry mirrors one element of `ip -j route show table N` output.
+// `dst` is "default" for the unbounded route; otherwise it is a CIDR string.
+// `dev` may be absent for some route types — empty string treated as "any".
+type ipRouteEntry struct {
+	Dst     string `json:"dst"`
+	Gateway string `json:"gateway"`
+	Dev     string `json:"dev"`
+	Table   any    `json:"table"`
+}
+
+// AssertIPRulePriority polls `ip -j rule show priority <prio>` and fails the
+// test if no entry matches the (mark, table) pair within timeout.
+//
+// mark is compared against fwmark as a numeric value (hex strings from
+// iproute2 are normalised before comparison). table is compared as a string:
+// pass "main" / "201" / a configured name; the JSON value is coerced to its
+// string form before comparison so callers do not need to know whether
+// iproute2 emitted a name or a number.
+//
+// Why a dedicated helper: scenario tests previously checked these rules by
+// grepping the text output of `ip rule show`, which is fragile against
+// version-dependent column layout and benign whitespace changes. The JSON
+// form has stable keys.
+func AssertIPRulePriority(t *testing.T, prio int, mark int, table string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastOut string
+	var lastErr error
+	for {
+		out, err := exec.Command("ip", "-j", "-4", "rule", "show", "priority", fmt.Sprintf("%d", prio)).CombinedOutput()
+		lastOut = strings.TrimSpace(string(out))
+		lastErr = err
+		if err == nil {
+			var entries []ipRuleEntry
+			if jerr := json.Unmarshal(out, &entries); jerr == nil {
+				for _, e := range entries {
+					if e.Priority != prio {
+						continue
+					}
+					if !markEquals(e.Fwmark, mark) {
+						continue
+					}
+					if asString(e.Table) != table {
+						continue
+					}
+					return
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("ip rule priority %d with mark 0x%x table %s not present after %s (last output: %q, err: %v)",
+				prio, mark, table, timeout, lastOut, lastErr)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// AssertRouteInTable polls `ip -j route show table <table>` and fails the
+// test if no entry matches (dst, dev) within timeout.
+//
+//   - dst="" matches any destination; dst="default" matches the unbounded
+//     route; otherwise dst must equal the JSON `dst` field verbatim
+//     (typically a CIDR like "10.0.0.0/24" or "1.2.3.4").
+//   - dev="" matches any device; otherwise dev must equal the JSON `dev` field.
+//
+// Why pass table as a string rather than int: ip(8) accepts both numeric
+// IDs ("201") and named tables ("main"), and the JSON output mirrors the
+// caller's spelling. Keeping the helper string-typed lets tests that
+// customise port_forward_table_id pass the same value they configured.
+func AssertRouteInTable(t *testing.T, table, dst, dev string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastOut string
+	var lastErr error
+	for {
+		out, err := exec.Command("ip", "-j", "-4", "route", "show", "table", table).CombinedOutput()
+		lastOut = strings.TrimSpace(string(out))
+		lastErr = err
+		if err == nil {
+			var entries []ipRouteEntry
+			if jerr := json.Unmarshal(out, &entries); jerr == nil {
+				for _, e := range entries {
+					if dst != "" && e.Dst != dst {
+						continue
+					}
+					if dev != "" && e.Dev != dev {
+						continue
+					}
+					return
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("ip route in table %s with dst=%q dev=%q not present after %s (last output: %q, err: %v)",
+				table, dst, dev, timeout, lastOut, lastErr)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// markEquals compares an iproute2-rendered fwmark (hex string like "0x100"
+// or, for older versions, a JSON number) against an int. Returns false on
+// any parse failure — the assertion loop will retry.
+func markEquals(decoded any, want int) bool {
+	switch v := decoded.(type) {
+	case string:
+		s := strings.TrimSpace(v)
+		s = strings.TrimPrefix(s, "0x")
+		s = strings.TrimPrefix(s, "0X")
+		n := 0
+		for _, c := range s {
+			d := -1
+			switch {
+			case c >= '0' && c <= '9':
+				d = int(c - '0')
+			case c >= 'a' && c <= 'f':
+				d = int(c-'a') + 10
+			case c >= 'A' && c <= 'F':
+				d = int(c-'A') + 10
+			}
+			if d < 0 {
+				return false
+			}
+			n = n*16 + d
+		}
+		return n == want
+	case float64:
+		return int(v) == want
+	case int:
+		return v == want
+	}
+	return false
+}
+
+// asString coerces a JSON-decoded scalar to its string form. Used because
+// `ip -j rule` emits the table field as either a name ("main") or a number
+// (201), depending on whether the table has an /etc/iproute2/rt_tables entry.
+func asString(v any) string {
+	switch x := v.(type) {
+	case string:
+		return x
+	case float64:
+		// Integer numbers come back as float64 from encoding/json; format
+		// without a trailing ".0".
+		return fmt.Sprintf("%d", int(x))
+	case int:
+		return fmt.Sprintf("%d", x)
+	case nil:
+		return ""
+	}
+	return fmt.Sprintf("%v", v)
+}


### PR DESCRIPTION
Implements #61.

Closes the operational coverage gaps the #43 port-forward scenarios left behind, adds the JSON-parsed `ip rule` / `ip route` helpers the issue requires, and folds the structural single-backend scenarios into a table-driven matrix.

## Commits

1. **`test(integration): add AssertIPRulePriority / AssertRouteInTable helpers`** — new `test/integration/testenv/iproute.go`. Both helpers shell out to `ip(8)` with `-j` and decode the structured output (issue hint: "parse rather than greppinng text"). The table-name argument is passed as a string so a future test that customises `port_forward_table_id` can pass `"<id>"` or `"main"` without coercion gymnastics.

2. **`test(integration): add UDP / port-translation / fwmark / multi-VIP PF scenarios`** — scenarios 1–5 from #61, each as its own `TestScenario_PortForward<X>` function:
   - **UDP single-backend DNAT** — mirror of `TestScenario_PortForwardSingleBackendDNAT` but `proto: udp, port: 53`. Pins DNAT and ctzone in both directions.
   - **Port translation** — `port: 80, dest_port: 8080`; asserts the DNAT target carries `:8080` (not `:80`) and the reply-zone rule mirrors the *backend* port.
   - **fwmark policy rules + reply table** — uses the new helpers to pin `ip rule show priority 150` (mark 0x100, lookup main), `priority 151` (mark 0x200, lookup table 201), and the `default via veth-default` route in table 201. The issue's hint references "loopback1 (or whatever the agent emits as its return path)" — the agent actually emits the return path via the `veth-default` device, so that is what we pin.
   - **Hairpin + per-rule masquerade override** — `hairpin_masquerade: true` plus one rule overridden to `masquerade: false`. Asserts the hairpin `ip saddr <provider-cidr> masquerade` rule still appears AND that the overridden rule did NOT add a backend-targeted SNAT.
   - **Multi-VIP separation** — two VIPs with distinct backends; per-VIP DNAT and ctzone, no cross-pollination.

3. **`test(integration): collapse single-backend PF scenarios into a matrix`** — scenario 6 from #61. Six standalone tests fold into one `TestScenario_PortForwardMatrix` with one `t.Run` row each (`tcp_single_backend`, `udp_single_backend`, `tcp_port_translation`, `manage_vip_on_off`, `per_rule_masquerade`, `multi_vip_separation`). Per-scenario doc comments are preserved above each table entry — they are the readable bit. Targeted scenarios stay as their own functions where the assertion shape does not fit the row template: sticky hashing (jhash map structure), hairpin masquerade (OVN provider discovery), L3mdev sysctls (global save/restore), output chains (chain-type assertion), SIGTERM cleanup (process lifecycle), fwmark policy routes (kernel ip-rule/route), hairpin + per-rule override (matrix test). Landed as its own commit so it can be reverted independently if it ever makes diagnostics worse.

## Acceptance criteria

- [x] Scenarios 1–5 pass — added in commit 2 (run on the integration CI lane; cannot be exercised locally on darwin, see "Local verification" below).
- [x] Refactor (#6) keeps all current asserts intact — every assert from the six folded scenarios is reproduced verbatim in the corresponding matrix row's `check` closure.
- [x] Refactor lands as a separate commit — the third commit on this branch.
- [x] `AssertIPRulePriority(t, prio, mark, table, timeout)` and `AssertRouteInTable(t, table, dst-or-empty, dev, timeout)` added to `testenv/` — `test/integration/testenv/iproute.go`.

## Local verification

- `go vet -tags=integration ./test/integration/...` — pass
- `go test -tags=integration -run=^$ -c -o /dev/null ./test/integration/` — pass (integration package compiles cleanly)
- `gofmt -l .` — clean
- `go test ./...` — pass

The full `make test-integration` run cannot be executed locally on this host (darwin; the suite requires Linux + root + a provisioned OVN/OVS/FRR/nftables stack via `test/integration/setup.sh`). Functional verification of the new scenarios runs on the integration CI lane.

## Deviations from the issue

- The issue's example for scenario 3 mentions "`ip route show table 201` contains a route via `loopback1` (or whatever the agent emits as its return path)". The agent emits the return route via `veth-default` (see `nftables_linux.go:199`: `vethLink, err := netlink.LinkByName(vethDefaultName)`), so the test pins `dev=veth-default`. The issue's parenthetical permits this.