### PR TITLE
ci: also run the E2E workflow on pull requests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,13 +1,17 @@
 name: E2E
 
-# Per issue #45, the E2E workflow does not run on pull requests: the
-# containerlab harness boots three OVN+OVS+FRR gateway containers plus
-# a central node and clients, and even on the green path eats ~10 min
-# of runner time. Reserving it for `main` pushes and explicit
-# `workflow_dispatch` keeps PR feedback fast while still proving the
-# topology before a release.
+# The containerlab harness boots three OVN+OVS+FRR gateway containers
+# plus a central node and clients, and even on the green path eats
+# ~10 min of runner time. We still run it on every push to `main` and
+# on `workflow_dispatch`, but also on pull requests so authors can
+# debug topology-level regressions on the same runners CI uses — the
+# GHA environment differs enough from local Docker hosts (kernel,
+# resource limits, image caches) that lab-up failures often only
+# reproduce here.
 on:
   push:
+    branches: [main]
+  pull_request:
     branches: [main]
   workflow_dispatch:
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,12 +40,25 @@ jobs:
         run: bash -c "$(curl -sL https://get.containerlab.dev)"
 
       # The gwnode image uses kernel OVS so OVN's BFD-driven cr-lrp
-      # election over geneve tunnels actually converges. The ubuntu
-      # GHA runner ships the module but does not auto-load it, and the
-      # container only inherits CAP_NET_ADMIN so it cannot load it
-      # itself — load it on the host before bringing the lab up.
-      - name: Load openvswitch kernel module
-        run: sudo modprobe openvswitch
+      # election over geneve tunnels actually converges, and the
+      # entrypoint creates a vrf-provider kernel VRF for the agent's
+      # veth-leak design. The gwnode containers only inherit
+      # CAP_NET_ADMIN (no CAP_SYS_MODULE), so the modules must be
+      # loaded on the host before lab-up. The Azure kernel on
+      # `ubuntu-latest` ships `openvswitch` in the base modules set
+      # but `vrf` only in `linux-modules-extra-<uname>` — install it
+      # on demand. Without `vrf`, gwnode-entrypoint.sh crash-loops on
+      # `ip link add vrf-provider type vrf table 100` with "Unknown
+      # device type".
+      - name: Load required kernel modules
+        run: |
+          set -euo pipefail
+          sudo modprobe openvswitch
+          if ! sudo modprobe vrf 2>/dev/null; then
+            sudo apt-get update -qq
+            sudo apt-get install -y "linux-modules-extra-$(uname -r)"
+            sudo modprobe vrf
+          fi
 
       - name: Bring the lab up
         run: make e2e-up
@@ -94,8 +107,16 @@ jobs:
       - name: Install containerlab
         run: bash -c "$(curl -sL https://get.containerlab.dev)"
 
-      - name: Load openvswitch kernel module
-        run: sudo modprobe openvswitch
+      # See the baseline job for the rationale; same modules required.
+      - name: Load required kernel modules
+        run: |
+          set -euo pipefail
+          sudo modprobe openvswitch
+          if ! sudo modprobe vrf 2>/dev/null; then
+            sudo apt-get update -qq
+            sudo apt-get install -y "linux-modules-extra-$(uname -r)"
+            sudo modprobe vrf
+          fi
 
       - name: Bring the lab up
         run: make e2e-up
@@ -144,8 +165,16 @@ jobs:
       - name: Install containerlab
         run: bash -c "$(curl -sL https://get.containerlab.dev)"
 
-      - name: Load openvswitch kernel module
-        run: sudo modprobe openvswitch
+      # See the baseline job for the rationale; same modules required.
+      - name: Load required kernel modules
+        run: |
+          set -euo pipefail
+          sudo modprobe openvswitch
+          if ! sudo modprobe vrf 2>/dev/null; then
+            sudo apt-get update -qq
+            sudo apt-get install -y "linux-modules-extra-$(uname -r)"
+            sudo modprobe vrf
+          fi
 
       - name: Bring the lab up
         run: make e2e-up

--- a/test/e2e/scenarios/collect-artifacts.sh
+++ b/test/e2e/scenarios/collect-artifacts.sh
@@ -20,9 +20,18 @@ set -u
 
 LAB="${LAB:-ovn-e2e}"
 TOPOLOGY="${TOPOLOGY:-test/e2e/topology.clab.yml}"
-GATEWAYS=("${GATEWAYS[@]:-gateway-1 gateway-2 gateway-3}")
+# Default node lists. The previous `("${GATEWAYS[@]:-a b c}")` form
+# collapsed the default into a single array element, so per-node
+# captures ran `docker logs clab-ovn-e2e-gateway-1 gateway-2 gateway-3`
+# once and only produced one bogus output file. Env-override is kept by
+# only applying the default when the array is unset.
+if [ -z "${GATEWAYS+x}" ]; then
+    GATEWAYS=(gateway-1 gateway-2 gateway-3)
+fi
+if [ -z "${CLIENTS+x}" ]; then
+    CLIENTS=(client-1 client-2)
+fi
 CENTRAL="${CENTRAL:-central}"
-CLIENTS=("${CLIENTS[@]:-client-1 client-2}")
 UPSTREAM="${UPSTREAM:-upstream}"
 OUT_DIR="${1:-}"
 


### PR DESCRIPTION
## Summary
- Add `pull_request` (to `main`) as an E2E trigger alongside `push` on `main` and `workflow_dispatch`, so authors can iterate on lab-up regressions from a PR.
- Fix per-node artifact collection in `collect-artifacts.sh`: the previous `("${GATEWAYS[@]:-…}")` default collapsed into a single array element, so every per-node capture ran `docker logs clab-ovn-e2e-gateway-1 gateway-2 gateway-3` once and produced one bogus output file ("No such container …") for the whole fleet.
- Load the `vrf` kernel module on the host in every E2E job before `make e2e-up`. The gwnode entrypoint creates a `vrf-provider` kernel VRF for the agent's veth-leak design; without it the entrypoint crash-loops with `Error: Unknown device type`. The Azure kernel on `ubuntu-latest` does not ship `vrf` in the base modules set, so `linux-modules-extra-$(uname -r)` is installed on demand.

## Motivation
Recent baseline-reachability failures on `main` (e.g. run 25869385979, `SB chassis registration timed out; missing: gateway-2`) only reproduced on GHA runners. Running E2E on PRs makes that loop debuggable; while iterating, the two real bugs above surfaced and are bundled here so the workflow is actually usable for debugging.

## Commits
- `ci: also run the E2E workflow on pull requests`
- `test/e2e: fix per-node artifact collection quoting`
- `ci: load the vrf kernel module before bringing the E2E lab up`

## Test plan
- [x] PR triggers the `E2E` workflow.
- [x] All three jobs (`baseline`, `failover`, `stale-chassis`) reach and pass the lab-up step on this PR's run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)