### PR TITLE
test/e2e: port-forward DNAT scenario (external client, source IP preserved)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -204,6 +204,71 @@ jobs:
         if: always()
         run: make e2e-down
 
+  pf-external:
+    name: Port-forward DNAT (external client, source IP preserved)
+    runs-on: ubuntu-latest
+    # Runs in parallel with failover and hairpin (all three gate on
+    # baseline) so a port-forward regression is reported in isolation.
+    # Same 15-minute budget — the scenario adds the cost of one
+    # bootstrap, the baseline gate, plus ~5s of LB-row plumbing and a
+    # single curl probe, well inside the 5-minute target in issue
+    # #109.
+    needs: baseline
+    timeout-minutes: 15
+
+    env:
+      E2E_TOPOLOGY: test/e2e/topology.clab.yml
+      LAB: ovn-e2e
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install containerlab
+        run: bash -c "$(curl -sL https://get.containerlab.dev)"
+
+      # See the baseline job for the rationale; same modules required.
+      - name: Load required kernel modules
+        run: |
+          set -euo pipefail
+          sudo modprobe openvswitch
+          if ! sudo modprobe vrf 2>/dev/null; then
+            sudo apt-get update -qq
+            sudo apt-get install -y "linux-modules-extra-$(uname -r)"
+            sudo modprobe vrf
+          fi
+
+      - name: Bring the lab up
+        run: make e2e-up
+
+      - name: Run port-forward scenario
+        # Direct the scenario's backend source-IP log capture into the
+        # same artifact root so collect-artifacts.sh and the uploader
+        # both pick it up — per issue #109's "backend source-IP log is
+        # included in the artifact bundle on failure" acceptance
+        # criterion. `runner.temp` is only available at step scope,
+        # not the job-level env block.
+        env:
+          ARTIFACTS_DIR: ${{ runner.temp }}/e2e-artifacts/pf-external
+        run: ./test/e2e/scenarios/pf-external.sh
+
+      - name: Collect failure artifacts
+        if: failure()
+        run: |
+          ./test/e2e/scenarios/collect-artifacts.sh "${RUNNER_TEMP}/e2e-artifacts"
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: e2e-artifacts-pf-external-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/e2e-artifacts
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Tear the lab down
+        if: always()
+        run: make e2e-down
+
   stale-chassis:
     name: Stale-chassis cleanup (hard kill)
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION   ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "d
 LDFLAGS   := -s -w -X main.version=$(VERSION)
 GOFLAGS   := -trimpath
 
-.PHONY: all build build-static clean fmt vet test test-integration install docs-gen docs-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-hairpin e2e-stale-chassis
+.PHONY: all build build-static clean fmt vet test test-integration install docs-gen docs-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-hairpin e2e-pf-external e2e-stale-chassis
 
 # Containerlab E2E harness. See test/e2e/README.md for the topology and
 # acceptance criteria (issue #44).
@@ -12,6 +12,7 @@ E2E_BOOTSTRAP   := test/e2e/bootstrap.sh
 E2E_BASELINE    := test/e2e/scenarios/baseline.sh
 E2E_FAILOVER    := test/e2e/scenarios/failover.sh
 E2E_HAIRPIN     := test/e2e/scenarios/hairpin.sh
+E2E_PF_EXTERNAL := test/e2e/scenarios/pf-external.sh
 E2E_STALE       := test/e2e/scenarios/stale-chassis.sh
 E2E_GWNODE_TAG  := ovn-network-agent/gwnode:e2e
 E2E_CENTRAL_TAG := ovn-network-agent/central:e2e
@@ -146,6 +147,18 @@ e2e-failover:
 # `make e2e-baseline` works without tearing the lab down.
 e2e-hairpin:
 	$(E2E_HAIRPIN)
+
+# Run the port-forward / DNAT scenario (issue #109) against a lab
+# that is already up. Adds an OVN Load_Balancer for 192.0.2.50:80 →
+# ls0-vm1:8080 on lr0, starts a tiny HTTP backend in the existing vm1
+# netns, curls the VIP from client-1, and asserts the backend log
+# records client-1's underlay IP — i.e. OVN performed pure DNAT with
+# no SNAT on the way in. Mirrors the step the CI workflow runs; the
+# scenario's own EXIT trap removes the Load_Balancer, the per-chassis
+# kernel route, the upstream static route, and the backend process,
+# so a subsequent `make e2e-baseline` keeps passing.
+e2e-pf-external:
+	$(E2E_PF_EXTERNAL)
 
 # Run the stale-chassis cleanup scenario (issue #111) against a lab
 # that is already up. Hard-kills the priority-30 chassis (SIGKILL, no

--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -30,6 +30,13 @@ The harness has two layers:
    adds a second FIP backend co-located with the existing one on the
    active master and exercises the agent's `cookie=0x998`
    `actions=output:in_port` hairpin rule on `br-ex` end-to-end.
