### PR TITLE
docs: realign explanations and integration-test layout with current code

### DIFF
--- a/docs/contributing/integration-tests.md
+++ b/docs/contributing/integration-tests.md
@@ -8,24 +8,31 @@ so the default `go test ./...` run does not pick them up.
 
 ```
 test/integration/
-  README.md                        — stub linking to this page
-  setup.sh                         — apt + service bootstrap (run once per host)
-  smoke_test.go                    — connect / initial-reconcile / clean-shutdown smoke test
-  scenarios_helpers_test.go        — shared per-scenario boilerplate (startScenario, readyAgent)
-  scenario_fip_test.go             — FIP add/remove, gatewayless gw, multi-router on one chassis
-  scenario_failover_test.go        — failover, stale-chassis cleanup (incl. multi-stale + one-stale-one-returning), drain & restore-drained
-  scenario_reconnect_test.go       — OVN database pause/resume resilience (#64 scenario 1)
-  scenario_drain_edges_test.go     — drain edge cases (timeout, no local routers, cleanup_on_shutdown=false)
-  scenario_network_cidrs_test.go   — manual network_cidr override vs. auto-discovery, empty-filter sweep
-  scenario_port_forward_test.go    — DNAT, sticky multi-backend, VIP mgmt, masquerade, hairpin
-  scenario_metrics_test.go         — Prometheus /metrics scrapes (reconcile counter, drain outcome, stale-chassis, desired-state gauges)
-  scenario_failure_injection_test.go         — mid-cycle vtysh/nft/ovs-ofctl failures + self-heal (#88 item 1)
-  scenario_route_tables_test.go              — non-overlapping route_table_id / port_forward_table_id / veth_leak_table_id (#88 item 2)
-  scenario_cleanup_no_drain_test.go          — RemoveManagedNBEntries with drain_on_shutdown=false (#88 item 3)
+  README.md                                   — stub linking to this page
+  setup.sh                                    — apt + service bootstrap (run once per host)
+  smoke_test.go                               — connect / initial-reconcile / clean-shutdown smoke test
+  scenarios_helpers_test.go                   — shared per-scenario boilerplate (startScenario, readyAgent)
+  scenario_fip_test.go                        — FIP add/remove, gatewayless gw, multi-router on one chassis
+  scenario_failover_test.go                   — failover, stale-chassis cleanup (incl. multi-stale + one-stale-one-returning), drain & restore-drained
+  scenario_reconnect_test.go                  — OVN database pause/resume resilience (#64 scenario 1)
+  scenario_drain_edges_test.go                — drain edge cases (timeout, no local routers, cleanup_on_shutdown=false)
+  scenario_drift_test.go                      — periodic-reconcile + verifyRoutes drift recovery (#55)
+  scenario_network_cidrs_test.go              — manual network_cidr override vs. auto-discovery, empty-filter sweep
+  scenario_gateway_port_test.go               — legacy single-router gateway_port filter (#62)
+  scenario_nat_types_test.go                  — `snat` vs `dnat_and_snat` rows + distributed `external_mac` (#62)
+  scenario_port_forward_test.go               — DNAT, sticky multi-backend, VIP mgmt, masquerade, hairpin
+  scenario_prefix_list_test.go                — ReconcileFRRPrefixList lifecycle on real FRR (#58)
+  scenario_bridge_ip_test.go                  — cold-start bridge IP + proxy_arp housekeeping (#63)
+  scenario_vethleak_test.go                   — SetupVethLeak / ReconcileVethLeakNetworks / TeardownVethLeak (#56)
+  scenario_ipv6_test.go                       — IPv6-capable OVS flow plumbing on br-ex (#54; kernel/FRR paths are v4-only today)
+  scenario_metrics_test.go                    — Prometheus /metrics scrapes (reconcile counter, drain outcome, stale-chassis, desired-state gauges)
+  scenario_failure_injection_test.go          — mid-cycle vtysh/nft/ovs-ofctl failures + self-heal (#88 item 1)
+  scenario_route_tables_test.go               — non-overlapping route_table_id / port_forward_table_id / veth_leak_table_id (#88 item 2)
+  scenario_cleanup_no_drain_test.go           — RemoveManagedNBEntries with drain_on_shutdown=false (#88 item 3)
   scenario_router_masquerade_ordering_test.go — router_masquerade configured before SNAT NAT exists (#88 item 4)
-  scenario_same_batch_fip_test.go            — single OVSDB transaction adds + removes FIPs (#88 item 5)
-  scenario_partial_failure_retry_test.go     — FRR write fails, kernel untouched, only FRR re-added (#88 item 6)
-  testenv/                         — Setup, Teardown, RunAgent, MakeLocalRouter, Assert*, ScrapeMetrics, WithFailingTool, …
+  scenario_same_batch_fip_test.go             — single OVSDB transaction adds + removes FIPs (#88 item 5)
+  scenario_partial_failure_retry_test.go      — FRR write fails, kernel untouched, only FRR re-added (#88 item 6)
+  testenv/                                    — Setup, Teardown, RunAgent, MakeLocalRouter, Assert*, ScrapeMetrics, WithFailingTool, …
 ```
 
 The failure-injection scenarios all share the `TestScenario_FailureInjection_`

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -35,11 +35,13 @@ the desired state:
                   │                    │     Reconciler       │  │
                   │                    │                      │  │
                   │                    │  1. Compute desired  │  │
