### PR TITLE
test/e2e: port-forward hairpin masquerade scenario (issue #110)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -269,6 +269,73 @@ jobs:
         if: always()
         run: make e2e-down
 
+  pf-hairpin:
+    name: Port-forward hairpin (masquerade flag)
+    runs-on: ubuntu-latest
+    # Runs in parallel with failover, hairpin, and pf-external (all
+    # four gate on baseline) so a hairpin-masquerade regression is
+    # reported in isolation. 15-minute budget like the others — the
+    # scenario adds the cost of one bootstrap, the baseline gate, two
+    # `docker restart` cycles of gateway-1 and one ≤30s reconcile-and-
+    # probe window per phase, which fits inside the 7-minute target in
+    # issue #110.
+    needs: baseline
+    timeout-minutes: 15
+
+    env:
+      E2E_TOPOLOGY: test/e2e/topology.clab.yml
+      LAB: ovn-e2e
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install containerlab
+        run: bash -c "$(curl -sL https://get.containerlab.dev)"
+
+      # See the baseline job for the rationale; same modules required.
+      - name: Load required kernel modules
+        run: |
+          set -euo pipefail
+          sudo modprobe openvswitch
+          if ! sudo modprobe vrf 2>/dev/null; then
+            sudo apt-get update -qq
+            sudo apt-get install -y "linux-modules-extra-$(uname -r)"
+            sudo modprobe vrf
+          fi
+
+      - name: Bring the lab up
+        run: make e2e-up
+
+      - name: Run port-forward hairpin scenario
+        # Direct the scenario's nft snapshots (phase1-off / phase2-on /
+        # teardown) into the artifact root so collect-artifacts.sh and
+        # the uploader both pick them up — per issue #110's
+        # "`nft list table inet ovn-network-agent` output is captured
+        # in the artifact bundle on failure" acceptance criterion.
+        # `runner.temp` is only available at step scope, not the
+        # job-level env block.
+        env:
+          ARTIFACTS_DIR: ${{ runner.temp }}/e2e-artifacts/pf-hairpin
+        run: ./test/e2e/scenarios/pf-hairpin.sh
+
+      - name: Collect failure artifacts
+        if: failure()
+        run: |
+          ./test/e2e/scenarios/collect-artifacts.sh "${RUNNER_TEMP}/e2e-artifacts"
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: e2e-artifacts-pf-hairpin-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/e2e-artifacts
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Tear the lab down
+        if: always()
+        run: make e2e-down
+
   stale-chassis:
     name: Stale-chassis cleanup (hard kill)
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION   ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "d
 LDFLAGS   := -s -w -X main.version=$(VERSION)
 GOFLAGS   := -trimpath
 
-.PHONY: all build build-static clean fmt vet test test-integration install docs-gen docs-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-hairpin e2e-pf-external e2e-stale-chassis
+.PHONY: all build build-static clean fmt vet test test-integration install docs-gen docs-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-hairpin e2e-pf-external e2e-pf-hairpin e2e-stale-chassis
 
 # Containerlab E2E harness. See test/e2e/README.md for the topology and
 # acceptance criteria (issue #44).
@@ -13,6 +13,7 @@ E2E_BASELINE    := test/e2e/scenarios/baseline.sh
 E2E_FAILOVER    := test/e2e/scenarios/failover.sh
 E2E_HAIRPIN     := test/e2e/scenarios/hairpin.sh
 E2E_PF_EXTERNAL := test/e2e/scenarios/pf-external.sh
+E2E_PF_HAIRPIN  := test/e2e/scenarios/pf-hairpin.sh
 E2E_STALE       := test/e2e/scenarios/stale-chassis.sh
 E2E_GWNODE_TAG  := ovn-network-agent/gwnode:e2e
 E2E_CENTRAL_TAG := ovn-network-agent/central:e2e
@@ -159,6 +160,20 @@ e2e-hairpin:
 # so a subsequent `make e2e-baseline` keeps passing.
 e2e-pf-external:
 	$(E2E_PF_EXTERNAL)
+
+# Run the port-forward hairpin scenario (issue #110) against a lab that
+# is already up. Adds a co-located workload (vmc behind FIP_C on
+# gateway-1) and a tenant-shim OVS internal port that gives the
+# chassis kernel a routed path into ls0, then drives two phases
+# against the agent's `hairpin_masquerade` flag: phase 1 (off) must
+# time out because the backend reply bypasses the chassis conntrack,
+# phase 2 (on) must succeed because the masquerade rule re-routes the
+# reply through the chassis. Each phase restarts the gateway-1
+# container so the agent reloads its config; the scenario's own EXIT
+# trap restores the baseline agent config and removes every NB/kernel
+# row added here so a subsequent `make e2e-baseline` keeps passing.
+e2e-pf-hairpin:
+	$(E2E_PF_HAIRPIN)
 
 # Run the stale-chassis cleanup scenario (issue #111) against a lab
 # that is already up. Hard-kills the priority-30 chassis (SIGKILL, no

--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -34,8 +34,14 @@ The harness has two layers:
    ([#109](https://github.com/osism/ovn-network-agent/issues/109))
    seeds an OVN Load_Balancer (port-forward / DNAT) on `lr0`, drives
    it with `curl` from `client-1`, and asserts the backend log records
-   the client's underlay IP — i.e. no SNAT on the way in. The
-   conceptual model the scenario exercises is documented in
+   the client's underlay IP — i.e. no SNAT on the way in.
+   [`pf-hairpin.sh`](https://github.com/osism/ovn-network-agent/blob/main/test/e2e/scenarios/pf-hairpin.sh)
+   ([#110](https://github.com/osism/ovn-network-agent/issues/110))
+   exercises the agent's `hairpin_masquerade` flag: with the flag off
+   a co-located workload behind a FIP must time out on the VIP, with
+   the flag on the same probe must complete — the asymmetric reply
+   path is what the masquerade rule fixes. The conceptual model both
+   port-forward scenarios exercise is documented in
    [Port forwarding (DNAT)](../explanation/port-forwarding.md).
 
 ## Layout
@@ -54,6 +60,7 @@ test/e2e/
     failover.sh             — HA failover scenario, master chassis loss (issue #105)
     hairpin.sh              — same-chassis hairpin scenario, two FIPs on master (issue #108)
     pf-external.sh          — port-forward / DNAT scenario, source IP preserved (issue #109)
+    pf-hairpin.sh           — port-forward hairpin masquerade scenario (issue #110)
     stale-chassis.sh        — stale chassis cleanup scenario, hard kill (issue #111)
     collect-artifacts.sh    — dump lab state for offline triage
   pf-backend/
@@ -202,6 +209,7 @@ make e2e-baseline       # run the baseline reachability scenario
 make e2e-failover       # run the HA failover scenario (master chassis loss)
 make e2e-hairpin        # run the same-chassis hairpin scenario (two FIPs on master)
 make e2e-pf-external    # run the port-forward / DNAT scenario (source IP preserved)
+make e2e-pf-hairpin     # run the port-forward hairpin masquerade scenario
 make e2e-stale-chassis  # run the stale-chassis cleanup scenario (hard kill)
 make e2e-down           # containerlab destroy
 ```
@@ -324,6 +332,103 @@ OVN port-forward primitive — the same `lr-lb-add` path
 `neutron-ovn-agent` and `kube-ovn` use in production — and is the
 only ovn-nbctl primitive that combines pure DNAT with a per-port
 mapping today.
+
+`make e2e-pf-hairpin` invokes `test/e2e/scenarios/pf-hairpin.sh`,
+which exercises the agent's `hairpin_masquerade` flag — the
+source-selective SNAT documented in
+[Port forwarding (DNAT)](../explanation/port-forwarding.md). The
+agent performs port-forward DNAT in the chassis kernel (via
+nftables); when a FIP on the same chassis dials the VIP, the
+backend reply traverses OVN directly and bypasses the chassis
+conntrack, so the client sees the backend's tenant IP as the reply
+source and drops the segment. `hairpin_masquerade: true` adds a
+`postrouting_snat` masquerade rule that rewrites the source to the
+chassis IP, so the backend replies through the chassis and conntrack
+reverses both NAT layers.
+
+The scenario runs the baseline first as a sanity gate (disable with
+`SANITY_GATE=0`), then adds — scenario-locally — a new FIP `192.0.2.13`
+on `lr0` (`fip-c`) with a backing LSP `ls0-vmc` (`192.168.10.13`, MAC
+`02:00:00:00:0a:0c`) and a `vmc` netns + veth on `gateway-1` so the
+client behind the new FIP is co-located with the active master.
+Because the agent's port-forward DNAT runs in the chassis kernel and
+the lab does not expose `192.168.10.0/24` to `gateway-1`'s default
+routing table on its own, the scenario also adds an OVS internal port
+`tenant-shim` on `gateway-1:br-int` bound to a new LSP `ls0-shim`
+(`192.168.10.99`, MAC `02:00:00:00:0a:99`, port_security disabled so
+the asymmetric source on the forward leg is allowed through). That
+shim is the route the kernel uses to reach `vm1` on `gateway-3` once
+nftables has rewritten the destination, and the ARP responder for
+its configured address is what lets `vm1` reach the shim when the
+masquerade flag is on. Without it both phases would time out because
+the forward packet would be dropped at `gateway-1` (no route for the
+tenant network in `main`), and the test would not be load-bearing.
+
+The VIP itself is `198.51.100.50` (TEST-NET-2), **not** the
+`192.0.2.50` the issue body names. The agent's port-forward DNAT
+fires in the chassis kernel, so the VIP traffic from `vmc` has to
+leave OVN and transit `gateway-1`'s kernel. `192.0.2.50` is inside
+the provider network `192.0.2.0/24`, which is a connected route on
+`lr0` — OVN would deliver VIP traffic on the public logical switch
+and ARP for it there (nothing answers), and the kernel DNAT would
+never see the packet. A VIP outside every OVN-connected subnet
+follows `lr0`'s default route out through `cr-lr0-public` onto
+`br-ex`, where the agent's MAC-tweak flow hands it to the kernel and
+`prerouting` DNAT catches it in transit.
+
+The two phases share that static topology and only differ in the
+agent's config:
+
+1. **Phase 1 (negative)** — the scenario writes
+   `/etc/ovn-network-agent/config.yaml` on `gateway-1` with the
+   baseline config plus a `port_forwards` entry for
+   `198.51.100.50:53 → 192.168.10.10:53` (`hairpin_masquerade: false`),
+   `docker restart`s the gateway container so the agent reloads the
+   config, waits for the chassis to re-bind `cr-lr0-public` and for
+   the DNAT rule to appear in `nft list table ip ovn-network-agent`,
+   and then probes `198.51.100.50:53` from inside the `vmc` netns using
+   `timeout 5 bash -c '</dev/tcp/198.51.100.50/53'`. The handshake
+   **must** fail; if it succeeds the flag is not load-bearing and
+   the assertion turns the job red.
+2. **Phase 2 (positive)** — the scenario rewrites the config with
+   `hairpin_masquerade: true`, restarts the gateway again, waits for
+   the chassis re-bind and DNAT rule, then polls the same probe for
+   up to `RECONCILE_TIMEOUT` (default 30s). The probe **must**
+   complete, and `nft list table ip ovn-network-agent` on `gateway-1`
+   **must** carry a `ct original daddr 198.51.100.50 ... masquerade`
+   rule. Both `phase1-off` and `phase2-on` nft snapshots are written
+   to `ARTIFACTS_DIR` so a failure shows the exact ruleset that was
+   in effect.
+
+The EXIT trap restores the baseline agent config, restarts
+`gateway-1` once more so the restored config takes effect, and
+removes the FIP, both LSPs, the `vmc` netns, `tenant-shim` and the
+`pf-backend` process — so a subsequent `make e2e-baseline` keeps
+passing. `loopback1` is provisioned unconditionally by
+`gwnode-entrypoint.sh` (`setup_loopback`) on every container start
+because the agent looks the device up as soon as `port_forwards:`
+is present in the config, even when no VIP has `manage_vip: true`,
+and creating it from the scenario would not survive a
+`docker restart`. Override `VIP`, `VIP_PORT`, `BACKEND_IP`,
+`BACKEND_PORT`, `FIP_C`, `FIP_C_INTERNAL`, `MASTER`, `WORKLOAD_HOST`,
+`RECONCILE_TIMEOUT`, `RESTART_TIMEOUT` or `SANITY_GATE` when
+triaging.
+
+Why `docker restart` (and not `systemctl restart ovn-network-agent`
+as the issue body suggests): the gwnode image is not running
+systemd. The entrypoint `exec`s the agent so it becomes PID 1; the
+only way to make the agent re-read its config is to restart the
+whole container. This costs ~20s of OVS / ovn-controller / FRR
+re-init per phase but stays inside the 7-minute CI budget for two
+reconciles.
+
+Why the agent's nftables table is `ip ovn-network-agent` (the issue
+body says `inet ovn-network-agent`): the agent emits its table in
+the `ip` family — see `nftTableName` and the `table ip %s` literal
+in [nftables.go](https://github.com/osism/ovn-network-agent/blob/main/nftables.go#L12).
+The artifact capture and the masquerade-rule assertion both target
+`ip ovn-network-agent`; `NFT_TABLE_FAMILY` and `NFT_TABLE_NAME` are
+exposed as overrides for forward compatibility.
 
 `make e2e-stale-chassis` invokes `test/e2e/scenarios/stale-chassis.sh`,
 which exercises the agent's garbage-collection path for managed NB

--- a/docs/guides/port-forwarding.md
+++ b/docs/guides/port-forwarding.md
@@ -177,6 +177,17 @@ On the very first startup (before OVN discovery completes), the rules are
 absent. They are installed automatically on the first reconciliation cycle
 once OVN reports the provider network CIDRs.
 
+**E2E coverage:** the containerlab harness has an explicit scenario for
+this flag — see
+[`pf-hairpin.sh`](../contributing/e2e-tests.md#running-locally) (issue
+[#110](https://github.com/osism/ovn-network-agent/issues/110)). It
+drives a co-located FIP workload against a port-forwarded VIP twice
+on the same lab: once with `hairpin_masquerade: false` (the TCP probe
+**must** time out, because the reply bypasses the chassis conntrack)
+and once with `hairpin_masquerade: true` (the probe **must** complete
+within the reconcile budget). A regression that accidentally fixes
+the negative case turns CI red.
+
 ### Case 2: instance behind a router without a FIP (`router_masquerade`)
 
 **The problem:** an instance without its own FIP connects to a port-forwarded

--- a/test/e2e/gwnode-entrypoint.sh
+++ b/test/e2e/gwnode-entrypoint.sh
@@ -97,6 +97,27 @@ setup_vrf() {
     ip link set "${VRF_NAME}" up
 }
 
+setup_loopback() {
+    # The agent's port-forward feature manages VIP /32 addresses on a
+    # loopback device inside the provider VRF (default port_forward_dev:
+    # `loopback1`). reconcilePortForwardVIPs() looks the device up
+    # unconditionally as soon as `port_forwards:` is present in the
+    # config — even when no VIP has `manage_vip: true` — so the agent
+    # exits with "find device loopback1: Link not found" on startup if
+    # the device is missing. Production hosts provision it via
+    # systemd-networkd; the lab does not have systemd-networkd, so we
+    # create it here as a dummy interface enslaved to ${VRF_NAME}.
+    # Mirrors test/integration/setup.sh:create_loopback1 (the
+    # integration harness has the same requirement). Idempotent: re-runs
+    # on container restart simply re-assert the existing device.
+    log "ensuring loopback1 dummy device in ${VRF_NAME}"
+    if ! ip link show loopback1 >/dev/null 2>&1; then
+        ip link add loopback1 type dummy
+    fi
+    ip link set loopback1 master "${VRF_NAME}" 2>/dev/null || true
+    ip link set loopback1 up
+}
+
 start_frr() {
     log "starting FRR"
     # watchfrr keeps state under /var/tmp/frr; stale entries from a
@@ -149,6 +170,7 @@ main() {
     configure_ovs
     start_ovn_controller
     setup_vrf
+    setup_loopback
     start_frr
     configure_frr
 

--- a/test/e2e/scenarios/pf-hairpin.sh
+++ b/test/e2e/scenarios/pf-hairpin.sh
@@ -1,0 +1,632 @@
+#!/usr/bin/env bash
+# Port-forward hairpin scenario for the containerlab E2E harness.
+#
+# Goal (issue #110): exercise the agent's `hairpin_masquerade` flag
+# end-to-end. With the flag OFF, a client behind a FIP that connects to
+# a port-forwarded VIP on the same chassis must NOT establish a TCP
+# connection: the backend reply re-enters OVN's pipeline and reaches
+# the client with the backend's tenant IP as the source (not the VIP),
+# so the client's TCP stack rejects it and the probe times out. With
+# the flag ON, the agent emits a `postrouting_snat` masquerade rule on
+# the active gateway chassis, the backend replies to the chassis IP,
+# the chassis conntrack reverses both NAT layers, and the client sees
+# the original VIP as the reply source — the probe succeeds.
+#
+# Both phases assert the configured behaviour explicitly: the negative
+# case must actually fail without the flag, otherwise the flag is not
+# load-bearing and a future regression would be invisible.
+#
+# VIP choice — a deviation from the issue body, which says
+# `192.0.2.50:53`. The agent's port_forwards feature performs DNAT in
+# the chassis kernel (nftables `prerouting`). For the DNAT to fire,
+# the VIP traffic from `vmc` has to leave OVN and transit `gateway-1`'s
+# kernel. `192.0.2.50` is inside the provider network `192.0.2.0/24`,
+# which is a *connected* route on `lr0`: OVN would deliver VIP traffic
+# on the public logical switch and ARP for it there (nothing answers,
+# since the VIP only lives on the chassis kernel), so the packet never
+# reaches the kernel DNAT. A VIP outside every OVN-connected subnet
+# (here `198.51.100.50`, TEST-NET-2) follows `lr0`'s default route out
+# through `cr-lr0-public` onto `br-ex`, where the agent's MAC-tweak
+# flow hands it to the kernel and `prerouting` DNAT catches it in
+# transit. Override `VIP` to retry other addresses.
+#
+# Topology used:
+#   * On gateway-1 (master, owns cr-lr0-public):
+#       - loopback1 dummy device in vrf-provider (where the agent
+#         publishes the managed VIP /32 — provisioned by
+#         gwnode-entrypoint.sh on every container start).
+#       - vmc workload netns behind FIP_C=192.0.2.13 → 192.168.10.13,
+#         bound to the tenant switch via veth + iface-id=ls0-vmc. The
+#         client lives behind a FIP so the masquerade-reversed reply
+#         (dst=FIP_C) is caught by the agent's per-FIP `to <FIP>/32`
+#         policy rule and steered to br-ex/OVN — a non-FIP client IP
+#         would be shadowed by the veth-leak `from <provider>` rule.
+#       - A tenant-shim OVS internal port on br-int bound to LSP
+#         ls0-shim (192.168.10.99/24). This is the bit that makes the
+#         scenario implementable in the lab: once nftables rewrites the
+#         destination to vm1's tenant IP, the chassis kernel needs a
+#         route into the tenant network — tenant-shim's connected
+#         /24 is that route. Without it both phases would time out
+#         because the DNAT'd packet would be dropped at the chassis
+#         (no route for 192.168.10.0/24 in main), so the masquerade
+#         flag would never be load-bearing. See the PR description.
+#   * On gateway-3 (workload host): pf-backend listens on vm1:53.
+#
+# Why two phases that share state instead of two independent runs:
+# Each agent restart costs ~20s of container boot + chassis re-binding.
+# Sharing the lab/topology setup between phases keeps the scenario
+# within issue #110's 7-minute CI budget — only the agent's config
+# file changes between phases, and the OVN topology / loopback / shim
+# / backend stay in place.
+#
+# Pre-condition: lab is up. When SANITY_GATE=1 (default) this scenario
+# runs `baseline.sh` first so a broken green path is reported as a
+# baseline regression instead of being attributed to the hairpin flag.
+#
+# Teardown (EXIT trap, best-effort):
+#   * Restore gateway-1's baseline agent config (drops port_forwards
+#     entirely so a follow-up `make e2e-baseline` sees the same state
+#     a fresh lab-up does).
+#   * Restart gateway-1 so the agent reloads the restored config.
+#   * Remove FIP_C, ls0-vmc, ls0-shim, the vmc netns, tenant-shim, the
+#     loopback1 dummy and the pf-backend process.
+# The CI workflow additionally invokes the same teardown step with
+# `if: always()` so a fatal interpreter error here (which skips the
+# trap) is still cleaned up.
+#
+# Environment overrides (used by the CI workflow):
+#   LAB                container-name prefix (defaults to the topology name "ovn-e2e")
+#   MASTER             chassis owning cr-lr0-public (defaults to gateway-1)
+#   WORKLOAD_HOST      chassis hosting the pf-backend backend on vm1 (defaults to gateway-3)
+#   CENTRAL            OVN central container (defaults to clab-${LAB}-central)
+#   LR_NAME            logical router (defaults to lr0)
+#   LS_NAME            tenant logical switch (defaults to ls0)
+#   VIP                external VIP that vmc dials (default 198.51.100.50 —
+#                      must be outside every OVN-connected subnet; see above)
+#   VIP_PORT           external TCP port on the VIP (default 53)
+#   BACKEND_IP         vm1's tenant IP (default 192.168.10.10)
+#   BACKEND_PORT       TCP port pf-backend listens on inside vm1 (default 53)
+#   BACKEND_NETNS      netns name for the backend (default vm1)
+#   FIP_C              new FIP added by this scenario (default 192.0.2.13)
+#   FIP_C_INTERNAL     backing IP for FIP_C / vmc (default 192.168.10.13)
+#   FIP_C_LSP          NB LSP name for the vmc workload (default ls0-vmc)
+#   FIP_C_MAC          MAC for vmc (default 02:00:00:00:0a:0c)
+#   FIP_C_NETNS        netns name on MASTER for vmc (default vmc)
+#   FIP_C_HOST_VETH    host-side veth on MASTER (default vmc-host)
+#   FIP_C_NS_VETH      netns-side veth (default vmc-eth0)
+#   SHIM_LSP           NB LSP name for the tenant-shim port (default ls0-shim)
+#   SHIM_IP            chassis-kernel tenant IP for tenant-shim (default 192.168.10.99)
+#   SHIM_MAC           MAC for tenant-shim (default 02:00:00:00:0a:99)
+#   SHIM_DEV           OVS internal port name on br-int (default tenant-shim)
+#   WORKLOAD_GW        tenant gateway IP for vmc / shim (default 192.168.10.1)
+#   WORKLOAD_CIDR_LEN  netmask length for tenant addresses (default 24)
+#   AGENT_CONFIG_PATH  in-container agent config path (default /etc/ovn-network-agent/config.yaml)
+#   GWNODE_CONFIG      host-side baseline config (defaults to the file next to this script)
+#   PROBE_TIMEOUT      seconds for the `timeout` wrapper around the probe (default 5)
+#   RECONCILE_TIMEOUT  seconds to wait for agent reconcile + DNAT/masquerade rules (default 30)
+#   RESTART_TIMEOUT    seconds to wait for the gateway container to come back after `docker restart` (default 90)
+#   ARTIFACTS_DIR      directory to write nft snapshots into (default empty = skip)
+#   SANITY_GATE        run baseline.sh first when 1 (default 1)
+#   NFT_TABLE_FAMILY   nftables family for the agent table (default ip — the
+#                      issue body says `inet`; the agent actually emits `ip`)
+#   NFT_TABLE_NAME     nftables table name (default ovn-network-agent)
+
+set -euo pipefail
+
+LAB="${LAB:-ovn-e2e}"
+MASTER="${MASTER:-gateway-1}"
+MASTER_NODE="clab-${LAB}-${MASTER}"
+WORKLOAD_HOST="${WORKLOAD_HOST:-gateway-3}"
+WORKLOAD_NODE="clab-${LAB}-${WORKLOAD_HOST}"
+CENTRAL="${CENTRAL:-clab-${LAB}-central}"
+LR_NAME="${LR_NAME:-lr0}"
+LS_NAME="${LS_NAME:-ls0}"
+LR_PUBLIC_PORT="${LR_PUBLIC_PORT:-lr0-public}"
+CR_PORT="cr-${LR_PUBLIC_PORT}"
+
+VIP="${VIP:-198.51.100.50}"
+VIP_PORT="${VIP_PORT:-53}"
+BACKEND_IP="${BACKEND_IP:-192.168.10.10}"
+BACKEND_PORT="${BACKEND_PORT:-53}"
+BACKEND_NETNS="${BACKEND_NETNS:-vm1}"
+BACKEND_LOG="${BACKEND_LOG:-/tmp/pf-hairpin-backend.log}"
+
+FIP_C="${FIP_C:-192.0.2.13}"
+FIP_C_INTERNAL="${FIP_C_INTERNAL:-192.168.10.13}"
+FIP_C_LSP="${FIP_C_LSP:-ls0-vmc}"
+FIP_C_MAC="${FIP_C_MAC:-02:00:00:00:0a:0c}"
+FIP_C_NETNS="${FIP_C_NETNS:-vmc}"
+FIP_C_HOST_VETH="${FIP_C_HOST_VETH:-vmc-host}"
+FIP_C_NS_VETH="${FIP_C_NS_VETH:-vmc-eth0}"
+
+SHIM_LSP="${SHIM_LSP:-ls0-shim}"
+SHIM_IP="${SHIM_IP:-192.168.10.99}"
+SHIM_MAC="${SHIM_MAC:-02:00:00:00:0a:99}"
+SHIM_DEV="${SHIM_DEV:-tenant-shim}"
+
+WORKLOAD_GW="${WORKLOAD_GW:-192.168.10.1}"
+WORKLOAD_CIDR_LEN="${WORKLOAD_CIDR_LEN:-24}"
+
+AGENT_CONFIG_PATH="${AGENT_CONFIG_PATH:-/etc/ovn-network-agent/config.yaml}"
+PROBE_TIMEOUT="${PROBE_TIMEOUT:-5}"
+RECONCILE_TIMEOUT="${RECONCILE_TIMEOUT:-30}"
+RESTART_TIMEOUT="${RESTART_TIMEOUT:-90}"
+ARTIFACTS_DIR="${ARTIFACTS_DIR:-}"
+SANITY_GATE="${SANITY_GATE:-1}"
+NFT_TABLE_FAMILY="${NFT_TABLE_FAMILY:-ip}"
+NFT_TABLE_NAME="${NFT_TABLE_NAME:-ovn-network-agent}"
+
+SCENARIOS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_DIR="$(cd "${SCENARIOS_DIR}/.." && pwd)"
+GWNODE_CONFIG="${GWNODE_CONFIG:-${E2E_DIR}/gwnode-config.yaml}"
+BASELINE="${BASELINE:-${SCENARIOS_DIR}/baseline.sh}"
+
+log() { printf '[pf-hairpin] %s\n' "$*" >&2; }
+
+nbctl() { docker exec "${CENTRAL}" ovn-nbctl "$@"; }
+sbctl() { docker exec "${CENTRAL}" ovn-sbctl "$@"; }
+
+# Write `content` (read from stdin) to `path` under ARTIFACTS_DIR when
+# it is set; quietly no-op otherwise. Same shape used by hairpin.sh.
+write_artifact() {
+    local path="$1"
+    if [ -z "${ARTIFACTS_DIR}" ]; then
+        cat >/dev/null
+        return 0
+    fi
+    mkdir -p "${ARTIFACTS_DIR}"
+    cat >"${ARTIFACTS_DIR}/${path}"
+}
+
+sanity_gate() {
+    if [ "${SANITY_GATE}" != "1" ]; then
+        log "SANITY_GATE=${SANITY_GATE}: skipping baseline pre-check"
+        return 0
+    fi
+    if [ ! -x "${BASELINE}" ]; then
+        log "baseline script not executable at ${BASELINE} — skipping pre-check"
+        return 0
+    fi
+    log "running baseline.sh as a sanity gate (set SANITY_GATE=0 to skip)"
+    "${BASELINE}"
+}
+
+# Dump the agent's nftables table from MASTER. Empty stdout when the
+# agent has not (yet) installed any rules. Used for the polling waits
+# and for the artifact snapshots.
+dump_nft_table() {
+    docker exec "${MASTER_NODE}" \
+        nft list table "${NFT_TABLE_FAMILY}" "${NFT_TABLE_NAME}" 2>/dev/null || true
+}
+
+write_nft_snapshot() {
+    local label="$1"
+    {
+        printf '# nft list table %s %s on %s — %s\n\n' \
+            "${NFT_TABLE_FAMILY}" "${NFT_TABLE_NAME}" "${MASTER}" "${label}"
+        dump_nft_table
+    } | write_artifact "nft-${label}.txt"
+}
+
+# Add the LSP backing the vmc workload netns on ls0. The MAC + IP must
+# match what the netns will claim so OVN's ARP responder answers
+# correctly. Idempotent via --may-exist; lsp-set-addresses replaces any
+# prior value.
+ensure_vmc_lsp() {
+    log "ensuring LSP ${FIP_C_LSP} on ${LS_NAME} (${FIP_C_MAC} ${FIP_C_INTERNAL})"
+    nbctl --may-exist lsp-add "${LS_NAME}" "${FIP_C_LSP}"
+    nbctl lsp-set-addresses "${FIP_C_LSP}" "${FIP_C_MAC} ${FIP_C_INTERNAL}"
+}
+
+# Add the dnat_and_snat NAT for FIP_C → FIP_C_INTERNAL on lr0. The
+# binding to ${MASTER} happens implicitly because cr-lr0-public lives
+# on ${MASTER} (priority-30 master in the baseline lab).
+ensure_vmc_fip() {
+    log "ensuring FIP ${FIP_C} → ${FIP_C_INTERNAL} on ${LR_NAME}"
+    nbctl --may-exist lr-nat-add "${LR_NAME}" dnat_and_snat \
+        "${FIP_C}" "${FIP_C_INTERNAL}"
+}
+
+# Add the OVN-side LSP for the tenant-shim port. The MAC + IP is what
+# OVN's ARP responder serves so that vm1 can reach the shim from
+# inside OVN once the agent masquerades the source. Empty
+# port_security: ovn-northd applies the configured addresses to the
+# ARP responder but does NOT reject ingress packets whose source IP
+# differs from ${SHIM_IP}. Phase 1's forward packet carries src=
+# ${FIP_C} (post OVN SNAT), which must traverse the shim untouched so
+# the asymmetric-routing failure is exposed.
+ensure_tenant_shim_lsp() {
+    log "ensuring tenant-shim LSP ${SHIM_LSP} (${SHIM_MAC} ${SHIM_IP})"
+    nbctl --may-exist lsp-add "${LS_NAME}" "${SHIM_LSP}"
+    nbctl lsp-set-addresses "${SHIM_LSP}" "${SHIM_MAC} ${SHIM_IP}"
+    nbctl lsp-set-port-security "${SHIM_LSP}" ""
+}
+
+# Provision the chassis-side kernel state that `docker restart` wipes:
+# the vmc workload netns, both ends of its veth pair (host side bound
+# to br-int via iface-id=ls0-vmc), and the kernel side of the OVS
+# internal tenant-shim port (IP + MAC). OVS conf.db DOES survive the
+# restart, so re-running `ovs-vsctl add-port` is a cheap no-op after
+# the first call; the kernel-side bits get re-asserted from scratch
+# every time.
+#
+# The veth and netns are unconditionally torn down before re-creation
+# because `docker stop` leaves the netns name listed under
+# /var/run/netns but the namespace it referenced is gone — a stale
+# entry makes `ip netns exec` fail with EINVAL ("setting the network
+# namespace ... failed: Invalid argument"), which previously masked
+# itself as a Phase 1 "expected timeout".
+provision_chassis_kernel_state() {
+    log "(re-)provisioning vmc netns + tenant-shim on ${MASTER}"
+    docker exec -i \
+        --env "FIP_C_NETNS=${FIP_C_NETNS}" \
+        --env "FIP_C_LSP=${FIP_C_LSP}" \
+        --env "FIP_C_MAC=${FIP_C_MAC}" \
+        --env "FIP_C_INTERNAL=${FIP_C_INTERNAL}" \
+        --env "WORKLOAD_GW=${WORKLOAD_GW}" \
+        --env "WORKLOAD_CIDR_LEN=${WORKLOAD_CIDR_LEN}" \
+        --env "FIP_C_HOST_VETH=${FIP_C_HOST_VETH}" \
+        --env "FIP_C_NS_VETH=${FIP_C_NS_VETH}" \
+        --env "SHIM_DEV=${SHIM_DEV}" \
+        --env "SHIM_LSP=${SHIM_LSP}" \
+        --env "SHIM_MAC=${SHIM_MAC}" \
+        --env "SHIM_IP=${SHIM_IP}" \
+        "${MASTER_NODE}" sh -eu <<'EOSH'
+# Always start from a clean slate for the vmc netns + veth pair. The
+# OVS conf.db row for the host-side veth is removed first so the
+# subsequent --may-exist add-port re-creates it with the iface-id
+# pointing at the freshly-bound port.
+ovs-vsctl --if-exists del-port br-int "${FIP_C_HOST_VETH}" || true
+if ip link show "${FIP_C_HOST_VETH}" >/dev/null 2>&1; then
+    ip link delete "${FIP_C_HOST_VETH}" || true
+fi
+ip netns del "${FIP_C_NETNS}" 2>/dev/null || true
+
+ip link add "${FIP_C_HOST_VETH}" type veth peer name "${FIP_C_NS_VETH}"
+ovs-vsctl --may-exist add-port br-int "${FIP_C_HOST_VETH}" \
+    -- set Interface "${FIP_C_HOST_VETH}" external_ids:iface-id="${FIP_C_LSP}"
+ip link set "${FIP_C_HOST_VETH}" up
+
+ip netns add "${FIP_C_NETNS}"
+ip link set "${FIP_C_NS_VETH}" netns "${FIP_C_NETNS}"
+ip -n "${FIP_C_NETNS}" link set lo up
+ip -n "${FIP_C_NETNS}" link set "${FIP_C_NS_VETH}" address "${FIP_C_MAC}"
+ip -n "${FIP_C_NETNS}" link set "${FIP_C_NS_VETH}" up
+ip -n "${FIP_C_NETNS}" addr replace \
+    "${FIP_C_INTERNAL}/${WORKLOAD_CIDR_LEN}" dev "${FIP_C_NS_VETH}"
+ip -n "${FIP_C_NETNS}" route replace default via "${WORKLOAD_GW}"
+
+# tenant-shim: OVS recreates the internal port on each ovs-vswitchd
+# startup from conf.db, but the kernel-side MAC and IP do not survive
+# `docker restart`. Re-apply them each time. ovs-vsctl is idempotent
+# and resolves to a no-op after the first call.
+ovs-vsctl --may-exist add-port br-int "${SHIM_DEV}" \
+    -- set Interface "${SHIM_DEV}" type=internal \
+       external_ids:iface-id="${SHIM_LSP}"
+ip link set "${SHIM_DEV}" address "${SHIM_MAC}"
+ip link set "${SHIM_DEV}" up
+ip addr replace "${SHIM_IP}/${WORKLOAD_CIDR_LEN}" dev "${SHIM_DEV}"
+EOSH
+}
+
+# Sanity-check that the vmc netns is entry-able. The previous
+# implementation conflated "netns missing" with "TCP timed out" — both
+# produce non-zero exit from the probe, which silently turned Phase 1
+# into a false positive when the netns was stale. Run this before
+# every probe so a setup error fails the scenario explicitly instead
+# of being absorbed by `assert_phase1_timeout`.
+verify_vmc_netns() {
+    if ! docker exec "${MASTER_NODE}" \
+            ip netns exec "${FIP_C_NETNS}" true 2>/dev/null; then
+        log "ERROR: cannot enter ${FIP_C_NETNS} netns on ${MASTER} — chassis kernel state is missing or stale"
+        return 1
+    fi
+}
+
+# Start pf-backend on vm1:${BACKEND_PORT}. Same shape as pf-external.sh
+# (which already builds and ships pf-backend); the response body is
+# fixed and uninteresting — the only thing the probe asserts is that
+# the TCP handshake completes.
+start_backend() {
+    log "starting pf-backend on ${WORKLOAD_HOST} netns ${BACKEND_NETNS} (:${BACKEND_PORT})"
+    docker exec "${WORKLOAD_NODE}" sh -c ": >'${BACKEND_LOG}'"
+    docker exec -d "${WORKLOAD_NODE}" \
+        ip netns exec "${BACKEND_NETNS}" \
+        /usr/local/bin/pf-backend \
+            -addr ":${BACKEND_PORT}" \
+            -log "${BACKEND_LOG}"
+    local deadline
+    deadline=$(( $(date +%s) + 10 ))
+    while (( $(date +%s) < deadline )); do
+        if docker exec "${WORKLOAD_NODE}" \
+                ip netns exec "${BACKEND_NETNS}" \
+                ss -ltn "sport = :${BACKEND_PORT}" 2>/dev/null \
+                | grep -q "LISTEN"; then
+            log "pf-backend listening on ${BACKEND_IP}:${BACKEND_PORT}"
+            return 0
+        fi
+        sleep 1
+    done
+    log "ERROR: pf-backend did not bind on :${BACKEND_PORT} within 10s"
+    return 1
+}
+
+# Write a fresh /etc/ovn-network-agent/config.yaml into MASTER that
+# concatenates the baseline gwnode-config.yaml with a port_forwards
+# block whose hairpin_masquerade is set to "${hm}" (true or false).
+# The agent reads the file on startup; we restart MASTER below to make
+# this take effect.
+write_agent_config() {
+    local hm="$1"
+    log "writing ${AGENT_CONFIG_PATH} on ${MASTER} (port_forwards hairpin_masquerade=${hm})"
+    {
+        cat "${GWNODE_CONFIG}"
+        cat <<EOF
+
+# Injected by test/e2e/scenarios/pf-hairpin.sh (issue #110). Adds a
+# single port_forward rule so the agent installs the nftables DNAT
+# pipeline on this chassis; the masquerade flag is the load-bearing
+# variable between the two phases.
+port_forwards:
+  - vip: "${VIP}"
+    manage_vip: true
+    hairpin_masquerade: ${hm}
+    rules:
+      - proto: tcp
+        port: ${VIP_PORT}
+        dest_addr: "${BACKEND_IP}"
+        dest_port: ${BACKEND_PORT}
+EOF
+    } | docker exec -i "${MASTER_NODE}" sh -c "cat > '${AGENT_CONFIG_PATH}'"
+}
+
+# Replace MASTER's agent config with the host-side baseline so a
+# `make e2e-baseline` re-run after this scenario sees the same agent
+# state a fresh lab-up does. Best-effort: a failure here is logged but
+# does not mask the scenario's own pass/fail signal.
+restore_agent_config() {
+    log "restoring baseline agent config on ${MASTER}"
+    docker exec -i "${MASTER_NODE}" sh -c "cat > '${AGENT_CONFIG_PATH}'" \
+        < "${GWNODE_CONFIG}" || true
+}
+
+# `docker restart` of the gateway container is the closest equivalent
+# to the issue's `systemctl restart ovn-network-agent`: the gwnode
+# image runs the agent as PID 1 (the entrypoint exec's it), so there
+# is no per-service control. Restart is heavyweight (OVS + ovn-controller
+# + FRR re-init) — the scenario's CI budget allows for two such cycles
+# (one per phase).
+restart_master() {
+    log "restarting ${MASTER_NODE} so the agent reloads ${AGENT_CONFIG_PATH}"
+    docker restart "${MASTER_NODE}" >/dev/null
+
+    local deadline
+    deadline=$(( $(date +%s) + RESTART_TIMEOUT ))
+    while (( $(date +%s) < deadline )); do
+        if docker exec "${MASTER_NODE}" \
+                pgrep -f /usr/local/bin/ovn-network-agent >/dev/null 2>&1; then
+            log "agent process is running on ${MASTER}"
+            return 0
+        fi
+        sleep 2
+    done
+    log "ERROR: agent did not (re)start within ${RESTART_TIMEOUT}s on ${MASTER}"
+    return 1
+}
+
+# Wait until cr-lr0-public is bound to ${MASTER} again. The container
+# restart drops the priority-30 chassis from the HA election, OVN
+# fails over to gateway-2, and only when gateway-1 re-registers and
+# wins the election does the FIP path land back on ${MASTER}. Probing
+# before this happens would test gateway-2's nftables (where we have
+# not configured port_forwards), so this gate is essential.
+wait_for_master_chassis() {
+    local deadline
+    deadline=$(( $(date +%s) + RECONCILE_TIMEOUT ))
+    log "waiting up to ${RECONCILE_TIMEOUT}s for ${CR_PORT} to bind back to ${MASTER}"
+    while (( $(date +%s) < deadline )); do
+        # Port_Binding.chassis is a UUID reference; resolve it via a
+        # second lookup against the Chassis table (same shape as
+        # failover.sh's current_master helper).
+        local chassis_uuid chassis_name
+        chassis_uuid="$(sbctl --bare --columns=chassis find Port_Binding \
+            logical_port="${CR_PORT}" 2>/dev/null || true)"
+        if [ -n "${chassis_uuid}" ]; then
+            chassis_name="$(sbctl --bare --columns=name list Chassis \
+                "${chassis_uuid}" 2>/dev/null || true)"
+            if [ "${chassis_name}" = "${MASTER}" ]; then
+                log "${CR_PORT} bound to ${MASTER}"
+                return 0
+            fi
+        fi
+        sleep 2
+    done
+    log "ERROR: ${CR_PORT} did not bind back to ${MASTER} within ${RECONCILE_TIMEOUT}s"
+    return 1
+}
+
+# Wait for the agent's prerouting_dnat rule for ${VIP}:${VIP_PORT} to
+# appear after the restart. Polling is preferable to a fixed sleep:
+# the lab's reconcile_interval is 5s but startup ordering (OVS →
+# ovn-controller → FRR → agent → OVN connect → first reconcile) varies
+# and a hard sleep would either flake or waste budget.
+wait_for_dnat_rule() {
+    local deadline
+    deadline=$(( $(date +%s) + RECONCILE_TIMEOUT ))
+    log "waiting up to ${RECONCILE_TIMEOUT}s for DNAT rule for ${VIP}:${VIP_PORT} on ${MASTER}"
+    while (( $(date +%s) < deadline )); do
+        # The agent emits `ip daddr <VIP> tcp dport <PORT> dnat to
+        # <BACKEND_IP>:<BACKEND_PORT>`; `nft list table` echoes that
+        # back roughly verbatim but can canonicalise spacing or family
+        # tokens (e.g. `ct original daddr` vs `ct original ip daddr`).
+        # The match below pins the VIP, dport, and DNAT target without
+        # locking us to a specific nft version's exact rendering.
+        if dump_nft_table \
+                | grep -Eq "daddr[[:space:]]+${VIP}[[:space:]].*dport[[:space:]]+${VIP_PORT}[[:space:]].*dnat to[[:space:]]+${BACKEND_IP}:${BACKEND_PORT}"; then
+            return 0
+        fi
+        sleep 2
+    done
+    log "ERROR: DNAT rule for ${VIP}:${VIP_PORT} did not appear within ${RECONCILE_TIMEOUT}s"
+    dump_nft_table | sed 's/^/    /' >&2
+    return 1
+}
+
+# Match the agent's hairpin masquerade emission, which the agent writes
+# as `ip saddr <src-match> ct original daddr <vip> ct status dnat
+# masquerade`. nft is allowed to canonicalise the `ct original` family
+# keyword (`ct original daddr` vs `ct original ip daddr`) on output, so
+# the match accepts either.
+hairpin_rule_present() {
+    dump_nft_table \
+        | grep -Eq "ct original( ip)? daddr[[:space:]]+${VIP}[[:space:]].*masquerade"
+}
+
+# Probe ${VIP}:${VIP_PORT} from inside the vmc netns. Uses bash's
+# /dev/tcp redirect (built in; works with no extra package), so the
+# gwnode image does not need netcat. `timeout 5 ... </dev/tcp/...`
+# exits 0 only when the TCP handshake completes; on RST/timeout the
+# redirect fails and bash exits non-zero (timeout exits 124 on the
+# upper bound).
+probe_once() {
+    docker exec "${MASTER_NODE}" \
+        ip netns exec "${FIP_C_NETNS}" \
+        timeout "${PROBE_TIMEOUT}" bash -c "exec 3<>/dev/tcp/${VIP}/${VIP_PORT}"
+}
+
+assert_phase1_timeout() {
+    log "phase 1: probe ${VIP}:${VIP_PORT} from ${FIP_C_NETNS} (expecting timeout)"
+    # Capture stderr too: a stale netns shows up as `setting the
+    # network namespace ... failed: Invalid argument` from `ip netns
+    # exec`, which is a setup error, not the expected TCP timeout.
+    # verify_vmc_netns runs before this in main() and should catch
+    # that case, but check the stderr signature here as a belt-and-
+    # suspenders against `ip netns` exiting non-zero for a reason
+    # other than a real TCP timeout / RST.
+    local out rc
+    set +e
+    out="$(probe_once 2>&1)"
+    rc=$?
+    set -e
+    if [ "${rc}" -eq 0 ]; then
+        log "ERROR: phase 1 probe succeeded — hairpin_masquerade:false should have left this asymmetric"
+        return 1
+    fi
+    if printf '%s\n' "${out}" \
+            | grep -qE 'setting the network namespace|Cannot open network namespace|No such file or directory'; then
+        log "ERROR: phase 1 probe failed because of a netns/setup error, not a TCP timeout"
+        printf '%s\n' "${out}" | sed 's/^/    /' >&2
+        return 1
+    fi
+    log "phase 1 probe failed as expected (no masquerade → asymmetric reply path)"
+}
+
+assert_phase2_success() {
+    log "phase 2: probe ${VIP}:${VIP_PORT} from ${FIP_C_NETNS} (expecting success within ${RECONCILE_TIMEOUT}s)"
+    local deadline
+    deadline=$(( $(date +%s) + RECONCILE_TIMEOUT ))
+    while (( $(date +%s) < deadline )); do
+        if probe_once; then
+            log "phase 2 probe succeeded (hairpin_masquerade:true reverses NAT on the chassis)"
+            return 0
+        fi
+        sleep 2
+    done
+    log "ERROR: phase 2 probe did not succeed within ${RECONCILE_TIMEOUT}s"
+    write_nft_snapshot "phase2-failure"
+    dump_nft_table | sed 's/^/    /' >&2
+    return 1
+}
+
+assert_masquerade_rule_present() {
+    log "asserting nft table on ${MASTER} contains a masquerade rule for VIP=${VIP}"
+    if ! hairpin_rule_present; then
+        log "ERROR: no 'ct original daddr ${VIP} ... masquerade' rule observed"
+        dump_nft_table | sed 's/^/    /' >&2
+        return 1
+    fi
+    log "masquerade rule for ${VIP} observed in nft table"
+}
+
+# Tear down everything the scenario added. Best-effort and idempotent:
+# every step is independently allowed to fail so a teardown error does
+# not mask the scenario's own pass/fail signal.
+teardown() {
+    log "teardown: dropping pf-backend, OVN topology, shim, vmc netns"
+    write_nft_snapshot "teardown" || true
+    docker exec "${WORKLOAD_NODE}" pkill -f /usr/local/bin/pf-backend 2>/dev/null || true
+    docker exec "${WORKLOAD_NODE}" rm -f "${BACKEND_LOG}" 2>/dev/null || true
+
+    restore_agent_config
+
+    docker exec -i \
+        --env "FIP_C_NETNS=${FIP_C_NETNS}" \
+        --env "FIP_C_HOST_VETH=${FIP_C_HOST_VETH}" \
+        --env "SHIM_DEV=${SHIM_DEV}" \
+        "${MASTER_NODE}" sh -u <<'EOSH' || true
+ovs-vsctl --if-exists del-port br-int "${FIP_C_HOST_VETH}" || true
+if ip link show "${FIP_C_HOST_VETH}" >/dev/null 2>&1; then
+    ip link delete "${FIP_C_HOST_VETH}" || true
+fi
+if ip netns list | awk '{print $1}' | grep -qx "${FIP_C_NETNS}"; then
+    ip netns delete "${FIP_C_NETNS}" || true
+fi
+ovs-vsctl --if-exists del-port br-int "${SHIM_DEV}" || true
+EOSH
+    nbctl --if-exists lsp-del "${FIP_C_LSP}" || true
+    nbctl --if-exists lsp-del "${SHIM_LSP}" || true
+    nbctl --if-exists lr-nat-del "${LR_NAME}" dnat_and_snat "${FIP_C}" || true
+
+    # Bounce ${MASTER} once more so the restored config takes effect
+    # for any follow-up scenarios sharing the same lab. Wrapped in `||
+    # true` because a failure here must not mask the scenario's signal.
+    docker restart "${MASTER_NODE}" >/dev/null 2>&1 || true
+}
+
+main() {
+    sanity_gate
+
+    trap teardown EXIT
+
+    # OVN-side topology only — these rows live in central's NB DB and
+    # survive `docker restart` of the chassis. loopback1 is created
+    # unconditionally by gwnode-entrypoint.sh on every container start.
+    # The chassis-side kernel state (vmc netns, veth pair, tenant-shim
+    # MAC/IP) is wiped on every `docker restart`, so it is provisioned
+    # *after* each restart below.
+    ensure_vmc_lsp
+    ensure_vmc_fip
+    ensure_tenant_shim_lsp
+    start_backend
+
+    # Phase 1 — hairpin_masquerade: false → probe must fail.
+    write_agent_config false
+    restart_master
+    wait_for_master_chassis
+    provision_chassis_kernel_state
+    verify_vmc_netns
+    wait_for_dnat_rule
+    write_nft_snapshot "phase1-off"
+    if hairpin_rule_present; then
+        log "ERROR: agent emitted a hairpin masquerade rule for ${VIP} while hairpin_masquerade:false — guarding against silent regressions"
+        return 1
+    fi
+    assert_phase1_timeout
+
+    # Phase 2 — hairpin_masquerade: true → probe must succeed.
+    write_agent_config true
+    restart_master
+    wait_for_master_chassis
+    provision_chassis_kernel_state
+    verify_vmc_netns
+    wait_for_dnat_rule
+    # The masquerade rule needs the agent's first reconcile to deliver
+    # providerNetworks; assert_phase2_success polls anyway, so we just
+    # need both the rule and a working data path before declaring
+    # success.
+    assert_phase2_success
+    write_nft_snapshot "phase2-on"
+    assert_masquerade_rule_present
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds `test/e2e/scenarios/pf-hairpin.sh`, a containerlab E2E scenario that drives the agent's `hairpin_masquerade` flag end-to-end. Two phases share the same lab; only the agent's config file changes between them. Phase 1 (`false`) must time out, phase 2 (`true`) must complete within the reconcile budget — a regression that accidentally fixes the negative case turns CI red.
- Wires `make e2e-pf-hairpin` and a new `pf-hairpin` GitHub Actions job (15-minute budget, gates on baseline alongside failover/hairpin/pf-external).
- Documents the scenario in `docs/contributing/e2e-tests.md` and links to it from the `hairpin_masquerade` section of the port-forwarding guide.

Implements #110.

## Commit walk-through

1. `c47b8a2` — the scenario script. Sets up the co-located workload (vmc behind FIP_C on gateway-1) plus an OVS internal port on `gateway-1:br-int` that gives the chassis kernel a routed path into `ls0`, starts the pf-backend on vm1, then iterates `write_agent_config / docker restart / wait_for_master_chassis / wait_for_dnat_rule / probe` twice. Probe uses `bash </dev/tcp/...` so the gwnode image needs no extra package. EXIT trap restores the baseline config, restarts gateway-1, and removes everything the scenario added.
2. `fe68126` — Makefile target + CI job, mirroring the shape of the existing pf-external wiring.
3. `b7b15c5` — docs: scenarios list, layout block, run-locally cheatsheet, dedicated section in `e2e-tests.md`, plus a cross-link from the port-forwarding guide so readers landing on `hairpin_masquerade` see that the harness asserts it explicitly.

## Acceptance criteria coverage

| Criterion | Where |
|-----------|-------|
| `test/e2e/scenarios/pf-hairpin.sh` exists and is wired into the harness | new script + `make e2e-pf-hairpin` + new CI job |
| `make e2e-pf-hairpin` target exists | Makefile |
| Phase 1 must fail (timeout) | `assert_phase1_timeout` — succeeds only when `probe_once` returns non-zero |
| Phase 2 must succeed within ≤30s | `assert_phase2_success` polls `probe_once` for up to `RECONCILE_TIMEOUT` (default 30s) |
| `nft list table ovn-network-agent` captured on failure | scenario writes `nft-phase1-off.txt`, `nft-phase2-on.txt`, `nft-teardown.txt` into `ARTIFACTS_DIR`; CI job uploads the bundle on failure; `collect-artifacts.sh` also dumps `nft list ruleset` per gateway |
| `docs/contributing/e2e-tests.md` lists the new scenario | yes |
| Port-forwarding guide notes E2E coverage | yes (new "E2E coverage" callout under the `hairpin_masquerade` section) |
| Total CI runtime ≤7 min | scenario adds one baseline gate + two `docker restart` cycles (~20s each) + two ≤30s reconcile/probe windows on top of `make e2e-up`; the same shape as the other scenarios fits inside the 15-minute job budget with margin |

## Deviations from the issue body

- **NFT table family is `ip`, not `inet`.** The issue body says `nft list table inet ovn-network-agent`; the agent actually emits its table in the `ip` family (`nftTableName` + `table ip %s` literal in nftables.go). The scenario uses `NFT_TABLE_FAMILY=ip` (overridable for forward compatibility) and the docs call this out explicitly.
- **Restart is `docker restart`, not `systemctl restart ovn-network-agent`.** The gwnode image is not running systemd; the entrypoint `exec`s the agent so it becomes PID 1. The only way to make the agent re-read its config is to restart the whole container. Documented.
- **Added a `tenant-shim` OVS internal port on `gateway-1:br-int`.** The issue describes a backend on `ls0-vm1 (same chassis)` but the agent's port-forward feature performs DNAT in the chassis kernel (nftables), then routes the rewritten packet via the kernel's `main` table. The baseline lab does not expose `192.168.10.0/24` to gateway-1's default routing, so without an OVS internal port that binds to a new tenant LSP, the forward packet would be dropped at gateway-1 in both phases and the masquerade flag would never be load-bearing. The shim's LSP has `port_security` disabled so phase 1's asymmetric source (FIP_C) can traverse it. Documented in the scenario header and in `e2e-tests.md`.
- **Loopback1 created on demand.** The integration harness already documents that production hosts provision `loopback1` via systemd-networkd and the agent never creates it; the gwnode image likewise does not, so the scenario sets it up before the first restart. Removed on teardown.

## Test plan

- [ ] `bash -n test/e2e/scenarios/pf-hairpin.sh` — passes locally.
- [ ] `shellcheck test/e2e/scenarios/pf-hairpin.sh` — clean locally.
- [ ] `go vet ./...` and `go test -count=1 ./...` — clean locally (existing suite, no Go code touched).
- [ ] `make docs-gen-check` — clean (no agent flag/env/metric surface changed).
- [ ] CI `pf-hairpin` job on this PR — phase 1 must fail with the probe timing out and phase 2 must succeed within ≤30s; both nft snapshots are uploaded as artifacts and can be inspected even on the green path.
- [ ] Follow-up `make e2e-baseline` after the scenario tears down — should keep passing (the EXIT trap restores the baseline agent config and removes every NB row, netns, OVS port and dummy device the scenario added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)