### PR TITLE
test: edge-case unit tests for validator/parser/writer paths (#87)

### DIFF
--- a/agent_test.go
+++ b/agent_test.go
@@ -388,3 +388,74 @@ func TestMissingChassisGracePeriodTracking(t *testing.T) {
 		t.Error("dead-node should still be in missingChassis")
 	}
 }
+
+// reconcile takes ctx and passes it to OVN methods that issue OVSDB
+// transactions, but it does not loop or block, so a pre-cancelled context
+// should never make it hang or panic — it should simply complete promptly
+// while the ctx-aware OVN calls observe the cancel and return early. With
+// a dry-run RouteManager and a fake OVN client carrying populated state,
+// the test exercises the full reconcile body to lock in that "context
+// cancellation while a reconcile is in flight" stays a no-side-effects
+// fast-return, not a partial-write hang.
+func TestReconcileCompletesPromptlyOnCancelledContext(t *testing.T) {
+	_, cidr, _ := net.ParseCIDR("198.51.100.0/24")
+	rm := &RouteManager{
+		bridgeDev:   "br-ex",
+		vrfName:     "vrf-provider",
+		vethNexthop: "169.254.0.1",
+		dryRun:      true,
+	}
+	c, _, _ := newOVNClientWithFakes(t, "host-a")
+	// Populate state so reconcile takes the HasLocalRouters branch and
+	// therefore reaches the ctx-aware EnsureGatewayRouting /
+	// EnsureActivePriorityLead calls.
+	c.state.LocalRouters = []LocalRouterInfo{
+		{
+			RouterName:  "router1",
+			RouterUUID:  "lr-1",
+			LRPName:     "lrp-abc",
+			LRPMAC:      "aa:aa:aa:aa:aa:aa",
+			LRPNetworks: []string{"198.51.100.0/24"},
+		},
+	}
+	c.state.HasLocalRouters = true
+	c.state.DiscoveredNetworks = []*net.IPNet{cidr}
+
+	a := &Agent{
+		cfg:            Config{},
+		ovn:            c,
+		routing:        rm,
+		reconcileCh:    make(chan struct{}, 1),
+		missingChassis: make(map[string]time.Time),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel BEFORE reconcile starts — the strict "mid-cycle" case
+
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		defer close(done)
+		// reconcile must not panic even with a cancelled ctx.
+		a.reconcile(ctx, "test")
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("reconcile did not return within 2s on cancelled ctx — possible hang")
+	}
+
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("reconcile returned in %s, expected near-instant on cancelled ctx", elapsed)
+	}
+
+	// effectiveFilters is recomputed each cycle and is the only piece of
+	// agent state mutated by reconcile. With HasLocalRouters=true and a
+	// discovered /24, the slice must be set — i.e. reconcile completed its
+	// state-derivation phase rather than aborting mid-flight in a way that
+	// would leave the agent half-initialised on the next tick.
+	if len(a.effectiveFilters) != 1 || a.effectiveFilters[0].String() != "198.51.100.0/24" {
+		t.Errorf("effectiveFilters = %v, want [198.51.100.0/24]", a.effectiveFilters)
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1472,6 +1472,29 @@ port_forwards:
 	}
 }
 
+// VethProviderIP is auto-computed as nextIPInSubnet(VethNexthop). With
+// VethNexthop=255.255.255.255 the helper wraps to 0.0.0.0 (see
+// TestNextIPInSubnet) and the subsequent net.ParseIP check accepts it — so
+// the validator ends up with a wrap-around address it would normally reject
+// from explicit config. Document the current "wrap + accept" behaviour so
+// any caller-side validation added later (e.g. rejecting an unspecified
+// VethProviderIP) trips this test instead of silently changing the contract.
+func TestVethProviderIPAutoComputeWrapsAt255_255_255_255(t *testing.T) {
+	cfg := Config{
+		VethNexthop:     "255.255.255.255",
+		VethLeakEnabled: true,
+		VethLeakTableID: 200,
+		// VethProviderIP intentionally unset — triggers auto-compute.
+	}
+
+	if err := validateConfig(&cfg); err != nil {
+		t.Fatalf("validateConfig() error: %v", err)
+	}
+	if cfg.VethProviderIP != "0.0.0.0" {
+		t.Errorf("VethProviderIP auto-compute at 255.255.255.255 = %q, want 0.0.0.0 (wrap)", cfg.VethProviderIP)
+	}
+}
+
 func TestNextIPInSubnet(t *testing.T) {
 	tests := []struct {
 		input string

--- a/config_test.go
+++ b/config_test.go
@@ -109,6 +109,54 @@ network_cidr:
 	}
 }
 
