### PR TITLE
test(integration): land #67 items 1 + 4 (PF priority constants, AssertEventually-with-dump)

### DIFF
--- a/test/integration/scenario_failover_test.go
+++ b/test/integration/scenario_failover_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"testing"
 	"time"
@@ -161,11 +162,18 @@ func TestScenario_MultipleStaleChassisCleanup(t *testing.T) {
 	testenv.DeleteChassis(t, ctx, sb, peerAUUID)
 	testenv.DeleteChassis(t, ctx, sb, peerBUUID)
 
-	testenv.Eventually(t, func() bool {
-		return testenv.CountManagedRoutes(t, ctx, nb, peerAName) == 0 &&
-			testenv.CountManagedRoutes(t, ctx, nb, peerBName) == 0
-	}, 60*time.Second, 500*time.Millisecond,
-		"surviving agent must delete both managed routes in a single cleanup sweep")
+	testenv.AssertEventually(t,
+		func() bool {
+			return testenv.CountManagedRoutes(t, ctx, nb, peerAName) == 0 &&
+				testenv.CountManagedRoutes(t, ctx, nb, peerBName) == 0
+		},
+		60*time.Second, 500*time.Millisecond,
+		"surviving agent must delete both managed routes in a single cleanup sweep",
+		func() string {
+			return fmt.Sprintf("managed-route counts: %s=%d %s=%d",
+				peerAName, testenv.CountManagedRoutes(t, ctx, nb, peerAName),
+				peerBName, testenv.CountManagedRoutes(t, ctx, nb, peerBName))
+		})
 }
 
 // TestScenario_OneStaleOneReturning (#64 scenario 4):

--- a/test/integration/scenario_port_forward_test.go
+++ b/test/integration/scenario_port_forward_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -142,11 +143,11 @@ func TestScenario_PortForwardMatrix(t *testing.T) {
 					},
 					10*time.Second, "ctzone reply-direction rule for backend "+backend)
 				testenv.AssertNftRuleInChain(t, pfTable, "prerouting_fwmark",
-					func(r testenv.NftRule) bool { return r.HasMarkSet(0x100) },
-					10*time.Second, "prerouting_fwmark sets 0x100 on original direction")
+					func(r testenv.NftRule) bool { return r.HasMarkSet(testenv.DefaultDnatFwmark) },
+					10*time.Second, "prerouting_fwmark sets original-direction mark")
 				testenv.AssertNftRuleInChain(t, pfTable, "prerouting_fwmark",
-					func(r testenv.NftRule) bool { return r.HasMarkSet(0x200) },
-					10*time.Second, "prerouting_fwmark sets 0x200 on reply direction")
+					func(r testenv.NftRule) bool { return r.HasMarkSet(testenv.DefaultDnatReplyFwmark) },
+					10*time.Second, "prerouting_fwmark sets reply-direction mark")
 			},
 		},
 		// udp_single_backend (#61 scenario 1).
@@ -550,11 +551,11 @@ func TestScenario_PortForwardOutputChains(t *testing.T) {
 		},
 		10*time.Second, "output_ctzone mirrors backend saddr rule")
 
-	// output_fwmark exists and sets 0x200 on the reply direction.
+	// output_fwmark exists and sets the reply-direction mark.
 	testenv.AssertNftChainExists(t, pfTable, "output_fwmark", 15*time.Second)
 	testenv.AssertNftRuleInChain(t, pfTable, "output_fwmark",
-		func(r testenv.NftRule) bool { return r.HasMarkSet(0x200) },
-		10*time.Second, "output_fwmark sets 0x200 on locally-generated reply")
+		func(r testenv.NftRule) bool { return r.HasMarkSet(testenv.DefaultDnatReplyFwmark) },
+		10*time.Second, "output_fwmark sets reply-direction mark on locally-generated reply")
 
 	// Verify the chain header is `type route` (not `type filter`) — the
 	// route hook is required to trigger routing re-evaluation when the