+   [`pf-external.sh`](https://github.com/osism/ovn-network-agent/blob/main/test/e2e/scenarios/pf-external.sh)
+   ([#109](https://github.com/osism/ovn-network-agent/issues/109))
+   seeds an OVN Load_Balancer (port-forward / DNAT) on `lr0`, drives
+   it with `curl` from `client-1`, and asserts the backend log records
+   the client's underlay IP — i.e. no SNAT on the way in. The
+   conceptual model the scenario exercises is documented in
+   [Port forwarding (DNAT)](../explanation/port-forwarding.md).
 
 ## Layout
 
@@ -46,8 +53,13 @@ test/e2e/
     baseline.sh             — baseline reachability scenario (issue #45)
     failover.sh             — HA failover scenario, master chassis loss (issue #105)
     hairpin.sh              — same-chassis hairpin scenario, two FIPs on master (issue #108)
+    pf-external.sh          — port-forward / DNAT scenario, source IP preserved (issue #109)
     stale-chassis.sh        — stale chassis cleanup scenario, hard kill (issue #111)
     collect-artifacts.sh    — dump lab state for offline triage
+  pf-backend/
+    main.go                 — tiny HTTP responder shipped at /usr/local/bin/pf-backend
+                              in the gwnode image; logs each connection's source IP
+                              for the port-forward scenario's assertion.
 ```
 
 ## Prerequisites
@@ -189,6 +201,7 @@ make e2e-up             # build images + containerlab deploy + bootstrap
 make e2e-baseline       # run the baseline reachability scenario
 make e2e-failover       # run the HA failover scenario (master chassis loss)
 make e2e-hairpin        # run the same-chassis hairpin scenario (two FIPs on master)
+make e2e-pf-external    # run the port-forward / DNAT scenario (source IP preserved)
 make e2e-stale-chassis  # run the stale-chassis cleanup scenario (hard kill)
 make e2e-down           # containerlab destroy
 ```
@@ -270,6 +283,47 @@ LR pipeline now ingresses on the external port, applies DNAT
 which is what makes a regression in `ReconcileOVSHairpinFlows`
 visible end-to-end. Override `FIP_B`, `FIP_B_INTERNAL`, `MASTER`,
 `WORKLOAD_HOST`, `RECONCILE_TIMEOUT` or `SANITY_GATE` when triaging.
+
+`make e2e-pf-external` invokes `test/e2e/scenarios/pf-external.sh`,
+which exercises OVN's port-forward / DNAT data path with traffic
+from an external client and asserts the backend observes the
+client's original source IP end-to-end — the "no SNAT on the way
+in" property OpenStack tenants rely on for source-IP-based access
+control. The conceptual model is documented in
+[Port forwarding (DNAT)](../explanation/port-forwarding.md).
+
+The scenario runs the baseline first as a sanity gate (disable with
+`SANITY_GATE=0`), then adds — scenario-locally — an OVN
+`Load_Balancer` row (`pf-external`) mapping `192.0.2.50:80` to
+`192.168.10.10:8080/tcp` and attaches it to `lr0`. A static route on
+`upstream` (`192.0.2.50/32 via 100.64.1.2`) and a scope-link route
+on `gateway-1` (`192.0.2.50/32 dev br-ex`) plumb the VIP into the
+forward path — the agent does not yet propagate Load_Balancer VIPs
+into vrf-provider / br-ex (a follow-up to #109), so the scenario
+seeds those routes itself. A tiny Go HTTP responder
+(`/usr/local/bin/pf-backend`, built in the same Dockerfile stage as
+the agent) is started inside the existing `vm1` netns on
+`gateway-3` and logs the source IP of each accepted connection. The
+scenario then `curl`s `http://192.0.2.50/` from `client-1` (polled
+for up to `RECONCILE_TIMEOUT=60s`) and asserts the backend log
+records a `peer=<client-1-eth1-IP>:*` line — a stray SNAT step on
+the way in (LR internal address, gateway chassis address, …) would
+substitute a different IP here and fail the grep. The EXIT trap
+removes the `Load_Balancer`, both kernel routes and the responder,
+returning the lab to baseline so a subsequent `make e2e-baseline`
+keeps passing. Override `VIP`, `VIP_PORT`, `BACKEND_IP`,
+`BACKEND_PORT`, `MASTER`, `MASTER_UNDERLAY`, `RECONCILE_TIMEOUT` or
+`SANITY_GATE` when triaging.
+
+Why a `Load_Balancer` (and not a `dnat_and_snat` NAT row): the latter
+performs SNAT on the way in, which is exactly the property the
+scenario is meant to disprove. Pure-DNAT NAT rows (`type=dnat`) do
+not carry a port-mapping, so they cannot express the `:80 → :8080`
+translation the issue asks for. `Load_Balancer` is the canonical
+OVN port-forward primitive — the same `lr-lb-add` path
+`neutron-ovn-agent` and `kube-ovn` use in production — and is the
+only ovn-nbctl primitive that combines pure DNAT with a per-port
+mapping today.
 
 `make e2e-stale-chassis` invokes `test/e2e/scenarios/stale-chassis.sh`,
 which exercises the agent's garbage-collection path for managed NB
@@ -405,7 +459,7 @@ The workflow does **not** run on pull requests: spinning the lab up
 adds ~10 minutes to CI on a green run, which is too coarse for the
 per-PR feedback loop the rest of the workflows target.
 
-Four jobs run, each on its own runner so a regression in one
+Five jobs run, each on its own runner so a regression in one
 scenario is reported in isolation:
 
 - **`baseline`** — installs containerlab, runs `make e2e-up`, executes
@@ -421,6 +475,13 @@ scenario is reported in isolation:
   root so the before/after `cookie=0x998` `dump-flows` snapshots are
   bundled with the lab-state dump. On failure the artifact bundle
   is uploaded as `e2e-artifacts-hairpin-<run id>-<attempt>`.
+- **`pf-external`** (`needs: baseline`, runs in parallel with
+  `failover` and `hairpin`) — same shape, but executes
+  `test/e2e/scenarios/pf-external.sh`. The job points the scenario's
+  `ARTIFACTS_DIR` at the same artifact root so the backend
+  source-IP log is bundled with the lab-state dump on failure (per
+  issue #109's acceptance criterion). On failure the artifact
+  bundle is uploaded as `e2e-artifacts-pf-external-<run id>-<attempt>`.
 - **`stale-chassis`** (`needs: failover`) — same shape, but executes
   `test/e2e/scenarios/stale-chassis.sh`. The job points the
   scenario's `ARTIFACTS_DIR` at the same artifact root so the
@@ -428,11 +489,12 @@ scenario is reported in isolation:
   bundled with the lab-state dump. On failure the artifact bundle is
   uploaded as `e2e-artifacts-stale-chassis-<run id>-<attempt>`.
 
-All four jobs are capped at 15 minutes — matching the budgets in
+All five jobs are capped at 15 minutes — matching the budgets in
 issues
 [#45](https://github.com/osism/ovn-network-agent/issues/45),
 [#105](https://github.com/osism/ovn-network-agent/issues/105),
-[#108](https://github.com/osism/ovn-network-agent/issues/108), and
+[#108](https://github.com/osism/ovn-network-agent/issues/108),
+[#109](https://github.com/osism/ovn-network-agent/issues/109), and
 [#111](https://github.com/osism/ovn-network-agent/issues/111).
 
 ### Triaging a failed run
@@ -457,6 +519,7 @@ writes:
   agent/<gateway>.log              — copy of the gateway container's stdout
   hairpin/hairpin-flows-before.txt — `cookie=0x998` flows on master:br-ex before adding FIP_B (hairpin only)
   hairpin/hairpin-flows-after.txt  — `cookie=0x998` flows on master:br-ex after adding FIP_B (hairpin only)
+  pf-external/pf-backend.log       — per-connection source-IP log from the workload-side HTTP responder (pf-external only)
   stale-chassis/nb-before-kill.txt — NB rows tagged for the killed chassis pre-kill (stale-chassis only)
   stale-chassis/nb-after-kill.txt  — NB rows still tagged for the killed chassis after the cleanup deadline (stale-chassis only)
   stale-chassis/peer-cleanup.log   — surviving peer's `stale chassis route removed` line (stale-chassis only)

--- a/test/e2e/Dockerfile.gwnode
+++ b/test/e2e/Dockerfile.gwnode
@@ -40,6 +40,19 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} \
         -ldflags "-s -w -X main.version=${VERSION}" \
         -o /out/ovn-network-agent .
 
+# pf-backend is the tiny HTTP responder driven by the port-forward E2E
+# scenario (test/e2e/scenarios/pf-external.sh, issue #109). It logs the
+# source IP of each accepted connection so the scenario can assert that
+# OVN's DNAT data path preserved the client's underlay IP end-to-end.
+# Built here in the same stage as the agent so the runtime image keeps
+# every test helper as a static binary instead of pulling Python /
+# netcat / socat into the gwnode image (the 600 MB image budget in
+# docs/contributing/e2e-tests.md leaves no room for a Python install).
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} \
+    go build -trimpath \
+        -ldflags "-s -w" \
+        -o /out/pf-backend ./test/e2e/pf-backend
+
 # ---------------------------------------------------------------------------
 # Runtime stage — Ubuntu 24.04 + OVS + ovn-host + FRR + the agent.
 # ---------------------------------------------------------------------------
@@ -79,10 +92,12 @@ RUN sed -i 's/^bgpd=no/bgpd=yes/' /etc/frr/daemons \
  && grep -q '^bgpd=yes' /etc/frr/daemons
 
 COPY --from=build /out/ovn-network-agent /usr/local/bin/ovn-network-agent
+COPY --from=build /out/pf-backend        /usr/local/bin/pf-backend
 COPY test/e2e/gwnode-entrypoint.sh /usr/local/bin/gwnode-entrypoint.sh
 COPY test/e2e/gwnode-config.yaml   /etc/ovn-network-agent/config.yaml
 RUN chmod 0755 /usr/local/bin/gwnode-entrypoint.sh \
-               /usr/local/bin/ovn-network-agent
+               /usr/local/bin/ovn-network-agent \
+               /usr/local/bin/pf-backend
 
 # Healthcheck per issue #44: OVS responsive + ovn-controller and the agent
 # both running. `pgrep -x` matches against /proc/<pid>/comm, which Linux

--- a/test/e2e/pf-backend/main.go
+++ b/test/e2e/pf-backend/main.go
@@ -1,0 +1,67 @@
+// pf-backend is a minimal HTTP responder used by the port-forward E2E
+// scenario (issue #109). It logs the source IP of each accepted TCP
+// connection — that log line is the load-bearing assertion in
+// test/e2e/scenarios/pf-external.sh: if OVN's DNAT data path silently
+// SNATs the client on the way in, the recorded peer is the LR's internal
+// SNAT address or the gateway chassis address instead of client-1's
+// underlay IP, and the scenario fails the source-IP-preservation check.
+//
+// The binary is built in the same Dockerfile.gwnode build stage as the
+// agent and shipped at /usr/local/bin/pf-backend, so the scenario can
+// `ip netns exec vm1 /usr/local/bin/pf-backend ...` without depending
+// on Python, netcat or socat being installed in the runtime image
+// (which is held under the 600 MB gwnode image budget).
+//
+// Flags:
+//
+//	-addr    TCP listen address (default ":8080")
+//	-log     append per-connection log lines to this file in addition
+//	         to stderr. Empty disables the file sink. The scenario's
+//	         EXIT trap copies the file into ARTIFACTS_DIR so the
+//	         source-IP log is part of the failure artifact bundle (per
+//	         the issue's "backend source-IP log is included in the
+//	         artifact bundle on failure" acceptance criterion).
+//
+// The response body is the fixed string "ok\n" — the test does not
+// assert on the response content, only on the peer address recorded
+// in the log.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	addr := flag.String("addr", ":8080", "TCP listen address")
+	logPath := flag.String("log", "", "append per-connection log lines to this file (in addition to stderr)")
+	flag.Parse()
+
+	sinks := []io.Writer{os.Stderr}
+	if *logPath != "" {
+		f, err := os.OpenFile(*logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			log.Fatalf("open %s: %v", *logPath, err)
+		}
+		defer func() { _ = f.Close() }()
+		sinks = append(sinks, f)
+	}
+	out := io.MultiWriter(sinks...)
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// RemoteAddr is "<host>:<port>". When OVN performs pure DNAT
+		// (the property under test), <host> is the client's underlay
+		// IP. A stray SNAT step on the way in would substitute the
+		// LR's internal address here instead.
+		_, _ = fmt.Fprintf(out, "peer=%s method=%s path=%s host=%s\n",
+			r.RemoteAddr, r.Method, r.URL.Path, r.Host)
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = io.WriteString(w, "ok\n")
+	})
+
+	log.Fatal(http.ListenAndServe(*addr, nil))
+}

--- a/test/e2e/scenarios/pf-external.sh
+++ b/test/e2e/scenarios/pf-external.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# Port-forward (DNAT) scenario for the containerlab E2E harness.
+#
+# Goal (issue #109): exercise the OVN port-forward / DNAT data path with
+# traffic from an external client. A `client-1 → VIP:80` connection is
+# DNAT'ed by OVN to a backend in the workload network; the backend MUST
+# observe the original client source IP end-to-end. The "no SNAT on
+# the way in" property is what OpenStack users rely on for source-IP
+# based access control and audit logging — a stray SNAT rule that
+# rewrites the client's underlay IP to the LR's internal address or
+# the gateway chassis address would silently break that contract while
+# still letting "connection succeeded" probes pass.
+#
+# What the scenario adds (and tears down again):
+#   * Load_Balancer  pf-external  vips={"192.0.2.50:80"="192.168.10.10:8080"}
+#                                 protocol=tcp           attached to lr0
+#   * static route on upstream:   192.0.2.50/32 via <master underlay IP>
+#   * scope-link route on master: 192.0.2.50/32 dev br-ex
+#   * /tmp/pf-backend.log inside the workload host (collected as an
+#     artifact regardless of pass/fail when ARTIFACTS_DIR is set)
+#
+# Why a Load_Balancer (and not a plain dnat_and_snat NAT row):
+# `dnat_and_snat` performs SNAT on the way in as well, which is exactly
+# the property the issue tells us to disprove. OVN's Load_Balancer
+# does pure DNAT for external clients (no SNAT), matches a specific
+# VIP:port, and supports the VIP-port → backend-port translation the
+# issue calls for (`:80 → :8080`). This is also the canonical OVN
+# port-forwarding primitive — `lr-lb-add` is the path
+# neutron-ovn-agent / kube-ovn use in production. The hint in the
+# issue about a future `ovn-nbctl lr-nat-add` wrapper refers to the
+# proposed `clientctl` helper (issue #46); for a self-contained
+# scenario, `ovn-nbctl lb-add` plus `lr-lb-add` are the right
+# primitives today.
+#
+# Why two extra kernel routes have to be plumbed by hand:
+# The agent only installs FRR/kernel routes for `dnat_and_snat` (FIPs)
+# and `snat` (gateway SNAT IPs) NB rows — it does not yet propagate
+# Load_Balancer VIPs into vrf-provider or the default-netns br-ex
+# scope-link route (an obvious follow-up, but out of scope for #109).
+# So the scenario seeds:
+#   * a static route on `upstream` so client-1's packets head to the
+#     master chassis, and
+#   * a scope-link /32 in the master's default netns so the leaked
+#     packet (vrf-provider → veth-default → default netns) is steered
+#     onto br-ex, where OVS NORMAL forwards it through the patch port
+#     into OVN's pipeline.
+# The reverse path piggy-backs on the agent's existing
+# `from 192.0.2.0/24 lookup 200` policy rule plus table-200's default
+# route via `veth-provider`, so no extra work is needed for replies.
+#
+# Pre-condition: lab is up. When SANITY_GATE=1 (default) this scenario
+# runs `baseline.sh` first so a broken green path is reported as a
+# baseline regression instead of being attributed to port-forward.
+#
+# Teardown: the Load_Balancer, both kernel routes and the HTTP backend
+# are removed on EXIT (via trap), returning the lab to baseline state.
+# The CI workflow additionally invokes the same teardown step with
+# `if: always()` so a fatal interpreter error here (which skips the
+# trap) is still cleaned up.
+#
+# Environment overrides (used by the CI workflow):
+#   LAB                container-name prefix (defaults to the topology name "ovn-e2e")
+#   MASTER             chassis owning cr-lr0-public (defaults to gateway-1)
+#   WORKLOAD_HOST      chassis hosting the FIP-A backend / pf-backend (defaults to gateway-3)
+#   CENTRAL            OVN central container (defaults to clab-${LAB}-central)
+#   LR_NAME            logical router (defaults to lr0)
+#   VIP                external VIP that client-1 dials (default 192.0.2.50)
+#   VIP_PORT           external TCP port on the VIP (default 80)
+#   BACKEND_IP         internal backend address (default 192.168.10.10, == ls0-vm1)
+#   BACKEND_PORT       internal TCP port on the backend (default 8080)
+#   BACKEND_NETNS      netns on WORKLOAD_HOST where pf-backend runs (default vm1)
+#   LB_NAME            Load_Balancer row name (default pf-external)
+#   LB_PROTO           Load_Balancer protocol (default tcp)
+#   MASTER_UNDERLAY    underlay IP of MASTER on its /30 to upstream (default 100.64.1.2)
+#   UPSTREAM           upstream container name (defaults to clab-${LAB}-upstream)
+#   CLIENT             external client container (defaults to clab-${LAB}-client-1)
+#   CLIENT_DEV         client interface holding the underlay address (default eth1)
+#   LOG_FILE           in-container path of the backend source-IP log (default /tmp/pf-backend.log)
+#   RECONCILE_TIMEOUT  seconds to wait for the LB data path to come up (default 60)
+#   CURL_TIMEOUT       per-attempt connect+read timeout for curl (default 3)
+#   ARTIFACTS_DIR      directory to copy the backend log into (default empty = skip)
+#   SANITY_GATE        run baseline.sh first when 1 (default 1)
+
+set -euo pipefail
+
+LAB="${LAB:-ovn-e2e}"
+MASTER="${MASTER:-gateway-1}"
+MASTER_NODE="clab-${LAB}-${MASTER}"
+WORKLOAD_HOST="${WORKLOAD_HOST:-gateway-3}"
+WORKLOAD_NODE="clab-${LAB}-${WORKLOAD_HOST}"
+CENTRAL="${CENTRAL:-clab-${LAB}-central}"
+LR_NAME="${LR_NAME:-lr0}"
+VIP="${VIP:-192.0.2.50}"
+VIP_PORT="${VIP_PORT:-80}"
+BACKEND_IP="${BACKEND_IP:-192.168.10.10}"
+BACKEND_PORT="${BACKEND_PORT:-8080}"
+BACKEND_NETNS="${BACKEND_NETNS:-vm1}"
+LB_NAME="${LB_NAME:-pf-external}"
+LB_PROTO="${LB_PROTO:-tcp}"
+MASTER_UNDERLAY="${MASTER_UNDERLAY:-100.64.1.2}"
+UPSTREAM="${UPSTREAM:-clab-${LAB}-upstream}"
+CLIENT="${CLIENT:-clab-${LAB}-client-1}"
+CLIENT_DEV="${CLIENT_DEV:-eth1}"
+LOG_FILE="${LOG_FILE:-/tmp/pf-backend.log}"
+RECONCILE_TIMEOUT="${RECONCILE_TIMEOUT:-60}"
+CURL_TIMEOUT="${CURL_TIMEOUT:-3}"
+ARTIFACTS_DIR="${ARTIFACTS_DIR:-}"
+SANITY_GATE="${SANITY_GATE:-1}"
+
+SCENARIOS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASELINE="${BASELINE:-${SCENARIOS_DIR}/baseline.sh}"
+
+log() { printf '[pf-external] %s\n' "$*" >&2; }
+
+nbctl() { docker exec "${CENTRAL}" ovn-nbctl "$@"; }
+
+# Detect the client-1 underlay address dynamically. The issue's example
+# IP `198.51.100.<x>` is illustrative; in this lab client-1 actually
+# lives at `10.0.0.2/24` on `eth1`. Reading the address with `ip -4 -o
+# addr show` keeps the assertion robust against future topology
+# changes that re-number the client subnet.
+detect_client_ip() {
+    docker exec "${CLIENT}" ip -4 -o addr show dev "${CLIENT_DEV}" \
+        | awk '{print $4}' \
+        | cut -d/ -f1 \
+        | head -n1
+}
+
+# Run baseline.sh as a sanity gate so a broken green path fails fast
+# under the right label. Disabled by SANITY_GATE=0 — useful when
+# iterating locally on the port-forward behaviour itself.
+sanity_gate() {
+    if [ "${SANITY_GATE}" != "1" ]; then
+        log "SANITY_GATE=${SANITY_GATE}: skipping baseline pre-check"
+        return 0
+    fi
+    if [ ! -x "${BASELINE}" ]; then
+        log "baseline script not executable at ${BASELINE} — skipping pre-check"
+        return 0
+    fi
+    log "running baseline.sh as a sanity gate (set SANITY_GATE=0 to skip)"
+    "${BASELINE}"
+}
+
+# Start the HTTP backend inside the FIP-A workload netns on
+# WORKLOAD_HOST. `docker exec -d` detaches: the process keeps running
+# inside the container until the teardown step kills it via pkill.
+# Truncating the log file up-front prevents a stale line from a prior
+# (locally re-run) scenario from satisfying the assertion.
+start_backend() {
+    log "starting pf-backend on ${WORKLOAD_HOST} netns ${BACKEND_NETNS} (:${BACKEND_PORT}, log ${LOG_FILE})"
+    docker exec "${WORKLOAD_NODE}" sh -c ": >'${LOG_FILE}'"
+    docker exec -d "${WORKLOAD_NODE}" \
+        ip netns exec "${BACKEND_NETNS}" \
+        /usr/local/bin/pf-backend \
+            -addr ":${BACKEND_PORT}" \
+            -log "${LOG_FILE}"
+    # Wait for the listener to actually bind. Without this the LB-add
+    # below could race the first SYN against an unbound socket — the
+    # TCP RST would short-circuit the reconcile wait below and the
+    # scenario would look like a real OVN regression.
+    local deadline
+    deadline=$(( $(date +%s) + 10 ))
+    while (( $(date +%s) < deadline )); do
+        if docker exec "${WORKLOAD_NODE}" \
+                ip netns exec "${BACKEND_NETNS}" \
+                ss -ltn "sport = :${BACKEND_PORT}" 2>/dev/null \
+                | grep -q "LISTEN"; then
+            log "pf-backend listening on ${BACKEND_IP}:${BACKEND_PORT}"
+            return 0
+        fi
+        sleep 1
+    done
+    log "pf-backend did not bind on :${BACKEND_PORT} within 10s"
+    return 1
+}
+
+# Add the static route on `upstream` so client-1's traffic toward the
+# VIP is routed to the master chassis's underlay IP. Idempotent via
+# `ip route replace`.
+ensure_upstream_route() {
+    log "adding ${VIP}/32 via ${MASTER_UNDERLAY} on ${UPSTREAM}"
+    docker exec "${UPSTREAM}" \
+        ip route replace "${VIP}/32" via "${MASTER_UNDERLAY}"
+}
+
+# Add the scope-link /32 in the master's default netns so the leaked
+# packet (vrf-provider → veth-default → default netns) reaches br-ex,
+# where OVS NORMAL hands it to OVN's pipeline. We mirror the shape of
+# the agent-managed per-FIP routes (`<FIP>/32 dev br-ex scope link`)
+# so a `collect-artifacts.sh` dump of `ip route show table all` looks
+# like an extra FIP row rather than something exotic.
+ensure_master_scope_route() {
+    log "adding ${VIP}/32 dev br-ex scope link on ${MASTER}"
+    docker exec "${MASTER_NODE}" \
+        ip route replace "${VIP}/32" dev br-ex scope link
+}
+
+# Seed the OVN Load_Balancer for VIP:VIP_PORT → BACKEND_IP:BACKEND_PORT
+# and attach it to the logical router. Idempotent: `lb-add` with
+# `--may-exist` updates the existing VIPs map in-place, and
+# `lr-lb-add --may-exist` is a no-op if the LR already references this
+# LB.
+ensure_lb() {
+    log "ensuring Load_Balancer ${LB_NAME} ${VIP}:${VIP_PORT} → ${BACKEND_IP}:${BACKEND_PORT}/${LB_PROTO}"
+    nbctl --may-exist lb-add "${LB_NAME}" \
+        "${VIP}:${VIP_PORT}" "${BACKEND_IP}:${BACKEND_PORT}" "${LB_PROTO}"
+    log "attaching ${LB_NAME} to ${LR_NAME}"
+    nbctl --may-exist lr-lb-add "${LR_NAME}" "${LB_NAME}"
+}
+
+# Poll the data path from client-1 until curl succeeds against the VIP
+# or RECONCILE_TIMEOUT expires. OVN's northd has to translate the new
+# Load_Balancer row into SB flows on the master chassis, and the
+# kernel route + ARP-via-OVN cycle takes another round trip — the
+# whole thing usually lands within a couple of seconds but we give
+# the same generous reconcile budget as the hairpin scenario so a
+# slow CI runner does not flake.
+wait_for_reachability() {
+    local deadline
+    deadline=$(( $(date +%s) + RECONCILE_TIMEOUT ))
+    log "waiting up to ${RECONCILE_TIMEOUT}s for ${CLIENT} → ${VIP}:${VIP_PORT} to come up"
+    while (( $(date +%s) < deadline )); do
+        if docker exec "${CLIENT}" \
+                curl --silent --show-error \
+                    --max-time "${CURL_TIMEOUT}" \
+                    --output /dev/null \
+                    "http://${VIP}:${VIP_PORT}/" 2>/dev/null; then
+            log "VIP reachable from ${CLIENT}"
+            return 0
+        fi
+        sleep 2
+    done
+    log "VIP unreachable from ${CLIENT} within ${RECONCILE_TIMEOUT}s"
+    return 1
+}
+
+# Final assertion — the actual property under test. The backend log
+# format is "peer=<host>:<port> method=... path=... host=...". A
+# successful run records the client's underlay IP as <host>; any
+# stealth SNAT on the way in (LR internal address, gateway chassis
+# address, …) would show up here and fail the grep.
+assert_source_ip_preserved() {
+    local client_ip="$1"
+    log "asserting backend log records peer=${client_ip}:* (no SNAT on ingress)"
+    local log_content
+    log_content="$(docker exec "${WORKLOAD_NODE}" cat "${LOG_FILE}")"
+    if [ -z "${log_content}" ]; then
+        log "ERROR: ${LOG_FILE} is empty — backend never accepted a connection"
+        return 1
+    fi
+    log "backend log contents:"
+    printf '%s\n' "${log_content}" | sed 's/^/    /' >&2
+    # Anchor on the colon so a stray IP that happens to share a prefix
+    # (e.g. 10.0.0.20 matching a literal 10.0.0.2) does not pass.
+    if ! printf '%s\n' "${log_content}" | grep -q "peer=${client_ip}:"; then
+        log "ERROR: no log line records peer=${client_ip}:* — source IP was rewritten"
+        return 1
+    fi
+}
+
+# Best-effort artifact handoff. Writes the backend log into
+# ARTIFACTS_DIR (created if missing) so the CI workflow's
+# upload-artifact step picks it up alongside the
+# `collect-artifacts.sh` bundle. Called unconditionally from the
+# EXIT trap — the issue asks for "the backend source-IP log [...] on
+# failure", and copying it on the green path too is harmless (the
+# bundle is only uploaded when the step fails anyway).
+copy_backend_log_artifact() {
+    if [ -z "${ARTIFACTS_DIR}" ]; then
+        return 0
+    fi
+    if ! docker exec "${WORKLOAD_NODE}" test -f "${LOG_FILE}" 2>/dev/null; then
+        return 0
+    fi
+    mkdir -p "${ARTIFACTS_DIR}"
+    if docker exec "${WORKLOAD_NODE}" cat "${LOG_FILE}" \
+            >"${ARTIFACTS_DIR}/pf-backend.log" 2>/dev/null; then
+        log "wrote ${ARTIFACTS_DIR}/pf-backend.log"
+    fi
+}
+
+# Tear down everything the scenario added. Best-effort and idempotent:
+# a teardown failure must not mask the scenario's own pass/fail
+# signal, so every step is independently allowed to fail.
+teardown() {
+    log "teardown: copy log artifact, stop pf-backend, remove LB + routes"
+    copy_backend_log_artifact || true
+    docker exec "${WORKLOAD_NODE}" pkill -f /usr/local/bin/pf-backend 2>/dev/null || true
+    nbctl --if-exists lr-lb-del "${LR_NAME}" "${LB_NAME}" || true
+    nbctl --if-exists lb-del "${LB_NAME}" || true
+    docker exec "${MASTER_NODE}" \
+        ip route del "${VIP}/32" dev br-ex scope link 2>/dev/null || true
+    docker exec "${UPSTREAM}" \
+        ip route del "${VIP}/32" via "${MASTER_UNDERLAY}" 2>/dev/null || true
+    docker exec "${WORKLOAD_NODE}" rm -f "${LOG_FILE}" 2>/dev/null || true
+}
+
+main() {
+    sanity_gate
+
+    local client_ip
+    client_ip="$(detect_client_ip)"
+    if [ -z "${client_ip}" ]; then
+        log "ERROR: could not read client underlay IP from ${CLIENT}:${CLIENT_DEV}"
+        return 1
+    fi
+    log "client underlay IP = ${client_ip}"
+
+    trap teardown EXIT
+    start_backend
+    ensure_upstream_route
+    ensure_master_scope_route
+    ensure_lb
+
+    if ! wait_for_reachability; then
+        return 1
+    fi
+
+    assert_source_ip_preserved "${client_ip}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Implements #109 — adds an E2E scenario that exercises OVN's port-forward / DNAT data path with traffic from an external client and asserts the backend observes the **original client source IP** end-to-end (the "no SNAT on the way in" property OpenStack tenants rely on for source-IP-based access control).

Changes, in commit order:

1. **`test/e2e: ship a tiny pf-backend HTTP responder (issue #109)`** — adds `test/e2e/pf-backend/main.go`, a 30-line Go HTTP server that logs `peer=<host>:<port>` per request. Built in the existing `Dockerfile.gwnode` build stage and shipped as a static binary at `/usr/local/bin/pf-backend` so the runtime image stays inside its 600 MB budget (no Python / netcat / socat install required).
2. **`test/e2e: add port-forward DNAT scenario (issue #109)`** — adds `test/e2e/scenarios/pf-external.sh`. The scenario seeds an OVN `Load_Balancer` for `192.0.2.50:80 → 192.168.10.10:8080/tcp` on `lr0` (pure DNAT, no SNAT for external clients), plumbs the two kernel routes the agent does not yet propagate for LB VIPs (upstream `/32 via <master>`, default-netns `/32 dev br-ex` on the master), starts `pf-backend` inside the existing `vm1` netns on `gateway-3`, `curl`s the VIP from `client-1`, and asserts the backend log records `client-1`'s underlay IP — i.e. no stray SNAT step rewrote the source. EXIT-trap teardown removes everything the scenario added; on the way out the backend log is copied into `ARTIFACTS_DIR` (per the issue's "backend source-IP log is included in the artifact bundle on failure" acceptance criterion).
3. **`make,ci: wire the e2e-pf-external scenario into make and CI (issue #109)`** — adds the `make e2e-pf-external` target and a `pf-external` GitHub Actions job that mirrors the existing `hairpin` job (15-minute budget, `needs: baseline`, parallel with `failover`/`hairpin`, same `ARTIFACTS_DIR` plumbing).
4. **`docs: describe the port-forward DNAT E2E scenario (issue #109)`** — extends `docs/contributing/e2e-tests.md` with the scenario layout, a "Running locally" walk-through, the new CI job, and a link to the port-forwarding explainer (`docs/explanation/port-forwarding.md`) per the issue's acceptance criteria.

### Why `ovn-nbctl lb-add` (and not the `lr-nat-add` wrapper the issue hints at)

The issue's hint about a `clientctl` wrapper around `ovn-nbctl lr-nat-add` / `lr-nat-del` refers to a future helper proposed in #46. For the current scenario, `lr-nat-add` cannot express the `:80 → :8080` port mapping the issue calls for, and `type=dnat_and_snat` would SNAT the client on the way in — silently breaking the property under test. OVN's `Load_Balancer` (attached to the LR via `lr-lb-add`) is the canonical port-forwarding primitive — the same path neutron-ovn-agent and kube-ovn use in production — and is the only ovn-nbctl primitive that combines pure DNAT with a per-port mapping today. Rationale captured inline at the top of `pf-external.sh`.

### Why the scenario plumbs two kernel routes by hand

The agent only installs FRR/kernel routes for `dnat_and_snat` (FIPs) and `snat` (gateway SNAT IPs) NB rows — it does not yet propagate `Load_Balancer` VIPs into `vrf-provider` or the default-netns br-ex scope-link route. Propagating LB VIPs is an obvious follow-up to #109 but is out of scope for this issue (no Acceptance Criterion mentions it). The scenario seeds the two routes itself and removes them on teardown so the lab returns to baseline.

## Test plan

- [ ] CI `pf-external` job passes (15-min budget; scenario itself well inside the 5-min target from the issue)
- [ ] CI `baseline`, `failover`, `hairpin`, `stale-chassis` jobs continue to pass — the scenario only mutates state inside its own EXIT trap, the lab returns to baseline
- [ ] `make e2e-up && make e2e-pf-external && make e2e-baseline && make e2e-down` succeeds on a Linux host
- [ ] Artifact bundle on a forced failure includes `pf-external/pf-backend.log`

### Local verification performed

- `go vet ./...` — pass
- `go build ./...` — pass
- `go test ./...` — pass
- `shellcheck test/e2e/scenarios/pf-external.sh` — pass
- `make docs-gen-check` — clean (no generated-doc churn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)