### PR TITLE
test(integration): bridge-IP and proxy-ARP lifecycle scenarios (#63)

### DIFF
--- a/test/integration/scenario_bridge_ip_test.go
+++ b/test/integration/scenario_bridge_ip_test.go
@@ -1,0 +1,244 @@
+//go:build integration
+
+package integration
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/osism/ovn-network-agent/test/integration/testenv"
+)
+
+// All scenarios in this file cover #63 — the cold-start bridge-IP and
+// proxy-ARP housekeeping that happens before any reconcile cycle. The
+// agent's Run() adds BridgeIP (default 169.254.169.254/32) to br-ex via
+// EnsureBridgeIP so the kernel has a source for ARP, and flips
+// /proc/sys/net/ipv4/conf/br-ex/proxy_arp to 1 via EnableProxyARP so the
+// kernel responds to ARP requests for FIPs. On SIGTERM with
+// cleanup_on_shutdown=true (the default) RemoveBridgeIP undoes the address
+// add; proxy_arp is currently NOT restored — TestScenario_ProxyARPNotRestored
+// pins that down so the operator-facing contract is explicit.
+//
+// State the harness's general Teardown does not scrub:
+//   - bridge addresses on br-ex (only added by these scenarios and the agent)
+//   - the per-device proxy_arp sysctl
+//
+// Each scenario therefore wraps proxy_arp in SaveSysctl and registers a
+// best-effort `ip addr del` for both the default and custom bridge IPs so
+// one failed test does not poison the next.
+
+const (
+	defaultBridgeIPCIDR = "169.254.169.254/32"
+	customBridgeIPCIDR  = "169.254.42.42/32"
+)
+
+// startBridgeIPScenario is the bridge-IP analogue of startScenario /
+// startPFScenario. It performs the host preconditions (Setup + failure
+// dump), saves the per-device proxy_arp sysctl so the agent's unconditional
+// flip to 1 does not leak into subsequent tests, and defensively scrubs any
+// bridge addresses left behind by a previous crash. The Setup-registered
+// Teardown does not touch bridge addresses, so the trailing-edge scrub here
+// is the only thing keeping scenarios in this file from interfering with
+// the rest of the suite.
+//
+// Returns a Defaults() AgentConfig. The caller mutates BridgeIP /
+// CleanupOnShutdown to drive the specific scenario.
+func startBridgeIPScenario(t *testing.T) testenv.AgentConfig {
+	t.Helper()
+	testenv.Setup(t)
+	testenv.RegisterFailureDump(t)
+	testenv.SaveSysctl(t, testenv.BridgeProxyARPPath(testenv.DefaultBridgeDev))
+
+	scrubBridgeIPs(t)
+	t.Cleanup(func() { scrubBridgeIPs(t) })
+
+	return testenv.Defaults()
+}
+
+// scrubBridgeIPs removes the default and custom bridge IPs from br-ex,
+// ignoring errors (the addresses may not be present). Used at both the
+// leading and trailing edges of every bridge-IP scenario.
+func scrubBridgeIPs(t *testing.T) {
+	t.Helper()
+	for _, cidr := range []string{defaultBridgeIPCIDR, customBridgeIPCIDR} {
+		_ = exec.Command("ip", "addr", "del", cidr, "dev", testenv.DefaultBridgeDev).Run()
+	}
+}
+
+// TestScenario_BridgeIPOnStartup (#63 scenario 1):
+//
+// Cold start the agent with default config. The agent must add the default
+// link-local /32 to br-ex during Run() before "agent running" is logged,
+// so AssertBridgeAddress lands as soon as WaitReady returns.
+func TestScenario_BridgeIPOnStartup(t *testing.T) {
+	cfg := startBridgeIPScenario(t)
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	testenv.AssertBridgeAddress(t, testenv.DefaultBridgeDev, defaultBridgeIPCIDR, 10*time.Second)
+}
+
+// TestScenario_BridgeIPNotDuplicatedOnRestart (#63 scenario 2):
+//
+// Stop and restart the agent without cleanup in between. The second Run()
+// must observe the existing address via EnsureBridgeIP's idempotency check
+// and short-circuit — never producing a duplicate entry. We assert exactly
+// one /32 (AssertBridgeAddress fails fast on count != 1) and that the
+// agent logged no "add IP" error line.
+//
+// cleanup_on_shutdown is disabled on the first run so the leftover address
+// is what the second run encounters; this is the load-bearing path because
+// a cleaned-up first run would leave nothing for the second run to
+// duplicate.
+func TestScenario_BridgeIPNotDuplicatedOnRestart(t *testing.T) {
+	cfg := startBridgeIPScenario(t)
+	off := false
+	cfg.CleanupOnShutdown = &off
+
+	a1 := readyAgent(t, cfg)
+	testenv.AssertBridgeAddress(t, testenv.DefaultBridgeDev, defaultBridgeIPCIDR, 10*time.Second)
+	if err := a1.Stop(15 * time.Second); err != nil {
+		t.Fatalf("first agent stop: %v", err)
+	}
+	// Still present — first agent had cleanup_on_shutdown=false.
+	testenv.AssertBridgeAddress(t, testenv.DefaultBridgeDev, defaultBridgeIPCIDR, 5*time.Second)
+
+	a2 := readyAgent(t, cfg)
+	defer a2.Stop(15 * time.Second)
+
+	// Exactly one entry after the second start — AssertBridgeAddress fails
+	// the test if the agent double-added the address.
+	testenv.AssertBridgeAddress(t, testenv.DefaultBridgeDev, defaultBridgeIPCIDR, 10*time.Second)
+
+	// EnsureBridgeIP's idempotency branch emits "bridge IP already present"
+	// at debug level (the harness sets log_level=debug). Asserting on that
+	// line is a stronger pin than just "no error" — it proves the agent
+	// took the fast path instead of issuing a redundant AddrAdd that would
+	// have come back as EEXIST.
+	logs := a2.LogTail(100000)
+	if !strings.Contains(logs, "bridge IP already present") {
+		t.Errorf("expected 'bridge IP already present' on restart; last logs:\n%s", a2.LogTail(40))
+	}
+}
+
+// TestScenario_BridgeIPCustom (#63 scenario 3):
+//
+// Configure bridge_ip to a non-default address. The agent must add that
+// address and MUST NOT also add the 169.254.169.254 default — the cold-
+// start path uses cfg.BridgeIP as the single source of truth.
+func TestScenario_BridgeIPCustom(t *testing.T) {
+	cfg := startBridgeIPScenario(t)
+	cfg.BridgeIP = "169.254.42.42"
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	testenv.AssertBridgeAddress(t, testenv.DefaultBridgeDev, customBridgeIPCIDR, 10*time.Second)
+	testenv.AssertNoBridgeAddress(t, testenv.DefaultBridgeDev, defaultBridgeIPCIDR, 5*time.Second)
+}
+
+// TestScenario_ProxyARPEnabled (#63 scenario 4):
+//
+// After the agent reaches ready the per-device proxy_arp sysctl must be 1.
+// EnableProxyARP runs in Run() before the "agent running" log line, so the
+// sysctl is already flipped by the time WaitReady returns.
+//
+// SaveSysctl in startBridgeIPScenario captures the pre-test value (typically
+// 0 on a fresh host) and restores it at test exit so subsequent tests do
+// not inherit the flipped value.
+func TestScenario_ProxyARPEnabled(t *testing.T) {
+	cfg := startBridgeIPScenario(t)
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	testenv.AssertSysctl(t, testenv.BridgeProxyARPPath(testenv.DefaultBridgeDev), "1", 5*time.Second)
+}
+
+// TestScenario_BridgeIPRemovedOnCleanup (#63 scenario 5):
+//
+// With cleanup_on_shutdown=true (the agent's default), SIGTERM must run
+// cleanup() which calls RemoveBridgeIP. The bridge address must be gone
+// once Stop returns.
+func TestScenario_BridgeIPRemovedOnCleanup(t *testing.T) {
+	cfg := startBridgeIPScenario(t)
+	on := true
+	cfg.CleanupOnShutdown = &on
+
+	a := readyAgent(t, cfg)
+	testenv.AssertBridgeAddress(t, testenv.DefaultBridgeDev, defaultBridgeIPCIDR, 10*time.Second)
+
+	if err := a.Stop(15 * time.Second); err != nil {
+		t.Fatalf("agent stop: %v", err)
+	}
+	testenv.AssertNoBridgeAddress(t, testenv.DefaultBridgeDev, defaultBridgeIPCIDR, 5*time.Second)
+}
+
+// TestScenario_BridgeIPRetainedWhenCleanupDisabled (#63 scenario 6):
+//
+// With cleanup_on_shutdown=false, the agent's shutdown branch logs
+// "shutting down, keeping routes in place" and skips cleanup() entirely.
+// The bridge IP must therefore remain on br-ex after Stop.
+//
+// The trailing-edge scrub registered by startBridgeIPScenario removes the
+// leftover address — the harness's general Teardown does not touch bridge
+// addresses, so without that scrub the next scenario would inherit a
+// 169.254.169.254/32 already on br-ex.
+func TestScenario_BridgeIPRetainedWhenCleanupDisabled(t *testing.T) {
+	cfg := startBridgeIPScenario(t)
+	off := false
+	cfg.CleanupOnShutdown = &off
+
+	a := readyAgent(t, cfg)
+	testenv.AssertBridgeAddress(t, testenv.DefaultBridgeDev, defaultBridgeIPCIDR, 10*time.Second)
+
+	if err := a.Stop(15 * time.Second); err != nil {
+		t.Fatalf("agent stop: %v", err)
+	}
+
+	// Bridge IP must still be present. AssertBridgeAddress with a short
+	// timeout is the right tool — it polls and fails fast if the address
+	// has disappeared (which would mean cleanup ran despite the flag).
+	testenv.AssertBridgeAddress(t, testenv.DefaultBridgeDev, defaultBridgeIPCIDR, 2*time.Second)
+
+	logs := a.LogTail(100000)
+	if !strings.Contains(logs, "shutting down, keeping routes in place") {
+		t.Errorf("expected keep-routes log line not found; last logs:\n%s", a.LogTail(40))
+	}
+}
+
+// TestScenario_ProxyARPNotRestoredOnShutdown (#63 scenario 7, optional):
+//
+// Pins the operator-facing contract: the agent enables proxy_arp on br-ex
+// at startup but does NOT track or restore its pre-startup value on
+// shutdown. EnableProxyARP unconditionally writes "1" to the sysctl, and
+// cleanup() does not call any "DisableProxyARP" counterpart — so after
+// SIGTERM the sysctl remains at 1 regardless of cleanup_on_shutdown.
+//
+// This test exists as a behavioural pin: if a future change adds a restore
+// path, this test will start failing and the change author can update both
+// the test and the documented contract together. SaveSysctl in
+// startBridgeIPScenario takes care of resetting the value for subsequent
+// tests on the host.
+func TestScenario_ProxyARPNotRestoredOnShutdown(t *testing.T) {
+	cfg := startBridgeIPScenario(t)
+	path := testenv.BridgeProxyARPPath(testenv.DefaultBridgeDev)
+
+	// Start from a known-off baseline so a "still 1 after shutdown" result
+	// cannot be confused with "was already 1 before the agent started".
+	if err := exec.Command("sh", "-c", "echo 0 > "+path).Run(); err != nil {
+		t.Fatalf("seed proxy_arp=0: %v", err)
+	}
+
+	a := readyAgent(t, cfg)
+	testenv.AssertSysctl(t, path, "1", 5*time.Second)
+
+	if err := a.Stop(15 * time.Second); err != nil {
+		t.Fatalf("agent stop: %v", err)
+	}
+
+	// Contract: proxy_arp stays at 1 after shutdown. Update this test (and
+	// the corresponding docs) only when adding a deliberate restore path.
+	testenv.AssertSysctl(t, path, "1", 2*time.Second)
+}

