### PR TITLE
test/e2e: stale-chassis cleanup scenario (issue #111)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -116,3 +116,59 @@ jobs:
       - name: Tear the lab down
         if: always()
         run: make e2e-down
+
+  stale-chassis:
+    name: Stale-chassis cleanup (hard kill)
+    runs-on: ubuntu-latest
+    # Runs after the failover job on its own runner so a stale-cleanup
+    # regression is reported in isolation. Same 15-minute budget — the
+    # scenario adds at most ~150s of wait time (grace + jitter +
+    # reconcile + safety) on top of the baseline gate. The reduced
+    # stale_chassis_grace_period (30s) is set in
+    # test/e2e/gwnode-config.yaml per issue #111 so this job stays well
+    # inside the 5-minute target.
+    needs: failover
+    timeout-minutes: 15
+
+    env:
+      E2E_TOPOLOGY: test/e2e/topology.clab.yml
+      LAB: ovn-e2e
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install containerlab
+        run: bash -c "$(curl -sL https://get.containerlab.dev)"
+
+      - name: Load openvswitch kernel module
+        run: sudo modprobe openvswitch
+
+      - name: Bring the lab up
+        run: make e2e-up
+
+      - name: Run stale-chassis scenario
+        # Direct the scenario's NB-snapshot + peer-cleanup-log captures
+        # into the same artifact root so collect-artifacts.sh and the
+        # uploader both pick them up. `runner.temp` is only available
+        # at step scope, not the job-level env block.
+        env:
+          ARTIFACTS_DIR: ${{ runner.temp }}/e2e-artifacts/stale-chassis
+        run: ./test/e2e/scenarios/stale-chassis.sh
+
+      - name: Collect failure artifacts
+        if: failure()
+        run: |
+          ./test/e2e/scenarios/collect-artifacts.sh "${RUNNER_TEMP}/e2e-artifacts"
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: e2e-artifacts-stale-chassis-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/e2e-artifacts
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Tear the lab down
+        if: always()
+        run: make e2e-down

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION   ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "d
 LDFLAGS   := -s -w -X main.version=$(VERSION)
 GOFLAGS   := -trimpath
 
-.PHONY: all build build-static clean fmt vet test test-integration install docs-gen docs-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover
+.PHONY: all build build-static clean fmt vet test test-integration install docs-gen docs-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-stale-chassis
 
 # Containerlab E2E harness. See test/e2e/README.md for the topology and
 # acceptance criteria (issue #44).
@@ -11,6 +11,7 @@ E2E_TOPOLOGY    := test/e2e/topology.clab.yml
 E2E_BOOTSTRAP   := test/e2e/bootstrap.sh
 E2E_BASELINE    := test/e2e/scenarios/baseline.sh
 E2E_FAILOVER    := test/e2e/scenarios/failover.sh
+E2E_STALE       := test/e2e/scenarios/stale-chassis.sh
 E2E_GWNODE_TAG  := ovn-network-agent/gwnode:e2e
 E2E_CENTRAL_TAG := ovn-network-agent/central:e2e
 
@@ -133,3 +134,13 @@ e2e-baseline:
 # tearing the lab down.
 e2e-failover:
 	$(E2E_FAILOVER)
+
+# Run the stale-chassis cleanup scenario (issue #111) against a lab
+# that is already up. Hard-kills the priority-30 chassis (SIGKILL, no
+# graceful agent shutdown) and asserts that NB rows tagged for the
+# dead chassis are removed by surviving peers within
+# stale_chassis_grace_period + a margin for jitter and reconcile
+# cadence. Mirrors the step the CI workflow runs; the scenario's own
+# EXIT trap restarts the killed chassis and waits for baseline-green.
+e2e-stale-chassis:
+	$(E2E_STALE)

--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -21,6 +21,10 @@ The harness has two layers:
    ([#105](https://github.com/osism/ovn-network-agent/issues/105))
    builds on the baseline and exercises HA re-election by stopping the
    priority-30 chassis.
+   [`stale-chassis.sh`](https://github.com/osism/ovn-network-agent/blob/main/test/e2e/scenarios/stale-chassis.sh)
+   ([#111](https://github.com/osism/ovn-network-agent/issues/111))
+   hard-kills the priority-30 chassis and asserts that NB rows owned
+   by the dead chassis are garbage-collected by surviving peers.
 
 ## Layout
 
@@ -36,6 +40,7 @@ test/e2e/
   scenarios/
     baseline.sh             — baseline reachability scenario (issue #45)
     failover.sh             — HA failover scenario, master chassis loss (issue #105)
+    stale-chassis.sh        — stale chassis cleanup scenario, hard kill (issue #111)
     collect-artifacts.sh    — dump lab state for offline triage
 ```
 
@@ -174,10 +179,11 @@ the lab in three layers:
 From the repository root:
 
 ```sh
-make e2e-up          # build images + containerlab deploy + bootstrap
-make e2e-baseline    # run the baseline reachability scenario
-make e2e-failover    # run the HA failover scenario (master chassis loss)
-make e2e-down        # containerlab destroy
+make e2e-up             # build images + containerlab deploy + bootstrap
+make e2e-baseline       # run the baseline reachability scenario
+make e2e-failover       # run the HA failover scenario (master chassis loss)
+make e2e-stale-chassis  # run the stale-chassis cleanup scenario (hard kill)
+make e2e-down           # containerlab destroy
 ```
 
 `make e2e-baseline` invokes `test/e2e/scenarios/baseline.sh`, which
@@ -213,6 +219,88 @@ does not re-establish them on container restart — `docker stop` /
 session, so the lab could not be returned to baseline. The OVN HA
 mechanism under test (re-election of `cr-lr0-public` after the
 priority-30 chassis's claim goes away) is the same either way.
+
+`make e2e-stale-chassis` invokes `test/e2e/scenarios/stale-chassis.sh`,
+which exercises the agent's garbage-collection path for managed NB
+rows after a peer chassis disappears WITHOUT a graceful shutdown. It
+runs the baseline first as a sanity gate (disable with
+`SANITY_GATE=0`), seeds a sentinel managed static route on `lr0`
+tagged with `external_ids:ovn-network-agent-chassis=<MASTER>`, then:
+
+1. **Hard-kills `gateway-1`** with `docker kill -s KILL` — the
+   agent's SIGTERM handler is intentionally skipped, so the dead
+   chassis leaves no trace cleaned up by itself.
+2. **Drains the dead chassis in NB** with
+   `ovn-nbctl lrp-set-gateway-chassis lr0-public <MASTER> 0` — the
+   same mutation the agent's own `DrainGateways` writes on graceful
+   shutdown ([ovn_gateway.go:589](https://github.com/osism/ovn-network-agent/blob/main/ovn_gateway.go#L589)).
+   We run it externally because the killed agent never got to do
+   it; in production an HA orchestrator (BFD monitor / Pacemaker /
+   neutron-ovn-agent) is responsible for this step.
+3. **Removes the SB Chassis row** with `ovn-sbctl chassis-del` —
+   simulates the external reaper (neutron-ovn-agent on
+   `chassis-down`, ovn-northd's own stale-chassis sweeper on recent
+   OVN versions, or an HA orchestrator observing the node down).
+   A killed ovn-controller does not remove its own SB row, so
+   without this surviving agents would keep seeing the dead chassis
+   as alive and the cleanup loop would never fire.
+
+Surviving agents on `gateway-2` and `gateway-3` then notice that
+the chassis row is gone from SB, wait `stale_chassis_grace_period`
+(configured to `30s` in the gwnode E2E config so the scenario stays
+inside its CI budget), and remove the rows tagged for the dead
+chassis via `CleanupStaleChassisManagedEntries`. The scenario polls
+NB for up to `STALE_TIMEOUT` (default 150s) and additionally greps
+the surviving agents' `docker logs` for the
+`stale chassis route removed` line referencing `chassis=<MASTER>` —
+both signals must fire to prove the cleanup was deliberate. On exit
+the killed chassis is restarted with `docker start` (so the
+artifact collector can still `docker exec` into it) and the
+residual sentinel route is removed. Override `MASTER`, `PEERS`,
+`STALE_TIMEOUT`, `SENTINEL_PREFIX`, `LR_PUBLIC_PORT` or
+`SANITY_GATE` when triaging.
+
+Because the scenario externally drains `gateway-1`'s
+`Gateway_Chassis` priority to 0 after the kill, OVN does **not**
+re-elect `gateway-1` on `docker start` and `gateway-2` stays master.
+`make e2e-baseline` against the same lab keeps passing —
+reachability via the new master is intact. The lab is, however,
+HA-asymmetric afterwards (single-master, `gateway-1` permanently
+drained at priority 0), so `make e2e-failover` against the same lab
+has no priority-30 master left to fail and will misbehave. Chain
+`make e2e-down && make e2e-up` between destructive scenarios when
+running locally. CI handles this automatically through the
+workflow's `make e2e-down` step, which runs with `if: always()`
+regardless of the scenario outcome.
+
+The explicit `chassis-del` after the kill simulates the external
+reaper that would remove a dead chassis row in production
+(neutron-ovn-agent on `chassis-down`, ovn-northd's own stale-chassis
+sweeper on recent OVN versions, or an HA orchestrator observing the
+node down). A killed ovn-controller does **not** remove its own SB
+row — the row is only released on graceful shutdown — so without
+the explicit deletion, surviving agents would keep seeing the dead
+chassis as alive and the cleanup loop would never fire. The path
+under test is what the agent does after the row disappears, not how
+the row disappears.
+
+A sentinel managed route is needed because the production code path
+that the cleanup loop targets (managed static routes tagged with a
+chassis name) is not exercised by the baseline lab on its own: the
+agent only creates a default route via the virtual gateway IP, and
+the new master re-tags that row instead of leaving an orphan for the
+cleanup loop to find (see `ensureDefaultRoute` in `ovn_gateway.go`).
+Seeding a unique sentinel prefix gives the cleanup loop a row that no
+surviving agent will reclaim, so its deletion is unambiguous evidence
+of the stale-chassis path running.
+
+Why a hard kill (and not `docker stop` or `ovn-ctl stop_controller`):
+`docker stop` delivers SIGTERM, which the agent traps to run its
+graceful-shutdown path — that case is what the failover scenario
+already covers. The stale-chassis path is specifically for the
+non-graceful death case where surviving peers are the only ones that
+can clean up. `docker kill -s KILL` skips every signal handler in the
+container.
 
 Equivalent manual sequence (useful for triage):
 
@@ -266,7 +354,7 @@ The workflow does **not** run on pull requests: spinning the lab up
 adds ~10 minutes to CI on a green run, which is too coarse for the
 per-PR feedback loop the rest of the workflows target.
 
-Two jobs run in sequence:
+Three jobs run in sequence:
 
 - **`baseline`** — installs containerlab, runs `make e2e-up`, executes
   `test/e2e/scenarios/baseline.sh`, dumps + uploads artifacts on
@@ -275,10 +363,18 @@ Two jobs run in sequence:
 - **`failover`** (`needs: baseline`) — same shape as baseline, but
   executes `test/e2e/scenarios/failover.sh`. On failure the artifact
   bundle is uploaded as `e2e-artifacts-failover-<run id>-<attempt>`.
+- **`stale-chassis`** (`needs: failover`) — same shape, but executes
+  `test/e2e/scenarios/stale-chassis.sh`. The job points the
+  scenario's `ARTIFACTS_DIR` at the same artifact root so the
+  before/after NB snapshots and the peer cleanup-log capture are
+  bundled with the lab-state dump. On failure the artifact bundle is
+  uploaded as `e2e-artifacts-stale-chassis-<run id>-<attempt>`.
 
-Both jobs are capped at 15 minutes — matching the budgets in issues
-[#45](https://github.com/osism/ovn-network-agent/issues/45) and
-[#105](https://github.com/osism/ovn-network-agent/issues/105).
+All three jobs are capped at 15 minutes — matching the budgets in
+issues
+[#45](https://github.com/osism/ovn-network-agent/issues/45),
+[#105](https://github.com/osism/ovn-network-agent/issues/105), and
+[#111](https://github.com/osism/ovn-network-agent/issues/111).
 
 ### Triaging a failed run
 
@@ -300,6 +396,9 @@ writes:
   frr/<gateway>-bgp-summary.txt    — `vtysh -c "show bgp summary"`
   kernel/<gateway>-ip-route.txt    — `ip route show table all`
   agent/<gateway>.log              — copy of the gateway container's stdout
+  stale-chassis/nb-before-kill.txt — NB rows tagged for the killed chassis pre-kill (stale-chassis only)
+  stale-chassis/nb-after-kill.txt  — NB rows still tagged for the killed chassis after the cleanup deadline (stale-chassis only)
+  stale-chassis/peer-cleanup.log   — surviving peer's `stale chassis route removed` line (stale-chassis only)
 ```
 
 You can reproduce the same dump on a local lab with:

--- a/test/e2e/gwnode-config.yaml
+++ b/test/e2e/gwnode-config.yaml
@@ -31,3 +31,16 @@ cleanup_on_shutdown: false
 # Drain is exercised explicitly in scenarios; default to off so a plain
 # `containerlab destroy` returns quickly.
 drain_on_shutdown: false
+
+# Reconcile cadence — tighter than the 60s production default so the
+# stale-chassis cleanup (which only triggers on a reconcile tick) lands
+# within the per-scenario CI budget. The baseline and failover scenarios
+# poll for ≤30s anyway, so a faster reconcile only helps them too.
+reconcile_interval: "5s"
+
+# Stale-chassis grace period — held well below the production default
+# (5m) so the stale-chassis scenario can complete inside the 5-min CI
+# budget without hiding a default-value regression. Set explicitly per
+# issue #111 so a change to the default does not silently affect the
+# scenario's wall-clock budget.
+stale_chassis_grace_period: "30s"

--- a/test/e2e/scenarios/stale-chassis.sh
+++ b/test/e2e/scenarios/stale-chassis.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+# Stale-chassis cleanup scenario for the containerlab E2E harness.
+#
+# Goal (issue #111): when a gateway disappears WITHOUT a graceful
+# shutdown (no SIGTERM, no drain), the NB DB rows the agent owned on
+# its behalf must be garbage-collected by surviving peers after
+# `stale_chassis_grace_period` elapses — otherwise NB grows unboundedly
+# across container churn and stale entries can black-hole traffic.
+#
+# Why a hard kill (and not `docker stop`):
+# `docker stop` delivers SIGTERM, which the agent traps for a graceful
+# shutdown — that path is exercised by #105's failover scenario via
+# `ovn-ctl stop_controller` and is intentionally NOT what this test
+# covers. `docker kill -s KILL` skips the agent's cleanup path entirely;
+# the process is reaped without ever running its EXIT hooks. The
+# surviving agents are the only ones that can clean up after the dead
+# chassis — which is exactly the behaviour under test.
+#
+# Why we also `ovn-sbctl chassis-del` after the kill:
+# A killed ovn-controller does NOT remove its own SB Chassis row — the
+# row was written by ovn-controller itself and is only released on
+# graceful shutdown. In production the row is reaped by an external
+# reaper (e.g. neutron-ovn-agent on chassis-down, ovn-northd's own
+# stale-chassis sweeper on recent OVN versions, or an HA orchestrator
+# observing the node down). The cleanup path under test only fires
+# when surviving agents see the chassis as absent from SB, so the
+# scenario removes the row explicitly after the kill to simulate that
+# external reaper. Without this, gateway-1 stays "alive" in SB
+# forever and the agent's stale-cleanup loop has nothing to mark
+# missing.
+#
+# Why a sentinel route is seeded:
+# In the baseline lab the only managed NB rows the agent writes are
+# default routes via the virtual gateway IP. When the master fails
+# over, the new master `ensureDefaultRoute` re-tags that row from
+# `gateway-1` to itself (see ovn_gateway.go:218) instead of deleting
+# it — so there is nothing left in NB tagged for the dead chassis,
+# and the cleanup path is never exercised. To make the cleanup path
+# observable in this lab, we seed one extra managed static route
+# tagged with `ovn-network-agent-chassis=gateway-1` BEFORE the kill;
+# the unique sentinel prefix is not the default route, so no
+# surviving agent will re-claim it. The agent's
+# CleanupStaleChassisManagedEntries deletes it after the grace period.
+#
+# Pre-condition: the lab is up. When SANITY_GATE=1 (default) this
+# scenario runs `baseline.sh` first so a broken green path is reported
+# as a baseline regression instead of being attributed to the
+# stale-chassis path.
+#
+# Why an external NB drain after the kill:
+# In production, when a node dies hard, an external HA orchestrator
+# (BFD-based monitor, Pacemaker, neutron-ovn-agent, …) reacts by
+# lowering the dead node's Gateway_Chassis priorities to 0 — the
+# exact same NB mutation the agent's own DrainGateways performs on
+# graceful shutdown (see ovn_gateway.go:589 / agent.go:164). Without
+# this step OVN re-elects gateway-1 as master the moment
+# `docker start` brings it back, because its priority-30 entry is
+# still in NB. Setting priority 0 after the kill keeps gateway-2
+# (priority 20) stable as master across the teardown.
+#
+# Teardown: gateway-1 is `docker start`ed so the artifact collector
+# can still `docker exec` into it for OVS/FRR dumps. The lab is left
+# in a "single-master on gateway-2, gateway-1 drained" state — not
+# baseline-HA-symmetric, but baseline-green: the workload is on
+# gateway-3 and gateway-2 is still advertising the FIPs, so
+# `make e2e-baseline` keeps passing against the same lab. The
+# containerlab veth `gateway-1:eth1 ↔ upstream:eth1` IS destroyed by
+# the kill and is not re-wired on restart, but that no longer
+# matters: gateway-1 is at priority 0 and never gets elected. The
+# follow-up failover scenario, however, can no longer find a master
+# to fail — local users who want to chain `make e2e-failover` after
+# `make e2e-stale-chassis` must recycle the lab with
+# `make e2e-down && make e2e-up` first. CI handles this
+# automatically — the workflow's `make e2e-down` step runs with
+# `if: always()` regardless of the scenario outcome.
+#
+# Environment overrides:
+#   LAB                    container-name prefix (defaults to the topology name "ovn-e2e")
+#   MASTER                 chassis to kill (default gateway-1, the priority-30 chassis)
+#   PEERS                  surviving chassis (space-separated, default "gateway-2 gateway-3")
+#   CENTRAL                OVN central container (defaults to clab-${LAB}-central)
+#   LR_NAME                logical router to attach the sentinel route to (default lr0)
+#   LR_PUBLIC_PORT         LR external port name (default lr0-public — used for the drain step)
+#   STALE_GRACE_PERIOD     agent grace period (informational; matches gwnode-config.yaml, default 30s)
+#   STALE_TIMEOUT          seconds to wait for cleanup after the kill (default 150)
+#   SENTINEL_PREFIX        unique prefix for the sentinel managed route (default 203.0.113.42/32)
+#   SENTINEL_NEXTHOP       nexthop for the sentinel route (default 169.254.0.1, the leak link-local)
+#   ARTIFACTS_DIR          directory to write before/after NB snapshots + peer cleanup log (default empty = skip)
+#   SANITY_GATE            run baseline.sh first when 1 (default 1)
+
+set -euo pipefail
+
+LAB="${LAB:-ovn-e2e}"
+MASTER="${MASTER:-gateway-1}"
+MASTER_NODE="clab-${LAB}-${MASTER}"
+PEERS="${PEERS:-gateway-2 gateway-3}"
+CENTRAL="${CENTRAL:-clab-${LAB}-central}"
+LR_NAME="${LR_NAME:-lr0}"
+LR_PUBLIC_PORT="${LR_PUBLIC_PORT:-lr0-public}"
+STALE_GRACE_PERIOD="${STALE_GRACE_PERIOD:-30s}"
+STALE_TIMEOUT="${STALE_TIMEOUT:-150}"
+SENTINEL_PREFIX="${SENTINEL_PREFIX:-203.0.113.42/32}"
+SENTINEL_NEXTHOP="${SENTINEL_NEXTHOP:-169.254.0.1}"
+ARTIFACTS_DIR="${ARTIFACTS_DIR:-}"
+SANITY_GATE="${SANITY_GATE:-1}"
+
+SCENARIOS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASELINE="${BASELINE:-${SCENARIOS_DIR}/baseline.sh}"
+
+log() { printf '[stale-chassis] %s\n' "$*" >&2; }
+
+nbctl() { docker exec "${CENTRAL}" ovn-nbctl "$@"; }
+sbctl() { docker exec "${CENTRAL}" ovn-sbctl "$@"; }
+
+# Write `content` to `path` under ARTIFACTS_DIR when it is set; quietly
+# no-op otherwise. Keeps the local-run path free of stray /tmp files
+# while still bundling triage evidence into the CI artifact tarball.
+write_artifact() {
+    local path="$1"
+    if [ -z "${ARTIFACTS_DIR}" ]; then
+        return 0
+    fi
+    mkdir -p "${ARTIFACTS_DIR}"
+    cat >"${ARTIFACTS_DIR}/${path}"
+}
+
+# Run baseline.sh as a sanity gate so a broken green path fails fast
+# under the right label. Disabled by SANITY_GATE=0 — useful when
+# iterating locally on the stale-chassis behaviour itself.
+sanity_gate() {
+    if [ "${SANITY_GATE}" != "1" ]; then
+        log "SANITY_GATE=${SANITY_GATE}: skipping baseline pre-check"
+        return 0
+    fi
+    if [ ! -x "${BASELINE}" ]; then
+        log "baseline script not executable at ${BASELINE} — skipping pre-check"
+        return 0
+    fi
+    log "running baseline.sh as a sanity gate (set SANITY_GATE=0 to skip)"
+    "${BASELINE}"
+}
+
+# Resolve the SB Chassis UUID for the named chassis. Returns empty
+# string when no such chassis exists (e.g. already killed and reaped).
+chassis_uuid() {
+    local name="$1"
+    sbctl --bare --columns=_uuid find Chassis name="${name}" 2>/dev/null \
+        | tr -d '\r' | head -n1
+}
+
+# List the UUIDs of NB static routes tagged with
+# `ovn-network-agent=managed` AND `ovn-network-agent-chassis=<name>`.
+# Empty stdout means no rows match.
+managed_route_uuids_for_chassis() {
+    local name="$1"
+    nbctl --bare --columns=_uuid find Logical_Router_Static_Route \
+        external_ids:ovn-network-agent=managed \
+        external_ids:ovn-network-agent-chassis="${name}" 2>/dev/null \
+        | tr -d '\r' | grep -v '^$' || true
+}
+
+# Full row dump of any NB static route tagged for the given chassis.
+# Used for triage on failure (written into the artifact bundle).
+managed_route_rows_for_chassis() {
+    local name="$1"
+    nbctl find Logical_Router_Static_Route \
+        external_ids:ovn-network-agent=managed \
+        external_ids:ovn-network-agent-chassis="${name}" 2>/dev/null || true
+}
+
+# Seed a sentinel managed static route tagged for MASTER. Done in a
+# single `ovn-nbctl` transaction so the row + the LR mutation are
+# atomic. Re-running is safe: the find/create pair only creates when
+# no row already matches the sentinel prefix.
+seed_sentinel_route() {
+    local existing
+    existing=$(nbctl --bare --columns=_uuid find Logical_Router_Static_Route \
+        ip_prefix="\"${SENTINEL_PREFIX}\"" \
+        external_ids:ovn-network-agent-chassis="${MASTER}" 2>/dev/null \
+        | tr -d '\r' | head -n1 || true)
+    if [ -n "${existing}" ]; then
+        log "sentinel route already present (uuid=${existing}); skipping create"
+        return 0
+    fi
+    log "seeding sentinel managed route ${SENTINEL_PREFIX} via ${SENTINEL_NEXTHOP} tagged for ${MASTER}"
+    nbctl --id=@route create Logical_Router_Static_Route \
+        ip_prefix="\"${SENTINEL_PREFIX}\"" \
+        nexthop="\"${SENTINEL_NEXTHOP}\"" \
+        external_ids:ovn-network-agent=managed \
+        external_ids:ovn-network-agent-chassis="${MASTER}" \
+        -- add Logical_Router "${LR_NAME}" static_routes @route >/dev/null
+}
+
+# Remove the sentinel route if it is still present at teardown time.
+# Idempotent — the post-cleanup expectation is that the row is already
+# gone, so the find returns empty and we no-op. Best-effort: a teardown
+# failure must never mask the scenario's own pass/fail signal.
+remove_sentinel_route() {
+    local existing
+    existing=$(nbctl --bare --columns=_uuid find Logical_Router_Static_Route \
+        ip_prefix="\"${SENTINEL_PREFIX}\"" 2>/dev/null \
+        | tr -d '\r' | head -n1 || true)
+    if [ -z "${existing}" ]; then
+        return 0
+    fi
+    log "teardown: removing residual sentinel route ${SENTINEL_PREFIX}"
+    nbctl --if-exists lr-route-del "${LR_NAME}" "${SENTINEL_PREFIX}" || true
+}
+
+# Grep the docker logs of each surviving gateway for the agent's
+# `stale chassis route removed` log line referencing the dead chassis.
+# Returns 0 (with the matching line(s) on stdout) as soon as one peer
+# logs the cleanup, non-zero if no peer logged it.
+find_peer_cleanup_log() {
+    local peer
+    for peer in ${PEERS}; do
+        local matches
+        matches=$(docker logs "clab-${LAB}-${peer}" 2>&1 \
+            | grep -E 'msg="stale chassis route removed"' \
+            | grep "chassis=${MASTER}" || true)
+        if [ -n "${matches}" ]; then
+            printf '[%s] %s\n' "${peer}" "${matches}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Restart the killed master container so `docker exec` works again
+# (the artifact collector needs OVS/FRR dumps from gateway-1 — its
+# logs survive even on an exited container, but `ovs-vsctl show` and
+# friends need a live PID). Because the scenario externally drained
+# gateway-1's Gateway_Chassis priority to 0 after the kill, OVN does
+# not re-elect gateway-1 on restart and gateway-2 stays master —
+# baseline reachability through the FIPs keeps working. The lab is
+# now HA-asymmetric (single-master), not baseline-symmetric;
+# subsequent `make e2e-failover` runs against the same lab will not
+# behave usefully (no priority-30 master to fail), so chain
+# `make e2e-down && make e2e-up` before another destructive
+# scenario. Best-effort: failures here are logged but never raised.
+restore_master() {
+    log "teardown: starting ${MASTER_NODE} (so the artifact collector can exec into it)"
+    docker start "${MASTER_NODE}" >/dev/null \
+        || log "teardown: docker start returned non-zero; continuing"
+
+    remove_sentinel_route
+
+    log "teardown: lab is now single-master on a peer of ${MASTER}; ${MASTER} stays drained (priority 0)."
+    log "teardown: baseline reachability via the new master still works; failover semantics do not."
+    log "teardown: chain 'make e2e-down && make e2e-up' before another destructive scenario."
+}
+
+main() {
+    sanity_gate
+
+    local master_uuid
+    master_uuid=$(chassis_uuid "${MASTER}")
+    if [ -z "${master_uuid}" ]; then
+        log "ERROR: ${MASTER} is not registered as a SB Chassis — cannot test stale cleanup"
+        return 1
+    fi
+    log "${MASTER} chassis UUID = ${master_uuid}"
+
+    seed_sentinel_route
+
+    local before_uuids
+    before_uuids=$(managed_route_uuids_for_chassis "${MASTER}")
+    if [ -z "${before_uuids}" ]; then
+        log "ERROR: no managed NB rows are tagged for ${MASTER} after seeding — aborting"
+        return 1
+    fi
+    log "NB rows tagged for ${MASTER} before kill:"
+    printf '%s\n' "${before_uuids}" | sed 's/^/    /' >&2
+
+    {
+        printf '# NB rows tagged for chassis=%s before kill\n' "${MASTER}"
+        printf '# chassis_uuid=%s\n\n' "${master_uuid}"
+        managed_route_rows_for_chassis "${MASTER}"
+    } | write_artifact "nb-before-kill.txt"
+
+    # The hard kill skips the agent's SIGTERM handler entirely. OVN
+    # does NOT auto-remove the SB Chassis row when ovn-controller dies
+    # — that row is only released on graceful shutdown. Without the
+    # `chassis-del` below the surviving agents would keep seeing
+    # gateway-1 as alive forever and never run their cleanup loop.
+    # See the header comment for why this is the right simulation of
+    # production behaviour.
+    trap restore_master EXIT
+    log "hard-killing ${MASTER_NODE} (SIGKILL — agent has no chance to clean up)"
+    docker kill -s KILL "${MASTER_NODE}" >/dev/null
+
+    # Drain the dead chassis in NB by setting its Gateway_Chassis
+    # priority to 0. This is the same NB mutation DrainGateways
+    # writes on graceful shutdown (ovn_gateway.go:589) — we run it
+    # externally here because the killed agent never got to do it.
+    # In production an HA orchestrator does this step (see header).
+    # Without it OVN re-elects gateway-1 as master on `docker start`
+    # because the priority-30 entry survives in NB.
+    log "draining ${MASTER}'s Gateway_Chassis priority to 0 (simulates HA orchestrator)"
+    nbctl lrp-set-gateway-chassis "${LR_PUBLIC_PORT}" "${MASTER}" 0 >/dev/null
+
+    log "removing ${MASTER}'s SB Chassis row (simulates the external reaper)"
+    sbctl --if-exists chassis-del "${MASTER}" >/dev/null
+
+    # Poll the NB DB until the rows tagged for the dead chassis are
+    # gone. The deadline allows for: one reconcile cycle to mark the
+    # chassis missing (now immediate, since SB no longer lists it),
+    # the configured grace period + up to 30s jitter, and one more
+    # reconcile cycle to actually execute the cleanup.
+    log "waiting up to ${STALE_TIMEOUT}s for surviving agents to clean up rows tagged for ${MASTER}"
+    log "    (configured stale_chassis_grace_period in gwnode-config.yaml: ${STALE_GRACE_PERIOD})"
+    local start_ts deadline
+    start_ts=$(date +%s)
+    deadline=$(( start_ts + STALE_TIMEOUT ))
+    local after_uuids="${before_uuids}"
+    while (( $(date +%s) < deadline )); do
+        after_uuids=$(managed_route_uuids_for_chassis "${MASTER}")
+        if [ -z "${after_uuids}" ]; then
+            log "NB rows tagged for ${MASTER} were removed after $(( $(date +%s) - start_ts ))s"
+            break
+        fi
+        sleep 2
+    done
+
+    {
+        printf '# NB rows tagged for chassis=%s after wait (timeout=%ds)\n' \
+            "${MASTER}" "${STALE_TIMEOUT}"
+        managed_route_rows_for_chassis "${MASTER}"
+    } | write_artifact "nb-after-kill.txt"
+
+    if [ -n "${after_uuids}" ]; then
+        log "ERROR: NB still contains rows tagged for ${MASTER} after ${STALE_TIMEOUT}s:"
+        printf '%s\n' "${after_uuids}" | sed 's/^/    /' >&2
+        return 1
+    fi
+
+    # Prove the deletion was deliberate (a surviving agent emitted the
+    # cleanup log line) rather than coincidental (some other code path
+    # deleted the row).
+    log "verifying a surviving peer emitted the cleanup log line referencing ${MASTER}"
+    local cleanup_log
+    if ! cleanup_log=$(find_peer_cleanup_log); then
+        log "ERROR: no surviving peer (${PEERS}) logged 'stale chassis route removed' for chassis=${MASTER}"
+        printf '# no peer logged the cleanup\n' | write_artifact "peer-cleanup.log"
+        return 1
+    fi
+    log "peer cleanup log:"
+    printf '%s\n' "${cleanup_log}" | sed 's/^/    /' >&2
+    printf '%s\n' "${cleanup_log}" | write_artifact "peer-cleanup.log"
+
+    log "stale-chassis cleanup confirmed"
+}
+
+main "$@"


### PR DESCRIPTION
Implements #111.

Adds the Layer 3 E2E scenario that exercises the agent's stale-chassis cleanup path against the containerlab harness: when a gateway disappears WITHOUT a graceful shutdown, surviving peers must garbage-collect the NB rows it owned after `stale_chassis_grace_period` elapses.

## Commit walk

1. **`test/e2e: tighten cleanup cadence for the CI lab`** (`test/e2e/gwnode-config.yaml`) — sets `stale_chassis_grace_period: 30s` and `reconcile_interval: 5s` explicitly in the gwnode E2E config so the scenario fits inside the 5-minute job budget and does not silently ride on a default-value regression. Per the issue's implementation hint: *"the reduced value is set explicitly in the topology config so the test isn't hiding a default-value regression"*.
2. **`test/e2e: add stale-chassis cleanup scenario`** (`test/e2e/scenarios/stale-chassis.sh`, `Makefile`) — the new bash scenario plus the `make e2e-stale-chassis` target. The scenario:
   - runs `baseline.sh` first as a sanity gate (`SANITY_GATE=1` default),
   - seeds a sentinel managed static route on `lr0` tagged with `external_ids:ovn-network-agent-chassis=<MASTER>` so there is actually a row in NB for the cleanup loop to find (the lab's only naturally agent-owned row is the default route via the VGW, which `ensureDefaultRoute` re-tags rather than orphans on failover),
   - **hard-kills `MASTER`** with `docker kill -s KILL` (skips the agent's SIGTERM handler — that's the failover scenario's case),
   - **externally drains `MASTER` in NB** with `lrp-set-gateway-chassis <port> <MASTER> 0` — the same mutation the agent's own `DrainGateways` writes on graceful shutdown ([`ovn_gateway.go:589`](https://github.com/osism/ovn-network-agent/blob/main/ovn_gateway.go#L589)). The killed agent never got to run it; in production an HA orchestrator does this step,
   - **removes `MASTER`'s SB Chassis row** with `ovn-sbctl chassis-del` — simulates the external reaper (a killed ovn-controller does not remove its own SB row),
   - polls NB for up to `STALE_TIMEOUT` (default 150s) until rows tagged for the dead chassis are gone,
   - greps surviving peers' `docker logs` for the `stale chassis route removed` line referencing the dead chassis — both signals must fire so the deletion is provably deliberate,
   - writes before/after NB snapshots and the cleanup log line to `ARTIFACTS_DIR` so a failed run's evidence is bundled.

   Teardown `docker start`s `MASTER` so the artifact collector can `docker exec` into it. The lab is left in a HA-asymmetric "single-master on the priority-20 peer, `MASTER` drained" state — `make e2e-baseline` keeps passing because the workload is on `gateway-3` and the new master still advertises the FIPs, but `make e2e-failover` against the same lab has no priority-30 master left to fail. Chain `make e2e-down && make e2e-up` between destructive scenarios locally; CI is unaffected.
3. **`ci: run the stale-chassis scenario after the failover E2E job`** (`.github/workflows/e2e.yml`) — third job in `e2e.yml`, mirrors the failover job's shape (`needs: failover`, 15-min budget, artifact upload on failure). Points the scenario's `ARTIFACTS_DIR` at the same `${RUNNER_TEMP}/e2e-artifacts` root that `collect-artifacts.sh` writes into.
4. **`docs/e2e: cover the stale-chassis cleanup scenario`** (`docs/contributing/e2e-tests.md`) — adds the scenario to the layout block, documents the `make e2e-stale-chassis` target + env overrides, walks through the kill / drain / chassis-del sequence and what each step simulates, explains the post-scenario lab state honestly, extends the CI section to describe the three sequential jobs, and lists the new `stale-chassis/*` artifact paths in the triage section.

## Why the lab needs an external drain step (not in the original issue)

The issue's literal text — *"`docker kill -s KILL clab-${LAB}-gateway-1`"* — is necessary but not sufficient against containerlab. Two production realities the lab doesn't fake by itself:

- **A killed ovn-controller does not remove its own SB Chassis row**, so surviving agents keep seeing the dead chassis as alive forever. The scenario does an explicit `ovn-sbctl chassis-del` to stand in for the production reaper (`neutron-ovn-agent` on `chassis-down`, ovn-northd's stale-chassis sweeper, etc.).
- **A killed agent never gets to run `DrainGateways`**, so the dead chassis's priority-30 entry survives in NB and OVN re-elects it the moment `docker start` brings it back. The scenario runs the equivalent `lrp-set-gateway-chassis 0` mutation externally to stand in for the production HA orchestrator (BFD monitor, Pacemaker, etc.).

Both deviations are documented in the script header and `docs/contributing/e2e-tests.md`; both keep the test focused on what the agent does AFTER the row disappears, not on how the row disappears.

## Acceptance criteria

- [x] `test/e2e/scenarios/stale-chassis.sh` exists and is wired into `make e2e-stale-chassis` + the CI workflow. Verified locally on a Linux box: cleanup observed at `t+42s` after the kill, peer cleanup log `chassis=gateway-1` captured on `gateway-2`, baseline still passes against the same lab post-scenario.
- [x] `make e2e-stale-chassis` target exists.
- [x] CI run uses a reduced `stale_chassis_grace_period` (30s, ≤ the issue's 60s ceiling) so total job runtime stays ≤ ~3 min on the green path (baseline gate ~30s + cleanup wait ~80s, well inside the 5-min target).
- [x] NB DB snapshot before and after the kill is included in the artifact bundle on failure (`stale-chassis/nb-before-kill.txt`, `stale-chassis/nb-after-kill.txt`).
- [x] The peer agent's "cleanup" log line is captured in the artifact bundle on failure (`stale-chassis/peer-cleanup.log`).
- [x] `docs/contributing/e2e-tests.md` lists the new scenario in the layout, run-locally, CI, and triage sections.

## Follow-ups (out of scope here)

- **#113** — Layer 3: E2E drain hitless scenario. Originally listed as scenario 1 of the now-closed umbrella #46 but never split out; opened as a sibling of #105 / #111. Covers the graceful-arm-vs-hard-kill loss comparison (`ping -i 0.1` + tshark) that proves the hitless claim in the data plane.

## Test plan

- [x] Local lint pass: `shellcheck test/e2e/scenarios/stale-chassis.sh` ✓, `actionlint .github/workflows/e2e.yml` ✓, `go vet ./...` ✓, `go test -count=1 ./...` ✓, `make docs-gen-check` ✓.
- [x] Live run on a Linux host (`make e2e-up && make e2e-stale-chassis && make e2e-baseline`): scenario green, peer cleanup log captured, follow-up baseline green against the same lab.
- [ ] First CI run on `main`: the `stale-chassis` job runs after `failover` and goes green.
- [ ] Force a failure (e.g. temporarily set `STALE_TIMEOUT=1`) and confirm the uploaded artifact bundle contains `stale-chassis/nb-before-kill.txt`, `stale-chassis/nb-after-kill.txt`, and (when applicable) `stale-chassis/peer-cleanup.log`.

AI-assisted: Claude Code