### PR TITLE
Reduce FIP outage during gateway drain (post-drain settle delay + faster takeover BGP)

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -573,12 +573,15 @@ func (a *Agent) ensureRoutes(desiredIPs []string) {
 		}
 	}
 
-	// Only trigger a BGP soft-refresh when routes were removed. For
-	// additions FRR's normal route redistribution announces the new
-	// static routes automatically. A blanket "clear ip bgp * soft out"
-	// re-evaluates outbound policy for ALL routes; doing this on every
-	// addition risks disrupting existing BGP announcements.
-	if len(delFRR) > 0 {
+	// Trigger a BGP soft-refresh whenever FRR routes were added or
+	// removed. On additions this pushes the new /32s out immediately
+	// instead of waiting for FRR's redistribution timing — critical on
+	// the takeover chassis during an HA failover, where every extra
+	// second of delay is external downtime. "clear ip bgp ... soft out"
+	// only re-evaluates outbound policy and re-sends; it never withdraws
+	// a route, so re-announcing the existing set alongside the new ones
+	// is harmless.
+	if len(addFRR) > 0 || len(delFRR) > 0 {
 		if err := a.routing.RefreshBGP(); err != nil {
 			slog.Warn("BGP soft-refresh failed, peers may wait for MRAI timer", "error", err)
 		}

--- a/config.go
+++ b/config.go
@@ -127,7 +127,15 @@ type Config struct {
 	CleanupOnShutdown bool
 	DrainOnShutdown   bool
 	DrainTimeout      time.Duration
-	FRRPrefixList     string // FRR prefix-list name to manage dynamically (e.g. ANNOUNCED-NETWORKS)
+
+	// DrainSettleDelay is how long to keep advertising FIP routes after
+	// the drain confirms all chassisredirect ports have migrated away,
+	// before cleanup withdraws them. The hold gives the takeover chassis
+	// time to finish OVN programming and BGP advertisement so external
+	// traffic is not blackholed. 0 = no hold.
+	DrainSettleDelay time.Duration
+
+	FRRPrefixList string // FRR prefix-list name to manage dynamically (e.g. ANNOUNCED-NETWORKS)
 
 	// Stale chassis cleanup: grace period before removing OVN NB entries
 	// from chassis that have disappeared from the SB Chassis table.
@@ -176,6 +184,7 @@ type configFile struct {
 	CleanupOnShutdown *bool         `yaml:"cleanup_on_shutdown"`
 	DrainOnShutdown   *bool         `yaml:"drain_on_shutdown"`
 	DrainTimeout      string        `yaml:"drain_timeout"`
+	DrainSettleDelay  string        `yaml:"drain_settle_delay"`
 
 	FRRPrefixList string `yaml:"frr_prefix_list"`
 
@@ -219,6 +228,7 @@ func loadConfig(args []string) (Config, error) {
 		fCleanupOnShutdown = fs.Bool("cleanup-on-shutdown", true, "Remove all managed routes on shutdown (SIGINT/SIGTERM)")
 		fDrainOnShutdown   = fs.Bool("drain-on-shutdown", true, "Drain HA gateways before shutdown by lowering Gateway_Chassis priority")
 		fDrainTimeout      = fs.String("drain-timeout", "", "Max time to wait for gateway drain (e.g. 60s)")
+		fDrainSettleDelay  = fs.String("drain-settle-delay", "", "Hold time after gateway drain before cleanup so the takeover chassis can finish coming up (e.g. 3s)")
 
 		fFRRPrefixList        = fs.String("frr-prefix-list", "", "FRR prefix-list name to manage dynamically (default: ANNOUNCED-NETWORKS)")
 		fStaleGrace           = fs.String("stale-chassis-grace-period", "", "Grace period before cleaning up entries from missing chassis (e.g. 5m, 0 to disable)")
@@ -254,6 +264,7 @@ func loadConfig(args []string) (Config, error) {
 		CleanupOnShutdown:       true,
 		DrainOnShutdown:         true,
 		DrainTimeout:            60 * time.Second,
+		DrainSettleDelay:        3 * time.Second,
 		FRRPrefixList:           "ANNOUNCED-NETWORKS",
 		StaleChassisGracePeriod: 5 * time.Minute,
 		VethLeakEnabled:         true,
@@ -314,6 +325,10 @@ func loadConfig(args []string) (Config, error) {
 		case "drain-timeout":
 			if d, err := time.ParseDuration(*fDrainTimeout); err == nil {
 				cfg.DrainTimeout = d
+			}
+		case "drain-settle-delay":
+			if d, err := time.ParseDuration(*fDrainSettleDelay); err == nil {
+				cfg.DrainSettleDelay = d
 			}
 		case "frr-prefix-list":
 			cfg.FRRPrefixList = *fFRRPrefixList
@@ -436,6 +451,9 @@ func validateConfig(cfg *Config) error {
 	}
 	if cfg.DrainOnShutdown && cfg.DrainTimeout == 0 {
 		return fmt.Errorf("drain-on-shutdown requires a positive drain-timeout")
+	}
+	if cfg.DrainSettleDelay < 0 {
+		return fmt.Errorf("invalid drain-settle-delay: must be non-negative")
 	}
 
 	if cfg.StaleChassisGracePeriod < 0 {
@@ -651,6 +669,13 @@ func applyFileConfig(cfg *Config, fc *configFile) {
 			slog.Warn("ignoring invalid drain_timeout in config file", "value", fc.DrainTimeout, "error", err)
 		}
 	}
+	if fc.DrainSettleDelay != "" {
+		if d, err := time.ParseDuration(fc.DrainSettleDelay); err == nil {
+			cfg.DrainSettleDelay = d
+		} else {
+			slog.Warn("ignoring invalid drain_settle_delay in config file", "value", fc.DrainSettleDelay, "error", err)
+		}
+	}
 	if fc.FRRPrefixList != "" {
 		cfg.FRRPrefixList = fc.FRRPrefixList
 	}
@@ -749,6 +774,13 @@ func applyEnvConfig(cfg *Config) {
 			cfg.DrainTimeout = d
 		} else {
 			slog.Warn("ignoring invalid OVN_NETWORK_DRAIN_TIMEOUT env var", "value", v, "error", err)
+		}
+	}
+	if v := os.Getenv("OVN_NETWORK_DRAIN_SETTLE_DELAY"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.DrainSettleDelay = d
+		} else {
+			slog.Warn("ignoring invalid OVN_NETWORK_DRAIN_SETTLE_DELAY env var", "value", v, "error", err)
 		}
 	}
 	if v := os.Getenv("OVN_NETWORK_FRR_PREFIX_LIST"); v != "" {

--- a/config_test.go
+++ b/config_test.go
@@ -960,6 +960,96 @@ func TestValidateConfigStaleChassisGracePeriodNegative(t *testing.T) {
 	}
 }
 
+func TestLoadConfigDrainSettleDelayDefault(t *testing.T) {
+	cfg, err := loadConfig(fullModeArgs())
+	if err != nil {
+		t.Fatalf("loadConfig() error: %v", err)
+	}
+	if cfg.DrainSettleDelay != 3*time.Second {
+		t.Errorf("DrainSettleDelay = %v, want %v", cfg.DrainSettleDelay, 3*time.Second)
+	}
+}
+
+func TestLoadConfigDrainSettleDelayCLI(t *testing.T) {
+	cfg, err := loadConfig(fullModeArgs("--drain-settle-delay", "8s"))
+	if err != nil {
+		t.Fatalf("loadConfig() error: %v", err)
+	}
+	if cfg.DrainSettleDelay != 8*time.Second {
+		t.Errorf("DrainSettleDelay = %v, want %v", cfg.DrainSettleDelay, 8*time.Second)
+	}
+}
+
+func TestLoadConfigDrainSettleDelayDisabled(t *testing.T) {
+	cfg, err := loadConfig(fullModeArgs("--drain-settle-delay", "0s"))
+	if err != nil {
+		t.Fatalf("loadConfig() error: %v", err)
+	}
+	if cfg.DrainSettleDelay != 0 {
+		t.Errorf("DrainSettleDelay = %v, want 0 (disabled)", cfg.DrainSettleDelay)
+	}
+}
+
+func TestApplyEnvConfigDrainSettleDelay(t *testing.T) {
+	cfg := Config{DrainSettleDelay: 3 * time.Second}
+	t.Setenv("OVN_NETWORK_DRAIN_SETTLE_DELAY", "5s")
+	applyEnvConfig(&cfg)
+	if cfg.DrainSettleDelay != 5*time.Second {
+		t.Errorf("DrainSettleDelay = %v, want %v", cfg.DrainSettleDelay, 5*time.Second)
+	}
+}
+
+func TestApplyFileConfigDrainSettleDelay(t *testing.T) {
+	cfg := Config{DrainSettleDelay: 3 * time.Second}
+	fc := configFile{DrainSettleDelay: "10s"}
+	applyFileConfig(&cfg, &fc)
+	if cfg.DrainSettleDelay != 10*time.Second {
+		t.Errorf("DrainSettleDelay = %v, want %v", cfg.DrainSettleDelay, 10*time.Second)
+	}
+}
+
+func TestApplyFileConfigDrainSettleDelayEmpty(t *testing.T) {
+	cfg := Config{DrainSettleDelay: 3 * time.Second}
+	fc := configFile{}
+	applyFileConfig(&cfg, &fc)
+	if cfg.DrainSettleDelay != 3*time.Second {
+		t.Errorf("DrainSettleDelay = %v, want %v (should keep default)", cfg.DrainSettleDelay, 3*time.Second)
+	}
+}
+
+func TestLoadConfigDrainSettleDelayYAML(t *testing.T) {
+	content := `
+ovn_sb_remote: "tcp:10.0.0.1:6642"
+ovn_nb_remote: "tcp:10.0.0.1:6641"
+veth_leak_enabled: false
+drain_settle_delay: "4s"
+`
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write test config: %v", err)
+	}
+
+	cfg, err := loadConfig([]string{"--config", path})
+	if err != nil {
+		t.Fatalf("loadConfig() error: %v", err)
+	}
+	if cfg.DrainSettleDelay != 4*time.Second {
+		t.Errorf("DrainSettleDelay = %v, want %v", cfg.DrainSettleDelay, 4*time.Second)
+	}
+}
+
+func TestValidateConfigDrainSettleDelayNegative(t *testing.T) {
+	cfg := Config{
+		VethNexthop:      "169.254.0.1",
+		VRFName:          "vrf-provider",
+		DrainSettleDelay: -1 * time.Second,
+	}
+	err := validateConfig(&cfg)
+	if err == nil {
+		t.Error("expected error for negative drain-settle-delay")
+	}
+}
+
 func TestApplyEnvConfigFRRPrefixList(t *testing.T) {
 	cfg := Config{}
 	t.Setenv("OVN_NETWORK_FRR_PREFIX_LIST", "MY-LIST")

--- a/docs/explanation/gateway-drain.md
+++ b/docs/explanation/gateway-drain.md
@@ -70,7 +70,18 @@ already moved. The result is a hitless shutdown.
                           │
                           ▼
   ┌───────────────────────────────────────────────────────┐
-  │  2. CLEANUP (if cleanup_on_shutdown=true)             │
+  │  2. SETTLE (hold for drain_settle_delay)              │
+  │                                                       │
+  │  Keep advertising FIP /32 routes and OVS flows so     │
+  │  this node still forwards external traffic            │
+  │  (hairpinned to the new gateway chassis) while the    │
+  │  takeover chassis finishes OVN programming, reconcile │
+  │  and BGP advertisement. Skipped if nothing migrated.  │
+  └───────────────────────┬───────────────────────────────┘
+                          │
+                          ▼
+  ┌───────────────────────────────────────────────────────┐
+  │  3. CLEANUP (if cleanup_on_shutdown=true)             │
   │                                                       │
   │  Remove kernel routes, FRR routes, OVS flows,         │
   │  bridge IP, nftables rules                            │
@@ -115,6 +126,48 @@ already moved. The result is a hitless shutdown.
                           ▼
                  Normal reconciliation loop
 ```
+
+## The takeover race and the settle delay
+
+Draining the priority and polling until the chassisredirect port has
+migrated away makes the **OVN-internal** failover hitless. But "the port
+moved" is not the same as "the takeover chassis can forward external
+traffic". The leaving node advertises each FIP as a BGP `/32`; so does the
+takeover node, once it is ready. Between the two events there is a second
+race:
+
+1. The leaving node sees the port migrate and — without a hold — proceeds
+   straight to cleanup, which **withdraws its FIP `/32` routes** from BGP.
+2. The takeover node still has to react to the `Port_Binding` change,
+   reconcile, install OVS flows and kernel routes, advertise its own FIP
+   `/32`s in FRR, and wait for the upstream fabric to reconverge.
+
+If step 1 wins, external traffic has no working path until step 2
+finishes — observed as roughly 5 s of packet loss on a continuous ping
+through a FIP.
+
+Two mechanisms close this race:
+
+- **Post-drain settle delay** (`drain_settle_delay`, default 3 s). After
+  the poll loop confirms the ports have migrated, the leaving node holds
+  before cleanup. During the hold it still advertises its FIP routes and
+  keeps its OVS flows, so it continues forwarding external traffic —
+  hairpinned to the new gateway chassis over the tunnel — while the
+  takeover node comes up. The hold is bounded by `drain_timeout`, so total
+  graceful shutdown never exceeds that budget, and it is skipped when there
+  was nothing to drain.
+- **BGP soft-refresh on the takeover node.** When the takeover node adds
+  FIP `/32`s to FRR, the agent immediately issues `clear ip bgp … soft out`
+  instead of waiting for FRR's normal redistribution timing. The soft
+  refresh only re-evaluates outbound policy and re-sends routes — it never
+  withdraws anything — so it shortens the takeover node's "ready" time
+  (and also speeds up ungraceful failovers) at the cost of a small extra
+  UPDATE burst.
+
+A portion of the remaining gap is OVN-intrinsic (`ovn-northd` /
+`ovn-controller` reprogramming) and cannot be closed from the agent; the
+settle delay only has to cover the takeover node's reconcile and BGP
+advertisement.
 
 ## Priority semantics
 

--- a/docs/guides/gateway-drain.md
+++ b/docs/guides/gateway-drain.md
@@ -7,7 +7,8 @@ and the shutdown sequence diagrams, see
 
 ## Default behavior
 
-Drain mode is **enabled by default** with a 60-second timeout:
+Drain mode is **enabled by default** with a 60-second timeout and a
+3-second post-drain settle delay:
 
 ```yaml
 # Enable/disable drain (default: true)
@@ -17,6 +18,11 @@ drain_on_shutdown: true
 # After this timeout, the agent proceeds with shutdown even if some
 # gateways have not yet migrated.
 drain_timeout: "60s"
+
+# Hold time after migration completes, before cleanup (default: 3s)
+# Keeps this node advertising its FIP routes while the takeover chassis
+# finishes coming up. Set to 0 to disable. See "Settle delay" below.
+drain_settle_delay: "3s"
 ```
 
 ## Override via CLI flags
@@ -24,6 +30,7 @@ drain_timeout: "60s"
 ```bash
 ovn-network-agent --drain-on-shutdown=false                 # disable drain
 ovn-network-agent --drain-timeout 120s                      # increase timeout
+ovn-network-agent --drain-settle-delay 5s                   # longer settle hold
 ```
 
 ## Override via environment variables
@@ -31,7 +38,30 @@ ovn-network-agent --drain-timeout 120s                      # increase timeout
 ```bash
 OVN_NETWORK_DRAIN_ON_SHUTDOWN=false                         # disable drain
 OVN_NETWORK_DRAIN_TIMEOUT=120s                              # increase timeout
+OVN_NETWORK_DRAIN_SETTLE_DELAY=5s                           # longer settle hold
 ```
+
+## Settle delay
+
+Migration of the chassisredirect port away from this node does **not**
+mean the takeover chassis is ready to receive external traffic. Before it
+is ready, `ovn-northd` recompute, `ovn-controller` flow programming, the
+takeover agent's reconcile and its FRR/BGP advertisement all still have to
+happen. If the leaving node withdrew its FIP routes the instant the port
+moved, external traffic would be blackholed for that gap (observed as
+~5 s of packet loss).
+
+`drain_settle_delay` closes that race: after the drain confirms the ports
+have migrated, the agent keeps advertising its FIP `/32` routes and keeps
+its OVS flows for this long, continuing to forward external traffic
+(hairpinned to the new gateway chassis over the tunnel) until the takeover
+chassis has come up. Only then does cleanup withdraw the routes.
+
+The trade-off is shutdown time: a graceful drain takes up to
+`drain_settle_delay` longer. The hold is bounded by `drain_timeout`, so
+total graceful shutdown never exceeds that budget. Set `drain_settle_delay`
+to `0` to disable the hold and have cleanup run as soon as the ports
+migrate.
 
 ## When to disable drain
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -30,6 +30,7 @@ regenerate it with `go generate ./...`.
 | `--cleanup-on-shutdown` | `true` | Remove all managed routes on shutdown (SIGINT/SIGTERM) |
 | `--drain-on-shutdown` | `true` | Drain HA gateways before shutdown by lowering Gateway_Chassis priority |
 | `--drain-timeout` | `60s` | Max time to wait for gateway drain (e.g. 60s) |
+| `--drain-settle-delay` | `3s` | Hold time after gateway drain before cleanup so the takeover chassis can finish coming up (e.g. 3s) |
 | `--frr-prefix-list` | `ANNOUNCED-NETWORKS` | FRR prefix-list name to manage dynamically (default: ANNOUNCED-NETWORKS) |
 | `--stale-chassis-grace-period` | `5m` | Grace period before cleaning up entries from missing chassis (e.g. 5m, 0 to disable) |
 | `--veth-leak-enabled` | `true` | Enable veth VRF route leaking |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -36,6 +36,7 @@ regenerate this page with `go generate ./...`.
 | `--cleanup-on-shutdown` | `OVN_NETWORK_CLEANUP_ON_SHUTDOWN` | `cleanup_on_shutdown` | `true` | Remove all managed routes on shutdown (SIGINT/SIGTERM) |
 | `--drain-on-shutdown` | `OVN_NETWORK_DRAIN_ON_SHUTDOWN` | `drain_on_shutdown` | `true` | Drain HA gateways before shutdown by lowering Gateway_Chassis priority |
 | `--drain-timeout` | `OVN_NETWORK_DRAIN_TIMEOUT` | `drain_timeout` | `60s` | Max time to wait for gateway drain (e.g. 60s) |
+| `--drain-settle-delay` | `OVN_NETWORK_DRAIN_SETTLE_DELAY` | `drain_settle_delay` | `3s` | Hold time after gateway drain before cleanup so the takeover chassis can finish coming up (e.g. 3s) |
 | `--frr-prefix-list` | `OVN_NETWORK_FRR_PREFIX_LIST` | `frr_prefix_list` | `ANNOUNCED-NETWORKS` | FRR prefix-list name to manage dynamically (default: ANNOUNCED-NETWORKS) |
 | `--stale-chassis-grace-period` | `OVN_NETWORK_STALE_CHASSIS_GRACE_PERIOD` | `stale_chassis_grace_period` | `5m` | Grace period before cleaning up entries from missing chassis (e.g. 5m, 0 to disable) |
 | `--veth-leak-enabled` | `OVN_NETWORK_VETH_LEAK_ENABLED` | `veth_leak_enabled` | `true` | Enable veth VRF route leaking |

--- a/ovn-network-agent.yaml.sample
+++ b/ovn-network-agent.yaml.sample
@@ -94,6 +94,14 @@ ovn_nb_remote: "tcp:10.10.0.1:6641,tcp:10.10.0.2:6641,tcp:10.10.0.3:6641"
 # gateways have not yet migrated.
 # drain_timeout: "60s"
 
+# Hold time after the drain before cleanup (default: 3s)
+# Once the chassisredirect ports have migrated away, the agent keeps
+# advertising its FIP routes for this long so the takeover chassis can
+# finish OVN programming and BGP advertisement before the routes are
+# withdrawn. This extends total shutdown by up to drain_settle_delay,
+# bounded by drain_timeout. Set to 0 to disable the hold.
+# drain_settle_delay: "3s"
+
 # FRR prefix-list to manage dynamically (default: ANNOUNCED-NETWORKS)
 # When set, the agent adds/removes "permit <network> ge 32 le 32" entries
 # for each discovered provider network. This replaces hardcoded prefix-list

--- a/ovn_gateway.go
+++ b/ovn_gateway.go
@@ -621,6 +621,10 @@ func (o *OVNClient) CleanupStaleChassisManagedEntries(ctx context.Context, stale
 // SB Port_Binding table until all gateways have moved away or the context
 // deadline is exceeded.
 //
+// Once the ports have migrated, it holds for cfg.DrainSettleDelay before
+// returning (see settleAfterDrain) so the caller does not withdraw this
+// chassis' BGP routes before the takeover chassis is ready to forward.
+//
 // On the next startup, RestoreDrainedGateways sets drained entries back to
 // priority 1 (standby level) so the chassis rejoins the HA group.
 // EnsureActivePriorityLead prevents reverse failover by ensuring the
@@ -697,6 +701,7 @@ func (o *OVNClient) DrainGateways(ctx context.Context, localChassisName string) 
 		}
 		if remaining == 0 {
 			slog.Info("drain: complete, all gateways migrated away")
+			o.settleAfterDrain(ctx)
 			return nil
 		}
 		slog.Info("drain: waiting for gateway migration", "remaining_gateways", remaining)
@@ -707,6 +712,31 @@ func (o *OVNClient) DrainGateways(ctx context.Context, localChassisName string) 
 			return nil
 		case <-ticker.C:
 		}
+	}
+}
+
+// settleAfterDrain pauses for cfg.DrainSettleDelay after the drain has
+// confirmed that all chassisredirect ports migrated away. During the hold
+// this chassis still advertises its FIP /32 routes and keeps its OVS flows,
+// so it continues forwarding external traffic — hairpinning to the new
+// gateway chassis over the tunnel — while the takeover chassis finishes its
+// OVN flow programming, reconcile and BGP advertisement. Without the hold,
+// cleanup() would withdraw the routes the instant the ports moved, before
+// the takeover chassis is ready, blackholing external traffic for the gap.
+//
+// The wait is bounded by ctx (the drain context), so the settle never
+// pushes total shutdown past drain_timeout. A delay of 0 disables the hold.
+func (o *OVNClient) settleAfterDrain(ctx context.Context) {
+	if o.cfg.DrainSettleDelay <= 0 {
+		return
+	}
+	slog.Info("drain: holding before cleanup so the takeover chassis can settle",
+		"settle_delay", o.cfg.DrainSettleDelay)
+	timer := time.NewTimer(o.cfg.DrainSettleDelay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+	case <-timer.C:
 	}
 }
 

--- a/ovn_gateway_writes_test.go
+++ b/ovn_gateway_writes_test.go
@@ -944,6 +944,53 @@ func TestDrainGateways_FallbackReturnsErrorOnTransactFailure(t *testing.T) {
 	}
 }
 
+// TestDrainGateways_SettleDelayHoldsBeforeReturn verifies that once the SB
+// shows all chassisredirect ports migrated away, DrainGateways holds for
+// cfg.DrainSettleDelay before returning so the caller does not withdraw BGP
+// routes before the takeover chassis is ready.
+func TestDrainGateways_SettleDelayHoldsBeforeReturn(t *testing.T) {
+	c, nb, sb := newOVNClientWithFakes(t, "host-a")
+	c.cfg.DrainSettleDelay = 80 * time.Millisecond
+
+	nb.setRows("Gateway_Chassis",
+		&NBGatewayChassis{UUID: "g1", Name: "lrp-a_host-a", ChassisName: "host-a", Priority: 5},
+	)
+	// SB shows no chassisredirect ports for host-a → first poll returns 0.
+	sb.setRows("Chassis", &SBChassis{UUID: "ch-a", Name: "ch-a", Hostname: "host-a"})
+
+	start := time.Now()
+	if err := c.DrainGateways(context.Background(), "host-a"); err != nil {
+		t.Fatalf("DrainGateways: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < c.cfg.DrainSettleDelay {
+		t.Errorf("drain returned after %v, want at least the settle delay %v", elapsed, c.cfg.DrainSettleDelay)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("drain blocked too long: %v (settle delay is %v)", elapsed, c.cfg.DrainSettleDelay)
+	}
+}
+
+// TestDrainGateways_SettleDelaySkippedWhenNothingToDrain ensures the settle
+// hold only applies after an actual migration: when there is nothing to
+// drain (non-HA / single-chassis / already drained) the function still
+// returns immediately even with a long settle delay configured.
+func TestDrainGateways_SettleDelaySkippedWhenNothingToDrain(t *testing.T) {
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+	c.cfg.DrainSettleDelay = 30 * time.Second
+	nb.setRows("Gateway_Chassis",
+		&NBGatewayChassis{UUID: "g1", ChassisName: "host-b", Priority: 5},
+	)
+
+	start := time.Now()
+	if err := c.DrainGateways(context.Background(), "host-a"); err != nil {
+		t.Fatalf("DrainGateways: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("drain held for %v with nothing to drain; settle delay must not apply", elapsed)
+	}
+}
+
 // TestSelectLocalGatewayChassis_DecodesRowFields covers the rowToGatewayChassis
 // decoder for the priority types it must accept: float64 (JSON wire format)
 // and int (in-process fakes / mappers).


### PR DESCRIPTION
## Summary

Implements #125. With `drain_on_shutdown` enabled, a graceful shutdown
still caused ~5 s of external FIP packet loss: the leaving node withdrew
its BGP `/32`s the instant the chassisredirect ports migrated away, but
"ports moved" does not mean the takeover chassis can yet forward external
traffic. This closes that race with two coordinated changes.

## Changes (commit order)

1. **`config: add drain_settle_delay option`** — new duration option,
   mirroring `drain_timeout`'s surface: flag `--drain-settle-delay`, env
   `OVN_NETWORK_DRAIN_SETTLE_DELAY`, yaml `drain_settle_delay`. Defaults
   to `3s`, rejected when negative, `0` disables the hold. Unit tests
   cover flag/env/file/YAML/default/validation.

2. **`agent: hold for the settle delay after drain before cleanup`** —
   `DrainGateways` now holds for `cfg.DrainSettleDelay` (new
   `settleAfterDrain` helper) once the SB poll confirms the ports
   migrated, before returning to the caller's cleanup. During the hold
   the leaving node still advertises its FIP routes and keeps its OVS
   flows, so it forwards traffic (hairpinned to the new gateway chassis
   over the tunnel) until the takeover chassis is up. The hold is bounded
   by the drain context, so total shutdown never exceeds `drain_timeout`,
   and is skipped when nothing migrated. Unit tests cover the hold and
   the skip path.

3. **`agent: soft-refresh BGP when takeover routes are added`** —
   `ensureRoutes` now triggers `RefreshBGP()` on FRR route **additions**
   too, not only removals. `clear ip bgp … soft out` only re-evaluates
   outbound policy and re-sends — it never withdraws — so this safely
   pushes the takeover node's new `/32`s out immediately instead of
   waiting for FRR redistribution timing. Speeds up ungraceful failovers
   as well.

4. **`docs: document the post-drain settle delay`** — explainer gains a
   "takeover race and the settle delay" section and a SETTLE step in the
   shutdown-sequence diagram; the guide documents the option and its
   effect on shutdown time; sample config updated; `docs/reference/`
   regenerated via `make docs-gen`.

## Acceptance criteria

- **External FIP outage reduced to OVN reprogramming time** — the leaving
  node keeps forwarding for `drain_settle_delay` after migration while
  the takeover node comes up, and the takeover node now advertises its
  `/32`s immediately. The OVN-intrinsic reprogramming portion remains and
  is explicitly out of scope per the issue.
- **`drain_settle_delay` is configurable and documented** — see commits 1
  and 4, including the effect on total shutdown time.

## Notes

- The settle delay is applied inside `DrainGateways` (right after the
  poll loop confirms `countLocalCRPorts == 0`), not in the `Run()` body.
  This places it precisely on the "ports migrated" path and auto-skips
  the "nothing to drain" and timeout paths without needing a richer
  return value.
- Because the settle now runs inside `DrainGateways`, the
  `drain_duration_seconds` metric includes the settle hold — it measures
  the full drain phase, which the hold is part of.
- No unit test was added for the `ensureRoutes` BGP-refresh-on-add change:
  `ensureRoutes` has no existing test harness (it drives kernel netlink
  and `vtysh`), and the issue's test checklist scoped tests to the config
  option and the drain settle path. Building a new harness would exceed
  the issue's scope.

## Verification

- `go build ./...`, `go vet ./...` — pass
- `go test ./...` — pass
- `go test -race` on the drain/config paths — pass
- `gofmt -l` — clean
- `golangci-lint run ./...` — 0 issues
- `make docs-gen-check` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
