### PR TITLE
test/e2e: HA failover scenario (master chassis loss)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,3 +69,50 @@ jobs:
       - name: Tear the lab down
         if: always()
         run: make e2e-down
+
+  failover:
+    name: HA failover (master chassis loss)
+    runs-on: ubuntu-latest
+    # Runs after the baseline job, but on its own runner so a failover
+    # regression is reported in isolation from the baseline path. Same
+    # 15-minute budget — the scenario only adds ~30s of failover wait
+    # on top of the baseline gate.
+    needs: baseline
+    timeout-minutes: 15
+
+    env:
+      E2E_TOPOLOGY: test/e2e/topology.clab.yml
+      LAB: ovn-e2e
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install containerlab
+        run: bash -c "$(curl -sL https://get.containerlab.dev)"
+
+      - name: Load openvswitch kernel module
+        run: sudo modprobe openvswitch
+
+      - name: Bring the lab up
+        run: make e2e-up
+
+      - name: Run failover scenario
+        run: ./test/e2e/scenarios/failover.sh
+
+      - name: Collect failure artifacts
+        if: failure()
+        run: |
+          ./test/e2e/scenarios/collect-artifacts.sh "${RUNNER_TEMP}/e2e-artifacts"
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: e2e-artifacts-failover-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/e2e-artifacts
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Tear the lab down
+        if: always()
+        run: make e2e-down

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,14 @@ VERSION   ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "d
 LDFLAGS   := -s -w -X main.version=$(VERSION)
 GOFLAGS   := -trimpath
 
-.PHONY: all build build-static clean fmt vet test test-integration install docs-gen docs-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline
+.PHONY: all build build-static clean fmt vet test test-integration install docs-gen docs-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover
 
 # Containerlab E2E harness. See test/e2e/README.md for the topology and
 # acceptance criteria (issue #44).
 E2E_TOPOLOGY    := test/e2e/topology.clab.yml
 E2E_BOOTSTRAP   := test/e2e/bootstrap.sh
 E2E_BASELINE    := test/e2e/scenarios/baseline.sh
+E2E_FAILOVER    := test/e2e/scenarios/failover.sh
 E2E_GWNODE_TAG  := ovn-network-agent/gwnode:e2e
 E2E_CENTRAL_TAG := ovn-network-agent/central:e2e
 
@@ -122,3 +123,13 @@ e2e-down:
 # machine reproduces the CI path exactly.
 e2e-baseline:
 	$(E2E_BASELINE)
+
+# Run the HA failover scenario (issue #105) against a lab that is
+# already up. Stops the priority-30 chassis to trigger OVN HA
+# re-election and waits for reachability through cr-lr0-public to
+# recover within FAILOVER_TIMEOUT (default 30s). Mirrors the step the
+# CI workflow runs; the scenario's own EXIT trap restores the lab to
+# baseline state so a subsequent `make e2e-baseline` works without
+# tearing the lab down.
+e2e-failover:
+	$(E2E_FAILOVER)

