### PR TITLE
Tests: integration failure-injection and recovery scenarios (#88)

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -19,7 +19,24 @@ test/integration/
   scenario_network_cidrs_test.go   — manual network_cidr override vs. auto-discovery, empty-filter sweep
   scenario_port_forward_test.go    — DNAT, sticky multi-backend, VIP mgmt, masquerade, hairpin
   scenario_metrics_test.go         — Prometheus /metrics scrapes (reconcile counter, drain outcome, stale-chassis, desired-state gauges)
-  testenv/                         — Setup, Teardown, RunAgent, MakeLocalRouter, Assert*, ScrapeMetrics, …
+  scenario_failure_injection_test.go         — mid-cycle vtysh/nft/ovs-ofctl failures + self-heal (#88 item 1)
+  scenario_route_tables_test.go              — non-overlapping route_table_id / port_forward_table_id / veth_leak_table_id (#88 item 2)
+  scenario_cleanup_no_drain_test.go          — RemoveManagedNBEntries with drain_on_shutdown=false (#88 item 3)
+  scenario_router_masquerade_ordering_test.go — router_masquerade configured before SNAT NAT exists (#88 item 4)
+  scenario_same_batch_fip_test.go            — single OVSDB transaction adds + removes FIPs (#88 item 5)
+  scenario_partial_failure_retry_test.go     — FRR write fails, kernel untouched, only FRR re-added (#88 item 6)
+  testenv/                         — Setup, Teardown, RunAgent, MakeLocalRouter, Assert*, ScrapeMetrics, WithFailingTool, …
+```
+
+The failure-injection scenarios all share the `TestScenario_FailureInjection_`
+prefix so they can be targeted as a group, e.g. for the flake-resistance
+check from issue #88:
+
+```sh
+sudo OVN_AGENT_BINARY=$PWD/ovn-network-agent \
+    go test -tags=integration -v -count=10 \
+            -run TestScenario_FailureInjection_ \
+            ./test/integration/...
 ```
 
 Port-forward scenarios additionally rely on:

--- a/test/integration/scenario_cleanup_no_drain_test.go
+++ b/test/integration/scenario_cleanup_no_drain_test.go
@@ -1,0 +1,91 @@
+//go:build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/osism/ovn-network-agent/test/integration/testenv"
+)
+
+// TestScenario_FailureInjection_RemoveManagedNBEntriesNoDrain (#88 item 3):
+//
+// Drive the agent's cleanup_on_shutdown path with drain_on_shutdown=false and
+// verify two contracts at once:
+//
+//   - RemoveManagedNBEntries removes the agent-tagged Logical_Router_Static_
+//     Route and Static_MAC_Binding rows. We use the gatewayless-virtual-
+//     gateway path (no pre-existing default route in NB) because that is the
+//     only feature today that plants entries with the "ovn-network-agent" =
+//     "managed" external_ids tag.
+//   - No "drain:" log lines appear in the agent's stderr. The drain branch
+//     in Agent.Run() is gated entirely on cfg.DrainOnShutdown, so a regression
+//     that started running drain unconditionally (or that emitted a drain
+//     log line from a stray code path) would surface as a spurious match here.
+func TestScenario_FailureInjection_RemoveManagedNBEntriesNoDrain(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "nodrain",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	cfg := testenv.Defaults()
+	on := true
+	off := false
+	cfg.CleanupOnShutdown = &on
+	cfg.DrainOnShutdown = &off
+	cfg.ReconcileInterval = "2s"
+	a := readyAgent(t, cfg)
+
+	// Wait for the agent to plant its gatewayless managed entries: a
+	// default-route on the router with the managed external_ids tag plus
+	// a static MAC binding for the synthesized virtual-gateway IP.
+	const vgw = "198.51.100.254"
+	testenv.Eventually(t, func() bool {
+		r, ok := testenv.FindStaticRoute(t, ctx, nb, router.RouterUUID, "0.0.0.0/0")
+		return ok && r.ExternalIDs["ovn-network-agent"] == "managed"
+	}, 15*time.Second, 200*time.Millisecond, "agent must plant managed default route")
+	testenv.EventuallyValue(t, func() (testenv.NBStaticMACBinding, bool) {
+		return testenv.FindMACBinding(t, ctx, nb, router.LRPName, vgw)
+	}, 15*time.Second, 200*time.Millisecond, "agent must plant managed MAC binding")
+
+	if err := a.Stop(20 * time.Second); err != nil {
+		t.Fatalf("agent stop: %v", err)
+	}
+
+	// NB cleanup ran: managed route + MAC binding are gone.
+	if _, ok := testenv.FindStaticRoute(t, ctx, nb, router.RouterUUID, "0.0.0.0/0"); ok {
+		t.Errorf("managed default route still present after SIGTERM with cleanup_on_shutdown=true")
+	}
+	if _, ok := testenv.FindMACBinding(t, ctx, nb, router.LRPName, vgw); ok {
+		t.Errorf("managed MAC binding still present after SIGTERM with cleanup_on_shutdown=true")
+	}
+
+	logs := a.LogTail(100000)
+
+	// Cleanup branch ran (positive marker so a misconfiguration that
+	// silently skipped both branches surfaces here, not as a missing
+	// negative assertion below).
+	if !strings.Contains(logs, "shutting down, cleaning up routes") {
+		t.Errorf("expected cleanup log line not found; tail:\n%s", a.LogTail(40))
+	}
+
+	// Drain branch did NOT run. We match on the "drain:" prefix the
+	// drain helpers in ovn_gateway.go use ("drain: no gateway chassis ...",
+	// "drain: gateway chassis priority lowered", "drain: complete, ...",
+	// "drain: timeout exceeded ...") plus the top-level "drain mode active"
+	// log line in agent.go.
+	for _, marker := range []string{
+		"drain mode active",
+		"drain:",
+		"drain failed",
+	} {
+		if strings.Contains(logs, marker) {
+			t.Errorf("spurious drain log line %q present; tail:\n%s", marker, a.LogTail(60))
+		}
+	}
+}

--- a/test/integration/scenario_failure_injection_test.go
+++ b/test/integration/scenario_failure_injection_test.go
@@ -128,6 +128,16 @@ func TestScenario_FailureInjection_NftConflict(t *testing.T) {
 	// Wait for the agent to attempt the re-apply and fail at least once.
 	// Capture the log marker the shim writes so a regression that doesn't
 	// hit the failure path cannot pass silently.
+	//
+	// On timeout, dump the shim's invocation log: a non-empty log proves
+	// the shim is on PATH and being reached (so the bug is in the
+	// arm/counter logic), an empty log says PATH override never landed
+	// (the env-propagation path is the suspect).
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Logf("nft shim invocation log:\n%s", shim.InvocationLog())
+		}
+	})
 	testenv.Eventually(t, func() bool {
 		return strings.Contains(a.LogTail(100000), "test shim: forced failure of nft")
 	}, 15*time.Second, 200*time.Millisecond, "agent must hit at least one forced nft failure")

--- a/test/integration/scenario_failure_injection_test.go
+++ b/test/integration/scenario_failure_injection_test.go
@@ -190,4 +190,3 @@ func TestScenario_FailureInjection_OvsOfctlFailsOnce(t *testing.T) {
 		t.Errorf("expected forced-failure marker for ovs-ofctl in agent log; tail:\n%s", a.LogTail(40))
 	}
 }
-

--- a/test/integration/scenario_failure_injection_test.go
+++ b/test/integration/scenario_failure_injection_test.go
@@ -1,0 +1,193 @@
+//go:build integration
+
+package integration
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/osism/ovn-network-agent/test/integration/testenv"
+)
+
+// Scenarios in this file cover #88 item 1: a transient failure of one of the
+// three external tools the agent shells out to (vtysh, nft, ovs-ofctl)
+// followed by self-heal on the next periodic reconcile. The shim helper
+// (testenv.WithFailingTool) is the common substrate — each sub-scenario arms
+// it at the moment that lets the agent observe the failure, then asserts the
+// desired state arrives after the shim disarms itself.
+//
+// All scenarios in this file share the TestScenario_FailureInjection_ prefix
+// so acceptance criterion #3 (no flakes on 10 consecutive runs of
+// `go test -count=10 -tags=integration -run TestScenario_FailureInjection_`)
+// can target the whole set with one -run argument.
+
+// TestScenario_FailureInjection_VtyshFailsOnce (#88 item 1, vtysh sub-case):
+//
+// Arm vtysh to fail every call in the next reconcile cycle. The agent's
+// initial reconcile then cannot install the FRR /32 route for a fresh FIP,
+// but the next periodic tick — by which point the shim has exhausted its
+// counter and disarmed — re-runs ensureRoutes and the route appears.
+//
+// We pick the shim's failCount high enough to also blow through verifyRoutes,
+// which runs ListFRRRoutes and AddFRRRoutes again after the initial add. Three
+// failures (List, Add, verify-List) is enough to keep FRR empty for the whole
+// cycle; the fourth call (the second cycle's List) finds the counter zero and
+// chains through to real vtysh.
+//
+// The kernel route is installed unconditionally — netlink doesn't go through
+// the shim — so the test pins it down separately as a sanity check that only
+// the FRR plane experienced the failure.
+func TestScenario_FailureInjection_VtyshFailsOnce(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "fivtysh",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	shim := testenv.WithFailingTool(t, "vtysh", 3)
+	cfg := testenv.FastDefaults()
+	cfg.ExtraEnv = append(cfg.ExtraEnv, shim.Env())
+	shim.Arm()
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	const fipExternal = "198.51.100.42"
+	testenv.AddFIP(t, ctx, nb, router, fipExternal, "10.0.0.42")
+
+	// Kernel route lands regardless of vtysh state — its install path is
+	// pure netlink. Asserting it first proves the agent saw the new FIP.
+	testenv.AssertKernelRoute(t, fipExternal, 15*time.Second)
+
+	// FRR route appears once the shim's counter exhausts and the next
+	// periodic reconcile retries the install. ReconcileInterval is 2s in
+	// FastDefaults, so two cycles fit comfortably inside 20s.
+	testenv.AssertFRRRoute(t, fipExternal, 20*time.Second)
+
+	// The shim wrote a marker line on every forced failure. Verify at
+	// least one made it to the agent log — otherwise we recovered without
+	// actually hitting the failure path the test claims to exercise.
+	logs := a.LogTail(100000)
+	if !strings.Contains(logs, "test shim: forced failure of vtysh") {
+		t.Errorf("expected forced-failure marker for vtysh in agent log; tail:\n%s", a.LogTail(40))
+	}
+}
+
+// TestScenario_FailureInjection_NftConflict (#88 item 1, nft sub-case):
+//
+// The agent's SetupPortForward path is fatal on nft failure, so we let the
+// agent come up cleanly before arming the shim. Once armed, the next
+// reconcile's `nft -f -` fails — but the agent already had a valid ruleset
+// installed at setup, so we induce a fresh `nft -f -` by deleting the table
+// out-of-band and waiting for the next periodic reconcile to detect drift
+// and re-apply. After the shim disarms (counter exhausted), the same
+// reconcile succeeds and the table reappears.
+//
+// The "syntactically valid but semantically conflicting prior rule" the
+// issue suggests is realised here as a shim-injected non-zero exit from
+// `nft -f -`. The reconcile path under test is the same regardless of
+// whether nft rejected the ruleset because of an external conflict or
+// because the binary itself was forced to fail.
+func TestScenario_FailureInjection_NftConflict(t *testing.T) {
+	cfg := startPFScenario(t)
+
+	const vip = "198.51.100.71"
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+		VIP:       vip,
+		ManageVIP: true,
+		Rules: []testenv.PortForwardRuleFixture{{
+			Proto: "tcp", Port: 80, DestAddr: "10.0.0.100",
+		}},
+	}}
+	cfg.ReconcileInterval = "2s"
+
+	shim := testenv.WithFailingTool(t, "nft", 1)
+	cfg.ExtraEnv = append(cfg.ExtraEnv, shim.Env())
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+	t.Cleanup(func() { testenv.ScrubPortForwardResidue(t) })
+
+	// Sanity: the agent installed its table during setup, since the shim
+	// is still disarmed at this point.
+	testenv.AssertNftChainExists(t, testenv.DefaultNftTable, "prerouting_dnat", 15*time.Second)
+
+	// Delete the table out-of-band so the next reconcile is forced to
+	// re-apply the ruleset. Then arm the shim so the very next `nft -f -`
+	// — i.e. that re-apply — fails. The shim's counter is 1, so exactly
+	// one apply is rejected before subsequent calls chain through.
+	if out, err := exec.Command("nft", "delete", "table", "ip", testenv.DefaultNftTable).CombinedOutput(); err != nil {
+		t.Fatalf("pre-arm delete table: %v (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	shim.Arm()
+
+	// Wait for the agent to attempt the re-apply and fail at least once.
+	// Capture the log marker the shim writes so a regression that doesn't
+	// hit the failure path cannot pass silently.
+	testenv.Eventually(t, func() bool {
+		return strings.Contains(a.LogTail(100000), "test shim: forced failure of nft")
+	}, 15*time.Second, 200*time.Millisecond, "agent must hit at least one forced nft failure")
+
+	// After the shim disarms (counter hit zero), the next reconcile's
+	// nft -f - succeeds and the table is restored. 30s is generous for a
+	// 2s reconcile interval.
+	testenv.AssertNftChainExists(t, testenv.DefaultNftTable, "prerouting_dnat", 30*time.Second)
+}
+
+// TestScenario_FailureInjection_OvsOfctlFailsOnce (#88 item 1, ovs-ofctl
+// sub-case):
+//
+// Arm ovs-ofctl to fail every call in the next reconcile cycle, then start
+// the agent with a local router + a FIP so a hairpin flow (cookie 0x998) is
+// part of the desired state. The startup reconcile's ovs-ofctl calls all
+// fail, so the hairpin flow never makes it onto br-ex. By the time the next
+// periodic reconcile fires, the shim has exhausted its counter and chains
+// through to real ovs-ofctl: EnsureOVSFlows + ReconcileOVSHairpinFlows
+// install both the MAC-tweak (cookie 0x999) and hairpin flows.
+//
+// EnsureOVSFlows uses ovs-vsctl (not shimmed) for discovery, so the
+// patchPort/ofport cache populates regardless of ovs-ofctl state — the
+// recovery on cycle two does not need to re-run discovery.
+func TestScenario_FailureInjection_OvsOfctlFailsOnce(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "fiofctl",
+		LRPMAC:      "fa:16:3e:aa:00:01",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	const fipA = "198.51.100.55"
+	testenv.AddFIP(t, ctx, nb, router, fipA, "10.0.0.55")
+
+	// failCount must exceed the ovs-ofctl call count in a single reconcile
+	// (del-flows MAC-tweak + add-flow v4 + add-flow v6 + del-flows hairpin
+	// + add-flow hairpin = 5). Setting it to 10 leaves headroom for any
+	// future call added inside the same cycle.
+	shim := testenv.WithFailingTool(t, "ovs-ofctl", 10)
+	cfg := testenv.FastDefaults()
+	cfg.ExtraEnv = append(cfg.ExtraEnv, shim.Env())
+	shim.Arm()
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// Hairpin flow with the router MAC must appear once the shim
+	// disarms — by then EnsureOVSFlows + ReconcileOVSHairpinFlows have
+	// run successfully on cycle two.
+	testenv.AssertOVSFlowMatches(t, "0x998",
+		func(line string) bool {
+			return strings.Contains(line, "nw_dst="+fipA) && strings.Contains(line, "mod_dl_dst:"+router.LRPMAC)
+		}, 25*time.Second, "hairpin flow for FIP A → router MAC after recovery")
+
+	logs := a.LogTail(100000)
+	if !strings.Contains(logs, "test shim: forced failure of ovs-ofctl") {
+		t.Errorf("expected forced-failure marker for ovs-ofctl in agent log; tail:\n%s", a.LogTail(40))
+	}
+}
+

--- a/test/integration/scenario_failure_injection_test.go
+++ b/test/integration/scenario_failure_injection_test.go
@@ -87,6 +87,14 @@ func TestScenario_FailureInjection_VtyshFailsOnce(t *testing.T) {
 // and re-apply. After the shim disarms (counter exhausted), the same
 // reconcile succeeds and the table reappears.
 //
+// The shim is filtered to `nft -f -` invocations only. The agent's
+// applyNftRuleset first runs `nft list table ip <name>` to decide whether
+// to prepend a `delete table` line; if that list call fails the agent
+// silently treats it as "table missing" and the subsequent ruleset load
+// happens anyway. Targeting `-f -` specifically guarantees the failure
+// hits the load step, which is the only step that maps to a reconcile-
+// level error in agent logs.
+//
 // The "syntactically valid but semantically conflicting prior rule" the
 // issue suggests is realised here as a shim-injected non-zero exit from
 // `nft -f -`. The reconcile path under test is the same regardless of
@@ -105,7 +113,7 @@ func TestScenario_FailureInjection_NftConflict(t *testing.T) {
 	}}
 	cfg.ReconcileInterval = "2s"
 
-	shim := testenv.WithFailingTool(t, "nft", 1)
+	shim := testenv.WithFailingTool(t, "nft", 1).MatchArg("-f -")
 	cfg.ExtraEnv = append(cfg.ExtraEnv, shim.Env())
 
 	a := readyAgent(t, cfg)

--- a/test/integration/scenario_partial_failure_retry_test.go
+++ b/test/integration/scenario_partial_failure_retry_test.go
@@ -1,0 +1,168 @@
+//go:build integration
+
+package integration
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/osism/ovn-network-agent/test/integration/testenv"
+)
+
+// TestScenario_FailureInjection_PartialFailureFRR (#88 item 6):
+//
+// Steady-state contract under test: when the FRR write plane fails but the
+// kernel plane is healthy, the agent retries only the failing plane on
+// subsequent reconciles. The kernel route stays a single entry on br-ex
+// (no spurious re-add), and the Prometheus counters separate the planes
+// correctly:
+//
+//   - route_readds_total{plane="frr"}   increments at least once
+//   - route_readds_total{plane="kernel"} stays at zero
+//
+// We realise the partial failure with the vtysh shim filtered to "conf t"
+// — that substring is present in AddFRRRoutes / DelFRRRoutes but not in
+// ListFRRRoutes (which uses `show ip route ...`). So the agent's
+// pre-reconcile reads succeed and accurately report "FRR route absent",
+// the subsequent add fails, and verifyRoutes hits its missing-FRR branch
+// (which is the branch that increments route_readds_total{plane="frr"}).
+//
+// The kernel-side delete operation isn't shimmed — netlink does not pay
+// the FRR plane any attention — so the kernel route is never withdrawn,
+// never re-added, and the kernel counter stays at zero.
+func TestScenario_FailureInjection_PartialFailureFRR(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "fipartial",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	shim := testenv.WithFailingTool(t, "vtysh", 10).MatchArg("conf t")
+
+	cfg := testenv.FastDefaults()
+	cfg.ExtraEnv = append(cfg.ExtraEnv, shim.Env())
+	addr := testenv.FreeLoopbackAddr(t)
+	cfg.MetricsListen = addr
+	a := readyAgent(t, cfg)
+
+	const fip = "198.51.100.42"
+	testenv.AddFIP(t, ctx, nb, router, fip, "10.0.0.42")
+
+	// Baseline: agent installs both planes cleanly while the shim is
+	// still disarmed.
+	testenv.AssertKernelRoute(t, fip, 15*time.Second)
+	testenv.AssertFRRRoute(t, fip, 15*time.Second)
+	testenv.AssertMetricEventually(t, addr,
+		"ovn_network_agent_route_readds_total",
+		map[string]string{"plane": "frr"},
+		func(v float64, present bool) bool { return present && v == 0 },
+		5*time.Second)
+	testenv.AssertMetricEventually(t, addr,
+		"ovn_network_agent_route_readds_total",
+		map[string]string{"plane": "kernel"},
+		func(v float64, present bool) bool { return present && v == 0 },
+		5*time.Second)
+
+	// Arm the shim, then rip the FRR route out of band so the agent
+	// detects drift on the next reconcile. We bypass the shim by
+	// invoking vtysh from the test process — the shim sits on PATH for
+	// the agent subprocess only.
+	shim.Arm()
+	if err := deleteFRRRouteRaw(t, fip); err != nil {
+		t.Fatalf("delete FRR route out of band: %v", err)
+	}
+
+	// Failure window: route_readds_total{plane="frr"} increments because
+	// verifyRoutes hits the missing-FRR branch while AddFRRRoutes is still
+	// being rejected. consecutive_readds settles at >= 1 in the same cycle.
+	testenv.AssertMetricEventually(t, addr,
+		"ovn_network_agent_route_readds_total",
+		map[string]string{"plane": "frr"},
+		func(v float64, present bool) bool { return present && v >= 1 },
+		20*time.Second)
+	testenv.AssertMetricEventually(t, addr,
+		"ovn_network_agent_consecutive_readds", nil,
+		func(v float64, present bool) bool { return present && v >= 1 },
+		5*time.Second)
+
+	// Disarm and let the next reconcile push FRR back. We Stop the agent
+	// before exit (deferred below) so the shutdown path also goes through
+	// real vtysh.
+	shim.Disarm()
+	testenv.AssertFRRRoute(t, fip, 20*time.Second)
+	testenv.AssertMetricEventually(t, addr,
+		"ovn_network_agent_consecutive_readds", nil,
+		func(v float64, present bool) bool { return present && v == 0 },
+		20*time.Second)
+
+	// Kernel plane was never re-added: route_readds_total{plane="kernel"}
+	// is still 0, and there is exactly one /32 route for the FIP on br-ex
+	// (an over-eager AddKernelRoute on a healthy entry would surface as a
+	// duplicate line in `ip route show`).
+	testenv.AssertMetricEventually(t, addr,
+		"ovn_network_agent_route_readds_total",
+		map[string]string{"plane": "kernel"},
+		func(v float64, present bool) bool { return present && v == 0 },
+		5*time.Second)
+	if dup := countKernelRouteEntries(t, fip); dup != 1 {
+		t.Errorf("kernel route for %s appeared %d times after recovery, want 1", fip, dup)
+	}
+
+	if err := a.Stop(15 * time.Second); err != nil {
+		t.Fatalf("agent stop: %v", err)
+	}
+}
+
+// deleteFRRRouteRaw removes a /32 static route from the agent's default VRF
+// using a fresh vtysh invocation. It is the test-side mirror of
+// RouteManager.DelFRRRoutes and is used to rip routes out of band so the
+// agent's reconcile observes drift it cannot have introduced itself.
+func deleteFRRRouteRaw(t *testing.T, ip string) error {
+	t.Helper()
+	args := []string{
+		"-c", "conf t",
+		"-c", "vrf " + testenv.DefaultVRFName,
+		"-c", "no ip route " + ip + "/32 " + testenv.DefaultVethNexthop,
+		"-c", "exit-vrf",
+		"-c", "end",
+	}
+	out, err := exec.Command("vtysh", args...).CombinedOutput()
+	if err != nil {
+		return &deleteFRRError{err: err, out: strings.TrimSpace(string(out))}
+	}
+	return nil
+}
+
+type deleteFRRError struct {
+	err error
+	out string
+}
+
+func (e *deleteFRRError) Error() string {
+	if e.out == "" {
+		return e.err.Error()
+	}
+	return e.err.Error() + " (output: " + e.out + ")"
+}
+
+// countKernelRouteEntries returns the number of `<ip>/32` entries on the
+// default bridge device. A healthy installation has exactly one; values
+// other than one indicate either a missing or a duplicated kernel route.
+func countKernelRouteEntries(t *testing.T, ip string) int {
+	t.Helper()
+	out, err := exec.Command("ip", "-4", "route", "show", ip+"/32", "dev", testenv.DefaultBridgeDev).CombinedOutput()
+	if err != nil {
+		t.Fatalf("countKernelRouteEntries: ip route show: %v (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	count := 0
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.TrimSpace(line) != "" {
+			count++
+		}
+	}
+	return count
+}

--- a/test/integration/scenario_route_tables_test.go
+++ b/test/integration/scenario_route_tables_test.go
@@ -1,0 +1,131 @@
+//go:build integration
+
+package integration
+
+import (
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/osism/ovn-network-agent/test/integration/testenv"
+)
+
+// TestScenario_FailureInjection_RouteTableCollisions (#88 item 2):
+//
+// Three writers — kernel /32 routes for FIPs/VIPs, port-forward DNAT reply
+// routing, veth-leak — each get a non-default routing table assigned via
+// route_table_id / port_forward_table_id / veth_leak_table_id, and we
+// verify nobody writes into a sibling's table.
+//
+// Provisioned state:
+//   - one local router with LRP 198.51.100.11/24 (gives the veth-leak writer
+//     a network to install per-network policy rules for)
+//   - one FIP (gives the kernel-route writer a /32 to install)
+//   - one port-forward VIP (gives the port-forward writer a default-route
+//     entry to install in its reply table)
+//
+// Assertions go in two directions:
+//
+//  1. Each table contains exactly what its owner is expected to write:
+//     200 holds the FIP /32, 201 holds the DNAT-reply default route, 202
+//     holds the veth-leak default route plus a per-network policy rule
+//     pointing at it.
+//  2. No table contains entries from another writer. The FIP /32 cannot
+//     leak into 201 or 202; the per-network rule cannot point at 200 or 201.
+//
+// The agent's setup path is order-sensitive (SetupVethLeak before
+// SetupPortForward), so the test does not assert on install ordering — it
+// waits for the steady-state convergence each writer is expected to reach.
+func TestScenario_FailureInjection_RouteTableCollisions(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+	testenv.EnsureLoopback1(t)
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "tblcoll",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	const (
+		fipExternal     = "198.51.100.42"
+		pfVIP           = "198.51.100.71"
+		providerNet     = "198.51.100.0/24"
+		routeTable      = 200
+		portForwardTbl  = 201
+		vethLeakTbl     = 202
+	)
+	testenv.AddFIP(t, ctx, nb, router, fipExternal, "10.0.0.42")
+
+	cfg := testenv.FastDefaults()
+	cfg.RouteTableID = intPtr(routeTable)
+	cfg.PortForwardTableID = intPtr(portForwardTbl)
+	cfg.VethLeakTableID = intPtr(vethLeakTbl)
+
+	cfg.PortForwardDev = testenv.PortForwardLoopbackDev
+	cfg.PortForwardCTZone = intPtr(64002)
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+		VIP:       pfVIP,
+		ManageVIP: true,
+		Rules: []testenv.PortForwardRuleFixture{{
+			Proto: "tcp", Port: 80, DestAddr: "10.0.0.71",
+		}},
+	}}
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+	// SIGKILL-on-test-failure leaves residue in non-default tables; the
+	// next scenario's scrubLocalState only flushes the harness defaults,
+	// so scrub each configured table here.
+	t.Cleanup(func() { testenv.ScrubPortForwardResidue(t) })
+	t.Cleanup(func() {
+		for _, id := range []int{routeTable, portForwardTbl, vethLeakTbl} {
+			// Best-effort, idempotent.
+			_ = flushIPTable(strconv.Itoa(id))
+		}
+	})
+
+	routeTableStr := strconv.Itoa(routeTable)
+	portForwardTblStr := strconv.Itoa(portForwardTbl)
+	vethLeakTblStr := strconv.Itoa(vethLeakTbl)
+
+	// === Positive: each writer placed its entries in its own table ====
+
+	// Kernel-route writer: the FIP /32 and the PF VIP /32 land on br-ex
+	// in table 200. iproute2 strips the /32 suffix for IPv4 in JSON output,
+	// so dst is the bare IP.
+	testenv.AssertRouteInTable(t, routeTableStr, fipExternal, testenv.DefaultBridgeDev, 20*time.Second)
+	testenv.AssertRouteInTable(t, routeTableStr, pfVIP, testenv.DefaultBridgeDev, 20*time.Second)
+
+	// Port-forward writer: a default route via veth-default in table 201.
+	testenv.AssertRouteInTable(t, portForwardTblStr, "default", testenv.VethDefaultName, 20*time.Second)
+
+	// Veth-leak writer: a default route via veth-default in table 202, plus
+	// the per-network policy rule from 198.51.100.0/24 pointing at 202.
+	testenv.AssertRouteInTable(t, vethLeakTblStr, "default", testenv.VethDefaultName, 20*time.Second)
+	testenv.AssertIPRuleAtPriorityTable(t, testenv.DefaultVethLeakRulePriority,
+		providerNet, vethLeakTbl, 20*time.Second)
+
+	// === Negative: no writer encroached on a sibling's table ===========
+
+	// FIP /32 must NOT appear in the port-forward or veth-leak tables.
+	testenv.AssertNoRouteInTable(t, portForwardTblStr, fipExternal, "", 1*time.Second)
+	testenv.AssertNoRouteInTable(t, vethLeakTblStr, fipExternal, "", 1*time.Second)
+
+	// PF VIP /32 likewise.
+	testenv.AssertNoRouteInTable(t, portForwardTblStr, pfVIP, "", 1*time.Second)
+	testenv.AssertNoRouteInTable(t, vethLeakTblStr, pfVIP, "", 1*time.Second)
+
+	// The kernel-route table must NOT contain the default-via-veth-default
+	// entry the other two writers planted in their own tables.
+	testenv.AssertNoRouteInTable(t, routeTableStr, "default", testenv.VethDefaultName, 1*time.Second)
+}
+
+// flushIPTable is the test-side equivalent of `ip route flush table <id>`.
+// Returns nil on success or on the harmless "table is empty" case. Used by
+// the t.Cleanup chain in the route-table scenario so non-default tables do
+// not leak into subsequent scenarios that assume the harness defaults.
+func flushIPTable(table string) error {
+	_, err := exec.Command("ip", "route", "flush", "table", table).CombinedOutput()
+	return err
+}

--- a/test/integration/scenario_route_tables_test.go
+++ b/test/integration/scenario_route_tables_test.go
@@ -48,12 +48,12 @@ func TestScenario_FailureInjection_RouteTableCollisions(t *testing.T) {
 	})
 
 	const (
-		fipExternal     = "198.51.100.42"
-		pfVIP           = "198.51.100.71"
-		providerNet     = "198.51.100.0/24"
-		routeTable      = 200
-		portForwardTbl  = 201
-		vethLeakTbl     = 202
+		fipExternal    = "198.51.100.42"
+		pfVIP          = "198.51.100.71"
+		providerNet    = "198.51.100.0/24"
+		routeTable     = 200
+		portForwardTbl = 201
+		vethLeakTbl    = 202
 	)
 	testenv.AddFIP(t, ctx, nb, router, fipExternal, "10.0.0.42")
 

--- a/test/integration/scenario_router_masquerade_ordering_test.go
+++ b/test/integration/scenario_router_masquerade_ordering_test.go
@@ -1,0 +1,99 @@
+//go:build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/osism/ovn-network-agent/test/integration/testenv"
+)
+
+// TestScenario_FailureInjection_RouterMasqueradeStartupBeforeSNAT (#88
+// item 4):
+//
+// router_masquerade rules are emitted only when both halves of the source
+// match are known: at least one VIP carries router_masquerade=true (from
+// agent config) AND at least one SNAT external IP is present on a locally-
+// active router (from OVN NB).
+//
+// Start the agent with router_masquerade configured but NO snat-type NAT
+// entry on the router. The postrouting_snat chain must not be emitted: the
+// ruleset would carry zero rules and emitting an empty chain serves no
+// purpose. After adding the SNAT NAT entry to NB the next reconcile picks
+// it up and the chain materialises with the matching rule.
+//
+// This is the inverse of TestScenario_PortForwardRouterMasquerade in
+// scenario_port_forward_test.go — that test asserts steady-state when
+// both inputs are present from the start. Here we pin the ordering edge
+// case: agent ready before NB has the data.
+func TestScenario_FailureInjection_RouterMasqueradeStartupBeforeSNAT(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+	testenv.EnsureLoopback1(t)
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "rmasqord",
+		LRPMAC:      "fa:16:3e:7a:00:02",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	const (
+		vip     = "198.51.100.41"
+		snatIP  = "198.51.100.50"
+		snatNet = "10.0.0.0/24"
+	)
+
+	cfg := testenv.FastDefaults()
+	cfg.PortForwardDev = testenv.PortForwardLoopbackDev
+	cfg.PortForwardCTZone = intPtr(64003)
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+		VIP:              vip,
+		RouterMasquerade: true,
+		Rules: []testenv.PortForwardRuleFixture{{
+			Proto: "tcp", Port: 80, DestAddr: "10.0.0.100",
+		}},
+	}}
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+	t.Cleanup(func() { testenv.ScrubPortForwardResidue(t) })
+
+	// Sanity: the rest of the port-forward ruleset is up (prerouting_dnat
+	// is emitted regardless of router_masquerade state). Asserting on it
+	// proves the agent reconciled the new VIP before we test for the
+	// absence of postrouting_snat.
+	testenv.AssertNftChainExists(t, testenv.DefaultNftTable, "prerouting_dnat", 15*time.Second)
+
+	// router_masquerade alone (no SNAT IP) must not emit the chain.
+	// 3s is two reconcile ticks at FastDefaults's 2s interval — plenty
+	// to surface a regression that emits the chain prematurely without
+	// stalling the suite.
+	testenv.AssertNftChainAbsent(t, testenv.DefaultNftTable, "postrouting_snat", 3*time.Second)
+
+	// Add a snat-type NAT entry on the same router. The next reconcile
+	// must see it (OVN.UpdateState extracts SNAT IPs from NB NAT rows of
+	// type=snat on locally-active routers) and emit the chain.
+	testenv.AddSNATEntry(t, ctx, nb, router, snatIP, snatNet)
+
+	// The rule shape mirrors TestScenario_PortForwardRouterMasquerade:
+	// saddr = snatIP, masquerade statement. Asserting on the rule (not
+	// just the chain existence) guards against a regression where the
+	// chain is emitted but the rule body is wrong.
+	testenv.AssertNftRuleInChain(t, testenv.DefaultNftTable, "postrouting_snat",
+		func(r testenv.NftRule) bool {
+			return r.HasMatch("ip", "saddr", snatIP) && r.HasMasquerade()
+		},
+		30*time.Second, "router masquerade rule for VIP "+vip+" with SNAT IP "+snatIP)
+
+	// Final sanity: the agent didn't log a hard failure on the SNAT
+	// transition. We're not asserting on a specific log marker — just
+	// that the per-reconcile log doesn't carry a fatal "failed to
+	// reconcile port forwarding" line for the new state.
+	logs := a.LogTail(100000)
+	if strings.Contains(logs, "failed to reconcile port forwarding") {
+		t.Errorf("agent logged a port-forward reconcile failure during the SNAT transition; tail:\n%s",
+			a.LogTail(40))
+	}
+}

--- a/test/integration/scenario_same_batch_fip_test.go
+++ b/test/integration/scenario_same_batch_fip_test.go
@@ -1,0 +1,117 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+
+	"github.com/osism/ovn-network-agent/test/integration/testenv"
+)
+
+// TestScenario_FailureInjection_SameBatchFIPAddRemove (#88 item 5):
+//
+// Issue a single OVSDB transaction that simultaneously adds one FIP and
+// removes another. The libovsdb monitor delivers both row changes in the
+// same update; the agent's debounced reconcile loop must observe both ends
+// of the change.
+//
+// TestImmediateStateRefreshCoalesces (in ovn_test.go) covers the unit-level
+// debounce. This scenario is the end-to-end variant: kernel routes for both
+// FIPs must converge to "A present, B absent" after the next reconcile.
+func TestScenario_FailureInjection_SameBatchFIPAddRemove(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "fipbatch",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	cfg := testenv.FastDefaults()
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	const (
+		fipA = "198.51.100.42"
+		fipB = "198.51.100.43"
+	)
+
+	// Pre-install FIP B and wait for it to land — that is the "old" state
+	// the same-batch transaction is going to undo.
+	natBUUID := testenv.AddFIP(t, ctx, nb, router, fipB, "10.0.0.43")
+	testenv.AssertKernelRoute(t, fipB, 15*time.Second)
+
+	// Build a single transaction that:
+	//   1. Inserts the new FIP A row.
+	//   2. Mutates the router to append A.
+	//   3. Mutates the router to delete B (parent → child reference).
+	//   4. Deletes the FIP B row itself.
+	//
+	// Steps 2-3 are separate mutate operations on the same Logical_Router;
+	// OVSDB processes them atomically in one transaction, so the monitor
+	// emits a single update with both the new and the removed NAT.
+	natA := &testenv.NBNAT{
+		UUID:       "nat_a",
+		Type:       "dnat_and_snat",
+		ExternalIP: fipA,
+		LogicalIP:  "10.0.0.42",
+	}
+	createOps, err := nb.Create(natA)
+	if err != nil {
+		t.Fatalf("build create op for FIP A: %v", err)
+	}
+
+	addOp := ovsdb.Operation{
+		Op:    "mutate",
+		Table: "Logical_Router",
+		Where: []ovsdb.Condition{{
+			Column:   "_uuid",
+			Function: ovsdb.ConditionEqual,
+			Value:    ovsdb.UUID{GoUUID: router.RouterUUID},
+		}},
+		Mutations: []ovsdb.Mutation{{
+			Column:  "nat",
+			Mutator: ovsdb.MutateOperationInsert,
+			Value:   ovsdb.OvsSet{GoSet: []any{ovsdb.UUID{GoUUID: "nat_a"}}},
+		}},
+	}
+	delOp := ovsdb.Operation{
+		Op:    "mutate",
+		Table: "Logical_Router",
+		Where: []ovsdb.Condition{{
+			Column:   "_uuid",
+			Function: ovsdb.ConditionEqual,
+			Value:    ovsdb.UUID{GoUUID: router.RouterUUID},
+		}},
+		Mutations: []ovsdb.Mutation{{
+			Column:  "nat",
+			Mutator: ovsdb.MutateOperationDelete,
+			Value:   ovsdb.OvsSet{GoSet: []any{ovsdb.UUID{GoUUID: natBUUID}}},
+		}},
+	}
+	deleteRowOps, err := nb.Where(&testenv.NBNAT{UUID: natBUUID}).Delete()
+	if err != nil {
+		t.Fatalf("build delete op for FIP B: %v", err)
+	}
+
+	ops := append([]ovsdb.Operation{}, createOps...)
+	ops = append(ops, addOp, delOp)
+	ops = append(ops, deleteRowOps...)
+	testenv.Transact(t, ctx, nb, ops)
+
+	// Convergence: A's route is installed, B's route is withdrawn. Both
+	// assertions poll independently — the ordering between the add and
+	// the remove inside the agent's reconcile is not under test, only
+	// the post-convergence steady state.
+	testenv.AssertKernelRoute(t, fipA, 15*time.Second)
+	testenv.AssertNoKernelRoute(t, fipB, 15*time.Second)
+
+	// FRR plane mirrors the kernel plane — pin it down too so a future
+	// regression that drops the OVSDB-batch update only on one of the
+	// two planes cannot pass silently.
+	testenv.AssertFRRRoute(t, fipA, 15*time.Second)
+	testenv.AssertNoFRRRoute(t, fipB, 15*time.Second)
+}

--- a/test/integration/testenv/agent.go
+++ b/test/integration/testenv/agent.go
@@ -158,9 +158,12 @@ func RunAgent(t *testing.T, cfg AgentConfig) *AgentProc {
 	bin := AgentBinary(t)
 	cmd := exec.Command(bin, "--config", configPath)
 	cmd.Env = append(os.Environ(), "GOTRACEBACK=all")
-	// ExtraEnv entries trail os.Environ() so they win when keys collide —
-	// PATH overrides from WithFailingTool depend on this order.
-	cmd.Env = append(cmd.Env, cfg.ExtraEnv...)
+	// ExtraEnv must REPLACE existing entries with the same key, not append.
+	// Linux's getenv() returns the first matching entry, so a trailing
+	// "PATH=<shim>:..." would be ignored — the agent would still resolve
+	// tools via the original PATH and the WithFailingTool shim would never
+	// fire. mergeEnv splices each "KEY=value" in over its prior occurrence.
+	cmd.Env = mergeEnv(cmd.Env, cfg.ExtraEnv)
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
@@ -407,4 +410,37 @@ func writeTempConfig(t *testing.T, cfg AgentConfig) string {
 		t.Fatalf("write config: %v", err)
 	}
 	return path
+}
+
+// mergeEnv returns base with each "KEY=value" entry from overrides spliced
+// in over its prior occurrence. Keys not yet present are appended at the
+// end. Unlike a naive `append`, this guarantees the override wins
+// regardless of whether libc's getenv() returns the first or last matching
+// entry — Linux libc returns the first, which is exactly the trap
+// WithFailingTool used to fall into.
+func mergeEnv(base, overrides []string) []string {
+	out := make([]string, len(base))
+	copy(out, base)
+	for _, entry := range overrides {
+		key := entry
+		if i := strings.IndexByte(entry, '='); i >= 0 {
+			key = entry[:i]
+		}
+		replaced := false
+		for i, existing := range out {
+			eKey := existing
+			if j := strings.IndexByte(existing, '='); j >= 0 {
+				eKey = existing[:j]
+			}
+			if eKey == key {
+				out[i] = entry
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			out = append(out, entry)
+		}
+	}
+	return out
 }

--- a/test/integration/testenv/agent.go
+++ b/test/integration/testenv/agent.go
@@ -63,6 +63,20 @@ type AgentConfig struct {
 	PortForwardL3mdevAccept *bool                   `yaml:"port_forward_l3mdev_accept,omitempty"`
 	PortForwardCTZone       *int                    `yaml:"port_forward_ct_zone,omitempty"`
 	PortForwards            []PortForwardVIPFixture `yaml:"port_forwards,omitempty"`
+
+	// Routing-table IDs for each writer plane. Mirrors the agent's
+	// route_table_id / veth_leak_table_id / port_forward_table_id options.
+	// Pointer so a test can opt into a non-default value without forcing
+	// every other test to populate them.
+	RouteTableID       *int `yaml:"route_table_id,omitempty"`
+	VethLeakTableID    *int `yaml:"veth_leak_table_id,omitempty"`
+	PortForwardTableID *int `yaml:"port_forward_table_id,omitempty"`
+
+	// ExtraEnv is appended to the agent subprocess's environment after
+	// os.Environ(). Scenario tests use it to prepend a shim directory to
+	// PATH (see WithFailingTool) — later "KEY=value" entries override
+	// earlier ones, which is how PATH overrides work.
+	ExtraEnv []string `yaml:"-"`
 }
 
 // PortForwardVIPFixture mirrors the agent's PortForwardVIP for scenario
@@ -144,6 +158,9 @@ func RunAgent(t *testing.T, cfg AgentConfig) *AgentProc {
 	bin := AgentBinary(t)
 	cmd := exec.Command(bin, "--config", configPath)
 	cmd.Env = append(os.Environ(), "GOTRACEBACK=all")
+	// ExtraEnv entries trail os.Environ() so they win when keys collide —
+	// PATH overrides from WithFailingTool depend on this order.
+	cmd.Env = append(cmd.Env, cfg.ExtraEnv...)
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
@@ -377,6 +394,10 @@ func writeTempConfig(t *testing.T, cfg AgentConfig) string {
 	if len(cfg.PortForwards) > 0 {
 		doc["port_forwards"] = cfg.PortForwards
 	}
+
+	putInt("route_table_id", cfg.RouteTableID)
+	putInt("veth_leak_table_id", cfg.VethLeakTableID)
+	putInt("port_forward_table_id", cfg.PortForwardTableID)
 
 	out, err := yaml.Marshal(doc)
 	if err != nil {

--- a/test/integration/testenv/iproute.go
+++ b/test/integration/testenv/iproute.go
@@ -80,6 +80,46 @@ func AssertIPRulePriority(t *testing.T, prio int, mark int, table string, timeou
 	}
 }
 
+// AssertNoRouteInTable polls `ip -j route show table <table>` and fails the
+// test if any entry matching (dst, dev) is still present past timeout. The
+// matching rules mirror AssertRouteInTable; pass dst="" / dev="" to match on
+// the unspecified field. Used by the table-collisions scenario (#88 item 2)
+// to assert that a route the agent placed in one table does NOT appear in
+// another writer's table.
+func AssertNoRouteInTable(t *testing.T, table, dst, dev string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastOut string
+	for {
+		out, err := exec.Command("ip", "-j", "-4", "route", "show", "table", table).CombinedOutput()
+		lastOut = strings.TrimSpace(string(out))
+		if err == nil {
+			var entries []ipRouteEntry
+			if jerr := json.Unmarshal(out, &entries); jerr == nil {
+				match := false
+				for _, e := range entries {
+					if dst != "" && e.Dst != dst {
+						continue
+					}
+					if dev != "" && e.Dev != dev {
+						continue
+					}
+					match = true
+					break
+				}
+				if !match {
+					return
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("ip route in table %s with dst=%q dev=%q unexpectedly present after %s (last output: %q)",
+				table, dst, dev, timeout, lastOut)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
 // AssertRouteInTable polls `ip -j route show table <table>` and fails the
 // test if no entry matches (dst, dev) within timeout.
 //

--- a/test/integration/testenv/nftjson.go
+++ b/test/integration/testenv/nftjson.go
@@ -440,6 +440,19 @@ func AssertNftChainExists(t *testing.T, table, chain string, timeout time.Durati
 	}, timeout, fmt.Sprintf("chain %s/%s should exist", table, chain))
 }
 
+// AssertNftChainAbsent fails the test if the named chain is still present
+// after timeout. Used by scenarios (e.g. #88 item 4) that pin the agent's
+// conditional-chain emission contract: a chain that only materialises in
+// the presence of a specific upstream input must not appear when the input
+// is absent.
+func AssertNftChainAbsent(t *testing.T, table, chain string, timeout time.Duration) {
+	t.Helper()
+	EventuallyNft(t, func(d NftDump) bool {
+		_, ok := d.Chain(table, chain)
+		return !ok
+	}, timeout, fmt.Sprintf("chain %s/%s should be absent", table, chain))
+}
+
 // =============================================================================
 // JSON value comparison helpers
 // =============================================================================

--- a/test/integration/testenv/shim.go
+++ b/test/integration/testenv/shim.go
@@ -91,14 +91,21 @@ SHIM_DIR=%q
 INVOKE=%q
 # Append one line per invocation so the test can verify the shim was on
 # the agent's PATH even when no failure was injected. Best-effort; loss
-# of this line never breaks the pass-through path.
-printf '%%s\n' "invoked: $*" >>"$INVOKE" 2>/dev/null || true
+# of this line never breaks the pass-through path. The "armed=" suffix
+# records whether the arm file is visible to the shim at the moment of
+# the call — distinguishing a missing-arm-file bug from a missing-shim
+# bug.
+armed=no
+if [ -e "$ARM" ]; then
+    armed=yes
+fi
+printf '%%s\n' "invoked (armed=$armed): $*" >>"$INVOKE" 2>/dev/null || true
 strip_path() {
     # Strip the shim directory from PATH so the real binary lookup
     # resolves to the system install, not back to us.
     printf '%%s' "$PATH" | awk -v RS=: -v ORS=: -v skip="$SHIM_DIR" '$0!=skip{print}' | sed 's/:$//'
 }
-if [ ! -e "$ARM" ]; then
+if [ "$armed" != yes ]; then
     PATH="$(strip_path)" exec "$REAL" "$@"
 fi
 if [ -s "$MATCH" ]; then

--- a/test/integration/testenv/shim.go
+++ b/test/integration/testenv/shim.go
@@ -1,0 +1,163 @@
+//go:build integration
+
+package testenv
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// FailingToolShim is the handle returned by WithFailingTool. The test holds it
+// to flip the shim between pass-through and fail-N-times mode at the right
+// moment in the scenario.
+//
+// The shim is disarmed at construction time: the agent's startup invocations
+// of the shimmed tool (e.g. SetupPortForward calling nft) succeed normally,
+// so the failure window can be scoped to a single point in the test.
+type FailingToolShim struct {
+	tool        string
+	dir         string
+	armPath     string
+	counterPath string
+	failCount   int
+	t           *testing.T
+}
+
+// WithFailingTool installs a shim for tool (e.g. "vtysh", "nft", "ovs-ofctl")
+// at the front of the agent's PATH. The shim starts disarmed (every call
+// chains through to the real binary). After Arm() the next failCount
+// invocations exit non-zero; subsequent invocations chain through again.
+//
+// Usage:
+//
+//	shim := testenv.WithFailingTool(t, "vtysh", 3)
+//	cfg := testenv.FastDefaults()
+//	cfg.ExtraEnv = append(cfg.ExtraEnv, shim.Env())
+//	shim.Arm()
+//	a := testenv.RunAgent(t, cfg)
+//
+// The helper is the issue #88 acceptance criterion #2 entry point: it lives
+// in testenv/ so all three sub-scenarios of failure injection (vtysh, nft,
+// ovs-ofctl) share one implementation.
+func WithFailingTool(t *testing.T, tool string, failCount int) *FailingToolShim {
+	t.Helper()
+	if tool == "" {
+		t.Fatal("WithFailingTool: tool name required")
+	}
+	if failCount < 0 {
+		t.Fatalf("WithFailingTool: failCount must be >= 0, got %d", failCount)
+	}
+
+	realPath, err := exec.LookPath(tool)
+	if err != nil {
+		t.Skipf("WithFailingTool: real %s not found in PATH: %v", tool, err)
+	}
+
+	dir := t.TempDir()
+	shim := &FailingToolShim{
+		tool:        tool,
+		dir:         dir,
+		armPath:     filepath.Join(dir, tool+".armed"),
+		counterPath: filepath.Join(dir, tool+".remaining"),
+		failCount:   failCount,
+		t:           t,
+	}
+
+	// The shim is a small POSIX shell script. Each invocation:
+	//   1. If the arm file is absent, chain through to the real tool.
+	//   2. Otherwise read the counter; if positive, decrement and exit 1.
+	//   3. If counter has hit zero, chain through.
+	//
+	// The shim strips its own directory from PATH before exec so the inner
+	// real-binary lookup cannot recurse into the shim — a recursion bug
+	// here would loop until kernel TASK_MAX with no useful diagnostic.
+	script := fmt.Sprintf(`#!/bin/sh
+set -e
+ARM=%q
+COUNTER=%q
+REAL=%q
+SHIM_DIR=%q
+if [ ! -e "$ARM" ]; then
+    exec "$REAL" "$@"
+fi
+remaining=$(cat "$COUNTER" 2>/dev/null || echo 0)
+case "$remaining" in
+    ''|*[!0-9]*) remaining=0 ;;
+esac
+if [ "$remaining" -gt 0 ]; then
+    new=$((remaining - 1))
+    printf '%%s\n' "$new" >"$COUNTER"
+    echo "ovn-network-agent test shim: forced failure of %s (remaining=$new)" >&2
+    exit 1
+fi
+# Strip the shim directory from PATH so the real binary lookup resolves to
+# the system install, not back to us.
+clean_path=$(printf '%%s' "$PATH" | awk -v RS=: -v ORS=: -v skip="$SHIM_DIR" '$0!=skip{print}' | sed 's/:$//')
+PATH="$clean_path" exec "$REAL" "$@"
+`, shim.armPath, shim.counterPath, realPath, dir, tool)
+	if err := os.WriteFile(filepath.Join(dir, tool), []byte(script), 0o755); err != nil {
+		t.Fatalf("WithFailingTool: write shim: %v", err)
+	}
+
+	return shim
+}
+
+// Env returns the AgentConfig.ExtraEnv entry that prepends the shim
+// directory to PATH. Pass this into cfg.ExtraEnv before starting the agent.
+func (s *FailingToolShim) Env() string {
+	current := os.Getenv("PATH")
+	if current == "" {
+		return "PATH=" + s.dir
+	}
+	return "PATH=" + s.dir + string(os.PathListSeparator) + current
+}
+
+// Arm enables the failure counter. The next failCount invocations of the
+// shimmed tool will exit non-zero with a "test shim: forced failure" line
+// on stderr.
+//
+// Idempotent: calling Arm() on an already-armed shim resets the counter so
+// the test can re-inject failures for a follow-up reconcile.
+func (s *FailingToolShim) Arm() {
+	s.t.Helper()
+	if err := os.WriteFile(s.counterPath, []byte(fmt.Sprintf("%d\n", s.failCount)), 0o600); err != nil {
+		s.t.Fatalf("FailingToolShim.Arm: write counter: %v", err)
+	}
+	if err := os.WriteFile(s.armPath, []byte("1\n"), 0o600); err != nil {
+		s.t.Fatalf("FailingToolShim.Arm: write arm file: %v", err)
+	}
+}
+
+// Disarm removes the arm file so subsequent invocations chain through
+// unconditionally. Tests do not normally need to call this — the shim
+// disarms itself once the counter reaches zero — but it is useful when a
+// scenario wants to guarantee no further failures before exit.
+func (s *FailingToolShim) Disarm() {
+	s.t.Helper()
+	if err := os.Remove(s.armPath); err != nil && !os.IsNotExist(err) {
+		s.t.Fatalf("FailingToolShim.Disarm: %v", err)
+	}
+}
+
+// Remaining returns the number of failures left in the current arm window.
+// Useful for diagnostics — tests can log this to see whether the agent
+// consumed all injected failures before recovery.
+func (s *FailingToolShim) Remaining() int {
+	s.t.Helper()
+	data, err := os.ReadFile(s.counterPath)
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, c := range strings.TrimSpace(string(data)) {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}

--- a/test/integration/testenv/shim.go
+++ b/test/integration/testenv/shim.go
@@ -24,6 +24,7 @@ type FailingToolShim struct {
 	armPath     string
 	counterPath string
 	matchPath   string
+	invokePath  string
 	failCount   int
 	t           *testing.T
 }
@@ -65,6 +66,7 @@ func WithFailingTool(t *testing.T, tool string, failCount int) *FailingToolShim 
 		armPath:     filepath.Join(dir, tool+".armed"),
 		counterPath: filepath.Join(dir, tool+".remaining"),
 		matchPath:   filepath.Join(dir, tool+".match"),
+		invokePath:  filepath.Join(dir, tool+".invocations"),
 		failCount:   failCount,
 		t:           t,
 	}
@@ -86,6 +88,11 @@ COUNTER=%q
 MATCH=%q
 REAL=%q
 SHIM_DIR=%q
+INVOKE=%q
+# Append one line per invocation so the test can verify the shim was on
+# the agent's PATH even when no failure was injected. Best-effort; loss
+# of this line never breaks the pass-through path.
+printf '%%s\n' "invoked: $*" >>"$INVOKE" 2>/dev/null || true
 strip_path() {
     # Strip the shim directory from PATH so the real binary lookup
     # resolves to the system install, not back to us.
@@ -115,7 +122,7 @@ if [ "$remaining" -gt 0 ]; then
     exit 1
 fi
 PATH="$(strip_path)" exec "$REAL" "$@"
-`, shim.armPath, shim.counterPath, shim.matchPath, realPath, dir, tool)
+`, shim.armPath, shim.counterPath, shim.matchPath, realPath, dir, shim.invokePath, tool)
 	if err := os.WriteFile(filepath.Join(dir, tool), []byte(script), 0o755); err != nil {
 		t.Fatalf("WithFailingTool: write shim: %v", err)
 	}
@@ -173,6 +180,24 @@ func (s *FailingToolShim) Disarm() {
 	if err := os.Remove(s.armPath); err != nil && !os.IsNotExist(err) {
 		s.t.Fatalf("FailingToolShim.Disarm: %v", err)
 	}
+}
+
+// InvocationLog returns the contents of the shim's invocation log — one line
+// per call ("invoked: <argv>") the agent made through the shim. Tests use
+// this as a diagnostic when a forced-failure assertion times out: a non-empty
+// log proves the shim is on PATH and being reached, narrowing the failure
+// down to the arm/counter logic rather than a missing PATH override.
+func (s *FailingToolShim) InvocationLog() string {
+	s.t.Helper()
+	data, err := os.ReadFile(s.invokePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		s.t.Logf("FailingToolShim.InvocationLog: read %s: %v", s.invokePath, err)
+		return ""
+	}
+	return string(data)
 }
 
 // Remaining returns the number of failures left in the current arm window.

--- a/test/integration/testenv/shim.go
+++ b/test/integration/testenv/shim.go
@@ -23,6 +23,7 @@ type FailingToolShim struct {
 	dir         string
 	armPath     string
 	counterPath string
+	matchPath   string
 	failCount   int
 	t           *testing.T
 }
@@ -63,14 +64,17 @@ func WithFailingTool(t *testing.T, tool string, failCount int) *FailingToolShim 
 		dir:         dir,
 		armPath:     filepath.Join(dir, tool+".armed"),
 		counterPath: filepath.Join(dir, tool+".remaining"),
+		matchPath:   filepath.Join(dir, tool+".match"),
 		failCount:   failCount,
 		t:           t,
 	}
 
 	// The shim is a small POSIX shell script. Each invocation:
 	//   1. If the arm file is absent, chain through to the real tool.
-	//   2. Otherwise read the counter; if positive, decrement and exit 1.
-	//   3. If counter has hit zero, chain through.
+	//   2. If a match file is present, only fail when the joined args
+	//      contain that substring; pass through otherwise.
+	//   3. Otherwise read the counter; if positive, decrement and exit 1.
+	//   4. If counter has hit zero, chain through.
 	//
 	// The shim strips its own directory from PATH before exec so the inner
 	// real-binary lookup cannot recurse into the shim — a recursion bug
@@ -79,10 +83,26 @@ func WithFailingTool(t *testing.T, tool string, failCount int) *FailingToolShim 
 set -e
 ARM=%q
 COUNTER=%q
+MATCH=%q
 REAL=%q
 SHIM_DIR=%q
+strip_path() {
+    # Strip the shim directory from PATH so the real binary lookup
+    # resolves to the system install, not back to us.
+    printf '%%s' "$PATH" | awk -v RS=: -v ORS=: -v skip="$SHIM_DIR" '$0!=skip{print}' | sed 's/:$//'
+}
 if [ ! -e "$ARM" ]; then
-    exec "$REAL" "$@"
+    PATH="$(strip_path)" exec "$REAL" "$@"
+fi
+if [ -s "$MATCH" ]; then
+    pattern=$(cat "$MATCH")
+    joined="$*"
+    case "$joined" in
+        *"$pattern"*) ;;
+        *)
+            PATH="$(strip_path)" exec "$REAL" "$@"
+            ;;
+    esac
 fi
 remaining=$(cat "$COUNTER" 2>/dev/null || echo 0)
 case "$remaining" in
@@ -94,11 +114,8 @@ if [ "$remaining" -gt 0 ]; then
     echo "ovn-network-agent test shim: forced failure of %s (remaining=$new)" >&2
     exit 1
 fi
-# Strip the shim directory from PATH so the real binary lookup resolves to
-# the system install, not back to us.
-clean_path=$(printf '%%s' "$PATH" | awk -v RS=: -v ORS=: -v skip="$SHIM_DIR" '$0!=skip{print}' | sed 's/:$//')
-PATH="$clean_path" exec "$REAL" "$@"
-`, shim.armPath, shim.counterPath, realPath, dir, tool)
+PATH="$(strip_path)" exec "$REAL" "$@"
+`, shim.armPath, shim.counterPath, shim.matchPath, realPath, dir, tool)
 	if err := os.WriteFile(filepath.Join(dir, tool), []byte(script), 0o755); err != nil {
 		t.Fatalf("WithFailingTool: write shim: %v", err)
 	}
@@ -130,6 +147,21 @@ func (s *FailingToolShim) Arm() {
 	if err := os.WriteFile(s.armPath, []byte("1\n"), 0o600); err != nil {
 		s.t.Fatalf("FailingToolShim.Arm: write arm file: %v", err)
 	}
+}
+
+// MatchArg narrows the shim's failure window to invocations whose joined
+// argv contains substring. The shim chains through unconditionally for
+// every call that does not match — useful when a scenario wants to fail
+// only one *kind* of invocation of a tool (e.g. vtysh's add-route call but
+// not its show-routes call).
+//
+// Returns the receiver to support fluent chaining at the call site.
+func (s *FailingToolShim) MatchArg(substring string) *FailingToolShim {
+	s.t.Helper()
+	if err := os.WriteFile(s.matchPath, []byte(substring), 0o600); err != nil {
+		s.t.Fatalf("FailingToolShim.MatchArg: %v", err)
+	}
+	return s
 }
 
 // Disarm removes the arm file so subsequent invocations chain through

--- a/test/integration/testenv/shim.go
+++ b/test/integration/testenv/shim.go
@@ -114,11 +114,13 @@ if [ -s "$MATCH" ]; then
     case "$joined" in
         *"$pattern"*) ;;
         *)
+            printf '%%s\n' "  match=skip pattern=$pattern joined=$joined" >>"$INVOKE" 2>/dev/null || true
             PATH="$(strip_path)" exec "$REAL" "$@"
             ;;
     esac
 fi
-remaining=$(cat "$COUNTER" 2>/dev/null || echo 0)
+remaining=$(cat "$COUNTER" 2>/dev/null || echo MISSING)
+printf '%%s\n' "  counter_raw=$remaining counter_file=$COUNTER" >>"$INVOKE" 2>/dev/null || true
 case "$remaining" in
     ''|*[!0-9]*) remaining=0 ;;
 esac

--- a/test/integration/testenv/shim.go
+++ b/test/integration/testenv/shim.go
@@ -114,13 +114,11 @@ if [ -s "$MATCH" ]; then
     case "$joined" in
         *"$pattern"*) ;;
         *)
-            printf '%%s\n' "  match=skip pattern=$pattern joined=$joined" >>"$INVOKE" 2>/dev/null || true
             PATH="$(strip_path)" exec "$REAL" "$@"
             ;;
     esac
 fi
-remaining=$(cat "$COUNTER" 2>/dev/null || echo MISSING)
-printf '%%s\n' "  counter_raw=$remaining counter_file=$COUNTER" >>"$INVOKE" 2>/dev/null || true
+remaining=$(cat "$COUNTER" 2>/dev/null || echo 0)
 case "$remaining" in
     ''|*[!0-9]*) remaining=0 ;;
 esac

--- a/test/integration/testenv/vethleak.go
+++ b/test/integration/testenv/vethleak.go
@@ -291,8 +291,17 @@ func AssertVethDefaultRouteInLeakTable(t *testing.T, timeout time.Duration) {
 // up to timeout to give the agent time to install rules after a state change.
 func AssertIPRuleAtPriority(t *testing.T, priority int, src string, timeout time.Duration) {
 	t.Helper()
+	AssertIPRuleAtPriorityTable(t, priority, src, DefaultVethLeakTableID, timeout)
+}
+
+// AssertIPRuleAtPriorityTable is the table-parameterised form of
+// AssertIPRuleAtPriority. Scenarios that override veth_leak_table_id (see
+// the table-collisions scenario in #88 item 2) need to assert against the
+// configured table rather than the agent's default.
+func AssertIPRuleAtPriorityTable(t *testing.T, priority int, src string, tableID int, timeout time.Duration) {
+	t.Helper()
 	if _, _, err := net.ParseCIDR(src); err != nil {
-		t.Fatalf("AssertIPRuleAtPriority: invalid CIDR %q: %v", src, err)
+		t.Fatalf("AssertIPRuleAtPriorityTable: invalid CIDR %q: %v", src, err)
 	}
 	deadline := time.Now().Add(timeout)
 	var lastOut string
@@ -305,7 +314,7 @@ func AssertIPRuleAtPriority(t *testing.T, priority int, src string, timeout time
 				for _, r := range rules {
 					if r.Priority == priority &&
 						r.srcCIDR() == src &&
-						tableMatches(r.Table, DefaultVethLeakTableID) {
+						tableMatches(r.Table, tableID) {
 						return
 					}
 				}
@@ -313,7 +322,7 @@ func AssertIPRuleAtPriority(t *testing.T, priority int, src string, timeout time
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("ip rule priority %d from %s table %d not present after %s (last: %q)",
-				priority, src, DefaultVethLeakTableID, timeout, strings.TrimSpace(lastOut))
+				priority, src, tableID, timeout, strings.TrimSpace(lastOut))
 		}
 		time.Sleep(150 * time.Millisecond)
 	}


### PR DESCRIPTION
## Summary

Implements #88 — the six follow-up integration scenarios from the test-coverage audit that exercise tool-level failures, configuration collisions, and ordering edge cases on the v4 / single-host surface. Every scenario lives behind the existing `integration` build tag and shares the new `TestScenario_FailureInjection_` prefix so AC #3 (no flakes on 10 consecutive runs) can target the whole set with one `-run` argument.

The core helper is `testenv.WithFailingTool` — a per-test PATH-prefix shim that fails the first N invocations of a tool after Arm() and then chains through to the real binary. It supports an optional `MatchArg(substr)` filter so a scenario can fail only one kind of invocation of a tool (used by the partial-failure scenario to break vtysh's add-route call while leaving show-routes healthy).

Implements #88

## Commits

In review order:

1. `test(integration): add WithFailingTool shim + table-id config knobs (#88)` — new testenv plumbing: armable shim, ExtraEnv passthrough on the agent subprocess, RouteTableID/VethLeakTableID/PortForwardTableID fields on AgentConfig.
2. `test(integration): mid-cycle vtysh/nft/ovs-ofctl failure + self-heal (#88 item 1)` — three sub-scenarios sharing the shim. Each pins the "test shim: forced failure" marker into the agent log so a regression that skips the failure path cannot pass silently.
3. `test(integration): route_table_id collision coverage (#88 item 2)` — three writers on 200/201/202, plus AssertNoRouteInTable / AssertIPRuleAtPriorityTable helpers for the negative / parameterised assertions.
4. `test(integration): cleanup-on-shutdown without drain phase (#88 item 3)` — drain_on_shutdown=false + managed gatewayless NB entries; asserts NB rows are removed and no "drain:" markers leak.
5. `test(integration): router_masquerade startup before SNAT NAT (#88 item 4)` — conditional-chain emission contract. Adds AssertNftChainAbsent.
6. `test(integration): same-batch FIP add + remove (#88 item 5)` — single OVSDB transaction inserts FIP A and removes FIP B; kernel + FRR planes converge on the post-batch steady state.
7. `test(integration): partial-failure FRR retry, kernel untouched (#88 item 6)` — adds `MatchArg("conf t")` to the shim, asserts route_readds_total separates the planes correctly and the kernel route is never duplicated.
8. `test(integration): gofmt fixes for the new failure-injection files`.
9. `docs(integration): index the new #88 failure-injection scenarios` — README layout block + flake-resistance one-liner.

## Acceptance criteria

- [x] Each scenario has its own `scenario_*_test.go` file. Six files added under `test/integration/`.
- [x] Tool-shim approach lives under `testenv/` and is reusable. `testenv/shim.go` exposes `WithFailingTool(t, tool, failCount)` returning a `*FailingToolShim` with `Env()`, `Arm()`, `Disarm()`, `MatchArg()`, and `Remaining()`.
- [ ] No flakes on 10 consecutive runs (requires Linux + root + the apt-installed OVN/OVS/FRR/nftables stack — not runnable in CI inside this PR description; the README now shows the exact command).
- [ ] CI runtime increase < 90s (depends on the integration host's reconcile cadence; the scenarios use FastDefaults' 2s tick where they observe drift and stop the agent promptly, but the absolute number can only be measured against the project's CI host).

The two unticked items are environmental observations rather than code changes — flagged here so the reviewer/CI operator can confirm them on the integration runner before flipping the PR out of draft.

## Test plan

- [x] `go test -count=1 ./...` — passes
- [x] `go vet -tags=integration ./...` — clean
- [x] `go build -tags=integration ./test/integration/...` — clean
- [x] gofmt clean (`gofmt -l .`)
- [x] Shim script logic verified manually against arm/disarm and MatchArg cases.
- [ ] `sudo OVN_AGENT_BINARY=$PWD/ovn-network-agent go test -tags=integration -v -count=10 -run TestScenario_FailureInjection_ ./test/integration/...` — to be run on the integration host (Ubuntu + setup.sh + apt-installed OVN stack), not reachable from the PR-author environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)