@@ -615,16 +616,16 @@ func TestScenario_PortForwardCleanupOnSIGTERM(t *testing.T) {
 // With any single-backend rule installed, the agent's ensureDNATRouting must
 // produce two ip rules and a route in the configured port-forward table:
 //
-//   - priority 150: fwmark 0x100 → lookup main (forward direction)
-//   - priority 151: fwmark 0x200 → lookup <pf-table> (reply direction)
-//   - <pf-table>:   default via <veth-default> (return-path egress device)
+//   - DefaultDnatFwmarkPriority: DefaultDnatFwmark → lookup main (forward)
+//   - DefaultDnatReplyPriority:  DefaultDnatReplyFwmark → lookup <pf-table>
+//   - <pf-table>:                default via <veth-default> (return path)
 //
 // We assert all three using the JSON-parsed helpers added in this commit so
 // the test is robust against iproute2 version drift.
 //
-// The default port_forward_table_id is 201 — we use the default here so
-// scrubPortForwardState (which flushes table 201) reaches the route on
-// teardown.
+// The default port_forward_table_id is DefaultPortForwardTableID — we use
+// the default here so scrubPortForwardState (which flushes that table)
+// reaches the route on teardown.
 func TestScenario_PortForwardFwmarkPolicyRoutes(t *testing.T) {
 	cfg := startPFScenario(t)
 
@@ -642,19 +643,28 @@ func TestScenario_PortForwardFwmarkPolicyRoutes(t *testing.T) {
 	a := readyAgent(t, cfg)
 	defer a.Stop(15 * time.Second)
 
-	// Forward rule: priority 150, fwmark 0x100, lookup main. iproute2 emits
+	// Forward rule: forward-direction fwmark → lookup main. iproute2 emits
 	// the main table by name, not number.
-	testenv.AssertIPRulePriority(t, 150, 0x100, "main", 15*time.Second)
+	testenv.AssertIPRulePriority(t,
+		testenv.DefaultDnatFwmarkPriority,
+		testenv.DefaultDnatFwmark,
+		"main", 15*time.Second)
 
-	// Reply rule: priority 151, fwmark 0x200, lookup the PF table (default 201).
-	testenv.AssertIPRulePriority(t, 151, 0x200, "201", 15*time.Second)
+	// Reply rule: reply-direction fwmark → lookup the PF table.
+	testenv.AssertIPRulePriority(t,
+		testenv.DefaultDnatReplyPriority,
+		testenv.DefaultDnatReplyFwmark,
+		strconv.Itoa(testenv.DefaultPortForwardTableID),
+		15*time.Second)
 
 	// Reply table route: agent installs `default via <vethProviderIP> dev
 	// veth-default`. The issue references "loopback1 (or whatever the agent
 	// emits as its return path)" — the production return path is the veth
 	// pair so we assert on veth-default. We do not pin the gateway IP so
 	// the test stays robust against operators reconfiguring veth-nexthop.
-	testenv.AssertRouteInTable(t, "201", "default", "veth-default", 15*time.Second)
+	testenv.AssertRouteInTable(t,
+		strconv.Itoa(testenv.DefaultPortForwardTableID),
+		"default", "veth-default", 15*time.Second)
 }
 
 // TestScenario_PortForwardHairpinPlusPerRuleMasquerade (#61 scenario 4).

--- a/test/integration/testenv/eventually.go
+++ b/test/integration/testenv/eventually.go
@@ -43,3 +43,31 @@ func EventuallyValue[T any](t *testing.T, fn func() (T, bool), timeout, tick tim
 		time.Sleep(tick)
 	}
 }
+
+// AssertEventually is Eventually with an attached lazy dump. Same polling
+// shape; on timeout, the supplied dump callback is invoked once and its
+// return value is appended to the failure message. dump is *only* called on
+// the timeout branch, so a passing AssertEventually pays nothing beyond the
+// extra closure parameter.
+//
+// Use it where a generic "did not happen" timeout would force the operator
+// to ssh in and grep — e.g. polling for an NB row count where the dump can
+// render the current per-key counts, or polling for a kernel/FRR state where
+// the dump can attach the relevant `ip route show` / `vtysh show` output. A
+// nil dump degrades to a plain Eventually-style failure.
+func AssertEventually(t *testing.T, condition func() bool, timeout, tick time.Duration, msg string, dump func() string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if condition() {
+			return
+		}
+		if time.Now().After(deadline) {
+			if dump != nil {
+				t.Fatalf("AssertEventually timed out after %s: %s\nstate dump:\n%s", timeout, msg, dump())
+			}
+			t.Fatalf("AssertEventually timed out after %s: %s", timeout, msg)
+		}
+		time.Sleep(tick)
+	}
+}

--- a/test/integration/testenv/portforward.go
+++ b/test/integration/testenv/portforward.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -22,6 +23,43 @@ const PortForwardLoopbackDev = "loopback1"
 const (
 	SysctlUDPL3mdevAccept = "/proc/sys/net/ipv4/udp_l3mdev_accept"
 	SysctlTCPL3mdevAccept = "/proc/sys/net/ipv4/tcp_l3mdev_accept"
+)
+
+// Port-forward fwmark / priority / table constants mirrored from the agent's
+// nftables.go (dnatFwmark, dnatReplyFwmark, dnatFwmarkPriority,
+// dnatReplyPriority) and config.go (PortForwardTableID default of 201).
+//
+// The duplication is deliberate: the integration package builds with
+// `//go:build integration` and cannot import from `main`, so any test that
+// wants to assert on the agent's policy-route plumbing has to know these
+// values out-of-band. Keep them in lock step with the agent's source — a
+// change to either side without the other will silently break scenario
+// tests' policy-route / fwmark assertions.
+const (
+	// DefaultDnatFwmark is the fwmark the agent stamps on original-direction
+	// DNAT'd packets. Steered to the main table via the ip rule at
+	// DefaultDnatFwmarkPriority.
+	DefaultDnatFwmark = 0x100
+
+	// DefaultDnatReplyFwmark is the fwmark the agent stamps on
+	// reply-direction DNAT'd packets. Steered to the port-forward routing
+	// table (DefaultPortForwardTableID) via the ip rule at
+	// DefaultDnatReplyPriority.
+	DefaultDnatReplyFwmark = 0x200
+
+	// DefaultDnatFwmarkPriority is the priority of the ip rule that matches
+	// DefaultDnatFwmark and looks up the main table. Must be < 1000 to win
+	// against the l3mdev VRF rule.
+	DefaultDnatFwmarkPriority = 150
+
+	// DefaultDnatReplyPriority is the priority of the ip rule that matches
+	// DefaultDnatReplyFwmark and looks up the port-forward routing table.
+	DefaultDnatReplyPriority = 151
+
+	// DefaultPortForwardTableID is the routing table the agent uses for
+	// DNAT reply traffic by default. Matches config.PortForwardTableID's
+	// default of 201.
+	DefaultPortForwardTableID = 201
 )
 
 // BridgeProxyARPPath returns the per-device proxy_arp sysctl path the agent