--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -17,6 +17,10 @@ The harness has two layers:
    was added by
    [#45](https://github.com/osism/ovn-network-agent/issues/45) together
    with the CI workflow that runs it.
+   [`failover.sh`](https://github.com/osism/ovn-network-agent/blob/main/test/e2e/scenarios/failover.sh)
+   ([#105](https://github.com/osism/ovn-network-agent/issues/105))
+   builds on the baseline and exercises HA re-election by stopping the
+   priority-30 chassis.
 
 ## Layout
 
@@ -31,6 +35,7 @@ test/e2e/
   bootstrap.sh              — idempotent OVN NB seed (1 LS, 1 LR with 2 FIPs, HA across 3 chassis)
   scenarios/
     baseline.sh             — baseline reachability scenario (issue #45)
+    failover.sh             — HA failover scenario, master chassis loss (issue #105)
     collect-artifacts.sh    — dump lab state for offline triage
 ```
 
@@ -152,11 +157,17 @@ the lab in three layers:
   neighbor pushed by `gwnode-entrypoint.sh` (`192.0.2.1`) is
   replaced by `bootstrap.sh` once the underlay is up.
 - `client-1`: `10.0.0.2/24` on `eth1`, default route via `10.0.0.1`.
-- `gateway-1` (the priority-30 chassis): a veth pair
+- `gateway-3` (the priority-10 chassis): a veth pair
   `vm1-host` ↔ `vm1-eth0` — the host side is bound to `br-int` with
   `external_ids:iface-id=ls0-vm1`, the peer side lives inside a `vm1`
   network namespace configured with `192.168.10.10/24` and a default
   route via `192.168.10.1`. This is the responder behind the FIP.
+  The workload sits on `gateway-3` (not the master) so failover
+  scenarios that stop the master chassis do not also take out the
+  responder — see issue
+  [#105](https://github.com/osism/ovn-network-agent/issues/105). As a
+  side effect, the baseline exercises cross-chassis geneve
+  (master `gateway-1` ↔ workload host `gateway-3`).
 
 ## Running locally
 
@@ -165,6 +176,7 @@ From the repository root:
 ```sh
 make e2e-up          # build images + containerlab deploy + bootstrap
 make e2e-baseline    # run the baseline reachability scenario
+make e2e-failover    # run the HA failover scenario (master chassis loss)
 make e2e-down        # containerlab destroy
 ```
 
@@ -174,6 +186,33 @@ to 30s for the agent's reconcile loop to install the routes. The exit
 code mirrors `ping`'s — any packet loss fails the scenario. Override
 `FIP`, `RECONCILE_TIMEOUT`, `PING_COUNT` or `PING_TIMEOUT` in the
 environment when triaging.
+
+`make e2e-failover` invokes `test/e2e/scenarios/failover.sh`, which
+runs the baseline first as a sanity gate (disable with
+`SANITY_GATE=0`), simulates chassis loss by stopping `ovn-controller`
+on `gateway-1` via `ovn-ctl stop_controller` (clean SIGTERM,
+ovn-controller releases its claim on `cr-lr0-public`, OVN re-elects
+to the priority-20 chassis), and polls reachability through the FIP
+until the new master answers. The deadline is `FAILOVER_TIMEOUT`
+(default 30s); after recovery the scenario asserts that
+`cr-lr0-public` actually migrated away from `MASTER` (guarding
+against a false pass where OVS keeps executing stale flows), then
+runs a 5-packet final probe that must return 100% success. An EXIT
+trap then starts `ovn-controller` again via `ovn-ctl start_controller`
+and waits up to `FAILBACK_TIMEOUT` (default 60s) for `cr-lr0-public`
+to bind back **and** for `client-1 → FIP` reachability to come back,
+leaving the lab at baseline state. Override `MASTER`, `FIP`,
+`FAILOVER_TIMEOUT`, `FAILBACK_TIMEOUT` or `SANITY_GATE` when
+triaging.
+
+The scenario stops just `ovn-controller` rather than the whole
+container because containerlab wires the per-gateway underlay
+(`gateway-N:eth1 ↔ upstream:ethN`) as veth pairs at deploy time and
+does not re-establish them on container restart — `docker stop` /
+`docker start` would leave the master with no underlay and no BGP
+session, so the lab could not be returned to baseline. The OVN HA
+mechanism under test (re-election of `cr-lr0-public` after the
+priority-30 chassis's claim goes away) is the same either way.
 
 Equivalent manual sequence (useful for triage):
 
@@ -227,20 +266,19 @@ The workflow does **not** run on pull requests: spinning the lab up
 adds ~10 minutes to CI on a green run, which is too coarse for the
 per-PR feedback loop the rest of the workflows target.
 
-The job:
+Two jobs run in sequence:
 
-1. installs containerlab via the upstream one-liner installer,
-2. runs `make e2e-up` to build the images, deploy the topology and
-   seed the NB DB,
-3. runs `test/e2e/scenarios/baseline.sh`,
-4. on failure: dumps lab state via
-   `test/e2e/scenarios/collect-artifacts.sh` and uploads the result
-   as an artifact named `e2e-artifacts-<run id>-<attempt>`,
-5. always runs `make e2e-down` so containers and docker networks do
-   not leak between runs.
+- **`baseline`** — installs containerlab, runs `make e2e-up`, executes
+  `test/e2e/scenarios/baseline.sh`, dumps + uploads artifacts on
+  failure (`e2e-artifacts-<run id>-<attempt>`), and always tears the
+  lab down.
+- **`failover`** (`needs: baseline`) — same shape as baseline, but
+  executes `test/e2e/scenarios/failover.sh`. On failure the artifact
+  bundle is uploaded as `e2e-artifacts-failover-<run id>-<attempt>`.
 
-The whole job is capped at 15 minutes — matching the budget in issue
-[#45](https://github.com/osism/ovn-network-agent/issues/45).
+Both jobs are capped at 15 minutes — matching the budgets in issues
+[#45](https://github.com/osism/ovn-network-agent/issues/45) and
+[#105](https://github.com/osism/ovn-network-agent/issues/105).
 
 ### Triaging a failed run
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -14,5 +14,6 @@ Quick reference:
 make e2e-install-tools   # one-time, installs containerlab on Linux
 make e2e-up              # build images, deploy topology, seed OVN NB
 make e2e-baseline        # run the baseline reachability scenario
+make e2e-failover        # run the HA failover scenario (master chassis loss)
 make e2e-down            # destroy the lab
 ```

--- a/test/e2e/bootstrap.sh
+++ b/test/e2e/bootstrap.sh
@@ -31,7 +31,12 @@
 #              192.0.2.10 → 192.168.10.10
 #              192.0.2.11 → 192.168.10.11
 #        * Workload LSP on ls0: 192.168.10.10 / 02:00:00:00:0a:0a
-#          (hosted by gateway-1 — the priority-30 chassis).
+#          (hosted by gateway-3 — the priority-10 chassis). Keeping
+#          the responder off the master chassis is what makes
+#          single-chassis failover scenarios (#105) testable: stopping
+#          the master never takes out the workload at the same time,
+#          and the baseline already exercises cross-chassis geneve
+#          (master gateway-1 ↔ workload host gateway-3).
 #   2. Per-gateway underlay
 #        * eth1 moves out of br-ex into vrf-provider; gateway-N gets
 #          100.64.N.2/30 on eth1.
@@ -49,7 +54,7 @@
 #          upstream learns where the FIPs live.
 #   5. Client-1 container
 #        * eth1 = 10.0.0.2/24, default route via 10.0.0.1.
-#   6. Kernel-side workload on gateway-1
+#   6. Kernel-side workload on gateway-3
 #        * veth pair `vm1-host`↔`vm1-eth0`, host side bound to br-int
 #          with `external_ids:iface-id=ls0-vm1`, peer side moved into a
 #          `vm1` netns with 192.168.10.10/24 + default route via
@@ -111,7 +116,7 @@ CLIENT_NODE="clab-${LAB_NAME}-${CLIENT_NAME}"
 CLIENT_CIDR="${CLIENT_CIDR:-10.0.0.2/24}"
 CLIENT_GW="${CLIENT_GW:-10.0.0.1}"
 
-WORKLOAD_HOST="${WORKLOAD_HOST:-gateway-1}"
+WORKLOAD_HOST="${WORKLOAD_HOST:-gateway-3}"
 WORKLOAD_NETNS="${WORKLOAD_NETNS:-vm1}"
 WORKLOAD_LSP="${WORKLOAD_LSP:-${LS_NAME}-vm1}"
 WORKLOAD_MAC="${WORKLOAD_MAC:-02:00:00:00:0a:0a}"

--- a/test/e2e/scenarios/failover.sh
+++ b/test/e2e/scenarios/failover.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# HA failover scenario for the containerlab E2E harness.
+#
+# Goal (issue #105): with the lab green (baseline passing), simulate
+# loss of the priority-30 master chassis (`gateway-1`). OVN must
+# re-elect `cr-lr0-public` to the priority-20 chassis (`gateway-2`),
+# BGP must withdraw the FIP /32s on the dead session and re-advertise
+# them from the new master, and `client-1 → FIP` must resume within
+# `FAILOVER_TIMEOUT` (default 30s).
+#
+# Implementation note — chassis loss simulation:
+# The issue's "Action" line says `docker stop clab-${LAB}-gateway-1`.
+# Containerlab wires the per-gateway underlay (gateway-N:eth1 ↔
+# upstream:ethN) as veth pairs at deploy time; `docker stop` destroys
+# the container's netns and with it BOTH ends of those veths. A
+# follow-up `docker start` brings the container back but containerlab
+# does not re-establish the link, so the master has no underlay, no
+# BGP session, and the FIP advertisement never comes back — the test
+# can't return the lab to baseline state and "3+ green runs in a row"
+# is impossible without `make e2e-down && make e2e-up` between runs.
+# Stop only ovn-controller via `ovn-ctl stop_controller` instead: it
+# terminates cleanly on SIGTERM, releases its claim on cr-lr0-public,
+# and OVN re-elects to the priority-20 chassis. The agent and FRR on
+# the "lost" chassis keep running, so they observe the Port_Binding
+# change and withdraw the FIP /32s from BGP themselves. Failback is
+# `ovn-ctl start_controller` on the same node — no container restart,
+# no veth re-create, no bootstrap re-run. The OVN HA mechanism under
+# test (BFD-monitored re-election of cr-lr0-public) is identical;
+# only the simulation of node death is softer.
+#
+# A note on why this is not SIGSTOP'ing ovn-controller: a frozen
+# process still holds its SB claim. The release happens at clean
+# shutdown via the SIGTERM handler, so re-election needs the process
+# to actually exit.
+#
+# Pre-condition: the lab is up. When SANITY_GATE=1 (default) this
+# scenario runs `baseline.sh` first so a broken green path is reported
+# as a baseline regression instead of being attributed to failover.
+#
+# Teardown: ovn-controller on the master is resumed on EXIT (via
+# trap). The script then waits up to FAILBACK_TIMEOUT seconds for
+# `cr-lr0-public` to bind back to MASTER and for `client-1 → FIP`
+# reachability to return, leaving the lab at baseline state. The CI
+# workflow additionally invokes the teardown step with `if: always()`
+# so a fatal interpreter error here (which skips the trap) is still
+# cleaned up.
+#
+# Environment overrides (used by the CI workflow):
+#   LAB                container-name prefix (defaults to the topology name "ovn-e2e")
+#   FIP                target FIP to ping (defaults to the priority-30 chassis FIP)
+#   CLIENT             source container (defaults to clab-${LAB}-client-1)
+#   MASTER             chassis to fail (defaults to gateway-1, the priority-30 chassis)
+#   CENTRAL            OVN central container (defaults to clab-${LAB}-central)
+#   LR_PUBLIC_PORT     LR external port name (defaults to lr0-public)
+#   FAILOVER_TIMEOUT   seconds to wait for reachability to recover (default 30)
+#   FAILBACK_TIMEOUT   seconds to wait for the lab to return to baseline (default 60)
+#   PING_COUNT         packets for the final reachability check (default 5)
+#   PING_TIMEOUT       per-packet wait, passed to ping -W (default 2)
+#   SANITY_GATE        run baseline.sh first when 1 (default 1)
+
+set -euo pipefail
+
+LAB="${LAB:-ovn-e2e}"
+FIP="${FIP:-192.0.2.10}"
+CLIENT="${CLIENT:-clab-${LAB}-client-1}"
+MASTER="${MASTER:-gateway-1}"
+MASTER_NODE="clab-${LAB}-${MASTER}"
+CENTRAL="${CENTRAL:-clab-${LAB}-central}"
+LR_PUBLIC_PORT="${LR_PUBLIC_PORT:-lr0-public}"
+CR_PORT="cr-${LR_PUBLIC_PORT}"
+FAILOVER_TIMEOUT="${FAILOVER_TIMEOUT:-30}"
+FAILBACK_TIMEOUT="${FAILBACK_TIMEOUT:-60}"
+PING_COUNT="${PING_COUNT:-5}"
+PING_TIMEOUT="${PING_TIMEOUT:-2}"
+SANITY_GATE="${SANITY_GATE:-1}"
+
+SCENARIOS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASELINE="${BASELINE:-${SCENARIOS_DIR}/baseline.sh}"
+
+log() { printf '[failover] %s\n' "$*" >&2; }
+
+# Resolve the chassis name currently anchoring `cr-lr0-public`. The
+# Port_Binding.chassis column is a UUID reference; resolve it via a
+# second lookup against the Chassis table. Returns empty string when
+# no chassis is bound (e.g. during re-election or when the master is
+# down and the port hasn't migrated yet).
+current_master() {
+    local chassis_uuid chassis_name
+    chassis_uuid=$(docker exec "${CENTRAL}" ovn-sbctl --bare \
+        --columns=chassis find Port_Binding \
+        logical_port="${CR_PORT}" 2>/dev/null || true)
+    if [ -z "${chassis_uuid}" ]; then
+        return 0
+    fi
+    chassis_name=$(docker exec "${CENTRAL}" ovn-sbctl --bare \
+        --columns=name list Chassis "${chassis_uuid}" 2>/dev/null || true)
+    printf '%s' "${chassis_name}"
+}
+
+# Stop ovn-controller cleanly on the master via the canonical OVN
+# service script. ovn-controller's SIGTERM handler releases its claim
+# on cr-lr0-public; OVN's ha_chassis_group election then promotes the
+# next-priority candidate. The agent and FRR on the chassis stay up
+# and observe the SB Port_Binding change so the FIP /32 statics in
+# vrf-provider get removed and FRR withdraws the BGP advertisement.
+stop_controller_on_master() {
+    log "stopping ovn-controller on ${MASTER_NODE} to trigger HA re-election"
+    docker exec "${MASTER_NODE}" \
+        /usr/share/ovn/scripts/ovn-ctl stop_controller >/dev/null
+}
+
+# Start ovn-controller again on the master. BFD comes back up, the
+# chassis registers as healthy in SB, OVN re-elects cr-lr0-public to
+# the priority-30 chassis. Idempotent: ovn-ctl is a no-op when the
+# controller is already running, so running this in the teardown
+# trap after a successful run is safe.
+start_controller_on_master() {
+    log "teardown: starting ovn-controller on ${MASTER_NODE}"
+    docker exec "${MASTER_NODE}" \
+        /usr/share/ovn/scripts/ovn-ctl start_controller >/dev/null \
+        || log "teardown: ovn-ctl start_controller returned non-zero; continuing"
+}
+
+# Wait against a single FAILBACK_TIMEOUT budget for two signals:
+#   1. SB rebind of cr-lr0-public to MASTER (control plane),
+#   2. client-1 → FIP reachability to come back (data plane).
+# Best-effort: a teardown failure must not mask the scenario's own
+# pass/fail signal, so this never aborts the script.
+restore_master() {
+    start_controller_on_master
+
+    local deadline
+    deadline=$(( $(date +%s) + FAILBACK_TIMEOUT ))
+
+    local who=""
+    while (( $(date +%s) < deadline )); do
+        who="$(current_master)"
+        if [ "${who}" = "${MASTER}" ]; then
+            log "teardown: ${CR_PORT} is bound to ${MASTER} again"
+            break
+        fi
+        sleep 2
+    done
+    if [ "${who}" != "${MASTER}" ]; then
+        log "teardown: ${CR_PORT} did not bind back to ${MASTER} within ${FAILBACK_TIMEOUT}s (currently: ${who:-<none>})"
+        return 0
+    fi
+
+    log "teardown: waiting for ${CLIENT} → ${FIP} to recover after failback"
+    while (( $(date +%s) < deadline )); do
+        if docker exec "${CLIENT}" ping -c 1 -W 1 "${FIP}" >/dev/null 2>&1; then
+            log "teardown: reachability through ${FIP} restored"
+            return 0
+        fi
+        sleep 2
+    done
+    log "teardown: reachability through ${FIP} did not recover within ${FAILBACK_TIMEOUT}s of failback"
+}
+
+# Run baseline.sh as a sanity gate so a broken green path fails fast
+# under the right label. Disabled by SANITY_GATE=0 — useful when
+# iterating locally on the failover behaviour itself.
+sanity_gate() {
+    if [ "${SANITY_GATE}" != "1" ]; then
+        log "SANITY_GATE=${SANITY_GATE}: skipping baseline pre-check"
+        return 0
+    fi
+    if [ ! -x "${BASELINE}" ]; then
+        log "baseline script not executable at ${BASELINE} — skipping pre-check"
+        return 0
+    fi
+    log "running baseline.sh as a sanity gate (set SANITY_GATE=0 to skip)"
+    "${BASELINE}"
+}
+
+# Poll the reachability check for up to FAILOVER_TIMEOUT seconds. As
+# soon as one packet gets through, OVN has re-elected the gateway,
+# BGP has re-advertised the FIP /32, and the new master's agent has
+# reconciled the leak path. Counts the wall-clock elapsed to make the
+# pass/fail log line useful for triage.
+wait_for_recovery() {
+    local start_ts deadline
+    start_ts=$(date +%s)
+    deadline=$(( start_ts + FAILOVER_TIMEOUT ))
+    log "waiting up to ${FAILOVER_TIMEOUT}s for ${CLIENT} → ${FIP} to recover"
+    while (( $(date +%s) < deadline )); do
+        if docker exec "${CLIENT}" ping -c 1 -W 1 "${FIP}" >/dev/null 2>&1; then
+            log "first packet through after $(( $(date +%s) - start_ts ))s"
+            return 0
+        fi
+        sleep 2
+    done
+    log "no reply within ${FAILOVER_TIMEOUT}s — falling through to the final probe so its output appears in the log"
+    return 0
+}
+
+# Final probe — the exit code of this scenario is the exit code of
+# the post-recovery ping, which is non-zero on any packet loss.
+probe() {
+    log "ping -c ${PING_COUNT} -W ${PING_TIMEOUT} ${FIP} from ${CLIENT}"
+    docker exec "${CLIENT}" ping -c "${PING_COUNT}" -W "${PING_TIMEOUT}" "${FIP}"
+}
+
+main() {
+    sanity_gate
+
+    local before
+    before="$(current_master)"
+    log "current ${CR_PORT} chassis before failover: ${before:-<none>}"
+    if [ "${before}" != "${MASTER}" ]; then
+        log "WARNING: expected master ${MASTER}, observed ${before:-<none>} — continuing anyway"
+    fi
+
+    trap restore_master EXIT
+    stop_controller_on_master
+
+    wait_for_recovery
+
+    # Guard against a false pass: a probe that succeeds because OVS on
+    # MASTER kept executing stale flows after ovn-controller died is
+    # NOT a successful failover. Confirm that cr-lr0-public actually
+    # migrated to a different chassis before declaring success.
+    local after
+    after="$(current_master)"
+    log "current ${CR_PORT} chassis after failover: ${after:-<none>}"
+    if [ "${after}" = "${MASTER}" ]; then
+        log "ERROR: ${CR_PORT} did not migrate away from ${MASTER} — re-election did not happen"
+        return 1
+    fi
+
+    probe
+}
+
+main "$@"


### PR DESCRIPTION
Implements #105.

Adds a containerlab E2E scenario that exercises OVN HA re-election after the priority-30 chassis loses its claim on `cr-lr0-public`, plus the bootstrap and CI plumbing the scenario needs to run deterministically.

## Commits

1. **`test/e2e: host the workload on gateway-3 instead of the master`** — required bootstrap change called out in the issue. Hosting `ls0-vm1` on the priority-30 chassis (gateway-1) co-locates the LR master and the responder, so stopping gateway-1 would take out both at once and the test would fail for the wrong reason. Moves the workload to `gateway-3` (priority 10), which single-chassis failover from gateway-1 never elects, so the workload chassis is stable. Side benefit: the baseline now exercises cross-chassis geneve (master `gateway-1` ↔ workload host `gateway-3`).

2. **`test/e2e: add HA failover scenario (master chassis loss)`** — new `test/e2e/scenarios/failover.sh`:
   - Runs `baseline.sh` first as a sanity gate (`SANITY_GATE=1`, default).
   - Stops `ovn-controller` on `gateway-1` via `ovn-ctl stop_controller`. Clean SIGTERM lets ovn-controller release its claim on `cr-lr0-public`; OVN's `ha_chassis_group` election promotes `gateway-2`. The agent and FRR on the demoted chassis stay up, observe the SB `Port_Binding` change, remove the FIP `/32` statics, and FRR withdraws the BGP advertisement. The new master's agent does the inverse.
   - Polls reachability from `client-1 → 192.0.2.10` with a deadline of `FAILOVER_TIMEOUT` (default 30s).
   - Asserts that `cr-lr0-public` actually migrated away from `MASTER` before declaring success — guards against a false pass where OVS keeps executing stale flows after ovn-controller exits.
   - Final 5-packet probe; any packet loss fails the scenario.
   - EXIT trap restores the lab to baseline by starting `ovn-controller` again and waiting up to `FAILBACK_TIMEOUT` (default 60s) for `cr-lr0-public` to bind back **and** for `client-1 → FIP` reachability to come back. Best-effort: a teardown failure never masks the scenario's own pass/fail.

3. **`ci: run the failover scenario after the baseline E2E job`** — adds the `failover` job to `.github/workflows/e2e.yml` (same shape as `baseline`, `needs: baseline`, 15-minute budget, dedicated artifact name `e2e-artifacts-failover-…`) and the `make e2e-failover` target.

4. **`docs/e2e: cover the failover scenario and the workload-host move`** — `docs/contributing/e2e-tests.md` and `test/e2e/README.md` updated with the new scenario, the workload-host rationale, and the two CI jobs.

## Acceptance criteria

- [x] `test/e2e/scenarios/failover.sh` passes consistently — verified on a real Linux lab with 3+ green runs in a row.
- [x] `make e2e-baseline` still passes after the bootstrap change.
- [x] The teardown restores the lab to baseline state (`ovn-ctl start_controller` + waits for both SB rebind and `client-1 → FIP` reachability).
- [x] Failure artifacts include BGP state and SB `Port_Binding` rows — `collect-artifacts.sh` (unchanged) already dumps `show bgp summary`, `show bgp ipv4 unicast`, `show ip route vrf all`, and the full SB `Port_Binding` table.

## Local verification

- `go vet ./...` — pass
- `gofmt -l .` — pass (no output)
- `go test ./...` — pass
- `shellcheck test/e2e/scenarios/*.sh test/e2e/bootstrap.sh` — clean
- `bash -n` on every touched script — pass
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e.yml'))"` — pass
- Full lab on Linux: `make e2e-up` followed by `make e2e-failover` 3× in a row — all green, `cr-lr0-public` observed migrating gateway-1 → gateway-2 → gateway-1 each cycle.

## Deviation from the issue's "Action" line

The issue text says `docker stop clab-${LAB}-gateway-1`. The scenario stops just `ovn-controller` inside the container instead, because containerlab wires the per-gateway underlay (`gateway-N:eth1 ↔ upstream:ethN`) as veth pairs at deploy time and does not re-establish them on container restart — `docker stop` / `docker start` would leave the master with no underlay, no BGP session, and the FIP advertisement never coming back, so the lab could not be returned to baseline state and the "3+ green runs in a row" acceptance criterion was unreachable. The OVN HA mechanism under test (re-election of `cr-lr0-public` after the priority-30 chassis releases its claim) is the same either way; only the simulation of node death is softer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)