### PR TITLE
Fix FIP reachability loss after repeated HA failover cycles

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -367,6 +367,10 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 		a.removeAllRoutes("no locally active routers and no port forward VIPs")
 	}
 
+	// Surface desired routes that are configured in FRR but not actually
+	// advertised via BGP — ensureRoutes alone cannot detect this.
+	a.checkFRRRouteActivity(desiredIPs)
+
 	// Check for stale chassis entries from dead nodes (runs on every agent).
 	// This runs after gateway routing reconciliation so that a surviving agent
 	// creates its own routes before removing entries from dead chassis.
@@ -746,6 +750,27 @@ func (a *Agent) verifyRoutes(desiredIPs []string) int {
 	setConsecutiveReAdds(a.consecutiveReAdds)
 
 	return totalReAdds
+}
+
+// checkFRRRouteActivity surfaces desired routes that exist as FRR static
+// routes but are not selected/installed, and therefore not advertised via BGP.
+// Such a route is invisible to ensureRoutes — ListFRRRoutes still reports it as
+// present — yet leaves the FIP unreachable from outside. Re-adding would not
+// help (the route already exists; the next-hop is the fault), so the condition
+// is reported loudly and exposed through the inactive_routes metric for
+// alerting. A failed check leaves the metric at its previous value rather than
+// falsely resetting it to zero.
+func (a *Agent) checkFRRRouteActivity(desiredIPs []string) {
+	inactive, err := a.routing.InactiveFRRRoutes(desiredIPs)
+	if err != nil {
+		slog.Warn("could not verify FRR route activity", "error", err)
+		return
+	}
+	setInactiveRoutes(len(inactive))
+	if len(inactive) > 0 {
+		slog.Error("FRR static routes are configured but inactive — these FIPs are not advertised via BGP",
+			"count", len(inactive), "ips", inactive, "vrf", a.cfg.VRFName)
+	}
 }
 
 // isManaged returns true if the IP is within any of the effective network CIDRs.

--- a/agent.go
+++ b/agent.go
@@ -194,6 +194,17 @@ func (a *Agent) Run(ctx context.Context) error {
 					recordDrain("completed", drainElapsed)
 				}
 				drainCancel()
+
+				// The OVN refresh loop stopped the moment ctx was cancelled,
+				// so o.state has been frozen since before the drain — it still
+				// lists the routers that have just migrated away. Refresh it
+				// once now, with a fresh context, so the RemoveManagedNBEntries
+				// call inside cleanup() sees the post-drain reality and does
+				// not delete the default routes and MAC bindings that the
+				// chassis taking over now depends on.
+				refreshCtx, refreshCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				a.ovn.refreshState(refreshCtx)
+				refreshCancel()
 			}
 			if a.cfg.CleanupOnShutdown {
 				slog.Info("shutting down, cleaning up routes")

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -33,6 +33,7 @@ regenerate it with `go generate ./...`.
 | `ovn_network_agent_effective_networks` | gauge | — | Number of effective network filters (manual config or auto-discovered). |
 | `ovn_network_agent_route_readds_total` | counter (vec) | `plane`={`kernel`,`frr`} | Total routes re-added by post-change verification, labelled by route plane. |
 | `ovn_network_agent_consecutive_readds` | gauge | — | Number of consecutive reconcile cycles that required route re-adds. Sustained non-zero indicates persistent route instability. |
+| `ovn_network_agent_inactive_routes` | gauge | — | Number of desired FIP/VIP routes that exist as FRR static routes but are not selected/installed — i.e. not advertised via BGP. Non-zero means those FIPs are unreachable from outside. |
 | `ovn_network_agent_ovn_connection_state` | gauge (vec) | `database`={`nb`,`sb`} | 1 when the named OVN database client is connected, 0 otherwise. |
 | `ovn_network_agent_drain_duration_seconds` | histogram | — | Duration of a gateway drain operation in seconds. |
 | `ovn_network_agent_drain_total` | counter (vec) | `outcome`={`completed`,`timeout`,`error`,`noop`} | Total drain operations, labelled by outcome (completed, timeout, error, noop). |
@@ -46,5 +47,8 @@ regenerate it with `go generate ./...`.
 - `ovn_connection_state{database="nb"} == 0` for >2m — NB DB unreachable;
   agent cannot write OVN state.
 - `rate(route_readds_total[10m]) > 0` — flapping routes.
+- `inactive_routes > 0` for >2m — FIP `/32`s configured in FRR but not
+  advertised via BGP (e.g. an unresolvable next-hop); those FIPs are
+  unreachable from outside.
 - `histogram_quantile(0.95, rate(reconcile_duration_seconds_bucket[5m])) > 5`
   — slow reconciles.

--- a/metrics.go
+++ b/metrics.go
@@ -34,6 +34,7 @@ type metricsRegistry struct {
 	// Route stability metrics
 	routeReAddsTotal  *prometheus.CounterVec
 	consecutiveReAdds prometheus.Gauge
+	inactiveRoutes    prometheus.Gauge
 
 	// OVN connection state
 	ovnConnectionState *prometheus.GaugeVec
@@ -117,6 +118,12 @@ func newMetricsRegistry() *metricsRegistry {
 			Help:      "Number of consecutive reconcile cycles that required route re-adds. Sustained non-zero indicates persistent route instability.",
 		}),
 
+		inactiveRoutes: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "inactive_routes",
+			Help:      "Number of desired FIP/VIP routes that exist as FRR static routes but are not selected/installed — i.e. not advertised via BGP. Non-zero means those FIPs are unreachable from outside.",
+		}),
+
 		ovnConnectionState: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
 			Name:      "ovn_connection_state",
@@ -158,6 +165,7 @@ func newMetricsRegistry() *metricsRegistry {
 		m.effectiveNetworks,
 		m.routeReAddsTotal,
 		m.consecutiveReAdds,
+		m.inactiveRoutes,
 		m.ovnConnectionState,
 		m.drainDuration,
 		m.drainTotal,
@@ -281,6 +289,13 @@ func setConsecutiveReAdds(n int) {
 		return
 	}
 	metrics.consecutiveReAdds.Set(float64(n))
+}
+
+func setInactiveRoutes(n int) {
+	if metrics == nil {
+		return
+	}
+	metrics.inactiveRoutes.Set(float64(n))
 }
 
 func setOVNConnectionState(database string, connected bool) {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -56,6 +56,7 @@ func TestNewMetricsRegistryRegistersAllCollectors(t *testing.T) {
 		"ovn_network_agent_local_routers",
 		"ovn_network_agent_route_readds_total",
 		"ovn_network_agent_consecutive_readds",
+		"ovn_network_agent_inactive_routes",
 		"ovn_network_agent_ovn_connection_state",
 		"ovn_network_agent_drain_duration_seconds",
 		"ovn_network_agent_drain_total",
@@ -294,6 +295,21 @@ func TestSetConsecutiveReAddsSetsGauge(t *testing.T) {
 		}
 		if v := mf.GetMetric()[0].GetGauge().GetValue(); v != 4 {
 			t.Errorf("consecutive_readds = %v, want 4", v)
+		}
+	}
+}
+
+func TestSetInactiveRoutesSetsGauge(t *testing.T) {
+	m := withTestMetrics(t)
+	setInactiveRoutes(3)
+
+	got, _ := m.registry.Gather()
+	for _, mf := range got {
+		if mf.GetName() != "ovn_network_agent_inactive_routes" {
+			continue
+		}
+		if v := mf.GetMetric()[0].GetGauge().GetValue(); v != 3 {
+			t.Errorf("inactive_routes = %v, want 3", v)
 		}
 	}
 }