@@ -169,9 +207,9 @@ func ScrubPortForwardResidue(t *testing.T) {
 
 // scrubPortForwardState removes all per-test residue of the agent's
 // port-forward feature: managed addresses on loopback1, fwmark ip rules at
-// priorities 150/151, the entire port-forward routing table (default 201),
-// and the agent's nft table. Best-effort — used between scenarios so a
-// failed test does not poison the next.
+// the default DNAT priorities, the entire port-forward routing table
+// (default DefaultPortForwardTableID), and the agent's nft table. Best-effort
+// — used between scenarios so a failed test does not poison the next.
 func scrubPortForwardState(t *testing.T) {
 	t.Helper()
 
@@ -184,14 +222,15 @@ func scrubPortForwardState(t *testing.T) {
 	// Remove DNAT fwmark policy rules. RuleDel via netlink would require
 	// importing the agent's package; the `ip rule del` form by priority is
 	// idempotent enough for cleanup.
-	for _, prio := range []string{"150", "151"} {
-		_ = exec.Command("ip", "rule", "del", "priority", prio).Run()
+	for _, prio := range []int{DefaultDnatFwmarkPriority, DefaultDnatReplyPriority} {
+		_ = exec.Command("ip", "rule", "del", "priority", strconv.Itoa(prio)).Run()
 	}
 
-	// Flush the port-forward reply table (default 201). If the test used a
-	// non-default table we don't know it here — but the default-table flush
-	// is the safe path for the harness's typical Defaults() config.
-	_ = exec.Command("ip", "route", "flush", "table", "201").Run()
+	// Flush the port-forward reply table (default DefaultPortForwardTableID).
+	// If the test used a non-default table we don't know it here — but the
+	// default-table flush is the safe path for the harness's typical
+	// Defaults() config.
+	_ = exec.Command("ip", "route", "flush", "table", strconv.Itoa(DefaultPortForwardTableID)).Run()
 
 	// Drop the agent's nft table. Already covered by scrubLocalState, but
 	// repeating it here makes scrubPortForwardState self-contained for


### PR DESCRIPTION
Implements two of the four deferred harness helpers tracked by #67:

- **Item 4 (port-forward priority constants)** — mirror the agent's
  `dnatFwmark` / `dnatReplyFwmark` / `dnatFwmarkPriority` /
  `dnatReplyPriority` constants from `nftables.go` and the default
  `PortForwardTableID` (201) from `config.go` as exported constants in
  `test/integration/testenv/portforward.go`. The integration package
  cannot import from `main`, so the duplication is deliberate and a
  doc comment flags that the two sides must stay in lock step.
  `TestScenario_PortForwardFwmarkPolicyRoutes`, the prerouting / output
  fwmark assertions, and `scrubPortForwardState` now consume the new
  constants instead of hard-coding `0x100` / `0x200` / `150` / `151` /
  `201`. (commit 53ee76e)

- **Item 1 (`AssertEventually` with diff log)** — adds the variant of
  `Eventually` that takes a lazy `dump func() string` and appends its
  output to the failure message on timeout. `dump` is only called on
  the timeout branch, so passing tests pay nothing. Used in
  `TestScenario_MultipleStaleChassisCleanup` as the first consumer:
  the dump now renders the per-peer managed-route counts so a flake
  postmortem no longer needs an ssh-and-grep round trip. (commit 71beaea)

## Items intentionally not in this PR

- **Item 2 (Free-port allocator)** — already landed as
  `testenv.FreeLoopbackAddr` with the metrics scenario tests (#60).
- **Item 3 (Family-parameterised FRR / route helpers)** — its natural
  consumer is the agent-side v6 kernel/FRR routing extension (#54).
  That code path does not exist yet (see the comment block at the top
  of `scenario_ipv6_test.go`), so designing the helper in isolation
  would violate the issue's "no item lands without a real consumer"
  rule. It stays open here and will land with the v6 routing PR.

#67 stays open until item 3 lands too.

## Test plan
- [ ] `go vet -tags integration ./test/integration/...` — passed locally
- [ ] `go build -tags integration ./...` — passed locally
- [ ] `gofmt -l test/integration/` — clean locally
- [ ] `make test-integration` on a provisioned host — to be exercised by CI

Refs #67