--- a/test/integration/testenv/agent.go
+++ b/test/integration/testenv/agent.go
@@ -26,6 +26,7 @@ type AgentConfig struct {
 	OVNNBRemote   string   `yaml:"ovn_nb_remote"`
 	OVNSBRemote   string   `yaml:"ovn_sb_remote"`
 	BridgeDev     string   `yaml:"bridge_dev"`
+	BridgeIP      string   `yaml:"bridge_ip,omitempty"`
 	VRFName       string   `yaml:"vrf_name"`
 	VethNexthop   string   `yaml:"veth_nexthop"`
 	NetworkCIDRs  []string `yaml:"network_cidrs"`
@@ -329,6 +330,7 @@ func writeTempConfig(t *testing.T, cfg AgentConfig) string {
 	put("ovn_nb_remote", cfg.OVNNBRemote)
 	put("ovn_sb_remote", cfg.OVNSBRemote)
 	put("bridge_dev", cfg.BridgeDev)
+	put("bridge_ip", cfg.BridgeIP)
 	put("vrf_name", cfg.VRFName)
 	put("veth_nexthop", cfg.VethNexthop)
 	// Manual NetworkCIDRs override auto-discovery from Logical_Router_Port.networks

--- a/test/integration/testenv/assert.go
+++ b/test/integration/testenv/assert.go
@@ -119,20 +119,17 @@ func AssertNoBridgeAddress(t *testing.T, bridge, cidr string, timeout time.Durat
 
 // parseCIDRForBridge splits "<ip>/<prefix>" into the canonical IP form and
 // integer prefix length. Rejects bare IPs so callers cannot accidentally
-// match a /24 entry when they meant /32.
+// match a /24 entry when they meant /32, and rejects IPv6 because the
+// callers only assert against `ip -j -4 addr show`.
 func parseCIDRForBridge(cidr string) (string, int, error) {
-	ipStr, prefixStr, ok := strings.Cut(cidr, "/")
-	if !ok {
-		return "", 0, fmt.Errorf("invalid CIDR %q: expected form ip/prefix", cidr)
+	ip, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid CIDR %q: %w", cidr, err)
 	}
-	ip := net.ParseIP(ipStr)
-	if ip == nil {
-		return "", 0, fmt.Errorf("invalid CIDR %q: bad IP", cidr)
+	if ip.To4() == nil {
+		return "", 0, fmt.Errorf("invalid CIDR %q: IPv4 required", cidr)
 	}
-	var prefix int
-	if _, err := fmt.Sscanf(prefixStr, "%d", &prefix); err != nil || prefix < 0 || prefix > 32 {
-		return "", 0, fmt.Errorf("invalid CIDR %q: bad prefix", cidr)
-	}
+	prefix, _ := ipnet.Mask.Size()
 	return ip.String(), prefix, nil
 }
 

--- a/test/integration/testenv/assert.go
+++ b/test/integration/testenv/assert.go
@@ -3,6 +3,7 @@
 package testenv
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"os/exec"
@@ -56,6 +57,113 @@ func AssertNoKernelRoute(t *testing.T, ip string, timeout time.Duration) {
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
+}
+
+// AssertBridgeAddress fails the test if cidr is not present on bridge within
+// timeout. cidr is matched against `ip -j -4 addr show dev <bridge>` as the
+// (local, prefixlen) pair extracted from each addr_info entry, so the caller
+// must pass the address in CIDR form (e.g. "169.254.169.254/32") to be
+// unambiguous about the mask length.
+//
+// Used by the bridge-IP lifecycle scenarios (#63): on cold start the agent
+// adds BridgeIP to br-ex via EnsureBridgeIP, and several scenarios assert
+// that exactly one such address exists, that a custom address replaces the
+// default, and that cleanup removes it.
+func AssertBridgeAddress(t *testing.T, bridge, cidr string, timeout time.Duration) {
+	t.Helper()
+	ip, prefix, err := parseCIDRForBridge(cidr)
+	if err != nil {
+		t.Fatalf("AssertBridgeAddress: %v", err)
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		count, lastOut, lastErr := countBridgeAddress(bridge, ip, prefix)
+		if count == 1 {
+			return
+		}
+		if count > 1 {
+			t.Fatalf("bridge %s has %d copies of %s (expected exactly 1); last output: %q",
+				bridge, count, cidr, lastOut)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("bridge address %s on %s not present after %s (last output: %q, err: %v)",
+				cidr, bridge, timeout, lastOut, lastErr)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// AssertNoBridgeAddress fails the test if cidr remains on bridge past timeout.
+// Mirrors AssertBridgeAddress for the negative case — used to verify that
+// CleanupOnShutdown removes the BridgeIP and that a configured non-default
+// BridgeIP excludes the default.
+func AssertNoBridgeAddress(t *testing.T, bridge, cidr string, timeout time.Duration) {
+	t.Helper()
+	ip, prefix, err := parseCIDRForBridge(cidr)
+	if err != nil {
+		t.Fatalf("AssertNoBridgeAddress: %v", err)
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		count, lastOut, _ := countBridgeAddress(bridge, ip, prefix)
+		if count == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("bridge address %s still present on %s after %s (last output: %q)",
+				cidr, bridge, timeout, lastOut)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// parseCIDRForBridge splits "<ip>/<prefix>" into the canonical IP form and
+// integer prefix length. Rejects bare IPs so callers cannot accidentally
+// match a /24 entry when they meant /32.
+func parseCIDRForBridge(cidr string) (string, int, error) {
+	ipStr, prefixStr, ok := strings.Cut(cidr, "/")
+	if !ok {
+		return "", 0, fmt.Errorf("invalid CIDR %q: expected form ip/prefix", cidr)
+	}
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return "", 0, fmt.Errorf("invalid CIDR %q: bad IP", cidr)
+	}
+	var prefix int
+	if _, err := fmt.Sscanf(prefixStr, "%d", &prefix); err != nil || prefix < 0 || prefix > 32 {
+		return "", 0, fmt.Errorf("invalid CIDR %q: bad prefix", cidr)
+	}
+	return ip.String(), prefix, nil
+}
+
+// countBridgeAddress runs `ip -j -4 addr show dev <bridge>` and returns the
+// number of addr_info entries whose (local, prefixlen) match (ip, prefix).
+// Returns the raw stdout for inclusion in diagnostic messages.
+func countBridgeAddress(bridge, ip string, prefix int) (int, string, error) {
+	out, err := exec.Command("ip", "-j", "-4", "addr", "show", "dev", bridge).CombinedOutput()
+	text := strings.TrimSpace(string(out))
+	if err != nil {
+		return 0, text, err
+	}
+	type addrInfo struct {
+		Local     string `json:"local"`
+		Prefixlen int    `json:"prefixlen"`
+	}
+	var entries []struct {
+		AddrInfo []addrInfo `json:"addr_info"`
+	}
+	if jerr := json.Unmarshal(out, &entries); jerr != nil {
+		return 0, text, jerr
+	}
+	count := 0
+	for _, e := range entries {
+		for _, a := range e.AddrInfo {
+			if a.Local == ip && a.Prefixlen == prefix {
+				count++
+			}
+		}
+	}
+	return count, text, nil
 }
 
 // AssertOVSFlow fails the test if no flow with the given cookie exists on

--- a/test/integration/testenv/portforward.go
+++ b/test/integration/testenv/portforward.go
@@ -24,6 +24,14 @@ const (
 	SysctlTCPL3mdevAccept = "/proc/sys/net/ipv4/tcp_l3mdev_accept"
 )
 
+// BridgeProxyARPPath returns the per-device proxy_arp sysctl path the agent
+// flips on startup via EnableProxyARP. Used by bridge-IP lifecycle scenarios
+// (#63) that wrap the path in SaveSysctl so the host is left as it was
+// regardless of how the agent currently treats restore-on-shutdown.
+func BridgeProxyARPPath(bridge string) string {
+	return "/proc/sys/net/ipv4/conf/" + bridge + "/proxy_arp"
+}
+
 // EnsureLoopback1 checks that the loopback1 dummy device exists and is
 // enslaved to vrf-provider. It does *not* create the device — that is
 // setup.sh's job and a missing device means the host was not bootstrapped.


### PR DESCRIPTION
## Summary

Implements #63 — seven scenarios for the cold-start housekeeping that
adds the bridge IP to br-ex and flips proxy_arp on. All of this happens
before any reconcile cycle and was previously uncovered by the integration
suite.

## Commit walk-through

1. **`test(integration): add bridge-address helpers for #63`**
   - `AssertBridgeAddress` / `AssertNoBridgeAddress` in `testenv/assert.go`
     match by `(local, prefixlen)` from `ip -j -4 addr show dev <bridge>`.
     Strict `count == 1` semantics let the no-duplicates scenario fail fast.
   - `BridgeProxyARPPath(bridge)` returns the per-device sysctl path so
     callers can wrap it in the existing `SaveSysctl` helper.

2. **`test(integration): add #63 bridge-IP and proxy-ARP lifecycle scenarios`**
   - New `scenario_bridge_ip_test.go` with the seven scenarios from the
     issue. Shared `startBridgeIPScenario` does `Setup`, registers the
     failure dump, wraps `proxy_arp` in `SaveSysctl`, and scrubs leftover
     bridge addresses at both leading and trailing edges (the harness's
     general `Teardown` does not touch bridge addresses).
   - `testenv.AgentConfig` gains a `bridge_ip` knob (omitempty) so
     scenario 3 can drive the custom-address path.
   - `parseCIDRForBridge` switches to `net.ParseCIDR` for stricter
     validation — found while wiring the scenarios.

## Scenario coverage

| # | Scenario | Test |
|---|----------|------|
| 1 | BridgeIP added on startup | `TestScenario_BridgeIPOnStartup` |
| 2 | BridgeIP not duplicated on restart | `TestScenario_BridgeIPNotDuplicatedOnRestart` |
| 3 | Custom BridgeIP | `TestScenario_BridgeIPCustom` |
| 4 | Proxy-ARP enabled | `TestScenario_ProxyARPEnabled` |
| 5 | BridgeIP removed on cleanup | `TestScenario_BridgeIPRemovedOnCleanup` |
| 6 | BridgeIP retained when cleanup disabled | `TestScenario_BridgeIPRetainedWhenCleanupDisabled` |
| 7 (opt.) | Proxy-ARP not restored on shutdown | `TestScenario_ProxyARPNotRestoredOnShutdown` |

Scenario 7 pins the current contract — the agent unconditionally writes
proxy_arp=1 and never restores it. Adding a restore path in the future
will turn this test red, prompting the author to update both behaviour
and docs together.

## Test plan

- [ ] `make test` (unit tests stay green)
- [ ] `make test-integration` on a host with the full OVN/OVS/FRR stack —
      cannot run from this macOS dev box; will rely on CI to exercise the
      integration suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)