+// StringOrSlice accepts either a scalar string or a YAML sequence. A mapping
+// node (the third YAML container kind) is malformed for this type and must
+// surface as a descriptive decode error — not a panic, not a silent empty
+// value that would make a typo'd `network_cidr: {foo: bar}` look like an
+// empty filter list and quietly disable network filtering.
+func TestStringOrSliceUnmarshalRejectsMappingInput(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "inline mapping",
+			yaml: `network_cidr: {foo: bar}` + "\n",
+		},
+		{
+			name: "block mapping",
+			yaml: "network_cidr:\n  foo: bar\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte(tt.yaml), 0644); err != nil {
+				t.Fatalf("write test config: %v", err)
+			}
+
+			// Must not panic on a mapping node — the function decodes the
+			// value into a []string in the non-scalar branch, and yaml.v3
+			// returns an error from Decode rather than panicking. Catch any
+			// panic explicitly so a future refactor that drops the safe
+			// Decode path is flagged here.
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("UnmarshalYAML panicked on mapping input: %v", r)
+				}
+			}()
+
+			fc, err := readConfigFile(path)
+			if err == nil {
+				t.Fatalf("expected decode error for mapping input, got success with NetworkCIDR=%v", fc.NetworkCIDR)
+			}
+			if errStr := err.Error(); errStr == "" {
+				t.Errorf("decode error message is empty")
+			}
+		})
+	}
+}
+
 func TestApplyEnvConfigMultipleCIDRs(t *testing.T) {
 	cfg := Config{}
 	t.Setenv("OVN_NETWORK_NETWORK_CIDR", "10.0.0.0/24,172.16.0.0/12")

--- a/config_test.go
+++ b/config_test.go
@@ -1133,6 +1133,31 @@ func TestPortForwardValidation(t *testing.T) {
 			t.Errorf("same port with different proto should be valid: %v", err)
 		}
 	})
