### PR TITLE
drain + active-lead: recover Gateway_Chassis rows missing from NB cache (#115)

### DIFF
--- a/ovn_fake_test.go
+++ b/ovn_fake_test.go
@@ -37,6 +37,14 @@ type fakeOVSDBClient struct {
 	// via ovsdb.CheckOperationResults.
 	opResults []ovsdb.OperationResult
 
+	// selectRows, when non-nil, supplies rows for OperationSelect ops keyed
+	// by table name, bypassing the cache view exposed via setRows/List. The
+	// drain fallback path uses Transact(OperationSelect) to read directly
+	// from the NB server when the cache appears incomplete (issue #115);
+	// tests populate this to simulate the "server has the row, cache does
+	// not" race.
+	selectRows map[string][]ovsdb.Row
+
 	// onTransact is invoked synchronously for each Transact call (after the
 	// op has been recorded). Used by drain tests to mutate rows mid-poll so
 	// countLocalCRPorts can converge.
@@ -176,6 +184,7 @@ func (f *fakeOVSDBClient) Transact(_ context.Context, ops ...ovsdb.Operation) ([
 	f.mu.Lock()
 	f.transacts = append(f.transacts, append([]ovsdb.Operation(nil), ops...))
 	hook := f.onTransact
+	selectRows := f.selectRows
 	f.mu.Unlock()
 
 	if hook != nil {
@@ -188,7 +197,28 @@ func (f *fakeOVSDBClient) Transact(_ context.Context, ops ...ovsdb.Operation) ([
 		return f.opResults, nil
 	}
 	results := make([]ovsdb.OperationResult, len(ops))
+	for i, op := range ops {
+		if op.Op == ovsdb.OperationSelect {
+			results[i].Rows = append([]ovsdb.Row(nil), selectRows[op.Table]...)
+		}
+	}
 	return results, nil
+}
+
+// setSelectRows registers rows returned by Transact(OperationSelect) for the
+// given table. The rows reflect the server-side view, which may differ from
+// the cache view set via setRows.
+func (f *fakeOVSDBClient) setSelectRows(table string, rows ...ovsdb.Row) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.selectRows == nil {
+		f.selectRows = make(map[string][]ovsdb.Row)
+	}
+	if len(rows) == 0 {
+		delete(f.selectRows, table)
+		return
+	}
+	f.selectRows[table] = append([]ovsdb.Row(nil), rows...)
 }
 
 // --- ConditionalAPI surface --------------------------------------------------

--- a/ovn_gateway.go
+++ b/ovn_gateway.go
@@ -597,6 +597,11 @@ func (o *OVNClient) CleanupStaleChassisManagedEntries(ctx context.Context, stale
 // EnsureActivePriorityLead prevents reverse failover by ensuring the
 // active chassis always has priority >= minActivePriority (currently 2),
 // which is strictly above the restore level of 1.
+//
+// The NB monitor cache occasionally drops Gateway_Chassis INSERTs delivered
+// shortly after the agent's initial subscription (see issue #115). When the
+// cache shows no row at all for the local chassis, fall back to a direct
+// OVSDB select so the drain does not silently no-op.
 func (o *OVNClient) DrainGateways(ctx context.Context, localChassisName string) error {
 	// Step 1: Find all Gateway_Chassis entries for this chassis with priority > 0.
 	var gwChassisList []NBGatewayChassis
@@ -604,15 +609,29 @@ func (o *OVNClient) DrainGateways(ctx context.Context, localChassisName string) 
 		return fmt.Errorf("list gateway chassis: %w", err)
 	}
 
-	var toDrain []NBGatewayChassis
-	for _, gwc := range gwChassisList {
-		if gwc.ChassisName == localChassisName && gwc.Priority > 0 {
-			toDrain = append(toDrain, gwc)
+	toDrain, hasLocalRow := filterDrainCandidates(gwChassisList, localChassisName)
+
+	// Cache may be missing the local row entirely if the Gateway_Chassis
+	// INSERT update was not delivered to this client. Confirm by reading
+	// directly from the NB server before silently skipping the drain.
+	if !hasLocalRow {
+		slog.Warn("drain: cache has no Gateway_Chassis row for this chassis, querying NB directly",
+			"local_chassis_name", localChassisName,
+			"cache_count", len(gwChassisList))
+		serverList, err := o.selectLocalGatewayChassis(ctx, localChassisName)
+		if err != nil {
+			return fmt.Errorf("drain: cache miss + NB select fallback failed: %w", err)
+		}
+		toDrain, _ = filterDrainCandidates(serverList, localChassisName)
+		if len(toDrain) > 0 {
+			slog.Info("drain: NB select recovered Gateway_Chassis rows hidden by the cache",
+				"local_chassis_name", localChassisName, "recovered", len(toDrain))
 		}
 	}
 
 	if len(toDrain) == 0 {
-		slog.Info("drain: no gateway chassis entries to drain on this chassis")
+		slog.Info("drain: no gateway chassis entries to drain on this chassis",
+			"local_chassis_name", localChassisName)
 		return nil
 	}
 
@@ -698,6 +717,83 @@ func (o *OVNClient) RestoreDrainedGateways(ctx context.Context, localChassisName
 	if err := o.transactOps(ctx, allOps); err != nil {
 		slog.Error("restore-drain: failed to restore gateway chassis priorities", "error", err)
 	}
+}
+
+// filterDrainCandidates returns the Gateway_Chassis rows that must have
+// their priority lowered to drain this chassis and reports whether the input
+// contained any row at all for localChassisName. The "row present at all"
+// signal lets the caller distinguish "nothing to drain because already
+// drained" (cache has rows at priority 0) from "nothing to drain because
+// the local row is absent" (cache is incomplete).
+func filterDrainCandidates(gwChassisList []NBGatewayChassis, localChassisName string) (toDrain []NBGatewayChassis, hasLocalRow bool) {
+	for _, gwc := range gwChassisList {
+		if gwc.ChassisName != localChassisName {
+			continue
+		}
+		hasLocalRow = true
+		if gwc.Priority > 0 {
+			toDrain = append(toDrain, gwc)
+		}
+	}
+	return toDrain, hasLocalRow
+}
+
+// selectLocalGatewayChassis performs a direct OVSDB select on Gateway_Chassis
+// for entries with chassis_name == localChassisName, bypassing the libovsdb
+// monitor cache. Used as the fallback path when the cache appears to have
+// missed an INSERT (see issue #115).
+func (o *OVNClient) selectLocalGatewayChassis(ctx context.Context, localChassisName string) ([]NBGatewayChassis, error) {
+	selectOp := ovsdb.Operation{
+		Op:    ovsdb.OperationSelect,
+		Table: "Gateway_Chassis",
+		Where: []ovsdb.Condition{{
+			Column:   "chassis_name",
+			Function: ovsdb.ConditionEqual,
+			Value:    localChassisName,
+		}},
+	}
+	results, err := o.nbClient.Transact(ctx, selectOp)
+	if err != nil {
+		return nil, fmt.Errorf("transact select: %w", err)
+	}
+	if _, err := ovsdb.CheckOperationResults(results, []ovsdb.Operation{selectOp}); err != nil {
+		return nil, fmt.Errorf("select result: %w", err)
+	}
+	if len(results) == 0 {
+		return nil, nil
+	}
+	out := make([]NBGatewayChassis, 0, len(results[0].Rows))
+	for _, row := range results[0].Rows {
+		out = append(out, rowToGatewayChassis(row))
+	}
+	return out, nil
+}
+
+// rowToGatewayChassis decodes the columns of a raw OVSDB Gateway_Chassis row
+// into the NBGatewayChassis fields the drain fallback consumes. Only the
+// subset of columns needed by the caller is read; everything else is left
+// at the zero value.
+func rowToGatewayChassis(row ovsdb.Row) NBGatewayChassis {
+	var gwc NBGatewayChassis
+	if u, ok := row["_uuid"].(ovsdb.UUID); ok {
+		gwc.UUID = u.GoUUID
+	}
+	if s, ok := row["name"].(string); ok {
+		gwc.Name = s
+	}
+	if s, ok := row["chassis_name"].(string); ok {
+		gwc.ChassisName = s
+	}
+	// JSON-RPC delivers integers as float64; an in-process fake may pass int.
+	switch p := row["priority"].(type) {
+	case float64:
+		gwc.Priority = int(p)
+	case int:
+		gwc.Priority = p
+	case int64:
+		gwc.Priority = int(p)
+	}
+	return gwc
 }
 
 // countLocalCRPorts returns the number of chassisredirect ports currently

--- a/ovn_gateway.go
+++ b/ovn_gateway.go
@@ -96,10 +96,39 @@ const minActivePriority = 2
 // prevents reverse failovers when a drained chassis restores to priority 1
 // and the active chassis is also at 1 (because it never boosted while the
 // peer was at 0).
+//
+// The NB monitor cache occasionally drops Gateway_Chassis INSERTs (see
+// issue #115); when no row for the local chassis is in the cache despite
+// having locally-active routers, fall back to a direct NB select so the
+// boost is not silently skipped.
 func (o *OVNClient) EnsureActivePriorityLead(ctx context.Context, localRouters []LocalRouterInfo, localChassisName string) error {
+	if len(localRouters) == 0 {
+		return nil
+	}
+
 	var gwChassisList []NBGatewayChassis
 	if err := o.nbClient.List(ctx, &gwChassisList); err != nil {
 		return fmt.Errorf("list gateway chassis: %w", err)
+	}
+
+	hasLocalRow := false
+	for _, gwc := range gwChassisList {
+		if gwc.ChassisName == localChassisName {
+			hasLocalRow = true
+			break
+		}
+	}
+	if !hasLocalRow {
+		slog.Warn("active-lead: cache has no Gateway_Chassis row for this chassis, querying NB directly",
+			"local_chassis_name", localChassisName,
+			"cache_count", len(gwChassisList))
+		serverList, err := o.selectLocalGatewayChassis(ctx, localChassisName)
+		if err != nil {
+			return fmt.Errorf("active-lead: cache miss + NB select fallback failed: %w", err)
+		}
+		// Merge the recovered local rows into the cache snapshot. Peer rows
+		// from the cache (other chassis) are still needed to compute maxPeer.
+		gwChassisList = append(gwChassisList, serverList...)
 	}
 
 	// Build set of locally-active LRP names.

--- a/ovn_gateway_writes_test.go
+++ b/ovn_gateway_writes_test.go
@@ -433,18 +433,23 @@ func TestEnsureActivePriorityLead(t *testing.T) {
 			}
 
 			tx := nb.recordedTransacts()
+			var updates []ovsdb.Operation
+			for _, batch := range tx {
+				for _, op := range batch {
+					if op.Op == ovsdb.OperationUpdate && op.Table == "Gateway_Chassis" {
+						updates = append(updates, op)
+					}
+				}
+			}
 			if len(tt.wantBoosts) == 0 {
-				if len(tx) != 0 {
-					t.Fatalf("expected no transacts, got %d: %+v", len(tx), tx)
+				if len(updates) != 0 {
+					t.Fatalf("expected no Gateway_Chassis updates, got %d: %+v", len(updates), updates)
 				}
 				return
 			}
 
-			if len(tx) != 1 {
-				t.Fatalf("expected one batched transact, got %d: %+v", len(tx), tx)
-			}
-			if len(tx[0]) != len(tt.wantBoosts) {
-				t.Fatalf("expected %d update ops, got %d: %+v", len(tt.wantBoosts), len(tx[0]), tx[0])
+			if len(updates) != len(tt.wantBoosts) {
+				t.Fatalf("expected %d update ops, got %d: %+v", len(tt.wantBoosts), len(updates), updates)
 			}
 			// Map each local UUID back to its LRP so we can assert the
 			// computed priority for each update op.
@@ -458,11 +463,7 @@ func TestEnsureActivePriorityLead(t *testing.T) {
 					lrpByLocalUUID[e.UUID] = lrp
 				}
 			}
-			for _, op := range tx[0] {
-				if op.Op != ovsdb.OperationUpdate || op.Table != "Gateway_Chassis" {
-					t.Errorf("unexpected op: %+v", op)
-					continue
-				}
+			for _, op := range updates {
 				lrp, ok := lrpByLocalUUID[op.UUID]
 				if !ok {
 					t.Errorf("update on unexpected UUID %q", op.UUID)
@@ -482,6 +483,52 @@ func TestEnsureActivePriorityLead(t *testing.T) {
 				t.Errorf("expected updates for local UUIDs %v but they were not issued", lrpByLocalUUID)
 			}
 		})
+	}
+}
+
+// TestEnsureActivePriorityLead_FallsBackToServerSelectOnCacheMiss covers the
+// issue #115 race in the active-lead reconciler: with the local row missing
+// from the cache, EnsureActivePriorityLead must recover it via a direct NB
+// select and still boost the priority above the peer instead of silently
+// skipping.
+func TestEnsureActivePriorityLead_FallsBackToServerSelectOnCacheMiss(t *testing.T) {
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+
+	// Cache only has the peer row — the local Gateway_Chassis INSERT was
+	// dropped between server and client.
+	nb.setRows("Gateway_Chassis",
+		&NBGatewayChassis{UUID: "g2", Name: "lrp-a_host-b", ChassisName: "host-b", Priority: 5},
+	)
+	nb.setSelectRows("Gateway_Chassis", ovsdb.Row{
+		"_uuid":        ovsdb.UUID{GoUUID: "g1"},
+		"name":         "lrp-a_host-a",
+		"chassis_name": "host-a",
+		"priority":     float64(1),
+	})
+
+	err := c.EnsureActivePriorityLead(context.Background(),
+		[]LocalRouterInfo{{LRPName: "lrp-a"}}, "host-a")
+	if err != nil {
+		t.Fatalf("EnsureActivePriorityLead: %v", err)
+	}
+
+	tx := nb.recordedTransacts()
+	var updates []ovsdb.Operation
+	for _, batch := range tx {
+		for _, op := range batch {
+			if op.Op == ovsdb.OperationUpdate && op.Table == "Gateway_Chassis" {
+				updates = append(updates, op)
+			}
+		}
+	}
+	if len(updates) != 1 {
+		t.Fatalf("expected one priority boost after select fallback, got %d: %+v", len(updates), updates)
+	}
+	if updates[0].UUID != "g1" {
+		t.Errorf("update should target the recovered local row (g1), got %q", updates[0].UUID)
+	}
+	if got, ok := updates[0].Row["priority"].(int); !ok || got != 6 {
+		t.Errorf("expected boost to 6 (max peer 5 + 1), got %#v", updates[0].Row["priority"])
 	}
 }
 

--- a/ovn_gateway_writes_test.go
+++ b/ovn_gateway_writes_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -806,6 +807,126 @@ func TestDrainGateways_TimeoutReturnsNilWithRemainingPorts(t *testing.T) {
 	tx := nb.recordedTransacts()
 	if len(tx) != 1 || len(tx[0]) != 1 {
 		t.Errorf("expected one batched priority update before timeout, got %+v", tx)
+	}
+}
+
+// TestDrainGateways_FallsBackToServerSelectOnCacheMiss exercises the
+// issue #115 race: the NB monitor cache is missing the local Gateway_Chassis
+// row, so the cache scan finds nothing to drain. DrainGateways must fall
+// back to a direct OVSDB select (which sees the server-side row) and lower
+// the priority instead of silently no-op'ing.
+func TestDrainGateways_FallsBackToServerSelectOnCacheMiss(t *testing.T) {
+	c, nb, sb := newOVNClientWithFakes(t, "host-a")
+
+	// Cache has only peer entries — no row for host-a (the missed INSERT).
+	nb.setRows("Gateway_Chassis",
+		&NBGatewayChassis{UUID: "g2", Name: "lrp-a_host-b", ChassisName: "host-b", Priority: 20},
+		&NBGatewayChassis{UUID: "g3", Name: "lrp-a_host-c", ChassisName: "host-c", Priority: 10},
+	)
+	// Server-side state (visible to OperationSelect) still has the local row.
+	nb.setSelectRows("Gateway_Chassis", ovsdb.Row{
+		"_uuid":        ovsdb.UUID{GoUUID: "g1"},
+		"name":         "lrp-a_host-a",
+		"chassis_name": "host-a",
+		// JSON-RPC numbers arrive as float64; reproduce that here so the
+		// row decoder is exercised on the real wire shape.
+		"priority": float64(30),
+	})
+	sb.setRows("Chassis", &SBChassis{UUID: "ch-a", Name: "ch-a", Hostname: "host-a"})
+
+	if err := c.DrainGateways(context.Background(), "host-a"); err != nil {
+		t.Fatalf("DrainGateways: %v", err)
+	}
+
+	tx := nb.recordedTransacts()
+	if len(tx) != 2 {
+		t.Fatalf("expected two transacts (select fallback + priority update), got %d: %+v", len(tx), tx)
+	}
+	// First transact is the OperationSelect against Gateway_Chassis.
+	if len(tx[0]) != 1 || tx[0][0].Op != ovsdb.OperationSelect || tx[0][0].Table != "Gateway_Chassis" {
+		t.Fatalf("expected first transact to be select on Gateway_Chassis, got %+v", tx[0])
+	}
+	if len(tx[0][0].Where) != 1 || tx[0][0].Where[0].Column != "chassis_name" || tx[0][0].Where[0].Value != "host-a" {
+		t.Errorf("select must filter on chassis_name == host-a, got %+v", tx[0][0].Where)
+	}
+	// Second transact lowers the recovered row's priority to 0.
+	updates := findOps(t, tx, 1, ovsdb.OperationUpdate, "Gateway_Chassis")
+	if len(updates) != 1 {
+		t.Fatalf("expected one priority update from the fallback, got %d: %+v", len(updates), tx[1])
+	}
+	if updates[0].UUID != "g1" {
+		t.Errorf("update should target the row recovered from the server (g1), got %q", updates[0].UUID)
+	}
+	if got, ok := updates[0].Row["priority"].(int); !ok || got != 0 {
+		t.Errorf("drain op must set priority=0, got %#v", updates[0].Row["priority"])
+	}
+}
+
+// TestDrainGateways_NoFallbackWhenLocalRowPresentAtZero asserts that an
+// already-drained local row (priority 0) does NOT trigger the select
+// fallback. The cache contains the row, so the existing "nothing to drain"
+// fast path runs and no extra OVSDB chatter is emitted.
+func TestDrainGateways_NoFallbackWhenLocalRowPresentAtZero(t *testing.T) {
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+	nb.setRows("Gateway_Chassis",
+		&NBGatewayChassis{UUID: "g1", Name: "lrp-a_host-a", ChassisName: "host-a", Priority: 0},
+	)
+
+	if err := c.DrainGateways(context.Background(), "host-a"); err != nil {
+		t.Fatalf("DrainGateways: %v", err)
+	}
+	if got := nb.recordedTransacts(); len(got) != 0 {
+		t.Errorf("expected no transacts (cache has the row), got %+v", got)
+	}
+}
+
+// TestDrainGateways_FallbackReturnsErrorOnTransactFailure ensures the drain
+// surfaces server-side errors from the select fallback instead of swallowing
+// them silently — the caller (shutdown path) needs to record the failure.
+func TestDrainGateways_FallbackReturnsErrorOnTransactFailure(t *testing.T) {
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+	// Cache has no local row, forcing the fallback.
+	nb.setRows("Gateway_Chassis",
+		&NBGatewayChassis{UUID: "g2", Name: "lrp-a_host-b", ChassisName: "host-b", Priority: 20},
+	)
+	nb.transactErr = errors.New("connection refused")
+
+	err := c.DrainGateways(context.Background(), "host-a")
+	if err == nil || !strings.Contains(err.Error(), "NB select fallback failed") {
+		t.Errorf("expected fallback error to be surfaced, got %v", err)
+	}
+}
+
+// TestSelectLocalGatewayChassis_DecodesRowFields covers the rowToGatewayChassis
+// decoder for the priority types it must accept: float64 (JSON wire format)
+// and int (in-process fakes / mappers).
+func TestSelectLocalGatewayChassis_DecodesRowFields(t *testing.T) {
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+	nb.setSelectRows("Gateway_Chassis",
+		ovsdb.Row{
+			"_uuid":        ovsdb.UUID{GoUUID: "g-float"},
+			"name":         "lrp-a_host-a",
+			"chassis_name": "host-a",
+			"priority":     float64(7),
+		},
+		ovsdb.Row{
+			"_uuid":        ovsdb.UUID{GoUUID: "g-int"},
+			"name":         "lrp-b_host-a",
+			"chassis_name": "host-a",
+			"priority":     3,
+		},
+	)
+
+	got, err := c.selectLocalGatewayChassis(context.Background(), "host-a")
+	if err != nil {
+		t.Fatalf("selectLocalGatewayChassis: %v", err)
+	}
+	want := []NBGatewayChassis{
+		{UUID: "g-float", Name: "lrp-a_host-a", ChassisName: "host-a", Priority: 7},
+		{UUID: "g-int", Name: "lrp-b_host-a", ChassisName: "host-a", Priority: 3},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("decoded rows mismatch:\n  got:  %+v\n  want: %+v", got, want)
 	}
 }
 


### PR DESCRIPTION
Implements #115.

The libovsdb NB monitor cache occasionally drops `Gateway_Chassis` INSERTs delivered shortly after the agent's initial subscription. When the local row is the missing one, both shutdown drain and the active-lead reconciler silently no-op even though the central NB itself is consistent — defeating `drain_on_shutdown` and (on a cold start) the priority-lead boost that prevents reverse failover. This is what blocks the drain-hitless E2E scenario in #113 from passing reliably.

The fix is the surgical option from the issue: when the cache view contains zero rows for the local chassis, fall back to a direct OVSDB `select` against `Gateway_Chassis` filtered on `chassis_name`. The select bypasses the cache and asks the NB server itself, so a dropped INSERT no longer hides the row.

## Changes

Two commits, each scoped to a single caller of the cache scan:

1. `drain: fall back to NB select when cache is missing the local row` — Distinguishes "already drained (priority 0 in cache)" from "row absent from cache" in `DrainGateways`, falls back to a raw `select` on cache miss, and decodes the rows by hand. Adds an `OperationSelect` handler to the in-process fake OVSDB client so tests can stage a "cache empty, server has the row" view.
2. `active-lead: fall back to NB select when cache is missing the local row` — Applies the same fallback in `EnsureActivePriorityLead`, where the bug is masked in practice but would silently skip the priority boost on a cold start after a missed INSERT. Also short-circuits the no-local-routers case so a cold agent does not pay for an NB select on every reconcile.

## Test plan

- [x] `go test -race -count=1 ./...` passes locally (`ovn_gateway_writes_test.go` exercises the cache-miss → select fallback for both `DrainGateways` and `EnsureActivePriorityLead`, plus the row decoder for both `float64` and `int` priority shapes).
- [x] `go vet ./...` clean.
- [x] `gofmt -l .` clean.
- [ ] Drain-hitless E2E scenario in #113 passes on repeated runs once both PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)