-                  │                    │     IPs (FIPs+SNATs) │  │
+                  │                    │     IPs (FIPs, SNATs,│  │
+                  │                    │     LRP gws, PF VIPs)│  │
                   │                    │  2. Ensure OVS flows │  │
                   │                    │  3. Ensure OVN GW ──────────► OVN NB
-                  │                    │     routing          │  │    (default route
-                  │                    │  4. Sync routes      │  │     + MAC binding)
+                  │                    │     routing + active │  │    (default route,
+                  │                    │     priority lead    │  │     MAC binding,
+                  │                    │  4. Sync routes      │  │     priority lead)
                   │                    │  5. Verify + re-add  │  │
                   │                    └──┬──────┬──────┬─────┘  │
                   └───────────────────────┼──────┼──────┼────────┘
@@ -61,21 +63,31 @@ For each locally-active router the agent:
    MAC binding** into OVN NB — the
    [virtual gateway](gatewayless-networks) makes reply traffic exit the
    logical router without a real upstream gateway.
-2. Installs **OVS MAC-tweak flows** on `br-ex` — rewrites the destination
+2. Boosts the **active `Gateway_Chassis` priority** to `max(max peer + 1, 2)`
+   so a previously-drained peer that returns at priority 1 cannot trigger
+   a reverse failover (see [gateway drain](gateway-drain#priority-semantics)).
+3. Installs **OVS MAC-tweak flows** on `br-ex` — rewrites the destination
    MAC on packets arriving from OVN's patch port so the kernel accepts them.
-3. Installs **OVS hairpin flows** on `br-ex` — reflects same-chassis
+4. Installs **OVS hairpin flows** on `br-ex` — reflects same-chassis
    cross-router traffic back into OVN via `output:in_port` with rewritten
    MACs.
-4. Creates `/32` **kernel routes** (with `ip rule` entries when using a
-   dedicated routing table) on `br-ex` so the kernel can receive packets
-   for each FIP.
-5. Creates `/32` **FRR static routes** in `vrf-provider` so BGP announces
-   each FIP to the external fabric.
-6. Triggers a **BGP outbound soft-refresh** only when routes are removed
+5. Reconciles **per-network veth-leak routes and policy rules** so the
+   provider subnet's reply traffic crosses from the default VRF into
+   `vrf-provider` for BGP delivery.
+6. Creates `/32` **kernel routes** (with `ip rule` entries when using a
+   dedicated routing table) on `br-ex` for every FIP, SNAT IP, router LRP
+   gateway IP, and configured port-forward VIP.
+7. Creates `/32` **FRR static routes** in `vrf-provider` for the same set
+   so BGP announces them to the external fabric.
+8. Triggers a **BGP outbound soft-refresh** only when routes are removed
    (withdrawals) — additions rely on FRR's normal route redistribution to
    avoid disrupting existing BGP announcements.
-7. **Verifies** all desired routes (FRR and kernel) after every route change
+9. **Verifies** all desired routes (FRR and kernel) after every route change
    and re-adds any that went missing as a safety net.
+
+Port forwarding (DNAT) reconciliation runs independently of router locality
+— configured VIPs always get kernel/FRR routes so they remain announced via
+BGP even on a chassis that currently hosts no OVN gateway.
 
 ## Data plane
 

--- a/docs/explanation/how-it-works.md
+++ b/docs/explanation/how-it-works.md
@@ -33,13 +33,23 @@ provider bridge).
      rewriting both source MAC (`br-ex` MAC) and destination MAC (owning
      router port MAC) — see
      [Hairpin OVS flows](gatewayless-networks#hairpin-ovs-flows-on-br-ex).
+   - Applies the **active priority lead boost** to its `Gateway_Chassis`
+     entries: when this chassis is active, its priority is raised to
+     `max(max peer + 1, 2)` so a peer returning from drain (restored to 1)
+     cannot trigger reverse failover — see
+     [Priority semantics](gateway-drain#priority-semantics).
+   - Reconciles **per-network veth-leak routes and policy rules** in the
+     veth leak table (default 200) so SNAT reply traffic on the provider
+     subnet crosses into `vrf-provider` for BGP delivery.
    - Ensures `/32` **kernel routes** (with IP rules when using a dedicated
-     routing table) and **FRR static routes** in the VRF for each FIP/SNAT
-     IP.
+     routing table) and **FRR static routes** in the VRF for each FIP, SNAT
+     IP, router LRP gateway IP, and (independent of router locality)
+     configured port-forward VIP.
    - If configured, reconciles the **FRR prefix-list** with
      `permit <network> ge 32 le 32` entries for each discovered provider
      network.
-   - If no routers are locally active: removes all managed routes.
+   - If no routers are locally active: removes all managed routes (port
+     forward VIPs still get kernel/FRR routes if any are configured).
 5. **Port forwarding (DNAT)** — optionally forwards traffic from anycast VIP
    addresses (on a loopback interface in the VRF) to internal backends.
    Supports multiple backends per rule with sticky source-IP hashing

--- a/ovn-network-agent.default
+++ b/ovn-network-agent.default
@@ -67,8 +67,9 @@ OVN_NETWORK_OVN_NB_REMOTE=tcp:10.10.0.1:6641,tcp:10.10.0.2:6641,tcp:10.10.0.3:66
 # When enabled, the agent lowers its Gateway_Chassis priority to 0 on shutdown,
 # causing OVN to migrate chassisredirect ports to standby chassis before cleanup.
 # Eliminates the disruption window between BGP withdrawal and OVN failover.
-# Priorities are NOT restored on shutdown; Neutron's L3 HA scheduler rebalances
-# when the chassis returns. Set to "0" or "false" to disable.
+# On the next startup the agent restores drained entries to priority 1 (standby
+# level); during reconciliation the active chassis maintains a strict priority
+# lead (>= 2) so reverse failover does not occur. Set to "0" or "false" to disable.
 #OVN_NETWORK_DRAIN_ON_SHUTDOWN=true
 
 # Maximum time to wait for gateway drain (Go duration format).


### PR DESCRIPTION
The reconcile loop now applies an active Gateway_Chassis priority lead and reconciles per-network veth-leak routes/policy rules; the desired-IP set also includes router LRP gateway IPs and port-forward VIPs. The how-it-works step list, architecture diagram, and per-router action list all missed these behaviours. The integration-tests page also lagged seven new scenario files (bridge_ip, drift, gateway_port, ipv6, nat_types, prefix_list, vethleak). The /etc/default file still claimed drained priorities are not restored — they are, on the next startup.

AI-assisted: Claude Code