+
+	// 0 and 254 are both kernel aliases for the "main" routing table, but the
+	// validator does not collapse them. Whatever the resolution, it must not
+	// silently let the pair through and end up with two different agent
+	// subsystems writing into the same on-disk table.
+	t.Run("route_table_id_0_collides_with_port_forward_main_alias", func(t *testing.T) {
+		cfg := base()
+		cfg.RouteTableID = 0       // main table (alias)
+		cfg.PortForwardTableID = 254 // main table (canonical id)
+		if err := validateConfig(&cfg); err == nil {
+			t.Error("expected error: port_forward_table_id 254 (main) must not coexist with route_table_id 0 (main alias)")
+		}
+	})
+
+	t.Run("route_table_id_0_collides_with_veth_leak_main_alias", func(t *testing.T) {
+		cfg := base()
+		cfg.RouteTableID = 0      // main table (alias)
+		cfg.VethLeakTableID = 254 // main table (canonical id)
+		// Use the matching port-forward range so the test fails specifically
+		// on the route/leak collision, not on an unrelated range check.
+		cfg.PortForwardTableID = 201
+		if err := validateConfig(&cfg); err == nil {
+			t.Error("expected error: veth_leak_table_id 254 (main) must not coexist with route_table_id 0 (main alias)")
+		}
+	})
 }
 
 func TestApplyEnvConfigPortForward(t *testing.T) {

--- a/config_test.go
+++ b/config_test.go
@@ -1188,7 +1188,7 @@ func TestPortForwardValidation(t *testing.T) {
 	// subsystems writing into the same on-disk table.
 	t.Run("route_table_id_0_collides_with_port_forward_main_alias", func(t *testing.T) {
 		cfg := base()
-		cfg.RouteTableID = 0       // main table (alias)
+		cfg.RouteTableID = 0         // main table (alias)
 		cfg.PortForwardTableID = 254 // main table (canonical id)
 		if err := validateConfig(&cfg); err == nil {
 			t.Error("expected error: port_forward_table_id 254 (main) must not coexist with route_table_id 0 (main alias)")

--- a/nftables_linux_test.go
+++ b/nftables_linux_test.go
@@ -129,6 +129,47 @@ func TestApplyNftRulesetReissuesIdenticalRulesetAfterFailure(t *testing.T) {
 	}
 }
 
+// ensureVethForwarding writes 1 to /proc/sys/net/ipv4/conf/<dev>/forwarding
+// for both veth ends. On a test process the veth interfaces are not created,
+// so the sysctl files do not exist and os.WriteFile fails with ENOENT.
+// Verify that the error is surfaced (wrapped, naming the device) rather than
+// silently swallowed — silent degradation here would mean live nodes serve
+// DNAT traffic with forwarding off, which black-holes return packets.
+func TestEnsureVethForwardingSurfacesSysctlError(t *testing.T) {
+	// Use a veth name that is guaranteed not to be a real interface so
+	// /proc/sys/net/ipv4/conf/<dev>/forwarding does not exist. We can't
+	// override the constant vethDefaultName from the test, so we rely on
+	// the agent never being run in a sandbox where it actually exists.
+	if _, err := os.Stat("/proc/sys/net/ipv4/conf/" + vethDefaultName + "/forwarding"); err == nil {
+		t.Skipf("veth %q exists in this test environment; cannot exercise the sysctl-failure path", vethDefaultName)
+	}
+
+	t.Run("base_forwarding_only", func(t *testing.T) {
+		rm := &RouteManager{}
+		err := rm.ensureVethForwarding()
+		if err == nil {
+			t.Fatal("expected error when veth sysctl path is missing, got nil")
+		}
+		if !strings.Contains(err.Error(), "enable forwarding on "+vethDefaultName) {
+			t.Errorf("error %q does not name the failing device wrapper", err)
+		}
+	})
+
+	t.Run("port_forward_accept_local", func(t *testing.T) {
+		rm := &RouteManager{portForwardEnabled: true}
+		err := rm.ensureVethForwarding()
+		if err == nil {
+			t.Fatal("expected error when veth sysctl path is missing, got nil")
+		}
+		// The base forwarding loop fails first, so we never reach the
+		// accept_local branch — but the test still pins the contract that
+		// errors propagate before any "best effort" silent skip.
+		if !strings.Contains(err.Error(), "forwarding") {
+			t.Errorf("error %q does not reference the forwarding sysctl path", err)
+		}
+	})
+}
+
 func atoiOrFail(t *testing.T, s string) int {
 	t.Helper()
 	n := 0

--- a/nftables_linux_test.go
+++ b/nftables_linux_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// installFakeNft writes a small POSIX shell script onto PATH that captures
+// each invocation's args and stdin into the returned dir and exits non-zero.
+// Tests use it to assert that applyNftRuleset surfaces the error and reissues
+// the identical ruleset on the next call (no caching of partial state).
+func installFakeNft(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := `#!/bin/sh
+N=$(cat "` + dir + `/count" 2>/dev/null || echo 0)
+N=$((N + 1))
+echo "$N" > "` + dir + `/count"
+echo "$@" > "` + dir + `/args.$N"
+cat > "` + dir + `/stdin.$N"
+echo "fake nft refused ruleset (invocation $N)" >&2
+exit 1
+`
+	bin := filepath.Join(dir, "nft")
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake nft: %v", err)
+	}
+	// Prepend dir so the fake takes precedence over a real nft on the host.
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return dir
+}
+
+// readNftStdin returns the captured stdin for invocation n (1-based).
+func readNftStdin(t *testing.T, dir string, n int) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, "stdin."+itoa(n)))
+	if err != nil {
+		t.Fatalf("read stdin.%d: %v", n, err)
+	}
+	return string(data)
+}
+
+// itoa avoids pulling strconv into the test for a single int-to-string.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [16]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}
+
+// applyNftRuleset returns the wrapped exec error when nft exits non-zero, and
+// because the RouteManager keeps no per-call ruleset state, a follow-up call
+// emits an identical ruleset rather than skipping or mutating the prior one.
+// This is the reapply contract the reconcile loop relies on: a transient
+// `nft -f -` failure must not bake stale state into the next attempt.
+func TestApplyNftRulesetReissuesIdenticalRulesetAfterFailure(t *testing.T) {
+	dir := installFakeNft(t)
+
+	rm := &RouteManager{
+		portForwardEnabled: true,
+		portForwardDev:     "loopback1",
+		portForwardCTZone:  64000,
+		portForwards: []PortForwardVIP{
+			{
+				VIP:       "198.51.100.10",
+				ManageVIP: true,
+				Rules: []PortForwardRule{
+					{Proto: "tcp", Port: 80, DestAddr: "10.0.0.100", DestPort: 8080},
+				},
+			},
+		},
+	}
+
+	// First call: nft fails → wrapped error returned.
+	err := rm.applyNftRuleset(nil, nil)
+	if err == nil {
+		t.Fatal("applyNftRuleset: expected error from failing nft, got nil")
+	}
+	if !strings.Contains(err.Error(), "nft apply ruleset") {
+		t.Errorf("error %q does not mention nft apply ruleset wrapper", err)
+	}
+
+	// Second call must re-issue the same ruleset — no cached "we already
+	// tried this" suppression, no half-applied state from the failed run.
+	err2 := rm.applyNftRuleset(nil, nil)
+	if err2 == nil {
+		t.Fatal("applyNftRuleset: expected error on re-issue, got nil")
+	}
+
+	// The fake nft captures both an `nft list table ...` probe and an
+	// `nft -f -` apply per call. Count the two -f - invocations and assert
+	// their stdin payloads match.
+	var applyStdins []string
+	dirEntries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range dirEntries {
+		if !strings.HasPrefix(e.Name(), "args.") {
+			continue
+		}
+		argsBytes, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		if strings.TrimSpace(string(argsBytes)) != "-f -" {
+			continue
+		}
+		n := strings.TrimPrefix(e.Name(), "args.")
+		applyStdins = append(applyStdins, readNftStdin(t, dir, atoiOrFail(t, n)))
+	}
+	if len(applyStdins) != 2 {
+		t.Fatalf("expected 2 `nft -f -` invocations, got %d", len(applyStdins))
+	}
+	if applyStdins[0] != applyStdins[1] {
+		t.Errorf("ruleset diverged between calls:\nfirst:\n%s\nsecond:\n%s", applyStdins[0], applyStdins[1])
+	}
+	if !strings.Contains(applyStdins[0], "table ip "+nftTableName) {
+		t.Errorf("apply stdin missing table header for %q:\n%s", nftTableName, applyStdins[0])
+	}
+}
+
+func atoiOrFail(t *testing.T, s string) int {
+	t.Helper()
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			t.Fatalf("non-numeric filename suffix %q", s)
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}

--- a/ovn_gateway_writes_test.go
+++ b/ovn_gateway_writes_test.go
@@ -397,6 +397,22 @@ func TestEnsureActivePriorityLead(t *testing.T) {
 			localRouters: []LocalRouterInfo{{LRPName: "lrp-a"}, {LRPName: "lrp-b"}},
 			wantBoosts:   map[string]int{"lrp-a": 5, "lrp-b": 8},
 		},
+		// LRP names with underscores hit the TrimSuffix derivation in
+		// EnsureActivePriorityLead: the Gateway_Chassis row name is
+		// {lrp_name}_{chassis_name}, so a router named `tenant_a_router` on
+		// chassis `host-a` produces `tenant_a_router_host-a`, and the
+		// suffix-trim must yield `tenant_a_router` — not a confused prefix
+		// like `tenant_a` that would silently drop the chassis-priority
+		// boost on multi-tenant deployments with snake_cased LRP names.
+		{
+			name: "LRP name with underscores still resolves under TrimSuffix",
+			entries: []*NBGatewayChassis{
+				{UUID: "g1", Name: "tenant_a_router_host-a", ChassisName: "host-a", Priority: 1},
+				{UUID: "g2", Name: "tenant_a_router_host-b", ChassisName: "host-b", Priority: 5},
+			},
+			localRouters: []LocalRouterInfo{{LRPName: "tenant_a_router"}},
+			wantBoosts:   map[string]int{"tenant_a_router": 6},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Implements #87 — adds the seven unit-test edge cases identified in the
post-#41–#67 audit. Pure test additions: no production-code changes.

Each commit lands one item from the issue's tracking list, in the order
the issue presented them.

| # | Item | Commit | Where |
|---|------|--------|-------|
| 1 | `validateConfig` — `route_table_id = 0` (main) collision with main-table aliases on `port_forward_table_id` / `veth_leak_table_id` | `test(config): cover route_table_id 0 vs main-table aliases` | `config_test.go` |
| 2 | `StringOrSlice.UnmarshalYAML` malformed (mapping) input | `test(config): cover StringOrSlice malformed-input path` | `config_test.go` |
| 3 | `nextIPInSubnet` wrap at `255.255.255.255` — caller-side `VethProviderIP` auto-compute | `test(config): cover nextIPInSubnet wrap at 255.255.255.255 caller` | `config_test.go` |
| 4 | `applyNftRuleset` reapply after `nft -f -` exit 1 — same ruleset re-emitted, no stale state | `test(nftables): cover applyNftRuleset reapply after nft failure` | `nftables_linux_test.go` (new) |
| 5 | `ensureVethForwarding` sysctl write failure surfaces as wrapped error (not silent degrade) | `test(nftables): cover ensureVethForwarding sysctl error path` | `nftables_linux_test.go` |
| 6 | `reconcile` mid-cycle context cancellation — returns promptly, no half-state | `test(agent): cover reconcile under pre-cancelled context` | `agent_test.go` |
| 7 | `EnsureActivePriorityLead` LRP name with underscores (`tenant_a_router`) under `TrimSuffix` | `test(ovn): cover EnsureActivePriorityLead with snake_cased LRP` | `ovn_gateway_writes_test.go` |

A trailing `test(config): gofmt fix for item 1 alignment` commit
applies a one-character gofmt alignment delta on the item-1 hunk.

## Notes for reviewers

- The issue cites `routing.go:21`, `routing.go:502`, and
  `routing_linux.go` for items 2, 3, and 5 respectively. Those symbols
  actually live in `config.go` (`StringOrSlice`, `nextIPInSubnet`) and
  `nftables_linux.go` (`ensureVethForwarding`); tests landed next to
  the real symbols. Line numbers match.
- Item 4 needs an exec hook to inject an nft failure. Since the
  acceptance criteria forbid production-code changes, the test uses a
  `t.Setenv("PATH", …)` shim with a tiny shell script that captures
  stdin and exits 1 — same shape as a recordingExec wrapper, but
  purely local to the test file.
- Item 6 is structured as a "context cancelled BEFORE reconcile starts"
  test, since reconcile has no internal `ctx.Done()` checkpoints to
  interrupt; the strict mid-cycle case reduces to "does it hang or
  panic when its ctx is dead from the first instruction?"

## Test plan

- [x] `go test -short ./...` — green
- [x] `go test ./...` — green
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean
- [x] `GOOS=linux go vet ./...` — clean (covers the linux-only test file)
- [x] `GOOS=linux go test -c ./...` — compiles
- [x] Linux CI run on the PR for the linux-only test file
      (`TestApplyNftRulesetReissuesIdenticalRulesetAfterFailure`,
      `TestEnsureVethForwardingSurfacesSysctlError`)