### PR TITLE
Agent: port-forward-only mode — run as a standalone VIP service without OVN connections

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -13,7 +13,10 @@ import (
 
 // Agent is the main OVN route synchronization agent.
 type Agent struct {
-	cfg     Config
+	cfg Config
+	// ovn is the OVN database client. It is nil in port-forward-only mode
+	// (cfg.PortForwardOnly), where the agent runs as a standalone VIP
+	// service without any OVN connection.
 	ovn     *OVNClient
 	routing *RouteManager
 
@@ -60,7 +63,11 @@ func NewAgent(cfg Config) (*Agent, error) {
 		staleCleanupJitter: time.Duration(rand.Int63n(int64(maxStaleCleanupJitter))),
 	}
 
-	a.ovn = NewOVNClient(cfg, a.triggerReconcile)
+	// In port-forward-only mode there is no OVN connection; a.ovn stays nil
+	// and every OVN-dependent step is gated on cfg.PortForwardOnly.
+	if !cfg.PortForwardOnly {
+		a.ovn = NewOVNClient(cfg, a.triggerReconcile)
+	}
 
 	return a, nil
 }
@@ -98,19 +105,24 @@ func connectWithRetry(ctx context.Context, connect func(context.Context) error, 
 // Run starts the agent: connects to OVN, runs initial reconciliation,
 // then loops on events and periodic reconciliation.
 func (a *Agent) Run(ctx context.Context) error {
-	// Verify that the bridge device exists and is up before proceeding.
-	if err := a.routing.CheckBridgeDevice(); err != nil {
-		return fmt.Errorf("bridge device check failed: %w", err)
-	}
+	// Bridge setup exists for FIP ARP resolution and is OVN-gateway
+	// specific. In port-forward-only mode the node need not have br-ex, so
+	// the bridge device, its link-local IP and proxy ARP are all skipped.
+	if !a.cfg.PortForwardOnly {
+		// Verify that the bridge device exists and is up before proceeding.
+		if err := a.routing.CheckBridgeDevice(); err != nil {
+			return fmt.Errorf("bridge device check failed: %w", err)
+		}
 
-	// Add a link-local IP to br-ex so the kernel can ARP on the interface.
-	if err := a.routing.EnsureBridgeIP(a.cfg.BridgeIP); err != nil {
-		return fmt.Errorf("ensure bridge IP: %w", err)
-	}
+		// Add a link-local IP to br-ex so the kernel can ARP on the interface.
+		if err := a.routing.EnsureBridgeIP(a.cfg.BridgeIP); err != nil {
+			return fmt.Errorf("ensure bridge IP: %w", err)
+		}
 
-	// Enable proxy ARP so the kernel responds to ARP requests for FIP addresses.
-	if err := a.routing.EnableProxyARP(); err != nil {
-		return fmt.Errorf("enable proxy ARP: %w", err)
+		// Enable proxy ARP so the kernel responds to ARP requests for FIP addresses.
+		if err := a.routing.EnableProxyARP(); err != nil {
+			return fmt.Errorf("enable proxy ARP: %w", err)
+		}
 	}
 
 	// Set up veth VRF leak for route leaking between default VRF and provider VRF.
@@ -123,21 +135,25 @@ func (a *Agent) Run(ctx context.Context) error {
 		return fmt.Errorf("port forward setup: %w", err)
 	}
 
-	if a.cfg.GatewayPort == "" {
-		slog.Info("tracking all chassisredirect ports (multi-router mode)")
+	if a.cfg.PortForwardOnly {
+		slog.Info("port-forward-only mode: serving configured VIPs without an OVN connection")
 	} else {
-		slog.Info("tracking single chassisredirect port", "gateway_port", a.cfg.GatewayPort)
-	}
+		if a.cfg.GatewayPort == "" {
+			slog.Info("tracking all chassisredirect ports (multi-router mode)")
+		} else {
+			slog.Info("tracking single chassisredirect port", "gateway_port", a.cfg.GatewayPort)
+		}
 
-	// Connect to OVN with retry.
-	if err := connectWithRetry(ctx, a.ovn.Connect, ovnConnectRetryInterval); err != nil {
-		return err
-	}
-	defer a.ovn.Close()
+		// Connect to OVN with retry.
+		if err := connectWithRetry(ctx, a.ovn.Connect, ovnConnectRetryInterval); err != nil {
+			return err
+		}
+		defer a.ovn.Close()
 
-	// Restore any gateway chassis priorities that were drained by a previous run.
-	if a.cfg.DrainOnShutdown {
-		a.ovn.RestoreDrainedGateways(ctx, a.ovn.GetState().LocalChassisName)
+		// Restore any gateway chassis priorities that were drained by a previous run.
+		if a.cfg.DrainOnShutdown {
+			a.ovn.RestoreDrainedGateways(ctx, a.ovn.GetState().LocalChassisName)
+		}
 	}
 
 	// Initial reconciliation
@@ -161,7 +177,8 @@ func (a *Agent) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			// Drain must happen BEFORE cleanup and BEFORE OVN connection close.
 			// Use a fresh context since the parent ctx is already cancelled.
-			if a.cfg.DrainOnShutdown {
+			// Drain is OVN-specific and is skipped in port-forward-only mode.
+			if !a.cfg.PortForwardOnly && a.cfg.DrainOnShutdown {
 				drainCtx, drainCancel := context.WithTimeout(context.Background(), a.cfg.DrainTimeout)
 				slog.Info("drain mode active, migrating gateways away", "timeout", a.cfg.DrainTimeout)
 				drainStart := time.Now()
@@ -207,7 +224,13 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 		recordReconcile(trigger, time.Since(start))
 	}()
 
-	state := a.ovn.GetState()
+	// In port-forward-only mode there is no OVN client; a zero-value
+	// OVNState (no local routers, no SNAT IPs, no discovered networks)
+	// drives the rest of the cycle through the port-forward-only path.
+	var state OVNState
+	if a.ovn != nil {
+		state = a.ovn.GetState()
+	}
 
 	// Compute effective network filters for this cycle.
 	a.effectiveFilters = a.computeEffectiveNetworks(state.DiscoveredNetworks)
@@ -268,7 +291,13 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 		slog.Debug("desired IP list", "ips", desiredIPs)
 	}
 
-	if state.HasLocalRouters {
+	switch {
+	case a.cfg.PortForwardOnly:
+		// Port-forward-only mode: no OVN state to act on. OVS flows,
+		// gateway routing, and veth-leak/prefix-list network
+		// reconciliation are all OVN-driven and skipped entirely — only
+		// port forwarding and the VIP routes below are managed.
+	case state.HasLocalRouters:
 		// Ensure OVS MAC-tweak flows are in place (only when active).
 		if err := a.routing.EnsureOVSFlows(); err != nil {
 			slog.Error("failed to ensure OVS flows", "error", err)
@@ -310,7 +339,7 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 		if err := a.routing.ReconcileFRRPrefixList(a.effectiveFilters); err != nil {
 			slog.Error("failed to reconcile FRR prefix-list", "error", err)
 		}
-	} else {
+	default:
 		// No locally active routers — remove per-network veth leak and prefix-list entries.
 		if err := a.routing.ReconcileVethLeakNetworks(nil); err != nil {
 			slog.Error("failed to clean veth leak networks", "error", err)
@@ -341,7 +370,10 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 	// Check for stale chassis entries from dead nodes (runs on every agent).
 	// This runs after gateway routing reconciliation so that a surviving agent
 	// creates its own routes before removing entries from dead chassis.
-	a.cleanupStaleChassis(ctx, state.AllChassisNames)
+	// Skipped in port-forward-only mode: there is no OVN SB Chassis table.
+	if !a.cfg.PortForwardOnly {
+		a.cleanupStaleChassis(ctx, state.AllChassisNames)
+	}
 }
 
 // cleanupStaleChassis detects chassis that have disappeared from the SB Chassis
@@ -429,14 +461,24 @@ func (a *Agent) ensureRoutes(desiredIPs []string) {
 		desiredSet[ip] = true
 	}
 
+	// Kernel routes live on the provider bridge (br-ex). In
+	// port-forward-only mode the node need not have br-ex, so only FRR
+	// static routes are managed — the VIP is reachable as a local address
+	// on port_forward_dev, and the FRR route handles BGP announcement.
+	manageKernel := !a.cfg.PortForwardOnly
+
 	// Collect current state so we only add what is actually missing.
 	currentKernelSet := make(map[string]bool)
-	currentKernel, err := a.routing.ListKernelRoutes()
-	if err != nil {
-		slog.Error("failed to list kernel routes", "error", err)
-	} else {
-		for _, ip := range currentKernel {
-			currentKernelSet[ip] = true
+	var currentKernel []string
+	if manageKernel {
+		var err error
+		currentKernel, err = a.routing.ListKernelRoutes()
+		if err != nil {
+			slog.Error("failed to list kernel routes", "error", err)
+		} else {
+			for _, ip := range currentKernel {
+				currentKernelSet[ip] = true
+			}
 		}
 	}
 
@@ -453,7 +495,7 @@ func (a *Agent) ensureRoutes(desiredIPs []string) {
 	// Collect missing and stale routes, then apply in batches.
 	var addFRR []string
 	for _, ip := range desiredIPs {
-		needsKernel := !currentKernelSet[ip]
+		needsKernel := manageKernel && !currentKernelSet[ip]
 		needsFRR := !currentFRRSet[ip]
 
 		if !needsKernel && !needsFRR {
@@ -558,16 +600,19 @@ func (a *Agent) removeAllRoutes(reason string) {
 		}
 	}
 
-	// Remove kernel routes.
-	currentKernel, err := a.routing.ListKernelRoutes()
-	if err != nil {
-		slog.Error("failed to list kernel routes", "error", err)
-	} else {
-		for _, ip := range currentKernel {
-			if a.isManaged(ip) {
-				slog.Info("removing kernel route", "ip", ip, "reason", reason)
-				if err := a.routing.DelKernelRoute(ip); err != nil {
-					slog.Error("failed to remove kernel route", "ip", ip, "error", err)
+	// Remove kernel routes. Skipped in port-forward-only mode, which does
+	// not manage kernel routes on the provider bridge.
+	if !a.cfg.PortForwardOnly {
+		currentKernel, err := a.routing.ListKernelRoutes()
+		if err != nil {
+			slog.Error("failed to list kernel routes", "error", err)
+		} else {
+			for _, ip := range currentKernel {
+				if a.isManaged(ip) {
+					slog.Info("removing kernel route", "ip", ip, "reason", reason)
+					if err := a.routing.DelKernelRoute(ip); err != nil {
+						slog.Error("failed to remove kernel route", "ip", ip, "error", err)
+					}
 				}
 			}
 		}
@@ -589,11 +634,15 @@ func (a *Agent) cleanup() {
 		slog.Error("failed to cleanup FRR prefix-list", "error", err)
 	}
 
-	if err := a.routing.RemoveOVSFlows(); err != nil {
-		slog.Error("failed to remove OVS flows", "error", err)
-	}
-	if err := a.routing.CleanupRoutingTable(); err != nil {
-		slog.Error("failed to flush routing table", "error", err)
+	// OVS flows and the dedicated kernel routing table are OVN-gateway
+	// specific and never created in port-forward-only mode.
+	if !a.cfg.PortForwardOnly {
+		if err := a.routing.RemoveOVSFlows(); err != nil {
+			slog.Error("failed to remove OVS flows", "error", err)
+		}
+		if err := a.routing.CleanupRoutingTable(); err != nil {
+			slog.Error("failed to flush routing table", "error", err)
+		}
 	}
 	// Tear down port forwarding before veth leak (DNAT return route uses veth).
 	if err := a.routing.TeardownPortForward(); err != nil {
@@ -601,6 +650,11 @@ func (a *Agent) cleanup() {
 	}
 	if err := a.routing.TeardownVethLeak(); err != nil {
 		slog.Error("failed to tear down veth VRF leak", "error", err)
+	}
+
+	// The bridge IP and managed OVN NB entries only exist in full mode.
+	if a.cfg.PortForwardOnly {
+		return
 	}
 	if err := a.routing.RemoveBridgeIP(a.cfg.BridgeIP); err != nil {
 		slog.Error("failed to remove bridge IP", "error", err)
@@ -636,15 +690,19 @@ func (a *Agent) verifyRoutes(desiredIPs []string) int {
 		frrSet[ip] = true
 	}
 
-	// Re-read current kernel routes.
-	currentKernel, err := a.routing.ListKernelRoutes()
-	if err != nil {
-		slog.Error("post-change kernel route verification failed", "error", err)
-		return 0
-	}
-	kernelSet := make(map[string]bool, len(currentKernel))
-	for _, ip := range currentKernel {
-		kernelSet[ip] = true
+	// Re-read current kernel routes. In port-forward-only mode kernel
+	// routes are not managed (see ensureRoutes), so this is skipped.
+	manageKernel := !a.cfg.PortForwardOnly
+	kernelSet := make(map[string]bool)
+	if manageKernel {
+		currentKernel, err := a.routing.ListKernelRoutes()
+		if err != nil {
+			slog.Error("post-change kernel route verification failed", "error", err)
+			return 0
+		}
+		for _, ip := range currentKernel {
+			kernelSet[ip] = true
+		}
 	}
 
 	var reAddFRR []string
@@ -657,7 +715,7 @@ func (a *Agent) verifyRoutes(desiredIPs []string) int {
 			slog.Warn("FRR route missing after route change, re-adding", "ip", ip)
 			reAddFRR = append(reAddFRR, ip)
 		}
-		if !kernelSet[ip] {
+		if manageKernel && !kernelSet[ip] {
 			slog.Warn("kernel route missing after route change, re-adding", "ip", ip)
 			if err := a.routing.AddKernelRoute(ip); err != nil {
 				slog.Error("failed to re-add kernel route", "ip", ip, "error", err)

--- a/agent_test.go
+++ b/agent_test.go
@@ -741,3 +741,103 @@ func TestReconcileCompletesPromptlyOnCancelledContext(t *testing.T) {
 		t.Errorf("effectiveFilters = %v, want [198.51.100.0/24]", a.effectiveFilters)
 	}
 }
+
+// portForwardOnlyConfig returns a minimal port-forward-only config (no OVN
+// remotes) suitable for the agent tests below.
+func portForwardOnlyConfig() Config {
+	return Config{
+		PortForwardOnly:    true,
+		PortForwardEnabled: true,
+		DryRun:             true,
+		CleanupOnShutdown:  true,
+		DrainOnShutdown:    true, // must be ignored: there is no OVN to drain
+		ReconcileInterval:  time.Hour,
+		VethNexthop:        "169.254.0.1",
+		VRFName:            "vrf-provider",
+		PortForwards: []PortForwardVIP{
+			{
+				VIP:       "198.51.100.10",
+				ManageVIP: true,
+				Rules:     []PortForwardRule{{Proto: "tcp", Port: 443, DestAddr: "10.0.0.100"}},
+			},
+		},
+	}
+}
+
+// TestNewAgentPortForwardOnlyHasNoOVNClient verifies that NewAgent does not
+// construct an OVN client in port-forward-only mode — the agent runs as a
+// standalone VIP service with no OVN connection.
+func TestNewAgentPortForwardOnlyHasNoOVNClient(t *testing.T) {
+	a, err := NewAgent(portForwardOnlyConfig())
+	if err != nil {
+		t.Fatalf("NewAgent() error: %v", err)
+	}
+	if a.ovn != nil {
+		t.Error("OVN client must not be created in port-forward-only mode")
+	}
+}
+
+// TestReconcilePortForwardOnly drives a reconcile cycle with no OVN client.
+// The cycle must complete without panicking on the nil client, derive an
+// empty OVN state, and leave effectiveFilters empty (nothing discovered).
+func TestReconcilePortForwardOnly(t *testing.T) {
+	cfg := portForwardOnlyConfig()
+	rm := NewRouteManager(cfg)
+	a := &Agent{
+		cfg:            cfg,
+		routing:        rm,
+		reconcileCh:    make(chan struct{}, 1),
+		missingChassis: make(map[string]time.Time),
+	}
+
+	a.reconcile(context.Background(), "test")
+
+	if len(a.effectiveFilters) != 0 {
+		t.Errorf("effectiveFilters should be empty in port-forward-only mode, got %v", a.effectiveFilters)
+	}
+}
+
+// TestCleanupPortForwardOnly verifies that cleanup() runs the port-forward
+// teardown path without dereferencing the nil OVN client (OVN NB cleanup is
+// skipped in port-forward-only mode).
+func TestCleanupPortForwardOnly(t *testing.T) {
+	cfg := portForwardOnlyConfig()
+	a := &Agent{
+		cfg:     cfg,
+		routing: NewRouteManager(cfg),
+	}
+	// Must not panic: a.ovn is nil and RemoveManagedNBEntries must be skipped.
+	a.cleanup()
+}
+
+// TestAgentRunPortForwardOnly exercises Run end-to-end in port-forward-only
+// mode with a pre-cancelled context: the agent starts (veth/port-forward
+// setup, startup reconcile), then the cancelled context drives it straight
+// into shutdown cleanup. It must never touch OVN and must return nil.
+func TestAgentRunPortForwardOnly(t *testing.T) {
+	cfg := portForwardOnlyConfig()
+	cfg.VethLeakEnabled = true
+
+	a, err := NewAgent(cfg)
+	if err != nil {
+		t.Fatalf("NewAgent() error: %v", err)
+	}
+	if a.ovn != nil {
+		t.Fatal("OVN client must not be created in port-forward-only mode")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // shut down immediately after the startup reconcile
+
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run() returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run() did not return within 2s in port-forward-only mode")
+	}
+}

--- a/config.go
+++ b/config.go
@@ -144,6 +144,11 @@ type Config struct {
 	VethLeakTableID      int    // Routing table for leak default route (default: 200)
 	VethLeakRulePriority int    // Policy rule priority (default: 2000)
 
+	// PortForwardOnly is derived by validateMode: true when no OVN remotes
+	// are configured but port_forwards are. In this mode the agent runs as
+	// a standalone VIP service and skips all OVN-dependent work.
+	PortForwardOnly bool
+
 	// Port forwarding (DNAT) settings
 	PortForwardEnabled      bool             // derived: len(PortForwards) > 0
 	PortForwardDev          string           // loopback device for VIP addresses (default: "loopback1")
@@ -344,7 +349,60 @@ func loadConfig(args []string) (Config, error) {
 		return Config{}, err
 	}
 
+	// Derive the operating mode (full vs port-forward-only) and reject
+	// invalid OVN/port-forward combinations.
+	if err := validateMode(&cfg); err != nil {
+		return Config{}, err
+	}
+
 	return cfg, nil
+}
+
+// validateMode derives the agent's operating mode from the presence of OVN
+// remotes and port-forward configuration, setting Config.PortForwardOnly and
+// rejecting invalid combinations:
+//
+//	ovn_sb_remote + ovn_nb_remote   port_forwards   mode
+//	------------------------------- --------------- -----------------------
+//	both set                        any             full mode
+//	both empty                      non-empty       port-forward-only mode
+//	both empty                      empty           error — nothing to do
+//	exactly one set                 any             error — incomplete OVN
+//
+// In port-forward-only mode it additionally rejects masquerade options that
+// depend on OVN-derived state: router_masquerade has no router-SNAT-IP source
+// without OVN, and hairpin_masquerade needs an explicit network_cidr because
+// provider CIDRs are otherwise auto-discovered from OVN.
+func validateMode(cfg *Config) error {
+	sbSet := cfg.OVNSBRemote != ""
+	nbSet := cfg.OVNNBRemote != ""
+
+	switch {
+	case sbSet && nbSet:
+		cfg.PortForwardOnly = false
+	case !sbSet && !nbSet:
+		if len(cfg.PortForwards) == 0 {
+			return fmt.Errorf("nothing to do: set ovn-sb-remote and ovn-nb-remote for full mode, or configure port_forwards for port-forward-only mode")
+		}
+		cfg.PortForwardOnly = true
+	default:
+		return fmt.Errorf("incomplete OVN configuration: ovn-sb-remote and ovn-nb-remote must both be set, or both be empty to run in port-forward-only mode")
+	}
+
+	if !cfg.PortForwardOnly {
+		return nil
+	}
+
+	for i, pf := range cfg.PortForwards {
+		if pf.RouterMasquerade {
+			return fmt.Errorf("port_forwards[%d] (vip=%s): router_masquerade requires an OVN connection — router SNAT IPs cannot be discovered in port-forward-only mode", i, pf.VIP)
+		}
+		if pf.HairpinMasquerade && len(cfg.NetworkCIDRs) == 0 {
+			return fmt.Errorf("port_forwards[%d] (vip=%s): hairpin_masquerade in port-forward-only mode requires network_cidr to be set — provider CIDRs cannot be auto-discovered without OVN", i, pf.VIP)
+		}
+	}
+
+	return nil
 }
 
 func validateConfig(cfg *Config) error {

--- a/config_test.go
+++ b/config_test.go
@@ -10,6 +10,17 @@ import (
 	"time"
 )
 
+// fullModeArgs prepends the OVN remote flags required for full mode to the
+// given extra flags. Tests that exercise unrelated config fields use it so
+// the operating-mode validation matrix (validateMode) does not reject an
+// otherwise-incomplete config.
+func fullModeArgs(extra ...string) []string {
+	return append([]string{
+		"--ovn-sb-remote", "tcp:10.0.0.1:6642",
+		"--ovn-nb-remote", "tcp:10.0.0.1:6641",
+	}, extra...)
+}
+
 func TestReadConfigFile(t *testing.T) {
 	content := `
 ovn_sb_remote: "tcp:10.0.0.1:6642,tcp:10.0.0.2:6642"
@@ -280,7 +291,7 @@ func TestApplyEnvConfigInvalidDuration(t *testing.T) {
 }
 
 func TestLoadConfigDefaults(t *testing.T) {
-	cfg, err := loadConfig(nil)
+	cfg, err := loadConfig(fullModeArgs())
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
@@ -319,7 +330,7 @@ func TestLoadConfigDefaults(t *testing.T) {
 
 func TestLoadConfigVethLeakEnabledByDefault(t *testing.T) {
 	// VethLeakEnabled defaults to true and requires network-cidr.
-	cfg, err := loadConfig([]string{"--network-cidr", "10.0.0.0/24"})
+	cfg, err := loadConfig(fullModeArgs("--network-cidr", "10.0.0.0/24"))
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
@@ -364,7 +375,7 @@ func TestLoadConfigCLIFlags(t *testing.T) {
 }
 
 func TestLoadConfigDryRunFlag(t *testing.T) {
-	cfg, err := loadConfig([]string{"--dry-run"})
+	cfg, err := loadConfig(fullModeArgs("--dry-run"))
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
@@ -374,7 +385,7 @@ func TestLoadConfigDryRunFlag(t *testing.T) {
 }
 
 func TestLoadConfigDryRunDefault(t *testing.T) {
-	cfg, err := loadConfig(nil)
+	cfg, err := loadConfig(fullModeArgs())
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
@@ -403,7 +414,7 @@ func TestApplyFileConfigDryRun(t *testing.T) {
 }
 
 func TestLoadConfigCleanupOnShutdownDefault(t *testing.T) {
-	cfg, err := loadConfig(nil)
+	cfg, err := loadConfig(fullModeArgs())
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
@@ -413,7 +424,7 @@ func TestLoadConfigCleanupOnShutdownDefault(t *testing.T) {
 }
 
 func TestLoadConfigCleanupOnShutdownDisabledViaCLI(t *testing.T) {
-	cfg, err := loadConfig([]string{"--cleanup-on-shutdown=false"})
+	cfg, err := loadConfig(fullModeArgs("--cleanup-on-shutdown=false"))
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
@@ -615,7 +626,7 @@ func TestValidateConfig(t *testing.T) {
 }
 
 func TestLoadConfigRouteTableIDCLI(t *testing.T) {
-	cfg, err := loadConfig([]string{"--route-table-id", "100"})
+	cfg, err := loadConfig(fullModeArgs("--route-table-id", "100"))
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
@@ -694,7 +705,7 @@ func TestIsValidIdentifier(t *testing.T) {
 
 func TestLoadConfigVethLeakWithoutNetworkCIDR(t *testing.T) {
 	// Veth leak no longer requires network-cidr — networks are auto-discovered from OVN.
-	cfg, err := loadConfig([]string{"--veth-leak-enabled"})
+	cfg, err := loadConfig(fullModeArgs("--veth-leak-enabled"))
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
@@ -704,7 +715,7 @@ func TestLoadConfigVethLeakWithoutNetworkCIDR(t *testing.T) {
 }
 
 func TestLoadConfigVethLeakDisabledWithoutNetworkCIDR(t *testing.T) {
-	cfg, err := loadConfig([]string{"--veth-leak-enabled=false"})
+	cfg, err := loadConfig(fullModeArgs("--veth-leak-enabled=false"))
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
@@ -714,10 +725,10 @@ func TestLoadConfigVethLeakDisabledWithoutNetworkCIDR(t *testing.T) {
 }
 
 func TestLoadConfigVethLeakAutoProviderIP(t *testing.T) {
-	cfg, err := loadConfig([]string{
+	cfg, err := loadConfig(fullModeArgs(
 		"--veth-nexthop", "169.254.0.1",
 		"--network-cidr", "10.0.0.0/24",
-	})
+	))
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
@@ -727,10 +738,10 @@ func TestLoadConfigVethLeakAutoProviderIP(t *testing.T) {
 }
 
 func TestLoadConfigVethLeakExplicitProviderIP(t *testing.T) {
-	cfg, err := loadConfig([]string{
+	cfg, err := loadConfig(fullModeArgs(
 		"--veth-provider-ip", "169.254.0.10",
 		"--network-cidr", "10.0.0.0/24",
-	})
+	))
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
@@ -843,7 +854,7 @@ veth_leak_rule_priority: 3000
 }
 
 func TestLoadConfigFRRPrefixListCLI(t *testing.T) {
-	cfg, err := loadConfig([]string{"--frr-prefix-list", "ANNOUNCED-NETWORKS"})
+	cfg, err := loadConfig(fullModeArgs("--frr-prefix-list", "ANNOUNCED-NETWORKS"))
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
@@ -860,7 +871,7 @@ func TestLoadConfigFRRPrefixListInvalid(t *testing.T) {
 }
 
 func TestLoadConfigStaleChassisGracePeriodDefault(t *testing.T) {
-	cfg, err := loadConfig(nil)
+	cfg, err := loadConfig(fullModeArgs())
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
@@ -870,7 +881,7 @@ func TestLoadConfigStaleChassisGracePeriodDefault(t *testing.T) {
 }
 
 func TestLoadConfigStaleChassisGracePeriodCLI(t *testing.T) {
-	cfg, err := loadConfig([]string{"--stale-chassis-grace-period", "10m"})
+	cfg, err := loadConfig(fullModeArgs("--stale-chassis-grace-period", "10m"))
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
@@ -880,7 +891,7 @@ func TestLoadConfigStaleChassisGracePeriodCLI(t *testing.T) {
 }
 
 func TestLoadConfigStaleChassisGracePeriodDisabled(t *testing.T) {
-	cfg, err := loadConfig([]string{"--stale-chassis-grace-period", "0s"})
+	cfg, err := loadConfig(fullModeArgs("--stale-chassis-grace-period", "0s"))
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
@@ -1518,7 +1529,7 @@ func TestNextIPInSubnet(t *testing.T) {
 }
 
 func TestLoadConfigMetricsListenDefaultDisabled(t *testing.T) {
-	cfg, err := loadConfig(nil)
+	cfg, err := loadConfig(fullModeArgs())
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
@@ -1528,7 +1539,7 @@ func TestLoadConfigMetricsListenDefaultDisabled(t *testing.T) {
 }
 
 func TestLoadConfigMetricsListenViaCLI(t *testing.T) {
-	cfg, err := loadConfig([]string{"--metrics-listen", "127.0.0.1:9273"})
+	cfg, err := loadConfig(fullModeArgs("--metrics-listen", "127.0.0.1:9273"))
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
@@ -1569,11 +1580,182 @@ func TestLoadConfigMetricsListenInvalid(t *testing.T) {
 
 func TestLoadConfigCLIOverridesEnvMetricsListen(t *testing.T) {
 	t.Setenv("OVN_NETWORK_METRICS_LISTEN", "127.0.0.1:9000")
-	cfg, err := loadConfig([]string{"--metrics-listen", "127.0.0.1:9273"})
+	cfg, err := loadConfig(fullModeArgs("--metrics-listen", "127.0.0.1:9273"))
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
 	if cfg.MetricsListen != "127.0.0.1:9273" {
 		t.Errorf("MetricsListen = %q, want %q (CLI > env)", cfg.MetricsListen, "127.0.0.1:9273")
 	}
+}
+
+// portForwardVIPs returns a minimal valid port-forward configuration for
+// operating-mode tests.
+func portForwardVIPs() []PortForwardVIP {
+	return []PortForwardVIP{
+		{
+			VIP:       "198.51.100.10",
+			ManageVIP: true,
+			Rules:     []PortForwardRule{{Proto: "tcp", Port: 443, DestAddr: "10.0.0.100"}},
+		},
+	}
+}
+
+// TestValidateMode covers the OVN-remote/port-forward matrix from issue #121:
+// the four combinations of OVN remotes and port_forwards and the mode (or
+// error) each produces.
+func TestValidateMode(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        Config
+		wantErr    bool
+		wantPFOnly bool
+	}{
+		{
+			"both remotes set: full mode",
+			Config{OVNSBRemote: "tcp:10.0.0.1:6642", OVNNBRemote: "tcp:10.0.0.1:6641"},
+			false, false,
+		},
+		{
+			"both remotes set with port forwards: full mode",
+			Config{OVNSBRemote: "tcp:10.0.0.1:6642", OVNNBRemote: "tcp:10.0.0.1:6641", PortForwards: portForwardVIPs()},
+			false, false,
+		},
+		{
+			"no remotes, port forwards set: port-forward-only mode",
+			Config{PortForwards: portForwardVIPs()},
+			false, true,
+		},
+		{
+			"no remotes, no port forwards: error",
+			Config{},
+			true, false,
+		},
+		{
+			"only SB remote set: error",
+			Config{OVNSBRemote: "tcp:10.0.0.1:6642"},
+			true, false,
+		},
+		{
+			"only NB remote set: error",
+			Config{OVNNBRemote: "tcp:10.0.0.1:6641"},
+			true, false,
+		},
+		{
+			"only SB remote set with port forwards: error",
+			Config{OVNSBRemote: "tcp:10.0.0.1:6642", PortForwards: portForwardVIPs()},
+			true, false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.cfg
+			err := validateMode(&cfg)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateMode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil && cfg.PortForwardOnly != tt.wantPFOnly {
+				t.Errorf("PortForwardOnly = %v, want %v", cfg.PortForwardOnly, tt.wantPFOnly)
+			}
+		})
+	}
+}
+
+// TestValidateModeMasquerade verifies that masquerade options depending on
+// OVN-derived state are rejected in port-forward-only mode but accepted in
+// full mode.
+func TestValidateModeMasquerade(t *testing.T) {
+	withVIP := func(mut func(*PortForwardVIP)) []PortForwardVIP {
+		v := portForwardVIPs()
+		mut(&v[0])
+		return v
+	}
+
+	t.Run("router_masquerade rejected in port-forward-only mode", func(t *testing.T) {
+		cfg := Config{PortForwards: withVIP(func(v *PortForwardVIP) { v.RouterMasquerade = true })}
+		if err := validateMode(&cfg); err == nil {
+			t.Error("expected error: router_masquerade requires OVN")
+		}
+	})
+
+	t.Run("hairpin_masquerade rejected without network_cidr", func(t *testing.T) {
+		cfg := Config{PortForwards: withVIP(func(v *PortForwardVIP) { v.HairpinMasquerade = true })}
+		if err := validateMode(&cfg); err == nil {
+			t.Error("expected error: hairpin_masquerade needs network_cidr in port-forward-only mode")
+		}
+	})
+
+	t.Run("hairpin_masquerade allowed with network_cidr", func(t *testing.T) {
+		cfg := Config{
+			NetworkCIDRs: []string{"203.0.113.0/24"},
+			PortForwards: withVIP(func(v *PortForwardVIP) { v.HairpinMasquerade = true }),
+		}
+		if err := validateMode(&cfg); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("router_masquerade allowed in full mode", func(t *testing.T) {
+		cfg := Config{
+			OVNSBRemote:  "tcp:10.0.0.1:6642",
+			OVNNBRemote:  "tcp:10.0.0.1:6641",
+			PortForwards: withVIP(func(v *PortForwardVIP) { v.RouterMasquerade = true }),
+		}
+		if err := validateMode(&cfg); err != nil {
+			t.Errorf("router_masquerade must be allowed in full mode: %v", err)
+		}
+	})
+}
+
+// TestLoadConfigPortForwardOnlyMode verifies that a config file with only
+// port_forwards (no OVN remotes) loads successfully and derives
+// port-forward-only mode.
+func TestLoadConfigPortForwardOnlyMode(t *testing.T) {
+	content := `
+port_forwards:
+  - vip: "198.51.100.10"
+    manage_vip: true
+    rules:
+      - proto: tcp
+        port: 443
+        dest_addr: "10.0.0.100"
+`
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write test config: %v", err)
+	}
+	cfg, err := loadConfig([]string{"--config", path})
+	if err != nil {
+		t.Fatalf("loadConfig() error: %v", err)
+	}
+	if !cfg.PortForwardOnly {
+		t.Error("PortForwardOnly should be true with port_forwards and no OVN remotes")
+	}
+	if !cfg.PortForwardEnabled {
+		t.Error("PortForwardEnabled should be true")
+	}
+}
+
+// TestLoadConfigRejectsEmptyMode verifies that a config with neither OVN
+// remotes nor port_forwards is rejected with a clear error.
+func TestLoadConfigRejectsEmptyMode(t *testing.T) {
+	if _, err := loadConfig(nil); err == nil {
+		t.Error("expected error when neither OVN remotes nor port_forwards are configured")
+	}
+}
+
+// TestLoadConfigRejectsIncompleteOVN verifies that setting only one of the
+// two OVN remotes is rejected.
+func TestLoadConfigRejectsIncompleteOVN(t *testing.T) {
+	t.Run("only SB", func(t *testing.T) {
+		if _, err := loadConfig([]string{"--ovn-sb-remote", "tcp:10.0.0.1:6642"}); err == nil {
+			t.Error("expected error when only ovn-sb-remote is set")
+		}
+	})
+	t.Run("only NB", func(t *testing.T) {
+		if _, err := loadConfig([]string{"--ovn-nb-remote", "tcp:10.0.0.1:6641"}); err == nil {
+			t.Error("expected error when only ovn-nb-remote is set")
+		}
+	})
 }

--- a/docs/explanation/port-forwarding.md
+++ b/docs/explanation/port-forwarding.md
@@ -364,3 +364,50 @@ locally (INPUT chain), and the reply originates from the OUTPUT hook. The
          External client
          (client IP preserved end-to-end)
 ```
+
+## Running as a standalone VIP service (port-forward-only mode)
+
+Port forwarding does not depend on OVN. The DNAT rules, the VIP addresses,
+the connmark-based return routing, and the FRR static routes that announce
+the VIPs are all managed independently of any OVN gateway state — the
+reconcile loop already asserts them regardless of local router presence.
+
+That makes it useful to run the agent as a *pure* VIP service on a node
+that is **not** an OVN gateway chassis at all: a node hosting DNS
+resolvers, monitoring collectors, or API proxies that should be reachable
+via anycast VIPs, but that has no Floating IPs, no chassisredirect ports,
+and no gateway routing to maintain.
+
+When `port_forwards` is configured but both OVN remotes (`ovn_sb_remote`
+and `ovn_nb_remote`) are left unset, the agent starts in
+**port-forward-only mode**. It manages only the VIPs and never opens an OVN
+connection — removing an operational dependency and the spurious
+`failed to connect to OVN, retrying` logging that an unreachable OVN
+endpoint would otherwise produce.
+
+What still runs in this mode:
+
+- `SetupPortForward` / `ReconcilePortForward` / `TeardownPortForward` — the
+  DNAT rules, VIP addresses, conntrack zones, and policy routing described
+  above.
+- The veth pair between the default VRF and `vrf-provider`, used by the
+  DNAT return path.
+- FRR static routes for the VIP addresses, so BGP announces them.
+- The periodic reconcile ticker, which re-asserts the VIP and DNAT state.
+
+What is skipped, because it is OVN-specific:
+
+- The OVN SB/NB connection and the entire OVN client lifecycle.
+- Gateway routing, OVS hairpin/MAC-tweak flows, stale chassis cleanup,
+  drain-on-shutdown, and FIP/SNAT-IP route management.
+- Provider-bridge setup (`br-ex`). A pure VIP-service node need not have
+  `br-ex`: no `<vip>/32` kernel route is installed on it, the VIP is
+  reachable as a local address on `port_forward_dev`, and the FRR static
+  route carries the BGP announcement.
+
+Because router SNAT IPs and provider CIDRs are normally discovered from
+OVN, the two source-selective masquerade options that rely on them are
+constrained in this mode (see
+[Configure the agent](../guides/configuration#port-forward-only-mode)):
+`router_masquerade` is rejected outright, and `hairpin_masquerade`
+requires an explicit `network_cidr`.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -42,14 +42,69 @@ ovn-network-agent --config /etc/ovn-network-agent/config.yaml --log-level debug 
 
 CLI flags take precedence over values in the config file.
 
+## Operating modes
+
+The agent runs in one of two modes, derived automatically from the
+configuration — there is no mode flag:
+
+| `ovn_sb_remote` / `ovn_nb_remote` | `port_forwards` | Mode |
+|---|---|---|
+| both set | any | **full mode** |
+| both empty | non-empty | **port-forward-only mode** |
+| both empty | empty | error — nothing to do |
+| exactly one set | any | error — incomplete OVN configuration |
+
+The active mode is logged in the startup banner (`mode=full` or
+`mode=port-forward-only`).
+
+### Full mode
+
+The default. The agent connects to the OVN Southbound and Northbound
+databases, synchronises Floating IP routes, manages gateway routing, and
+also serves any configured `port_forwards`.
+
+### Port-forward-only mode
+
+When `port_forwards` is configured but **both** OVN remotes are left unset,
+the agent runs as a standalone VIP service: it manages only the configured
+port-forward VIPs — DNAT rules, VIP addresses, connmark return routing, and
+FRR static routes for BGP announcement — and never connects to OVN.
+
+Use this for a node that should only expose configured VIPs (for example a
+DNS resolver, monitoring collector, or API proxy) and is not an OVN gateway
+chassis. Such a node needs no provider bridge (`br-ex`), no FIPs, and no
+gateway routing.
+
+Two masquerade options depend on OVN-derived state and are therefore
+rejected at startup in port-forward-only mode:
+
+- `router_masquerade` — router SNAT IPs are discovered from OVN; without an
+  OVN connection there is no source for them.
+- `hairpin_masquerade` — requires an explicit `network_cidr`, because
+  provider CIDRs are normally auto-discovered from OVN.
+
+```yaml
+# Port-forward-only config: no OVN remotes, only port_forwards.
+port_forwards:
+  - vip: "198.51.100.10"
+    manage_vip: true
+    rules:
+      - proto: tcp
+        port: 443
+        dest_addr: "10.0.0.100"
+```
+
+Switching modes at runtime is not supported — it requires a restart.
+
 ## Prerequisites
 
-- **OVN**: TCP access to OVN Southbound and Northbound databases on the
-  control nodes (the agent runs on network/gateway nodes where no local DB
-  sockets exist).
+- **OVN** (full mode only): TCP access to OVN Southbound and Northbound
+  databases on the control nodes (the agent runs on network/gateway nodes
+  where no local DB sockets exist). Not needed in port-forward-only mode.
 - **FRR**: `vtysh` must be available and the VRF + BGP configuration must
   already exist.
-- **Linux**: provider bridge (e.g. `br-ex`) must exist.
+- **Linux**: provider bridge (e.g. `br-ex`) must exist in full mode;
+  port-forward-only mode does not use it.
 - **VRF route leaking**: the agent automatically creates and manages a veth
   pair connecting the default VRF to `vrf-provider` (enabled by default via
   `--veth-leak-enabled`). Per-network routes are reconciled dynamically based

--- a/docs/guides/port-forwarding.md
+++ b/docs/guides/port-forwarding.md
@@ -16,6 +16,10 @@ fwmarks, VRF crossing, packet-flow diagrams — see
 - **IP forwarding** on the veth interfaces — enabled automatically by the
   agent at startup.
 
+Port forwarding works whether or not the node is an OVN gateway. A node that
+should *only* expose VIPs can run with no OVN remotes configured at all — see
+[port-forward-only mode](configuration#port-forward-only-mode).
+
 ## Example configuration
 
 ```yaml

--- a/main.go
+++ b/main.go
@@ -30,18 +30,24 @@ func main() {
 
 	setupLogging(cfg.LogLevel)
 
-	if cfg.OVNSBRemote == "" || cfg.OVNNBRemote == "" {
-		slog.Error("OVN database remotes are required, set --ovn-sb-remote / --ovn-nb-remote, OVN_NETWORK_OVN_SB_REMOTE / OVN_NETWORK_OVN_NB_REMOTE, or use a config file (--config)")
-		os.Exit(1)
+	// The OVN-vs-port-forward-only decision is made in config validation
+	// (validateMode); main only reports the resulting mode.
+	mode := "full"
+	if cfg.PortForwardOnly {
+		mode = "port-forward-only"
 	}
 
 	networkMode := "auto-discover from OVN"
-	if len(cfg.NetworkCIDRs) > 0 {
+	switch {
+	case len(cfg.NetworkCIDRs) > 0:
 		networkMode = "manual"
+	case cfg.PortForwardOnly:
+		networkMode = "none (port-forward-only)"
 	}
 
 	slog.Info("ovn-network-agent starting",
 		"version", version,
+		"mode", mode,
 		"dry_run", cfg.DryRun,
 		"cleanup_on_shutdown", cfg.CleanupOnShutdown,
 		"drain_on_shutdown", cfg.DrainOnShutdown,

--- a/ovn-network-agent.yaml.sample
+++ b/ovn-network-agent.yaml.sample
@@ -5,12 +5,26 @@
 #
 # Usage:
 #   ovn-network-agent --config /etc/ovn-network-agent/config.yaml
+#
+# Operating mode is derived from configuration presence:
+#   - both OVN remotes set            -> full mode (synchronise FIP routes,
+#                                        gateway routing, port forwarding)
+#   - both OVN remotes empty +        -> port-forward-only mode: run as a
+#     port_forwards configured           standalone VIP service, no OVN
+#                                        connection (see the port forwarding
+#                                        section at the bottom of this file)
+#   - both OVN remotes empty +        -> error (nothing to do)
+#     no port_forwards
+#   - exactly one OVN remote set      -> error (incomplete OVN configuration)
 
-# OVN Southbound DB remote (required)
-# Comma-separated for clustered setups (failover).
+# OVN Southbound DB remote.
+# Required for full mode; leave unset (together with ovn_nb_remote) for
+# port-forward-only mode. Comma-separated for clustered setups (failover).
 ovn_sb_remote: "tcp:10.10.0.1:6642,tcp:10.10.0.2:6642,tcp:10.10.0.3:6642"
 
-# OVN Northbound DB remote (required)
+# OVN Northbound DB remote.
+# Required for full mode; leave unset (together with ovn_sb_remote) for
+# port-forward-only mode.
 ovn_nb_remote: "tcp:10.10.0.1:6641,tcp:10.10.0.2:6641,tcp:10.10.0.3:6641"
 
 # Provider bridge device for kernel routes (default: br-ex)
@@ -128,6 +142,13 @@ ovn_nb_remote: "tcp:10.10.0.1:6641,tcp:10.10.0.2:6641,tcp:10.10.0.3:6641"
 # policy routing through the veth pair.
 #
 # Requires: veth_leak_enabled: true, nft binary in PATH.
+#
+# Port-forward-only mode: when port_forwards is configured but both OVN
+# remotes are left unset, the agent runs purely as a VIP service — it manages
+# the VIPs (DNAT rules, VIP addresses, return routing, FRR routes) and never
+# connects to OVN. In this mode router_masquerade is rejected (router SNAT IPs
+# come from OVN), and hairpin_masquerade requires an explicit network_cidr
+# (provider CIDRs are otherwise auto-discovered from OVN).
 #
 # Device for VIP addresses in VRF (default: "loopback1")
 # port_forward_dev: "loopback1"


### PR DESCRIPTION
## Summary

Implements #121 — adds a **port-forward-only mode** so the agent can run as a
standalone VIP service without any OVN connection.

The operating mode is derived implicitly from configuration presence (no new
flag):

| `ovn_sb_remote` / `ovn_nb_remote` | `port_forwards` | Mode |
|---|---|---|
| both set | any | full mode (unchanged) |
| both empty | non-empty | **port-forward-only mode (new)** |
| both empty | empty | error — nothing to do |
| exactly one set | any | error — incomplete OVN config |

## Changes (in commit order)

1. **`config`: derive operating mode and validate the OVN/port-forward matrix**
   — adds the derived `Config.PortForwardOnly` flag and a `validateMode` step
   run from `loadConfig`. `validateMode` enforces the matrix above and, in
   port-forward-only mode, rejects masquerade options that depend on
   OVN-derived state (`router_masquerade`; `hairpin_masquerade` without an
   explicit `network_cidr`). Existing `loadConfig` tests for unrelated fields
   relied on the OVN requirement living in `main.go`; they now go through a
   `fullModeArgs` helper.

2. **`agent`: make the OVN client optional** — in port-forward-only mode
   `NewAgent` does not construct an `OVNClient` (`a.ovn` stays `nil`). `Run`
   skips bridge setup, the OVN connect-with-retry, drain restore, and
   drain-on-shutdown. `reconcile` derives a zero-value `OVNState` and skips
   OVS flows, gateway routing, veth-leak/prefix-list network reconciliation,
   and stale chassis cleanup — port forwarding and VIP routes still run.
   `ensureRoutes` / `verifyRoutes` / `removeAllRoutes` manage only FRR static
   routes (no `<vip>/32` kernel route on `br-ex`). `cleanup` tears down port
   forwarding and veth leak but skips OVS flows, the kernel routing table,
   the bridge IP, and OVN NB entry removal.

3. **`main`: relax the OVN-remote requirement** — removes the hard `os.Exit`
   when remotes are empty (the decision now lives in `validateMode`) and logs
   the active mode in the startup banner.

4. **`docs`: document port-forward-only mode** — sample config, configuration
   guide (new "Operating modes" section), and the port-forwarding
   explanation/guide.

## Design note — open question #1 (bridge device)

The issue left the `br-ex` handling open. Per maintainer confirmation, in
port-forward-only mode bridge setup is skipped entirely and **no `<vip>/32`
kernel route** is installed — the node need not have `br-ex`. The VIP is
reachable as a local address on `port_forward_dev` and the FRR static route
carries the BGP announcement. Open question #4 (explicit override flag) is
resolved as the issue's Proposal states: implicit detection, no new flag.

## Tests

- `validateMode` matrix + masquerade rejection (`config_test.go`).
- `loadConfig` integration: port-forward-only success, empty-config and
  incomplete-OVN rejection.
- Agent start / reconcile / shutdown with OVN disabled, including a full
  `Run` cycle in port-forward-only mode (`agent_test.go`).

Local verification: `go build ./...`, `go vet ./...`, `gofmt -l .`,
`golangci-lint run ./...` (0 issues), `go test ./... -count=1` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