--- a/ovn.go
+++ b/ovn.go
@@ -815,6 +815,18 @@ func (h *nbEventHandler) handleChange(table string) {
 	switch table {
 	case "NAT", "Logical_Router", "Logical_Router_Port":
 		h.ovn.debounceStateRefresh()
+	case "Gateway_Chassis":
+		// refreshState does not read Gateway_Chassis, but a priority change
+		// must still wake the agent: the reconcile that follows the refresh
+		// runs EnsureActivePriorityLead, which is how the active chassis
+		// reacts to a peer draining (priority→0), restoring (→1) or
+		// boosting. Without this trigger a peer's drain/restore is invisible
+		// until the 60s periodic reconcile — long enough for a priority tie
+		// to leave ovn-northd flapping the chassisredirect port and
+		// stranding the FIPs. Rapid stop/start cycles are bursts of
+		// Gateway_Chassis writes, which is why the hang is worst under quick
+		// succession.
+		h.ovn.debounceStateRefresh()
 	}
 }
 

--- a/ovn.go
+++ b/ovn.go
@@ -421,14 +421,18 @@ func (o *OVNClient) GetState() OVNState {
 //	  → NB NAT (external_ip)
 func (o *OVNClient) refreshState(ctx context.Context) {
 	// Step 1: Find all chassisredirect port bindings and resolve chassis hostnames.
-	var portBindings []SBPortBinding
-	if err := o.sbClient.List(ctx, &portBindings); err != nil {
+	// Every table is read through cachedList, which falls back to a direct
+	// server select when the monitor cache is missing rows (see ovn_cache.go).
+	portBindings, err := cachedList(ctx, o.sbClient, "Port_Binding",
+		func(p SBPortBinding) string { return p.UUID }, decodeSBPortBinding)
+	if err != nil {
 		slog.Error("failed to list port bindings", "error", err)
 		return
 	}
 
-	var chassis []SBChassis
-	if err := o.sbClient.List(ctx, &chassis); err != nil {
+	chassis, err := cachedList(ctx, o.sbClient, "Chassis",
+		func(c SBChassis) string { return c.UUID }, decodeSBChassis)
+	if err != nil {
 		slog.Error("failed to list chassis", "error", err)
 		return
 	}
@@ -463,8 +467,9 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 	}
 
 	// Step 2: Build NB Logical_Router_Port name → UUID map.
-	var lrps []NBLogicalRouterPort
-	if err := o.nbClient.List(ctx, &lrps); err != nil {
+	lrps, err := cachedList(ctx, o.nbClient, "Logical_Router_Port",
+		func(p NBLogicalRouterPort) string { return p.UUID }, decodeNBLogicalRouterPort)
+	if err != nil {
 		slog.Error("failed to list logical router ports", "error", err)
 		return
 	}
@@ -486,8 +491,9 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 	}
 
 	// Step 3: Find routers that own a locally-active LRP. Collect their NAT UUIDs.
-	var routers []NBLogicalRouter
-	if err := o.nbClient.List(ctx, &routers); err != nil {
+	routers, err := cachedList(ctx, o.nbClient, "Logical_Router",
+		func(r NBLogicalRouter) string { return r.UUID }, decodeNBLogicalRouter)
+	if err != nil {
 		slog.Error("failed to list logical routers", "error", err)
 		return
 	}
@@ -542,8 +548,9 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 	effectiveFilters := effectiveNetworkFilters(o.cfg.NetworkFilters, discoveredNets)
 
 	// Step 5: Filter NAT entries to only those belonging to locally-active routers.
-	var nats []NBNAT
-	if err := o.nbClient.List(ctx, &nats); err != nil {
+	nats, err := cachedList(ctx, o.nbClient, "NAT",
+		func(n NBNAT) string { return n.UUID }, decodeNBNAT)
+	if err != nil {
 		slog.Error("failed to list NAT entries", "error", err)
 		return
 	}

--- a/ovn_cache.go
+++ b/ovn_cache.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+)
+
+// =============================================================================
+// Monitor-cache consistency guard
+// =============================================================================
+//
+// refreshState builds the agent's entire view of FIPs and locally-active
+// routers from the libovsdb monitor cache. That cache occasionally drops
+// table INSERTs delivered shortly after a fresh monitor subscription (issue
+// #115): the cache then stays permanently short of rows for the lifetime of
+// the connection, and a cache-backed List() cannot see its own gap.
+//
+// A short cache is silently dangerous here. A missing NAT/router row shrinks
+// the desired-IP set, and ensureRoutes then deletes the corresponding FRR
+// /32 as "orphaned" — the FIP stops being advertised even though OVN itself
+// is perfectly healthy. The drain and active-lead paths already guard against
+// this for Gateway_Chassis via a direct NB select; the helpers below extend
+// the same defence to every table refreshState reads.
+//
+// The cache stays the primary, fast path. On every refresh the row set is
+// cross-checked against a cheap server-side _uuid select; only on a genuine
+// mismatch is the slice rebuilt from a full direct select.
+
+// cachedList lists a table from the monitor cache and then cross-checks the
+// row set against the OVN server. It returns a server-authoritative slice
+// whenever the monitor cache turns out to be incomplete. uuidOf extracts the
+// UUID of a cached model; decode rebuilds a model from a raw select row.
+func cachedList[T any](
+	ctx context.Context,
+	c ovsdbClient,
+	table string,
+	uuidOf func(T) string,
+	decode func(ovsdb.Row) T,
+) ([]T, error) {
+	var cached []T
+	if err := c.List(ctx, &cached); err != nil {
+		return nil, err
+	}
+	return authoritativeList(ctx, c, table, cached, uuidOf, decode), nil
+}
+
+// authoritativeList returns the rows of table that refreshState should act on.
+// It trusts the monitor-cache snapshot (cached) unless a direct server select
+// proves it incomplete, in which case it logs the gap and rebuilds the slice
+// from a full select. Any error reading from the server degrades gracefully to
+// the cache: a transient OVSDB blip must not stall reconciliation.
+func authoritativeList[T any](
+	ctx context.Context,
+	c ovsdbClient,
+	table string,
+	cached []T,
+	uuidOf func(T) string,
+	decode func(ovsdb.Row) T,
+) []T {
+	serverUUIDs, err := serverUUIDSet(ctx, c, table)
+	if err != nil {
+		slog.Warn("cache consistency check skipped: direct select failed, trusting monitor cache",
+			"table", table, "error", err)
+		return cached
+	}
+
+	cacheUUIDs := make(map[string]bool, len(cached))
+	for _, m := range cached {
+		cacheUUIDs[uuidOf(m)] = true
+	}
+	if uuidSetsEqual(cacheUUIDs, serverUUIDs) {
+		return cached
+	}
+
+	slog.Error("OVN monitor cache out of sync with the server, rebuilding from a direct select",
+		"table", table,
+		"cache_rows", len(cacheUUIDs),
+		"server_rows", len(serverUUIDs))
+
+	rows, err := directSelect(ctx, c, table, nil)
+	if err != nil {
+		slog.Error("cache recovery select failed, falling back to the monitor cache",
+			"table", table, "error", err)
+		return cached
+	}
+	out := make([]T, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, decode(row))
+	}
+	return out
+}
+
+// serverUUIDSet returns the set of _uuid values currently in table on the OVN
+// server. Only the _uuid column is selected so the common (in-sync) path stays
+// cheap.
+func serverUUIDSet(ctx context.Context, c ovsdbClient, table string) (map[string]bool, error) {
+	rows, err := directSelect(ctx, c, table, []string{"_uuid"})
+	if err != nil {
+		return nil, err
+	}
+	set := make(map[string]bool, len(rows))
+	for _, row := range rows {
+		if u := rowUUID(row); u != "" {
+			set[u] = true
+		}
+	}
+	return set, nil
+}
+
+// directSelect runs an OVSDB select on table, bypassing the monitor cache.
+// With columns nil every column is returned; otherwise only the named ones.
+// Where is left empty — Operation.MarshalJSON encodes a conditionless select
+// as the match-everything form.
+func directSelect(ctx context.Context, c ovsdbClient, table string, columns []string) ([]ovsdb.Row, error) {
+	op := ovsdb.Operation{
+		Op:      ovsdb.OperationSelect,
+		Table:   table,
+		Columns: columns,
+	}
+	results, err := c.Transact(ctx, op)
+	if err != nil {
+		return nil, fmt.Errorf("select from %s: %w", table, err)
+	}
+	if _, err := ovsdb.CheckOperationResults(results, []ovsdb.Operation{op}); err != nil {
+		return nil, fmt.Errorf("select from %s: %w", table, err)
+	}
+	if len(results) == 0 {
+		return nil, nil
+	}
+	return results[0].Rows, nil
+}
+
+// uuidSetsEqual reports whether two UUID sets contain exactly the same members.
+func uuidSetsEqual(a, b map[string]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if !b[k] {
+			return false
+		}
+	}
+	return true
+}
+
+// =============================================================================
+// Raw OVSDB row decoders
+// =============================================================================
+//
+// These rebuild the typed models from the raw rows returned by directSelect.
+// Only the columns refreshState actually consumes are decoded; everything else
+// is left at its zero value. OVSDB encodes a set of exactly one element as the
+// bare element and larger sets as an OvsSet, so the helpers normalise both.
+
+func decodeSBPortBinding(row ovsdb.Row) SBPortBinding {
+	return SBPortBinding{
+		UUID:         rowUUID(row),
+		Type:         rowString(row, "type"),
+		LogicalPort:  rowString(row, "logical_port"),
+		Chassis:      rowOptString(row, "chassis"),
+		Options:      rowStringMap(row, "options"),
+		ExternalIDs:  rowStringMap(row, "external_ids"),
+		NatAddresses: rowStringSet(row, "nat_addresses"),
+	}
+}
+
+func decodeSBChassis(row ovsdb.Row) SBChassis {
+	return SBChassis{
+		UUID:     rowUUID(row),
+		Name:     rowString(row, "name"),
+		Hostname: rowString(row, "hostname"),
+	}
+}
+
+func decodeNBNAT(row ovsdb.Row) NBNAT {
+	return NBNAT{
+		UUID:       rowUUID(row),
+		Type:       rowString(row, "type"),
+		ExternalIP: rowString(row, "external_ip"),
+	}
+}
+
+func decodeNBLogicalRouter(row ovsdb.Row) NBLogicalRouter {
+	return NBLogicalRouter{
+		UUID:  rowUUID(row),
+		Name:  rowString(row, "name"),
+		Ports: rowStringSet(row, "ports"),
+		Nat:   rowStringSet(row, "nat"),
+	}
+}
+
+func decodeNBLogicalRouterPort(row ovsdb.Row) NBLogicalRouterPort {
+	return NBLogicalRouterPort{
+		UUID:     rowUUID(row),
+		Name:     rowString(row, "name"),
+		MAC:      rowString(row, "mac"),
+		Networks: rowStringSet(row, "networks"),
+	}
+}
+
+// rowUUID extracts the _uuid column from a raw OVSDB row.
+func rowUUID(row ovsdb.Row) string {
+	if u, ok := row["_uuid"].(ovsdb.UUID); ok {
+		return u.GoUUID
+	}
+	return ""
+}
+
+// rowString returns a scalar string column, or "" when absent.
+func rowString(row ovsdb.Row, col string) string {
+	s, _ := row[col].(string)
+	return s
+}
+
+// rowOptString returns an optional (set-of-max-1) column as a pointer. OVSDB
+// sends an empty optional as an empty set and a present one as the bare value;
+// UUID references are flattened to their GoUUID string.
+func rowOptString(row ovsdb.Row, col string) *string {
+	switch v := row[col].(type) {
+	case string:
+		return &v
+	case ovsdb.UUID:
+		s := v.GoUUID
+		return &s
+	case ovsdb.OvsSet:
+		if vals := ovsSetToStrings(v); len(vals) > 0 {
+			return &vals[0]
+		}
+	}
+	return nil
+}
+
+// rowStringSet returns a set-valued column as a Go slice.
+func rowStringSet(row ovsdb.Row, col string) []string {
+	return ovsSetToStrings(row[col])
+}
+
+// ovsSetToStrings flattens an OVSDB set value into a string slice, handling the
+// bare-single-element encoding and flattening UUID references to GoUUID.
+func ovsSetToStrings(v any) []string {
+	switch s := v.(type) {
+	case string:
+		return []string{s}
+	case ovsdb.UUID:
+		return []string{s.GoUUID}
+	case ovsdb.OvsSet:
+		out := make([]string, 0, len(s.GoSet))
+		for _, e := range s.GoSet {
+			switch ev := e.(type) {
+			case string:
+				out = append(out, ev)
+			case ovsdb.UUID:
+				out = append(out, ev.GoUUID)
+			}
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	}
+	return nil
+}
+
+// rowStringMap returns a string→string map column, or nil when absent.
+func rowStringMap(row ovsdb.Row, col string) map[string]string {
+	m, ok := row[col].(ovsdb.OvsMap)
+	if !ok {
+		return nil
+	}
+	out := make(map[string]string, len(m.GoMap))
+	for k, v := range m.GoMap {
+		ks, kok := k.(string)
+		vs, vok := v.(string)
+		if kok && vok {
+			out[ks] = vs
+		}
+	}
+	return out
+}

--- a/ovn_cache_test.go
+++ b/ovn_cache_test.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
+)
+
+// uuidRow builds a minimal select row carrying only the _uuid column.
+func uuidRow(uuid string) ovsdb.Row {
+	return ovsdb.Row{"_uuid": ovsdb.UUID{GoUUID: uuid}}
+}
+
+// TestCachedListNoDrift: when the monitor cache and the server agree, cachedList
+// returns the cache snapshot untouched (no recovery, no decode).
+func TestCachedListNoDrift(t *testing.T) {
+	_, _, sb := newOVNClientWithFakes(t, "host-a")
+	chA := "ch-a"
+	sb.setRows("Port_Binding",
+		&SBPortBinding{UUID: "pb-1", LogicalPort: "cr-lrp-1", Type: "chassisredirect", Chassis: &chA},
+		&SBPortBinding{UUID: "pb-2", LogicalPort: "cr-lrp-2", Type: "chassisredirect", Chassis: &chA},
+	)
+
+	got, err := cachedList(context.Background(), sb, "Port_Binding",
+		func(p SBPortBinding) string { return p.UUID }, decodeSBPortBinding)
+	if err != nil {
+		t.Fatalf("cachedList: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	if got[0].LogicalPort != "cr-lrp-1" || got[1].LogicalPort != "cr-lrp-2" {
+		t.Errorf("cache snapshot not preserved: %+v", got)
+	}
+}
+
+// TestCachedListRecoversDroppedRow is the core regression test for issue #115:
+// the monitor cache is missing a row that the server has. cachedList must
+// detect the gap via the direct select and rebuild the full slice.
+func TestCachedListRecoversDroppedRow(t *testing.T) {
+	_, _, sb := newOVNClientWithFakes(t, "host-a")
+
+	// Cache only knows about pb-1 — pb-2's INSERT was dropped.
+	chA := "ch-a"
+	sb.setRows("Port_Binding",
+		&SBPortBinding{UUID: "pb-1", LogicalPort: "cr-lrp-1", Type: "chassisredirect", Chassis: &chA},
+	)
+	// The server has both rows.
+	sb.setSelectRows("Port_Binding",
+		uuidRow("pb-1"),
+		ovsdb.Row{
+			"_uuid":        ovsdb.UUID{GoUUID: "pb-2"},
+			"logical_port": "cr-lrp-2",
+			"type":         "chassisredirect",
+			"chassis":      ovsdb.UUID{GoUUID: "ch-a"},
+		},
+	)
+
+	got, err := cachedList(context.Background(), sb, "Port_Binding",
+		func(p SBPortBinding) string { return p.UUID }, decodeSBPortBinding)
+	if err != nil {
+		t.Fatalf("cachedList: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2 (cache gap not recovered)", len(got))
+	}
+	byUUID := map[string]SBPortBinding{}
+	for _, p := range got {
+		byUUID[p.UUID] = p
+	}
+	pb2, ok := byUUID["pb-2"]
+	if !ok {
+		t.Fatal("recovered slice is missing the dropped row pb-2")
+	}
+	if pb2.LogicalPort != "cr-lrp-2" || pb2.Type != "chassisredirect" {
+		t.Errorf("pb-2 decoded incorrectly: %+v", pb2)
+	}
+	if pb2.Chassis == nil || *pb2.Chassis != "ch-a" {
+		t.Errorf("pb-2.Chassis = %v, want ch-a", pb2.Chassis)
+	}
+}
+
+// TestAuthoritativeListServerSelectErrorTrustsCache: a failing direct select
+// must degrade to the monitor cache rather than stall reconciliation.
+func TestAuthoritativeListServerSelectErrorTrustsCache(t *testing.T) {
+	_, _, sb := newOVNClientWithFakes(t, "host-a")
+	sb.transactErr = errors.New("connection refused")
+
+	cached := []SBChassis{{UUID: "ch-1", Name: "ch-1", Hostname: "host-a"}}
+	got := authoritativeList(context.Background(), sb, "Chassis", cached,
+		func(c SBChassis) string { return c.UUID }, decodeSBChassis)
+	if !reflect.DeepEqual(got, cached) {
+		t.Errorf("got %+v, want cache snapshot %+v on select error", got, cached)
+	}
+}
+
+// TestRefreshStateRecoversDroppedNATFromCache exercises the fix end-to-end:
+// the NB monitor cache dropped the FIP's NAT row. Without the consistency
+// guard the FIP would silently vanish from the desired set (and ensureRoutes
+// would withdraw its /32). With the guard, refreshState recovers it.
+func TestRefreshStateRecoversDroppedNATFromCache(t *testing.T) {
+	c, nb, sb := newOVNClientWithFakes(t, "host-a")
+
+	sb.setRows("Chassis", &SBChassis{UUID: "ch-a", Name: "ch-a", Hostname: "host-a"})
+	chA := "ch-a"
+	sb.setRows("Port_Binding", &SBPortBinding{
+		UUID: "pb-1", LogicalPort: "cr-lrp-local", Type: "chassisredirect", Chassis: &chA,
+	})
+	nb.setRows("Logical_Router_Port", &NBLogicalRouterPort{
+		UUID: "lrp-uuid-local", Name: "lrp-local",
+		MAC: "fa:16:3e:aa:aa:aa", Networks: []string{"198.51.100.1/24"},
+	})
+	nb.setRows("Logical_Router", &NBLogicalRouter{
+		UUID: "lr-local", Name: "router-local",
+		Ports: []string{"lrp-uuid-local"}, Nat: []string{"nat-fip", "nat-snat"},
+	})
+
+	// The NB cache is missing nat-fip — only nat-snat made it in.
+	nb.setRows("NAT", &NBNAT{UUID: "nat-snat", Type: "snat", ExternalIP: "198.51.100.51"})
+	// The server, however, has both NAT rows.
+	nb.setSelectRows("NAT",
+		ovsdb.Row{"_uuid": ovsdb.UUID{GoUUID: "nat-fip"}, "type": "dnat_and_snat", "external_ip": "198.51.100.50"},
+		ovsdb.Row{"_uuid": ovsdb.UUID{GoUUID: "nat-snat"}, "type": "snat", "external_ip": "198.51.100.51"},
+	)
+
+	c.state.LocalChassisName = "host-a"
+	c.refreshState(context.Background())
+	snap := c.GetState()
+
+	if got := snap.FIPs; len(got) != 1 || got[0] != "198.51.100.50" {
+		t.Fatalf("FIPs = %v, want [198.51.100.50] — dropped NAT row not recovered", got)
+	}
+	if snap.NATIPToRouterMAC["198.51.100.50"] != "fa:16:3e:aa:aa:aa" {
+		t.Errorf("NATIPToRouterMAC[FIP] = %q, want fa:16:3e:aa:aa:aa",
+			snap.NATIPToRouterMAC["198.51.100.50"])
+	}
+}
+
+func TestDecodeNBLogicalRouter(t *testing.T) {
+	// ports: multi-element set; nat: bare single UUID.
+	row := ovsdb.Row{
+		"_uuid": ovsdb.UUID{GoUUID: "lr-1"},
+		"name":  "router-1",
+		"ports": ovsdb.OvsSet{GoSet: []any{
+			ovsdb.UUID{GoUUID: "p1"}, ovsdb.UUID{GoUUID: "p2"},
+		}},
+		"nat": ovsdb.UUID{GoUUID: "nat-1"},
+	}
+	got := decodeNBLogicalRouter(row)
+	want := NBLogicalRouter{
+		UUID: "lr-1", Name: "router-1",
+		Ports: []string{"p1", "p2"}, Nat: []string{"nat-1"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("decodeNBLogicalRouter = %+v, want %+v", got, want)
+	}
+}
+
+func TestDecodeSBPortBindingSetsAndMaps(t *testing.T) {
+	row := ovsdb.Row{
+		"_uuid":        ovsdb.UUID{GoUUID: "pb-1"},
+		"type":         "patch",
+		"logical_port": "external-port",
+		"options":      ovsdb.OvsMap{GoMap: map[any]any{"peer": "lrp-local"}},
+		"external_ids": ovsdb.OvsMap{GoMap: map[any]any{"neutron:device_owner": "network:router_gateway"}},
+		"nat_addresses": ovsdb.OvsSet{GoSet: []any{
+			"fa:16:3e:11:22:33 198.51.100.60",
+		}},
+		// chassis omitted entirely — an unbound port.
+	}
+	got := decodeSBPortBinding(row)
+	if got.Options["peer"] != "lrp-local" {
+		t.Errorf("Options = %v", got.Options)
+	}
+	if got.ExternalIDs["neutron:device_owner"] != "network:router_gateway" {
+		t.Errorf("ExternalIDs = %v", got.ExternalIDs)
+	}
+	if len(got.NatAddresses) != 1 || got.NatAddresses[0] != "fa:16:3e:11:22:33 198.51.100.60" {
+		t.Errorf("NatAddresses = %v", got.NatAddresses)
+	}
+	if got.Chassis != nil {
+		t.Errorf("Chassis = %v, want nil for an unbound port", *got.Chassis)
+	}
+}
+
+func TestRowHelpers(t *testing.T) {
+	t.Run("ovsSetToStrings", func(t *testing.T) {
+		cases := []struct {
+			name string
+			in   any
+			want []string
+		}{
+			{"bare string", "a", []string{"a"}},
+			{"bare uuid", ovsdb.UUID{GoUUID: "u"}, []string{"u"}},
+			{"set of strings", ovsdb.OvsSet{GoSet: []any{"a", "b"}}, []string{"a", "b"}},
+			{"set of uuids", ovsdb.OvsSet{GoSet: []any{ovsdb.UUID{GoUUID: "u1"}}}, []string{"u1"}},
+			{"empty set", ovsdb.OvsSet{GoSet: []any{}}, nil},
+			{"absent", nil, nil},
+		}
+		for _, tc := range cases {
+			if got := ovsSetToStrings(tc.in); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("%s: ovsSetToStrings(%v) = %v, want %v", tc.name, tc.in, got, tc.want)
+			}
+		}
+	})
+
+	t.Run("rowOptString", func(t *testing.T) {
+		if got := rowOptString(ovsdb.Row{"c": "x"}, "c"); got == nil || *got != "x" {
+			t.Errorf("bare string: got %v", got)
+		}
+		if got := rowOptString(ovsdb.Row{"c": ovsdb.UUID{GoUUID: "u"}}, "c"); got == nil || *got != "u" {
+			t.Errorf("bare uuid: got %v", got)
+		}
+		if got := rowOptString(ovsdb.Row{"c": ovsdb.OvsSet{GoSet: []any{}}}, "c"); got != nil {
+			t.Errorf("empty set: got %v, want nil", *got)
+		}
+		if got := rowOptString(ovsdb.Row{}, "c"); got != nil {
+			t.Errorf("absent: got %v, want nil", *got)
+		}
+	})
+}
+
+func TestUUIDSetsEqual(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b map[string]bool
+		want bool
+	}{
+		{"equal", map[string]bool{"x": true, "y": true}, map[string]bool{"y": true, "x": true}, true},
+		{"both empty", map[string]bool{}, map[string]bool{}, true},
+		{"different len", map[string]bool{"x": true}, map[string]bool{"x": true, "y": true}, false},
+		{"same len different member", map[string]bool{"x": true}, map[string]bool{"y": true}, false},
+	}
+	for _, tc := range cases {
+		if got := uuidSetsEqual(tc.a, tc.b); got != tc.want {
+			t.Errorf("%s: uuidSetsEqual = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/ovn_fake_test.go
+++ b/ovn_fake_test.go
@@ -39,10 +39,12 @@ type fakeOVSDBClient struct {
 
 	// selectRows, when non-nil, supplies rows for OperationSelect ops keyed
 	// by table name, bypassing the cache view exposed via setRows/List. The
-	// drain fallback path uses Transact(OperationSelect) to read directly
-	// from the NB server when the cache appears incomplete (issue #115);
-	// tests populate this to simulate the "server has the row, cache does
-	// not" race.
+	// drain fallback and refreshState's cache-consistency guard use
+	// Transact(OperationSelect) to read directly from the server when the
+	// cache appears incomplete (issue #115); tests populate this to simulate
+	// the "server has the row, cache does not" race. When a table has no
+	// entry here, Transact synthesises a minimal _uuid-only row per cached
+	// model, i.e. the server view is modelled as identical to the cache.
 	selectRows map[string][]ovsdb.Row
 
 	// onTransact is invoked synchronously for each Transact call (after the
@@ -184,7 +186,6 @@ func (f *fakeOVSDBClient) Transact(_ context.Context, ops ...ovsdb.Operation) ([
 	f.mu.Lock()
 	f.transacts = append(f.transacts, append([]ovsdb.Operation(nil), ops...))
 	hook := f.onTransact
-	selectRows := f.selectRows
 	f.mu.Unlock()
 
 	if hook != nil {
@@ -196,10 +197,24 @@ func (f *fakeOVSDBClient) Transact(_ context.Context, ops ...ovsdb.Operation) ([
 	if f.opResults != nil {
 		return f.opResults, nil
 	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	results := make([]ovsdb.OperationResult, len(ops))
 	for i, op := range ops {
-		if op.Op == ovsdb.OperationSelect {
-			results[i].Rows = append([]ovsdb.Row(nil), selectRows[op.Table]...)
+		if op.Op != ovsdb.OperationSelect {
+			continue
+		}
+		if rows, ok := f.selectRows[op.Table]; ok {
+			results[i].Rows = append([]ovsdb.Row(nil), rows...)
+			continue
+		}
+		// No explicit override: model the server view as identical to the
+		// cache. refreshState's consistency check only reads _uuid here, so
+		// one minimal row per cached model is enough to signal "no drift".
+		for _, m := range f.rows[op.Table] {
+			results[i].Rows = append(results[i].Rows,
+				ovsdb.Row{"_uuid": ovsdb.UUID{GoUUID: uuidOfModel(m)}})
 		}
 	}
 	return results, nil

--- a/ovn_test.go
+++ b/ovn_test.go
@@ -711,7 +711,10 @@ func TestNBEventHandlerOnlyRelevantTablesTriggerDebounce(t *testing.T) {
 	c.ready.Store(true)
 	h := &nbEventHandler{ovn: c}
 
-	tables := []string{"NAT", "Logical_Router", "Logical_Router_Port"}
+	// Gateway_Chassis is included: a peer's drain/restore/boost is a
+	// Gateway_Chassis write, and the agent must wake so the following
+	// reconcile runs EnsureActivePriorityLead and resolves any priority tie.
+	tables := []string{"NAT", "Logical_Router", "Logical_Router_Port", "Gateway_Chassis"}
 	for _, table := range tables {
 		// Drain first so each iteration starts empty.
 		select {

--- a/ovs.go
+++ b/ovs.go
@@ -49,31 +49,15 @@ func (rm *RouteManager) runOVS(binary string, args ...string) ([]byte, error) {
 // integration bridge (via the patch-provnet port) to the bridge device's own
 // MAC, so the kernel can properly receive and route them.
 //
-// Discovery results are cached after the first successful call.
+// The patch port is re-validated on every call via refreshOVSDiscovery.
 func (rm *RouteManager) EnsureOVSFlows() error {
 	if rm.dryRun {
 		slog.Info("[dry-run] would ensure OVS MAC-tweak flows", "dev", rm.bridgeDev)
 		return nil
 	}
 
-	// Use cached values if available; discover on first call.
-	if rm.cachedPatchPort == "" {
-		patchPort, err := rm.discoverPatchPort()
-		if err != nil {
-			return fmt.Errorf("discover patch port on %s: %w", rm.bridgeDev, err)
-		}
-		ofport, err := rm.getOFPort(patchPort)
-		if err != nil {
-			return fmt.Errorf("get ofport for %s: %w", patchPort, err)
-		}
-		mac, err := rm.GetBridgeMAC()
-		if err != nil {
-			return fmt.Errorf("get bridge MAC: %w", err)
-		}
-		rm.cachedPatchPort = patchPort
-		rm.cachedOfport = ofport
-		rm.cachedBridgeMAC = mac.String()
-		slog.Info("OVS discovery complete", "patch_port", patchPort, "ofport", ofport, "mac", rm.cachedBridgeMAC)
+	if err := rm.refreshOVSDiscovery(); err != nil {
+		return err
 	}
 
 	// Delete existing agent-managed flows (idempotent replace).
@@ -94,6 +78,49 @@ func (rm *RouteManager) EnsureOVSFlows() error {
 	}
 
 	slog.Debug("OVS MAC-tweak flows ensured", "dev", rm.bridgeDev)
+	return nil
+}
+
+// refreshOVSDiscovery makes sure cachedPatchPort, cachedOfport and
+// cachedBridgeMAC reflect the current br-ex state.
+//
+// The discovery results cannot be cached for the process lifetime:
+// ovn-controller can delete and recreate the br-ex patch port — on a
+// bridge-mapping change, an OVS resync, or its own restart — which assigns
+// the port a new OpenFlow port number. A stale cached ofport makes every
+// MAC-tweak and hairpin flow match a dead in_port, silently breaking the
+// OVN↔kernel data path until the agent is restarted.
+//
+// The fast path keeps the cache whenever the cached patch port still resolves
+// to the cached ofport; otherwise (first call, or the port was recreated) it
+// rediscovers from scratch.
+func (rm *RouteManager) refreshOVSDiscovery() error {
+	if rm.cachedPatchPort != "" {
+		if ofport, err := rm.getOFPort(rm.cachedPatchPort); err == nil && ofport == rm.cachedOfport {
+			return nil
+		}
+		slog.Info("br-ex patch port changed or gone, rediscovering OVS flow target",
+			"cached_patch_port", rm.cachedPatchPort, "cached_ofport", rm.cachedOfport)
+		rm.cachedPatchPort = ""
+		rm.cachedOfport = ""
+	}
+
+	patchPort, err := rm.discoverPatchPort()
+	if err != nil {
+		return fmt.Errorf("discover patch port on %s: %w", rm.bridgeDev, err)
+	}
+	ofport, err := rm.getOFPort(patchPort)
+	if err != nil {
+		return fmt.Errorf("get ofport for %s: %w", patchPort, err)
+	}
+	mac, err := rm.GetBridgeMAC()
+	if err != nil {
+		return fmt.Errorf("get bridge MAC: %w", err)
+	}
+	rm.cachedPatchPort = patchPort
+	rm.cachedOfport = ofport
+	rm.cachedBridgeMAC = mac.String()
+	slog.Info("OVS discovery complete", "patch_port", patchPort, "ofport", ofport, "mac", rm.cachedBridgeMAC)
 	return nil
 }
 

--- a/ovs_test.go
+++ b/ovs_test.go
@@ -162,6 +162,12 @@ func TestOVSCmdNoWrapper(t *testing.T) {
 
 func TestEnsureOVSFlowsWithCachedDiscovery(t *testing.T) {
 	rec := newOVSRecorder()
+	// EnsureOVSFlows re-validates the cached patch port on every call; here
+	// it still resolves to ofport 42, so no full rediscovery (list-ports) runs.
+	rec.on(
+		[]string{"ovs-vsctl", "get", "Interface", "patch-provnet-0", "ofport"},
+		"42\n", nil,
+	)
 	rm := &RouteManager{
 		bridgeDev:       "br-ex",
 		cachedPatchPort: "patch-provnet-0",
@@ -174,14 +180,18 @@ func TestEnsureOVSFlowsWithCachedDiscovery(t *testing.T) {
 		t.Fatalf("EnsureOVSFlows() error: %v", err)
 	}
 
-	// Expect: 1 del-flows + 2 add-flows (IPv4 + IPv6 MAC-tweak).
-	if len(rec.calls) != 3 {
-		t.Fatalf("expected 3 OVS commands, got %d: %v", len(rec.calls), rec.calls)
+	// Expect: 1 ofport validation + 1 del-flows + 2 add-flows (IPv4 + IPv6).
+	if len(rec.calls) != 4 {
+		t.Fatalf("expected 4 OVS commands, got %d: %v", len(rec.calls), rec.calls)
 	}
 
+	wantValidate := []string{"ovs-vsctl", "get", "Interface", "patch-provnet-0", "ofport"}
+	if !reflect.DeepEqual(rec.calls[0], wantValidate) {
+		t.Errorf("first call = %v, want %v", rec.calls[0], wantValidate)
+	}
 	wantDel := []string{"ovs-ofctl", "del-flows", "br-ex", "cookie=0x999/-1"}
-	if !reflect.DeepEqual(rec.calls[0], wantDel) {
-		t.Errorf("first call = %v, want %v", rec.calls[0], wantDel)
+	if !reflect.DeepEqual(rec.calls[1], wantDel) {
+		t.Errorf("second call = %v, want %v", rec.calls[1], wantDel)
 	}
 
 	flows := rec.findAddFlows()
@@ -241,6 +251,10 @@ func TestEnsureOVSFlowsTolersDelFailure(t *testing.T) {
 	// subsequent add-flow calls.
 	rec := newOVSRecorder()
 	rec.on(
+		[]string{"ovs-vsctl", "get", "Interface", "patch-provnet-0", "ofport"},
+		"42\n", nil,
+	)
+	rec.on(
 		[]string{"ovs-ofctl", "del-flows", "br-ex", "cookie=0x999/-1"},
 		"some output", errors.New("transient ofctl error"),
 	)
@@ -263,6 +277,10 @@ func TestEnsureOVSFlowsTolersDelFailure(t *testing.T) {
 
 func TestEnsureOVSFlowsAddFailurePropagates(t *testing.T) {
 	rec := newOVSRecorder()
+	rec.on(
+		[]string{"ovs-vsctl", "get", "Interface", "patch-provnet-0", "ofport"},
+		"42\n", nil,
+	)
 	// First add-flow (IPv4) fails — function must return an error.
 	rec.on(
 		[]string{"ovs-ofctl", "add-flow", "br-ex",
@@ -283,6 +301,45 @@ func TestEnsureOVSFlowsAddFailurePropagates(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "add IPv4 MAC-tweak flow") {
 		t.Errorf("expected wrapped IPv4 error, got: %v", err)
+	}
+}
+
+// TestEnsureOVSFlowsRediscoversWhenOfportChanges covers the core of the
+// patch-port staleness fix: the cached patch port now resolves to a different
+// ofport (as if ovn-controller had recreated it). EnsureOVSFlows must drop the
+// stale cache and rediscover, rather than keep installing flows for a dead
+// in_port. Rediscovery runs through discoverPatchPort + getOFPort and then
+// fails at GetBridgeMAC (no real bridge in a unit test) — which proves the
+// stale cache was abandoned instead of trusted.
+func TestEnsureOVSFlowsRediscoversWhenOfportChanges(t *testing.T) {
+	rec := newOVSRecorder()
+	rec.on(
+		[]string{"ovs-vsctl", "get", "Interface", "patch-provnet-0", "ofport"},
+		"99\n", nil,
+	)
+	rec.on(
+		[]string{"ovs-vsctl", "list-ports", "br-ex"},
+		"patch-provnet-0\n", nil,
+	)
+	rec.on(
+		[]string{"ovs-vsctl", "--if-exists", "get", "Interface", "patch-provnet-0", "type"},
+		"patch\n", nil,
+	)
+	rm := &RouteManager{
+		bridgeDev:       "br-ex",
+		cachedPatchPort: "patch-provnet-0",
+		cachedOfport:    "42",
+		cachedBridgeMAC: "aa:bb:cc:dd:ee:ff",
+		execOVSHook:     rec.hook(),
+	}
+
+	err := rm.EnsureOVSFlows()
+	if err == nil || !strings.Contains(err.Error(), "get bridge MAC") {
+		t.Fatalf("expected rediscovery to reach GetBridgeMAC, got: %v", err)
+	}
+	if rm.cachedPatchPort != "" || rm.cachedOfport != "" {
+		t.Errorf("stale cache must be cleared on rediscovery: patch=%q ofport=%q",
+			rm.cachedPatchPort, rm.cachedOfport)
 	}
 }
 

--- a/routing.go
+++ b/routing.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -234,6 +236,62 @@ func (rm *RouteManager) ListFRRRoutes() ([]string, error) {
 		}
 	}
 	return ips, nil
+}
+
+// frrRouteEntry is the subset of an FRR `show ip route ... json` route object
+// that the agent inspects. A static route is only advertised via BGP once it
+// is both selected (FRR's best route for the prefix) and installed (present in
+// the kernel FIB); FRR omits these keys when false, so the zero value is the
+// correct default.
+type frrRouteEntry struct {
+	Selected  bool `json:"selected"`
+	Installed bool `json:"installed"`
+}
+
+// InactiveFRRRoutes returns, from the given /32 IPs, those whose static route
+// exists in the VRF but is not selected and installed by FRR — i.e. configured
+// but not actually advertised (typically an unresolvable next-hop). IPs with no
+// static route at all are not reported: that case is a plain "missing route"
+// handled by ensureRoutes. ListFRRRoutes cannot tell the two apart because it
+// matches any configured route, which is why this distinct check exists.
+func (rm *RouteManager) InactiveFRRRoutes(ips []string) ([]string, error) {
+	if rm.dryRun || len(ips) == 0 {
+		return nil, nil
+	}
+	output, err := rm.runVtysh("-c", fmt.Sprintf("show ip route vrf %s static json", rm.vrfName))
+	if err != nil {
+		return nil, fmt.Errorf("vtysh list routes json: %w (output: %s)", err, strings.TrimSpace(string(output)))
+	}
+	// FRR emits an empty body rather than "{}" when the VRF has no static
+	// routes; treat that as "nothing configured".
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return nil, nil
+	}
+	var routes map[string][]frrRouteEntry
+	if err := json.Unmarshal([]byte(trimmed), &routes); err != nil {
+		return nil, fmt.Errorf("parse vtysh route json: %w", err)
+	}
+
+	var inactive []string
+	for _, ip := range ips {
+		entries, ok := routes[ip+"/32"]
+		if !ok {
+			continue // not configured at all — not this check's concern
+		}
+		active := false
+		for _, e := range entries {
+			if e.Selected && e.Installed {
+				active = true
+				break
+			}
+		}
+		if !active {
+			inactive = append(inactive, ip)
+		}
+	}
+	sort.Strings(inactive)
+	return inactive, nil
 }
 
 // RefreshBGP triggers an outbound BGP soft-refresh so that peers learn about

--- a/routing_test.go
+++ b/routing_test.go
@@ -601,6 +601,87 @@ func TestListFRRRoutes_PropagatesVtyshError(t *testing.T) {
 	}
 }
 
+func TestInactiveFRRRoutes(t *testing.T) {
+	const cmd = "show ip route vrf vrf-provider static json"
+
+	t.Run("all selected and installed are active", func(t *testing.T) {
+		j := `{
+  "198.51.100.10/32": [{"prefix":"198.51.100.10/32","protocol":"static","selected":true,"installed":true}],
+  "198.51.100.11/32": [{"prefix":"198.51.100.11/32","protocol":"static","selected":true,"installed":true}]
+}`
+		rec := newVtyshRecorder()
+		rec.on([]string{"vtysh", "-c", cmd}, j, nil)
+		rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+		got, err := rm.InactiveFRRRoutes([]string{"198.51.100.10", "198.51.100.11"})
+		if err != nil {
+			t.Fatalf("InactiveFRRRoutes: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("got %v, want no inactive routes", got)
+		}
+	})
+
+	t.Run("reports configured-but-inactive, ignores absent", func(t *testing.T) {
+		// .10 active; .11 configured but neither selected nor installed;
+		// .12 not configured at all (absent → not this check's concern).
+		j := `{
+  "198.51.100.10/32": [{"prefix":"198.51.100.10/32","protocol":"static","selected":true,"installed":true}],
+  "198.51.100.11/32": [{"prefix":"198.51.100.11/32","protocol":"static"}]
+}`
+		rec := newVtyshRecorder()
+		rec.on([]string{"vtysh", "-c", cmd}, j, nil)
+		rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+		got, err := rm.InactiveFRRRoutes([]string{"198.51.100.10", "198.51.100.11", "198.51.100.12"})
+		if err != nil {
+			t.Fatalf("InactiveFRRRoutes: %v", err)
+		}
+		if !reflect.DeepEqual(got, []string{"198.51.100.11"}) {
+			t.Errorf("got %v, want [198.51.100.11]", got)
+		}
+	})
+
+	t.Run("selected but not installed is inactive", func(t *testing.T) {
+		j := `{"198.51.100.11/32":[{"prefix":"198.51.100.11/32","protocol":"static","selected":true}]}`
+		rec := newVtyshRecorder()
+		rec.on([]string{"vtysh", "-c", cmd}, j, nil)
+		rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+		got, _ := rm.InactiveFRRRoutes([]string{"198.51.100.11"})
+		if !reflect.DeepEqual(got, []string{"198.51.100.11"}) {
+			t.Errorf("got %v, want [198.51.100.11]", got)
+		}
+	})
+
+	t.Run("empty body means nothing configured", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		rec.on([]string{"vtysh", "-c", cmd}, "", nil)
+		rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+		got, err := rm.InactiveFRRRoutes([]string{"198.51.100.10"})
+		if err != nil || got != nil {
+			t.Errorf("got (%v, %v), want (nil, nil)", got, err)
+		}
+	})
+
+	t.Run("vtysh error propagates", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		rec.on([]string{"vtysh", "-c", cmd}, "boom", errors.New("exit 1"))
+		rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+		if _, err := rm.InactiveFRRRoutes([]string{"198.51.100.10"}); err == nil {
+			t.Fatal("expected error when vtysh fails")
+		}
+	})
+
+	t.Run("dry-run and empty input short-circuit", func(t *testing.T) {
+		rmDry := &RouteManager{vrfName: "vrf-provider", dryRun: true}
+		if got, err := rmDry.InactiveFRRRoutes([]string{"198.51.100.10"}); got != nil || err != nil {
+			t.Errorf("dry-run: got (%v, %v), want (nil, nil)", got, err)
+		}
+		rm := &RouteManager{vrfName: "vrf-provider"}
+		if got, err := rm.InactiveFRRRoutes(nil); got != nil || err != nil {
+			t.Errorf("empty input: got (%v, %v), want (nil, nil)", got, err)
+		}
+	})
+}
+
 func TestAddFRRRoutesBatchesVtyshCommands(t *testing.T) {
 	rec := newVtyshRecorder()
 	rm := &RouteManager{

--- a/tools/docgen/render.go
+++ b/tools/docgen/render.go
@@ -192,6 +192,9 @@ func renderMetrics(info *sourceInfo) string {
 	b.WriteString("- `ovn_connection_state{database=\"nb\"} == 0` for >2m — NB DB unreachable;\n")
 	b.WriteString("  agent cannot write OVN state.\n")
 	b.WriteString("- `rate(route_readds_total[10m]) > 0` — flapping routes.\n")
+	b.WriteString("- `inactive_routes > 0` for >2m — FIP `/32`s configured in FRR but not\n")
+	b.WriteString("  advertised via BGP (e.g. an unresolvable next-hop); those FIPs are\n")
+	b.WriteString("  unreachable from outside.\n")
 	b.WriteString("- `histogram_quantile(0.95, rate(reconcile_duration_seconds_bucket[5m])) > 5`\n")
 	b.WriteString("  — slow reconciles.\n")
 


### PR DESCRIPTION
## Problem

After repeated gateway-agent stop/start cycles in a 2-agent HA setup, the
OVN side keeps looking correct — chassisredirect ports bound to the right
node, `Gateway_Chassis` priorities converged — yet FIPs become unreachable
from outside on the node that holds all logical routers. Because each cause
is a race with a per-restart probability, it only surfaces "after a few
cycles", and worst under rapid succession.

Root-cause analysis turned up five independent latent bugs, each fixed in
its own commit.

## Changes

### 1. Guard `refreshState` against monitor-cache INSERT drops

`refreshState` builds the agent's whole view of FIPs/routers from the
libovsdb monitor cache, which occasionally drops INSERTs delivered shortly
after a fresh subscription (the issue #115 cache-drop class). A short cache
shrinks the desired-IP set, and `ensureRoutes` withdraws the FRR `/32` of
every FIP it no longer sees. Every table `refreshState` reads is now
cross-checked against a cheap server-side `_uuid` select and rebuilt from a
full select on a genuine mismatch; the cache stays the fast path.

### 2. Detect FRR static routes that are configured but not advertised

A static route with an unresolvable next-hop — present in FRR but not
`selected`/`installed`, hence not in BGP — looked healthy to the agent.
`InactiveFRRRoutes` now parses `show ip route ... static json`, every
reconcile logs inactive desired `/32`s, and the count is exposed as the
`ovn_network_agent_inactive_routes` gauge.

### 3. Refresh OVN state after drain so shutdown keeps the peer's entries

`Run()` and the OVN refresh loop share one context, so the loop exits when
`ctx` is cancelled — before `DrainGateways` runs. The chassisredirect
migration never reaches `o.state`, so `RemoveManagedNBEntries` acts on a
stale `LocalRouters` snapshot and deletes default routes / MAC bindings the
new active chassis depends on. Fixed by one fresh `refreshState` after the
drain and before cleanup.

### 4. Rediscover the br-ex patch port instead of caching it forever

`EnsureOVSFlows` discovered the OVS patch port once and cached its ofport
for the process lifetime. When ovn-controller recreates the patch port it
gets a new ofport, and the agent keeps installing MAC-tweak/hairpin flows
with a dead `in_port`. `refreshOVSDiscovery` now re-validates the patch
port on every call and rediscovers when the ofport changed.

### 5. Wake on `Gateway_Chassis` changes so priority ties resolve fast

The NB event handler triggered a refresh for NAT/Logical_Router/
Logical_Router_Port changes but not `Gateway_Chassis`. A peer draining,
restoring or boosting its priority was invisible until the 60s periodic
reconcile — and `EnsureActivePriorityLead` (which keeps the active chassis
out of a priority tie) only runs inside a reconcile. A tie could therefore
persist long enough for ovn-northd to flap the chassisredirect port and
strand the FIPs; rapid stop/start cycles are bursts of `Gateway_Chassis`
writes, so the hang is worst under quick succession. `Gateway_Chassis`
changes now also drive `debounceStateRefresh`.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt`, `make docs-gen-check` — clean.
- Full unit suite green, including new/updated tests in `ovn_cache_test.go`,
  `routing_test.go`, `metrics_test.go`, `ovs_test.go` and `ovn_test.go`.
- Each commit builds and tests independently (bisectable).
- Not run here: `make test-integration` (needs a live OVN environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)