### PR TITLE
Fix residual FIP reachability loss: content-aware OVN cache guard + restore-drain fallback

### DIFF
--- a/ovn.go
+++ b/ovn.go
@@ -424,14 +424,14 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 	// Every table is read through cachedList, which falls back to a direct
 	// server select when the monitor cache is missing rows (see ovn_cache.go).
 	portBindings, err := cachedList(ctx, o.sbClient, "Port_Binding",
-		func(p SBPortBinding) string { return p.UUID }, decodeSBPortBinding)
+		pbCheckColumns, keyOfSBPortBinding, decodeSBPortBinding)
 	if err != nil {
 		slog.Error("failed to list port bindings", "error", err)
 		return
 	}
 
 	chassis, err := cachedList(ctx, o.sbClient, "Chassis",
-		func(c SBChassis) string { return c.UUID }, decodeSBChassis)
+		chCheckColumns, keyOfSBChassis, decodeSBChassis)
 	if err != nil {
 		slog.Error("failed to list chassis", "error", err)
 		return
@@ -468,7 +468,7 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 
 	// Step 2: Build NB Logical_Router_Port name → UUID map.
 	lrps, err := cachedList(ctx, o.nbClient, "Logical_Router_Port",
-		func(p NBLogicalRouterPort) string { return p.UUID }, decodeNBLogicalRouterPort)
+		lrpCheckColumns, keyOfNBLogicalRouterPort, decodeNBLogicalRouterPort)
 	if err != nil {
 		slog.Error("failed to list logical router ports", "error", err)
 		return
@@ -492,7 +492,7 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 
 	// Step 3: Find routers that own a locally-active LRP. Collect their NAT UUIDs.
 	routers, err := cachedList(ctx, o.nbClient, "Logical_Router",
-		func(r NBLogicalRouter) string { return r.UUID }, decodeNBLogicalRouter)
+		lrCheckColumns, keyOfNBLogicalRouter, decodeNBLogicalRouter)
 	if err != nil {
 		slog.Error("failed to list logical routers", "error", err)
 		return
@@ -549,7 +549,7 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 
 	// Step 5: Filter NAT entries to only those belonging to locally-active routers.
 	nats, err := cachedList(ctx, o.nbClient, "NAT",
-		func(n NBNAT) string { return n.UUID }, decodeNBNAT)
+		natCheckColumns, keyOfNBNAT, decodeNBNAT)
 	if err != nil {
 		slog.Error("failed to list NAT entries", "error", err)
 		return

--- a/ovn_cache.go
+++ b/ovn_cache.go
@@ -46,11 +46,13 @@ import (
 // selects exactly these — keeping the common in-sync round-trip cheap — and
 // the matching keyOf* helper must read only the model fields they back.
 var (
-	pbCheckColumns  = []string{"_uuid", "type", "chassis", "nat_addresses"}
-	chCheckColumns  = []string{"_uuid", "hostname"}
-	lrCheckColumns  = []string{"_uuid", "ports", "nat"}
-	lrpCheckColumns = []string{"_uuid", "mac", "networks"}
-	natCheckColumns = []string{"_uuid", "type", "external_ip"}
+	pbCheckColumns   = []string{"_uuid", "type", "chassis", "nat_addresses"}
+	chCheckColumns   = []string{"_uuid", "hostname"}
+	lrCheckColumns   = []string{"_uuid", "ports", "nat", "static_routes"}
+	lrpCheckColumns  = []string{"_uuid", "mac", "networks"}
+	natCheckColumns  = []string{"_uuid", "type", "external_ip"}
+	lrsrCheckColumns = []string{"_uuid", "ip_prefix", "nexthop", "output_port", "external_ids"}
+	smbCheckColumns  = []string{"_uuid", "logical_port", "ip", "mac"}
 )
 
 func keyOfSBPortBinding(p SBPortBinding) string {
@@ -66,7 +68,7 @@ func keyOfSBChassis(c SBChassis) string {
 }
 
 func keyOfNBLogicalRouter(r NBLogicalRouter) string {
-	return contentKey(r.UUID, sortedJoin(r.Ports), sortedJoin(r.Nat))
+	return contentKey(r.UUID, sortedJoin(r.Ports), sortedJoin(r.Nat), sortedJoin(r.StaticRoutes))
 }
 
 func keyOfNBLogicalRouterPort(p NBLogicalRouterPort) string {
@@ -75,6 +77,19 @@ func keyOfNBLogicalRouterPort(p NBLogicalRouterPort) string {
 
 func keyOfNBNAT(n NBNAT) string {
 	return contentKey(n.UUID, n.Type, n.ExternalIP)
+}
+
+func keyOfNBLogicalRouterStaticRoute(r NBLogicalRouterStaticRoute) string {
+	outputPort := ""
+	if r.OutputPort != nil {
+		outputPort = *r.OutputPort
+	}
+	// fmt %v renders a map with its keys sorted, so the key stays stable.
+	return contentKey(r.UUID, r.IPPrefix, r.Nexthop, outputPort, fmt.Sprintf("%v", r.ExternalIDs))
+}
+
+func keyOfNBStaticMACBinding(b NBStaticMACBinding) string {
+	return contentKey(b.UUID, b.LogicalPort, b.IP, b.MAC)
 }
 
 // contentKey joins row attributes into a single comparison key. The unit
@@ -259,10 +274,11 @@ func decodeNBNAT(row ovsdb.Row) NBNAT {
 
 func decodeNBLogicalRouter(row ovsdb.Row) NBLogicalRouter {
 	return NBLogicalRouter{
-		UUID:  rowUUID(row),
-		Name:  rowString(row, "name"),
-		Ports: rowStringSet(row, "ports"),
-		Nat:   rowStringSet(row, "nat"),
+		UUID:         rowUUID(row),
+		Name:         rowString(row, "name"),
+		Ports:        rowStringSet(row, "ports"),
+		Nat:          rowStringSet(row, "nat"),
+		StaticRoutes: rowStringSet(row, "static_routes"),
 	}
 }
 
@@ -272,6 +288,25 @@ func decodeNBLogicalRouterPort(row ovsdb.Row) NBLogicalRouterPort {
 		Name:     rowString(row, "name"),
 		MAC:      rowString(row, "mac"),
 		Networks: rowStringSet(row, "networks"),
+	}
+}
+
+func decodeNBLogicalRouterStaticRoute(row ovsdb.Row) NBLogicalRouterStaticRoute {
+	return NBLogicalRouterStaticRoute{
+		UUID:        rowUUID(row),
+		IPPrefix:    rowString(row, "ip_prefix"),
+		Nexthop:     rowString(row, "nexthop"),
+		OutputPort:  rowOptString(row, "output_port"),
+		ExternalIDs: rowStringMap(row, "external_ids"),
+	}
+}
+
+func decodeNBStaticMACBinding(row ovsdb.Row) NBStaticMACBinding {
+	return NBStaticMACBinding{
+		UUID:        rowUUID(row),
+		LogicalPort: rowString(row, "logical_port"),
+		IP:          rowString(row, "ip"),
+		MAC:         rowString(row, "mac"),
 	}
 }
 

--- a/ovn_cache.go
+++ b/ovn_cache.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
+	"strings"
 
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 )
@@ -13,72 +15,138 @@ import (
 // =============================================================================
 //
 // refreshState builds the agent's entire view of FIPs and locally-active
-// routers from the libovsdb monitor cache. That cache occasionally drops
-// table INSERTs delivered shortly after a fresh monitor subscription (issue
-// #115): the cache then stays permanently short of rows for the lifetime of
-// the connection, and a cache-backed List() cannot see its own gap.
+// routers from the libovsdb monitor cache. That cache can drift from the OVN
+// server in two ways:
 //
-// A short cache is silently dangerous here. A missing NAT/router row shrinks
-// the desired-IP set, and ensureRoutes then deletes the corresponding FRR
-// /32 as "orphaned" — the FIP stops being advertised even though OVN itself
-// is perfectly healthy. The drain and active-lead paths already guard against
-// this for Gateway_Chassis via a direct NB select; the helpers below extend
-// the same defence to every table refreshState reads.
+//   - A dropped table INSERT delivered shortly after a fresh monitor
+//     subscription (issue #115): the row is missing from the cache entirely.
+//   - A dropped UPDATE to a row already in the cache: the row is present but
+//     a column value is stale.
 //
-// The cache stays the primary, fast path. On every refresh the row set is
-// cross-checked against a cheap server-side _uuid select; only on a genuine
-// mismatch is the slice rebuilt from a full direct select.
+// Both are silently dangerous, and the HA-failover signal lives entirely in
+// reference/set columns — Port_Binding.chassis (which chassis owns the
+// chassisredirect port), Logical_Router.nat/.ports (which FIPs belong to a
+// router), Logical_Router_Port.networks. A missing row or a stale column
+// shrinks or misdirects the desired-IP set, and ensureRoutes then withdraws
+// the FRR /32 of every FIP it no longer sees as desired — the FIP stops being
+// advertised even though OVN itself is perfectly healthy, so the node looks
+// fine but is unreachable from outside.
+//
+// The cache stays the primary, fast path. On every refresh the cache snapshot
+// is cross-checked against a server-side select of the failover-critical
+// columns: a content key is built per row from exactly those columns, so a
+// stale column value — not only a dropped or extra row — registers as a
+// mismatch. A bare _uuid comparison cannot see a dropped UPDATE because the
+// _uuid set is unchanged. Only on a genuine mismatch is the slice rebuilt from
+// a full direct select; any error reading from the server degrades gracefully
+// to the cache so a transient OVSDB blip cannot stall reconciliation.
 
-// cachedList lists a table from the monitor cache and then cross-checks the
-// row set against the OVN server. It returns a server-authoritative slice
-// whenever the monitor cache turns out to be incomplete. uuidOf extracts the
-// UUID of a cached model; decode rebuilds a model from a raw select row.
+// The *CheckColumns slices list, per table, the columns whose drift would
+// change the desired-IP set refreshState computes. The consistency check
+// selects exactly these — keeping the common in-sync round-trip cheap — and
+// the matching keyOf* helper must read only the model fields they back.
+var (
+	pbCheckColumns  = []string{"_uuid", "type", "chassis", "nat_addresses"}
+	chCheckColumns  = []string{"_uuid", "hostname"}
+	lrCheckColumns  = []string{"_uuid", "ports", "nat"}
+	lrpCheckColumns = []string{"_uuid", "mac", "networks"}
+	natCheckColumns = []string{"_uuid", "type", "external_ip"}
+)
+
+func keyOfSBPortBinding(p SBPortBinding) string {
+	chassis := ""
+	if p.Chassis != nil {
+		chassis = *p.Chassis
+	}
+	return contentKey(p.UUID, p.Type, chassis, sortedJoin(p.NatAddresses))
+}
+
+func keyOfSBChassis(c SBChassis) string {
+	return contentKey(c.UUID, c.Hostname)
+}
+
+func keyOfNBLogicalRouter(r NBLogicalRouter) string {
+	return contentKey(r.UUID, sortedJoin(r.Ports), sortedJoin(r.Nat))
+}
+
+func keyOfNBLogicalRouterPort(p NBLogicalRouterPort) string {
+	return contentKey(p.UUID, p.MAC, sortedJoin(p.Networks))
+}
+
+func keyOfNBNAT(n NBNAT) string {
+	return contentKey(n.UUID, n.Type, n.ExternalIP)
+}
+
+// contentKey joins row attributes into a single comparison key. The unit
+// separator (0x1f) cannot occur in a UUID, MAC, IP, hostname or OVN name, so
+// distinct attribute tuples always yield distinct keys.
+func contentKey(parts ...string) string {
+	return strings.Join(parts, "\x1f")
+}
+
+// sortedJoin renders a set-valued column deterministically. OVSDB sets are
+// unordered, so the monitor cache and a direct select may list the members in
+// different orders; that must not register as content drift.
+func sortedJoin(values []string) string {
+	sorted := append([]string(nil), values...)
+	sort.Strings(sorted)
+	return strings.Join(sorted, ",")
+}
+
+// cachedList lists a table from the monitor cache and then cross-checks it
+// against the OVN server. It returns a server-authoritative slice whenever the
+// monitor cache turns out to be incomplete or to hold a stale column value.
+// columns is the cheap server-side check projection; keyOf builds a content
+// key over exactly those columns; decode rebuilds a model from a raw row.
 func cachedList[T any](
 	ctx context.Context,
 	c ovsdbClient,
 	table string,
-	uuidOf func(T) string,
+	columns []string,
+	keyOf func(T) string,
 	decode func(ovsdb.Row) T,
 ) ([]T, error) {
 	var cached []T
 	if err := c.List(ctx, &cached); err != nil {
 		return nil, err
 	}
-	return authoritativeList(ctx, c, table, cached, uuidOf, decode), nil
+	return authoritativeList(ctx, c, table, columns, cached, keyOf, decode), nil
 }
 
 // authoritativeList returns the rows of table that refreshState should act on.
 // It trusts the monitor-cache snapshot (cached) unless a direct server select
-// proves it incomplete, in which case it logs the gap and rebuilds the slice
-// from a full select. Any error reading from the server degrades gracefully to
-// the cache: a transient OVSDB blip must not stall reconciliation.
+// of the failover-critical columns proves it stale, in which case it logs the
+// gap and rebuilds the slice from a full select. Any error reading from the
+// server degrades gracefully to the cache: a transient OVSDB blip must not
+// stall reconciliation.
 func authoritativeList[T any](
 	ctx context.Context,
 	c ovsdbClient,
 	table string,
+	columns []string,
 	cached []T,
-	uuidOf func(T) string,
+	keyOf func(T) string,
 	decode func(ovsdb.Row) T,
 ) []T {
-	serverUUIDs, err := serverUUIDSet(ctx, c, table)
+	serverKeys, err := serverKeySet(ctx, c, table, columns, keyOf, decode)
 	if err != nil {
 		slog.Warn("cache consistency check skipped: direct select failed, trusting monitor cache",
 			"table", table, "error", err)
 		return cached
 	}
 
-	cacheUUIDs := make(map[string]bool, len(cached))
+	cacheKeys := make(map[string]bool, len(cached))
 	for _, m := range cached {
-		cacheUUIDs[uuidOf(m)] = true
+		cacheKeys[keyOf(m)] = true
 	}
-	if uuidSetsEqual(cacheUUIDs, serverUUIDs) {
+	if keySetsEqual(cacheKeys, serverKeys) {
 		return cached
 	}
 
 	slog.Error("OVN monitor cache out of sync with the server, rebuilding from a direct select",
 		"table", table,
-		"cache_rows", len(cacheUUIDs),
-		"server_rows", len(serverUUIDs))
+		"cache_rows", len(cacheKeys),
+		"server_rows", len(serverKeys))
 
 	rows, err := directSelect(ctx, c, table, nil)
 	if err != nil {
@@ -93,19 +161,24 @@ func authoritativeList[T any](
 	return out
 }
 
-// serverUUIDSet returns the set of _uuid values currently in table on the OVN
-// server. Only the _uuid column is selected so the common (in-sync) path stays
-// cheap.
-func serverUUIDSet(ctx context.Context, c ovsdbClient, table string) (map[string]bool, error) {
-	rows, err := directSelect(ctx, c, table, []string{"_uuid"})
+// serverKeySet returns the set of content keys currently in table on the OVN
+// server. Only the failover-critical columns are selected so the common
+// (in-sync) path stays cheap; keyOf must build its key from no more than those.
+func serverKeySet[T any](
+	ctx context.Context,
+	c ovsdbClient,
+	table string,
+	columns []string,
+	keyOf func(T) string,
+	decode func(ovsdb.Row) T,
+) (map[string]bool, error) {
+	rows, err := directSelect(ctx, c, table, columns)
 	if err != nil {
 		return nil, err
 	}
 	set := make(map[string]bool, len(rows))
 	for _, row := range rows {
-		if u := rowUUID(row); u != "" {
-			set[u] = true
-		}
+		set[keyOf(decode(row))] = true
 	}
 	return set, nil
 }
@@ -133,8 +206,9 @@ func directSelect(ctx context.Context, c ovsdbClient, table string, columns []st
 	return results[0].Rows, nil
 }
 
-// uuidSetsEqual reports whether two UUID sets contain exactly the same members.
-func uuidSetsEqual(a, b map[string]bool) bool {
+// keySetsEqual reports whether two content-key sets contain exactly the same
+// members.
+func keySetsEqual(a, b map[string]bool) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/ovn_cache_test.go
+++ b/ovn_cache_test.go
@@ -9,11 +9,6 @@ import (
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 )
 
-// uuidRow builds a minimal select row carrying only the _uuid column.
-func uuidRow(uuid string) ovsdb.Row {
-	return ovsdb.Row{"_uuid": ovsdb.UUID{GoUUID: uuid}}
-}
-
 // TestCachedListNoDrift: when the monitor cache and the server agree, cachedList
 // returns the cache snapshot untouched (no recovery, no decode).
 func TestCachedListNoDrift(t *testing.T) {
@@ -25,7 +20,7 @@ func TestCachedListNoDrift(t *testing.T) {
 	)
 
 	got, err := cachedList(context.Background(), sb, "Port_Binding",
-		func(p SBPortBinding) string { return p.UUID }, decodeSBPortBinding)
+		pbCheckColumns, keyOfSBPortBinding, decodeSBPortBinding)
 	if err != nil {
 		t.Fatalf("cachedList: %v", err)
 	}
@@ -50,7 +45,12 @@ func TestCachedListRecoversDroppedRow(t *testing.T) {
 	)
 	// The server has both rows.
 	sb.setSelectRows("Port_Binding",
-		uuidRow("pb-1"),
+		ovsdb.Row{
+			"_uuid":        ovsdb.UUID{GoUUID: "pb-1"},
+			"logical_port": "cr-lrp-1",
+			"type":         "chassisredirect",
+			"chassis":      ovsdb.UUID{GoUUID: "ch-a"},
+		},
 		ovsdb.Row{
 			"_uuid":        ovsdb.UUID{GoUUID: "pb-2"},
 			"logical_port": "cr-lrp-2",
@@ -60,7 +60,7 @@ func TestCachedListRecoversDroppedRow(t *testing.T) {
 	)
 
 	got, err := cachedList(context.Background(), sb, "Port_Binding",
-		func(p SBPortBinding) string { return p.UUID }, decodeSBPortBinding)
+		pbCheckColumns, keyOfSBPortBinding, decodeSBPortBinding)
 	if err != nil {
 		t.Fatalf("cachedList: %v", err)
 	}
@@ -90,8 +90,8 @@ func TestAuthoritativeListServerSelectErrorTrustsCache(t *testing.T) {
 	sb.transactErr = errors.New("connection refused")
 
 	cached := []SBChassis{{UUID: "ch-1", Name: "ch-1", Hostname: "host-a"}}
-	got := authoritativeList(context.Background(), sb, "Chassis", cached,
-		func(c SBChassis) string { return c.UUID }, decodeSBChassis)
+	got := authoritativeList(context.Background(), sb, "Chassis", chCheckColumns, cached,
+		keyOfSBChassis, decodeSBChassis)
 	if !reflect.DeepEqual(got, cached) {
 		t.Errorf("got %+v, want cache snapshot %+v on select error", got, cached)
 	}
@@ -136,6 +136,83 @@ func TestRefreshStateRecoversDroppedNATFromCache(t *testing.T) {
 	if snap.NATIPToRouterMAC["198.51.100.50"] != "fa:16:3e:aa:aa:aa" {
 		t.Errorf("NATIPToRouterMAC[FIP] = %q, want fa:16:3e:aa:aa:aa",
 			snap.NATIPToRouterMAC["198.51.100.50"])
+	}
+}
+
+// TestAuthoritativeListRecoversStaleColumn is the regression test for a
+// dropped UPDATE: the monitor cache holds the right row (same _uuid) but a
+// stale column value. A _uuid-set comparison sees no drift; the content-key
+// check must catch it and rebuild the row from a direct select.
+func TestAuthoritativeListRecoversStaleColumn(t *testing.T) {
+	_, _, sb := newOVNClientWithFakes(t, "host-a")
+
+	// Cache holds the chassisredirect port bound to ch-a.
+	chA := "ch-a"
+	cached := []SBPortBinding{
+		{UUID: "pb-1", LogicalPort: "cr-lrp-1", Type: "chassisredirect", Chassis: &chA},
+	}
+	// The server has the same row (same _uuid) but bound to ch-b — a failover
+	// UPDATE the monitor cache dropped.
+	sb.setSelectRows("Port_Binding", ovsdb.Row{
+		"_uuid":        ovsdb.UUID{GoUUID: "pb-1"},
+		"logical_port": "cr-lrp-1",
+		"type":         "chassisredirect",
+		"chassis":      ovsdb.UUID{GoUUID: "ch-b"},
+	})
+
+	got := authoritativeList(context.Background(), sb, "Port_Binding", pbCheckColumns, cached,
+		keyOfSBPortBinding, decodeSBPortBinding)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].Chassis == nil || *got[0].Chassis != "ch-b" {
+		t.Errorf("stale chassis column not recovered: got %v, want ch-b", got[0].Chassis)
+	}
+}
+
+// TestRefreshStateRecoversStaleChassisBinding exercises the fix end-to-end: the
+// SB monitor cache shows the chassisredirect port bound to a peer (the router
+// looks non-local), but the server has since migrated it to this chassis. With
+// only a _uuid check the stale binding would be trusted and the FIP dropped
+// from the desired set; the content-key check recovers it.
+func TestRefreshStateRecoversStaleChassisBinding(t *testing.T) {
+	c, nb, sb := newOVNClientWithFakes(t, "host-a")
+
+	chB := "ch-b"
+	sb.setRows("Chassis",
+		&SBChassis{UUID: "ch-a", Name: "ch-a", Hostname: "host-a"},
+		&SBChassis{UUID: "ch-b", Name: "ch-b", Hostname: "host-b"},
+	)
+	// Cache view: the chassisredirect port is bound to host-b — not local.
+	sb.setRows("Port_Binding", &SBPortBinding{
+		UUID: "pb-1", LogicalPort: "cr-lrp-local", Type: "chassisredirect", Chassis: &chB,
+	})
+	// Server view: the same row (same _uuid) has migrated to host-a.
+	sb.setSelectRows("Port_Binding", ovsdb.Row{
+		"_uuid":        ovsdb.UUID{GoUUID: "pb-1"},
+		"logical_port": "cr-lrp-local",
+		"type":         "chassisredirect",
+		"chassis":      ovsdb.UUID{GoUUID: "ch-a"},
+	})
+	nb.setRows("Logical_Router_Port", &NBLogicalRouterPort{
+		UUID: "lrp-uuid-local", Name: "lrp-local",
+		MAC: "fa:16:3e:aa:aa:aa", Networks: []string{"198.51.100.1/24"},
+	})
+	nb.setRows("Logical_Router", &NBLogicalRouter{
+		UUID: "lr-local", Name: "router-local",
+		Ports: []string{"lrp-uuid-local"}, Nat: []string{"nat-fip"},
+	})
+	nb.setRows("NAT", &NBNAT{UUID: "nat-fip", Type: "dnat_and_snat", ExternalIP: "198.51.100.50"})
+
+	c.state.LocalChassisName = "host-a"
+	c.refreshState(context.Background())
+	snap := c.GetState()
+
+	if !snap.HasLocalRouters {
+		t.Fatal("HasLocalRouters = false — stale chassisredirect binding not recovered")
+	}
+	if got := snap.FIPs; len(got) != 1 || got[0] != "198.51.100.50" {
+		t.Fatalf("FIPs = %v, want [198.51.100.50]", got)
 	}
 }
 
@@ -223,7 +300,7 @@ func TestRowHelpers(t *testing.T) {
 	})
 }
 
-func TestUUIDSetsEqual(t *testing.T) {
+func TestKeySetsEqual(t *testing.T) {
 	cases := []struct {
 		name string
 		a, b map[string]bool
@@ -235,8 +312,8 @@ func TestUUIDSetsEqual(t *testing.T) {
 		{"same len different member", map[string]bool{"x": true}, map[string]bool{"y": true}, false},
 	}
 	for _, tc := range cases {
-		if got := uuidSetsEqual(tc.a, tc.b); got != tc.want {
-			t.Errorf("%s: uuidSetsEqual = %v, want %v", tc.name, got, tc.want)
+		if got := keySetsEqual(tc.a, tc.b); got != tc.want {
+			t.Errorf("%s: keySetsEqual = %v, want %v", tc.name, got, tc.want)
 		}
 	}
 }

--- a/ovn_fake_test.go
+++ b/ovn_fake_test.go
@@ -93,6 +93,22 @@ func (f *fakeOVSDBClient) recordedTransacts() [][]ovsdb.Operation {
 	return out
 }
 
+// writeTransacts returns the recorded transactions that contain at least one
+// non-select operation. cachedList issues read-only OperationSelect probes for
+// its consistency check; tests asserting on writes filter those out.
+func (f *fakeOVSDBClient) writeTransacts() [][]ovsdb.Operation {
+	var out [][]ovsdb.Operation
+	for _, batch := range f.recordedTransacts() {
+		for _, op := range batch {
+			if op.Op != ovsdb.OperationSelect {
+				out = append(out, batch)
+				break
+			}
+		}
+	}
+	return out
+}
+
 func (f *fakeOVSDBClient) tableForType(t reflect.Type) string {
 	for table, mt := range f.dbm.Types() {
 		if mt == t {

--- a/ovn_fake_test.go
+++ b/ovn_fake_test.go
@@ -41,10 +41,11 @@ type fakeOVSDBClient struct {
 	// by table name, bypassing the cache view exposed via setRows/List. The
 	// drain fallback and refreshState's cache-consistency guard use
 	// Transact(OperationSelect) to read directly from the server when the
-	// cache appears incomplete (issue #115); tests populate this to simulate
-	// the "server has the row, cache does not" race. When a table has no
-	// entry here, Transact synthesises a minimal _uuid-only row per cached
-	// model, i.e. the server view is modelled as identical to the cache.
+	// cache appears incomplete or stale (issue #115); tests populate this to
+	// simulate a "server has the row, cache does not" or "server has fresh
+	// content, cache is stale" race. When a table has no entry here, Transact
+	// synthesises a full row per cached model via modelToRow, i.e. the server
+	// view is modelled as identical to the cache.
 	selectRows map[string][]ovsdb.Row
 
 	// onTransact is invoked synchronously for each Transact call (after the
@@ -112,6 +113,55 @@ func uuidOfModel(m model.Model) string {
 		return ""
 	}
 	return f.String()
+}
+
+// modelToRow renders a model.Model into the OVSDB wire-ish row shape the
+// decode* helpers in ovn_cache.go consume, so a Transact(select) without an
+// explicit setSelectRows override mirrors the cache exactly — the in-sync
+// case the consistency guard must not flag as drift. Only the field kinds the
+// production decoders read are emitted; anything else is left out of the row.
+func modelToRow(m model.Model) ovsdb.Row {
+	row := ovsdb.Row{}
+	v := reflect.ValueOf(m)
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("ovsdb")
+		if tag == "" {
+			continue
+		}
+		fv := v.Field(i)
+		switch {
+		case tag == "_uuid":
+			row[tag] = ovsdb.UUID{GoUUID: fv.String()}
+		case fv.Kind() == reflect.String:
+			row[tag] = fv.String()
+		case fv.Kind() == reflect.Int:
+			row[tag] = int(fv.Int())
+		case fv.Kind() == reflect.Pointer && fv.Type().Elem().Kind() == reflect.String:
+			// OVSDB encodes an absent optional as an empty set.
+			if fv.IsNil() {
+				row[tag] = ovsdb.OvsSet{}
+			} else {
+				row[tag] = fv.Elem().String()
+			}
+		case fv.Kind() == reflect.Slice && fv.Type().Elem().Kind() == reflect.String:
+			set := make([]any, fv.Len())
+			for j := 0; j < fv.Len(); j++ {
+				set[j] = fv.Index(j).String()
+			}
+			row[tag] = ovsdb.OvsSet{GoSet: set}
+		case fv.Kind() == reflect.Map:
+			gm := make(map[any]any, fv.Len())
+			for iter := fv.MapRange(); iter.Next(); {
+				gm[iter.Key().Interface()] = iter.Value().Interface()
+			}
+			row[tag] = ovsdb.OvsMap{GoMap: gm}
+		}
+	}
+	return row
 }
 
 // --- ovsdbClient surface -----------------------------------------------------
@@ -210,11 +260,11 @@ func (f *fakeOVSDBClient) Transact(_ context.Context, ops ...ovsdb.Operation) ([
 			continue
 		}
 		// No explicit override: model the server view as identical to the
-		// cache. refreshState's consistency check only reads _uuid here, so
-		// one minimal row per cached model is enough to signal "no drift".
+		// cache. The consistency check builds a content key over several
+		// columns, so the synthesised row must mirror the whole model — a
+		// bare _uuid row would read back as drift on every refresh.
 		for _, m := range f.rows[op.Table] {
-			results[i].Rows = append(results[i].Rows,
-				ovsdb.Row{"_uuid": ovsdb.UUID{GoUUID: uuidOfModel(m)}})
+			results[i].Rows = append(results[i].Rows, modelToRow(m))
 		}
 	}
 	return results, nil

--- a/ovn_gateway.go
+++ b/ovn_gateway.go
@@ -716,6 +716,16 @@ func (o *OVNClient) DrainGateways(ctx context.Context, localChassisName string) 
 // strictly higher priority via EnsureActivePriorityLead, which prevents
 // reverse failover even when both chassis would otherwise have the same
 // priority. This should be called on startup before the first reconciliation.
+//
+// RestoreDrainedGateways runs immediately after Connect(), exactly when the NB
+// monitor cache is most exposed to the issue #115 INSERT-drop race. When the
+// cache shows no row at all for this chassis it falls back to a direct NB
+// select, the same defence DrainGateways and EnsureActivePriorityLead already
+// use: a drained row hidden by the cache would otherwise leave the chassis
+// stuck at priority 0 forever. It never rejoins the HA group, and
+// EnsureActivePriorityLead — which only boosts the active chassis — can never
+// lift a standby off 0, so the loss of redundancy is permanent until a restart
+// happens to deliver a complete cache.
 func (o *OVNClient) RestoreDrainedGateways(ctx context.Context, localChassisName string) {
 	var gwChassisList []NBGatewayChassis
 	if err := o.nbClient.List(ctx, &gwChassisList); err != nil {
@@ -723,12 +733,27 @@ func (o *OVNClient) RestoreDrainedGateways(ctx context.Context, localChassisName
 		return
 	}
 
-	var allOps []ovsdb.Operation
-	for _, gwc := range gwChassisList {
-		if gwc.ChassisName != localChassisName || gwc.Priority != 0 {
-			continue
-		}
+	toRestore, hasLocalRow := filterRestoreCandidates(gwChassisList, localChassisName)
 
+	if !hasLocalRow {
+		slog.Warn("restore-drain: cache has no Gateway_Chassis row for this chassis, querying NB directly",
+			"local_chassis_name", localChassisName,
+			"cache_count", len(gwChassisList))
+		serverList, err := o.selectLocalGatewayChassis(ctx, localChassisName)
+		if err != nil {
+			slog.Error("restore-drain: cache miss + NB select fallback failed", "error", err)
+			return
+		}
+		toRestore, _ = filterRestoreCandidates(serverList, localChassisName)
+		if len(toRestore) > 0 {
+			slog.Info("restore-drain: NB select recovered Gateway_Chassis rows hidden by the cache",
+				"local_chassis_name", localChassisName, "recovered", len(toRestore))
+		}
+	}
+
+	var allOps []ovsdb.Operation
+	for i := range toRestore {
+		gwc := toRestore[i]
 		gwc.Priority = 1
 		ops, err := o.nbClient.Where(&gwc).Update(&gwc, &gwc.Priority)
 		if err != nil {
@@ -746,6 +771,25 @@ func (o *OVNClient) RestoreDrainedGateways(ctx context.Context, localChassisName
 	if err := o.transactOps(ctx, allOps); err != nil {
 		slog.Error("restore-drain: failed to restore gateway chassis priorities", "error", err)
 	}
+}
+
+// filterRestoreCandidates returns the Gateway_Chassis rows that must be lifted
+// back to standby priority (those drained to 0 for this chassis) and reports
+// whether the input contained any row at all for localChassisName. The "row
+// present at all" signal lets the caller tell "nothing to restore because the
+// chassis was never drained" apart from "nothing to restore because the local
+// row is missing from an incomplete cache" (issue #115).
+func filterRestoreCandidates(gwChassisList []NBGatewayChassis, localChassisName string) (toRestore []NBGatewayChassis, hasLocalRow bool) {
+	for _, gwc := range gwChassisList {
+		if gwc.ChassisName != localChassisName {
+			continue
+		}
+		hasLocalRow = true
+		if gwc.Priority == 0 {
+			toRestore = append(toRestore, gwc)
+		}
+	}
+	return toRestore, hasLocalRow
 }
 
 // filterDrainCandidates returns the Gateway_Chassis rows that must have

--- a/ovn_gateway.go
+++ b/ovn_gateway.go
@@ -380,14 +380,18 @@ func (o *OVNClient) RemoveManagedNBEntries(ctx context.Context) error {
 		return nil
 	}
 
-	// Remove managed static routes on locally-active routers.
-	var routes []NBLogicalRouterStaticRoute
-	if err := o.nbClient.List(ctx, &routes); err != nil {
+	// Remove managed static routes on locally-active routers. Read through the
+	// consistency guard: a stale cache could otherwise hide a managed route
+	// (leaving an orphan) or a router's static_routes linkage.
+	routes, err := cachedList(ctx, o.nbClient, "Logical_Router_Static_Route",
+		lrsrCheckColumns, keyOfNBLogicalRouterStaticRoute, decodeNBLogicalRouterStaticRoute)
+	if err != nil {
 		return fmt.Errorf("list static routes: %w", err)
 	}
 
-	var routers []NBLogicalRouter
-	if err := o.nbClient.List(ctx, &routers); err != nil {
+	routers, err := cachedList(ctx, o.nbClient, "Logical_Router",
+		lrCheckColumns, keyOfNBLogicalRouter, decodeNBLogicalRouter)
+	if err != nil {
 		return fmt.Errorf("list routers: %w", err)
 	}
 
@@ -437,8 +441,9 @@ func (o *OVNClient) RemoveManagedNBEntries(ctx context.Context) error {
 	}
 
 	// Remove static MAC bindings on locally-active router ports.
-	var bindings []NBStaticMACBinding
-	if err := o.nbClient.List(ctx, &bindings); err != nil {
+	bindings, err := cachedList(ctx, o.nbClient, "Static_MAC_Binding",
+		smbCheckColumns, keyOfNBStaticMACBinding, decodeNBStaticMACBinding)
+	if err != nil {
 		return fmt.Errorf("list static MAC bindings: %w", err)
 	}
 
@@ -464,8 +469,9 @@ func (o *OVNClient) RemoveManagedNBEntries(ctx context.Context) error {
 // ListManagedRouteChassis returns the set of chassis names referenced in
 // ExternalIDs["ovn-network-agent-chassis"] of all managed static routes.
 func (o *OVNClient) ListManagedRouteChassis(ctx context.Context) map[string]bool {
-	var routes []NBLogicalRouterStaticRoute
-	if err := o.nbClient.List(ctx, &routes); err != nil {
+	routes, err := cachedList(ctx, o.nbClient, "Logical_Router_Static_Route",
+		lrsrCheckColumns, keyOfNBLogicalRouterStaticRoute, decodeNBLogicalRouterStaticRoute)
+	if err != nil {
 		slog.Error("failed to list static routes for chassis scan", "error", err)
 		return nil
 	}
@@ -493,13 +499,15 @@ type staleMACBindingKey struct {
 // Only entries with ExternalIDs["ovn-network-agent"] == "managed" and a matching
 // chassis tag are removed. Neutron-created entries are never touched.
 func (o *OVNClient) CleanupStaleChassisManagedEntries(ctx context.Context, staleChassis map[string]bool) error {
-	var routes []NBLogicalRouterStaticRoute
-	if err := o.nbClient.List(ctx, &routes); err != nil {
+	routes, err := cachedList(ctx, o.nbClient, "Logical_Router_Static_Route",
+		lrsrCheckColumns, keyOfNBLogicalRouterStaticRoute, decodeNBLogicalRouterStaticRoute)
+	if err != nil {
 		return fmt.Errorf("list static routes: %w", err)
 	}
 
-	var routers []NBLogicalRouter
-	if err := o.nbClient.List(ctx, &routers); err != nil {
+	routers, err := cachedList(ctx, o.nbClient, "Logical_Router",
+		lrCheckColumns, keyOfNBLogicalRouter, decodeNBLogicalRouter)
+	if err != nil {
 		return fmt.Errorf("list routers: %w", err)
 	}
 
@@ -588,8 +596,9 @@ func (o *OVNClient) CleanupStaleChassisManagedEntries(ctx context.Context, stale
 
 	// Delete MAC bindings that match the exact (LogicalPort, IP) pairs from stale routes.
 	if len(staleBindingKeys) > 0 {
-		var bindings []NBStaticMACBinding
-		if err := o.nbClient.List(ctx, &bindings); err != nil {
+		bindings, err := cachedList(ctx, o.nbClient, "Static_MAC_Binding",
+			smbCheckColumns, keyOfNBStaticMACBinding, decodeNBStaticMACBinding)
+		if err != nil {
 			return fmt.Errorf("list static MAC bindings: %w", err)
 		}
 		for _, b := range bindings {
@@ -872,13 +881,19 @@ func rowToGatewayChassis(row ovsdb.Row) NBGatewayChassis {
 // countLocalCRPorts returns the number of chassisredirect ports currently
 // bound to the given chassis hostname in the SB Port_Binding table.
 func (o *OVNClient) countLocalCRPorts(ctx context.Context, localChassisName string) (int, error) {
-	var portBindings []SBPortBinding
-	if err := o.sbClient.List(ctx, &portBindings); err != nil {
+	// countLocalCRPorts drives the drain poll loop: a stale SB cache here makes
+	// the drain converge on the wrong answer (hang until timeout, or finish
+	// early while ports are still bound). Read through the consistency guard
+	// so a dropped INSERT or a stale chassis column is corrected.
+	portBindings, err := cachedList(ctx, o.sbClient, "Port_Binding",
+		pbCheckColumns, keyOfSBPortBinding, decodeSBPortBinding)
+	if err != nil {
 		return 0, fmt.Errorf("list port bindings: %w", err)
 	}
 
-	var chassis []SBChassis
-	if err := o.sbClient.List(ctx, &chassis); err != nil {
+	chassis, err := cachedList(ctx, o.sbClient, "Chassis",
+		chCheckColumns, keyOfSBChassis, decodeSBChassis)
+	if err != nil {
 		return 0, fmt.Errorf("list chassis: %w", err)
 	}
 

--- a/ovn_gateway.go
+++ b/ovn_gateway.go
@@ -101,6 +101,14 @@ const minActivePriority = 2
 // issue #115); when no row for the local chassis is in the cache despite
 // having locally-active routers, fall back to a direct NB select so the
 // boost is not silently skipped.
+//
+// Before issuing a boost, the chassisredirect binding for each LRP is
+// re-confirmed against the SB server. localRouters is a reconcile snapshot,
+// and a boost is a priority write: if OVN has already migrated the port to a
+// peer, boosting a no-longer-active chassis would raise it into — or above —
+// a priority tie, which is exactly the ovn-northd flapping this function is
+// meant to prevent. A boost is skipped when SB positively shows the port
+// bound elsewhere.
 func (o *OVNClient) EnsureActivePriorityLead(ctx context.Context, localRouters []LocalRouterInfo, localChassisName string) error {
 	if len(localRouters) == 0 {
 		return nil
@@ -165,6 +173,19 @@ func (o *OVNClient) EnsureActivePriorityLead(ctx context.Context, localRouters [
 		}
 	}
 
+	// Confirm, with a fresh SB read, that this chassis still owns each LRP's
+	// chassisredirect port before boosting. A failed lookup degrades to
+	// trusting the snapshot so a transient SB blip cannot stall the boost.
+	crChassis, crErr := o.selectCRPortChassis(ctx)
+	if crErr != nil {
+		slog.Warn("active-lead: chassisredirect binding check failed, trusting reconcile snapshot",
+			"error", crErr)
+	}
+	crPortByLRP := make(map[string]string, len(localRouters))
+	for _, lr := range localRouters {
+		crPortByLRP[lr.LRPName] = lr.CRPort
+	}
+
 	var allOps []ovsdb.Operation
 	for lrpName, g := range groups {
 		if g.local == nil || g.maxPeer < 0 {
@@ -172,6 +193,13 @@ func (o *OVNClient) EnsureActivePriorityLead(ctx context.Context, localRouters [
 		}
 		if g.local.Priority > g.maxPeer && g.local.Priority >= minActivePriority {
 			continue // Already has the lead with safe margin
+		}
+		if crErr == nil {
+			if boundTo, known := crChassis[crPortByLRP[lrpName]]; known && boundTo != localChassisName {
+				slog.Info("active-lead: skipping priority boost, chassisredirect bound to another chassis",
+					"lrp", lrpName, "bound_to", boundTo, "local_chassis_name", localChassisName)
+				continue
+			}
 		}
 		newPriority := g.maxPeer + 1
 		if newPriority < minActivePriority {
@@ -917,4 +945,52 @@ func (o *OVNClient) countLocalCRPorts(ctx context.Context, localChassisName stri
 		}
 	}
 	return count, nil
+}
+
+// selectCRPortChassis returns, for every chassisredirect Port_Binding, the
+// hostname of the chassis it is currently bound to, read directly from the SB
+// server so the answer is not a monitor-cache snapshot. EnsureActivePriorityLead
+// uses it to confirm — at write time — that this chassis still owns a router's
+// gateway before boosting its priority. A port that is bound nowhere is left
+// out of the map: that is an in-progress election, where a boost is harmless.
+func (o *OVNClient) selectCRPortChassis(ctx context.Context) (map[string]string, error) {
+	chassisRows, err := directSelect(ctx, o.sbClient, "Chassis", []string{"_uuid", "name", "hostname"})
+	if err != nil {
+		return nil, fmt.Errorf("select chassis: %w", err)
+	}
+	hostByRef := make(map[string]string, len(chassisRows)*2)
+	for _, row := range chassisRows {
+		ch := decodeSBChassis(row)
+		hostByRef[ch.UUID] = ch.Hostname
+		hostByRef[ch.Name] = ch.Hostname
+	}
+
+	pbOp := ovsdb.Operation{
+		Op:      ovsdb.OperationSelect,
+		Table:   "Port_Binding",
+		Columns: []string{"_uuid", "type", "logical_port", "chassis"},
+		Where: []ovsdb.Condition{{
+			Column:   "type",
+			Function: ovsdb.ConditionEqual,
+			Value:    "chassisredirect",
+		}},
+	}
+	results, err := o.sbClient.Transact(ctx, pbOp)
+	if err != nil {
+		return nil, fmt.Errorf("select chassisredirect port bindings: %w", err)
+	}
+	if _, err := ovsdb.CheckOperationResults(results, []ovsdb.Operation{pbOp}); err != nil {
+		return nil, fmt.Errorf("select chassisredirect port bindings: %w", err)
+	}
+	bound := make(map[string]string)
+	if len(results) > 0 {
+		for _, row := range results[0].Rows {
+			pb := decodeSBPortBinding(row)
+			if pb.Type != "chassisredirect" || pb.Chassis == nil || *pb.Chassis == "" {
+				continue
+			}
+			bound[pb.LogicalPort] = hostByRef[*pb.Chassis]
+		}
+	}
+	return bound, nil
 }

--- a/ovn_gateway_writes_test.go
+++ b/ovn_gateway_writes_test.go
@@ -1043,6 +1043,73 @@ func TestRestoreDrainedGateways_ListErrorIsLoggedNotPanicking(t *testing.T) {
 	}
 }
 
+// TestRestoreDrainedGateways_FallsBackToServerSelectOnCacheMiss covers the
+// issue #115 race on the startup restore path: the NB monitor cache is missing
+// the local Gateway_Chassis row, so the cache scan finds nothing to restore.
+// RestoreDrainedGateways must fall back to a direct OVSDB select and lift the
+// drained row back to standby priority — otherwise the chassis stays at
+// priority 0 and out of the HA group until a later restart happens to deliver
+// a complete cache.
+func TestRestoreDrainedGateways_FallsBackToServerSelectOnCacheMiss(t *testing.T) {
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+
+	// Cache has only a peer row — the local Gateway_Chassis INSERT was dropped.
+	nb.setRows("Gateway_Chassis",
+		&NBGatewayChassis{UUID: "g2", Name: "lrp-a_host-b", ChassisName: "host-b", Priority: 1},
+	)
+	// Server-side state (visible to OperationSelect) still has the drained
+	// local row.
+	nb.setSelectRows("Gateway_Chassis", ovsdb.Row{
+		"_uuid":        ovsdb.UUID{GoUUID: "g1"},
+		"name":         "lrp-a_host-a",
+		"chassis_name": "host-a",
+		"priority":     float64(0),
+	})
+
+	c.RestoreDrainedGateways(context.Background(), "host-a")
+
+	tx := nb.recordedTransacts()
+	if len(tx) != 2 {
+		t.Fatalf("expected two transacts (select fallback + restore update), got %d: %+v", len(tx), tx)
+	}
+	if len(tx[0]) != 1 || tx[0][0].Op != ovsdb.OperationSelect || tx[0][0].Table != "Gateway_Chassis" {
+		t.Fatalf("expected first transact to be select on Gateway_Chassis, got %+v", tx[0])
+	}
+	if len(tx[0][0].Where) != 1 || tx[0][0].Where[0].Column != "chassis_name" || tx[0][0].Where[0].Value != "host-a" {
+		t.Errorf("select must filter on chassis_name == host-a, got %+v", tx[0][0].Where)
+	}
+	updates := findOps(t, tx, 1, ovsdb.OperationUpdate, "Gateway_Chassis")
+	if len(updates) != 1 {
+		t.Fatalf("expected one restore update from the fallback, got %d: %+v", len(updates), tx[1])
+	}
+	if updates[0].UUID != "g1" {
+		t.Errorf("update should target the row recovered from the server (g1), got %q", updates[0].UUID)
+	}
+	if got, ok := updates[0].Row["priority"].(int); !ok || got != 1 {
+		t.Errorf("restore op must set priority=1, got %#v", updates[0].Row["priority"])
+	}
+}
+
+// TestRestoreDrainedGateways_NoFallbackWhenLocalRowPresent asserts that a
+// present local row suppresses the select fallback: the cache is trusted and
+// no extra OVSDB select is emitted.
+func TestRestoreDrainedGateways_NoFallbackWhenLocalRowPresent(t *testing.T) {
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+	nb.setRows("Gateway_Chassis",
+		&NBGatewayChassis{UUID: "g1", Name: "lrp-a_host-a", ChassisName: "host-a", Priority: 0},
+	)
+
+	c.RestoreDrainedGateways(context.Background(), "host-a")
+
+	for _, batch := range nb.recordedTransacts() {
+		for _, op := range batch {
+			if op.Op == ovsdb.OperationSelect {
+				t.Errorf("unexpected select fallback while the cache has the local row: %+v", op)
+			}
+		}
+	}
+}
+
 // =============================================================================
 // ListManagedRouteChassis
 // =============================================================================

--- a/ovn_gateway_writes_test.go
+++ b/ovn_gateway_writes_test.go
@@ -580,7 +580,7 @@ func TestRemoveManagedNBEntries_DeletesManagedRouteAndMACBinding(t *testing.T) {
 		t.Fatalf("RemoveManagedNBEntries: %v", err)
 	}
 
-	tx := nb.recordedTransacts()
+	tx := nb.writeTransacts()
 	// Expect: one transact for the route (mutate + delete), one for the local MAC binding.
 	if len(tx) != 2 {
 		t.Fatalf("expected 2 transacts, got %d: %+v", len(tx), tx)
@@ -638,7 +638,7 @@ func TestRemoveManagedNBEntries_SkipsManagedRouteOnNonLocalRouter(t *testing.T) 
 	if err := c.RemoveManagedNBEntries(context.Background()); err != nil {
 		t.Fatalf("RemoveManagedNBEntries: %v", err)
 	}
-	if got := nb.recordedTransacts(); len(got) != 0 {
+	if got := nb.writeTransacts(); len(got) != 0 {
 		t.Errorf("must not touch routes on non-local routers, got %+v", got)
 	}
 }
@@ -673,7 +673,7 @@ func TestCleanupStale_DeletesRouteAndCorrelatedMACBinding(t *testing.T) {
 		t.Fatalf("CleanupStaleChassisManagedEntries: %v", err)
 	}
 
-	tx := nb.recordedTransacts()
+	tx := nb.writeTransacts()
 	if len(tx) != 2 {
 		t.Fatalf("expected 2 transacts (route + mac), got %d: %+v", len(tx), tx)
 	}
@@ -719,7 +719,7 @@ func TestCleanupStale_PreservesMACBindingWhenLiveChassisOwnsSamePort(t *testing.
 		t.Fatalf("CleanupStaleChassisManagedEntries: %v", err)
 	}
 
-	tx := nb.recordedTransacts()
+	tx := nb.writeTransacts()
 	// Stale route is deleted; MAC binding is preserved because lrp-abc is still live.
 	if len(tx) != 1 {
 		t.Fatalf("expected only the route-delete transact (no MAC binding delete), got %d: %+v", len(tx), tx)
@@ -743,7 +743,7 @@ func TestCleanupStale_SkipsLegacyRouteWithoutChassisTag(t *testing.T) {
 	if err := c.CleanupStaleChassisManagedEntries(context.Background(), map[string]bool{"host-gone": true}); err != nil {
 		t.Fatalf("CleanupStaleChassisManagedEntries: %v", err)
 	}
-	if got := nb.recordedTransacts(); len(got) != 0 {
+	if got := nb.writeTransacts(); len(got) != 0 {
 		t.Errorf("legacy untagged routes must be left alone, got %+v", got)
 	}
 }
@@ -765,7 +765,7 @@ func TestCleanupStale_SkipsUnmanagedRoutes(t *testing.T) {
 	if err := c.CleanupStaleChassisManagedEntries(context.Background(), map[string]bool{"host-gone": true}); err != nil {
 		t.Fatalf("CleanupStaleChassisManagedEntries: %v", err)
 	}
-	if got := nb.recordedTransacts(); len(got) != 0 {
+	if got := nb.writeTransacts(); len(got) != 0 {
 		t.Errorf("unmanaged routes must be left alone, got %+v", got)
 	}
 }
@@ -1187,6 +1187,49 @@ func TestListManagedRouteChassis_ListErrorReturnsNil(t *testing.T) {
 	nb.listErr = errors.New("connection refused")
 	if got := c.ListManagedRouteChassis(context.Background()); got != nil {
 		t.Errorf("expected nil on list error, got %v", got)
+	}
+}
+
+// TestListManagedRouteChassis_RecoversDroppedRouteFromCache exercises the
+// consistency guard on the stale-chassis scan: the monitor cache dropped a
+// managed route, so its chassis tag would be missed. cachedList must detect
+// the gap against the server and recover the route.
+func TestListManagedRouteChassis_RecoversDroppedRouteFromCache(t *testing.T) {
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+
+	// Cache knows only the host-a route; the host-b route's INSERT was dropped.
+	nb.setRows("Logical_Router_Static_Route", &NBLogicalRouterStaticRoute{
+		UUID:     "r1",
+		IPPrefix: "0.0.0.0/0",
+		ExternalIDs: map[string]string{
+			"ovn-network-agent":         "managed",
+			"ovn-network-agent-chassis": "host-a",
+		},
+	})
+	// The server has both routes.
+	nb.setSelectRows("Logical_Router_Static_Route",
+		ovsdb.Row{
+			"_uuid":     ovsdb.UUID{GoUUID: "r1"},
+			"ip_prefix": "0.0.0.0/0",
+			"external_ids": ovsdb.OvsMap{GoMap: map[any]any{
+				"ovn-network-agent":         "managed",
+				"ovn-network-agent-chassis": "host-a",
+			}},
+		},
+		ovsdb.Row{
+			"_uuid":     ovsdb.UUID{GoUUID: "r2"},
+			"ip_prefix": "0.0.0.0/0",
+			"external_ids": ovsdb.OvsMap{GoMap: map[any]any{
+				"ovn-network-agent":         "managed",
+				"ovn-network-agent-chassis": "host-b",
+			}},
+		},
+	)
+
+	got := c.ListManagedRouteChassis(context.Background())
+	want := map[string]bool{"host-a": true, "host-b": true}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ListManagedRouteChassis() = %v, want %v (dropped route not recovered)", got, want)
 	}
 }
 

--- a/ovn_gateway_writes_test.go
+++ b/ovn_gateway_writes_test.go
@@ -532,6 +532,82 @@ func TestEnsureActivePriorityLead_FallsBackToServerSelectOnCacheMiss(t *testing.
 	}
 }
 
+// gatewayChassisUpdates returns the Gateway_Chassis priority updates recorded
+// on the fake NB client.
+func gatewayChassisUpdates(tx [][]ovsdb.Operation) []ovsdb.Operation {
+	var updates []ovsdb.Operation
+	for _, batch := range tx {
+		for _, op := range batch {
+			if op.Op == ovsdb.OperationUpdate && op.Table == "Gateway_Chassis" {
+				updates = append(updates, op)
+			}
+		}
+	}
+	return updates
+}
+
+// TestEnsureActivePriorityLead_SkipsBoostWhenCRPortMovedAway covers the
+// anti-ratchet guard: the local Gateway_Chassis row trails the peer, so the
+// reconcile snapshot would boost — but SB shows the chassisredirect port has
+// already migrated to the peer. Boosting a no-longer-active chassis would
+// create a higher-priority tie, so the boost must be skipped.
+func TestEnsureActivePriorityLead_SkipsBoostWhenCRPortMovedAway(t *testing.T) {
+	c, nb, sb := newOVNClientWithFakes(t, "host-a")
+
+	nb.setRows("Gateway_Chassis",
+		&NBGatewayChassis{UUID: "g1", Name: "lrp-a_host-a", ChassisName: "host-a", Priority: 1},
+		&NBGatewayChassis{UUID: "g2", Name: "lrp-a_host-b", ChassisName: "host-b", Priority: 5},
+	)
+	sb.setRows("Chassis",
+		&SBChassis{UUID: "ch-a", Name: "ch-a", Hostname: "host-a"},
+		&SBChassis{UUID: "ch-b", Name: "ch-b", Hostname: "host-b"},
+	)
+	// The chassisredirect port for lrp-a is bound to host-b, not host-a.
+	sb.setRows("Port_Binding", &SBPortBinding{
+		UUID: "pb-1", LogicalPort: "cr-lrp-a", Type: "chassisredirect", Chassis: strPtr("ch-b"),
+	})
+
+	err := c.EnsureActivePriorityLead(context.Background(),
+		[]LocalRouterInfo{{LRPName: "lrp-a", CRPort: "cr-lrp-a"}}, "host-a")
+	if err != nil {
+		t.Fatalf("EnsureActivePriorityLead: %v", err)
+	}
+
+	if got := gatewayChassisUpdates(nb.recordedTransacts()); len(got) != 0 {
+		t.Errorf("must not boost when the chassisredirect port moved away, got %+v", got)
+	}
+}
+
+// TestEnsureActivePriorityLead_BoostsWhenCRPortConfirmedLocal is the companion:
+// the same trailing priority, but SB confirms the chassisredirect port is
+// still bound here, so the boost proceeds.
+func TestEnsureActivePriorityLead_BoostsWhenCRPortConfirmedLocal(t *testing.T) {
+	c, nb, sb := newOVNClientWithFakes(t, "host-a")
+
+	nb.setRows("Gateway_Chassis",
+		&NBGatewayChassis{UUID: "g1", Name: "lrp-a_host-a", ChassisName: "host-a", Priority: 1},
+		&NBGatewayChassis{UUID: "g2", Name: "lrp-a_host-b", ChassisName: "host-b", Priority: 5},
+	)
+	sb.setRows("Chassis", &SBChassis{UUID: "ch-a", Name: "ch-a", Hostname: "host-a"})
+	sb.setRows("Port_Binding", &SBPortBinding{
+		UUID: "pb-1", LogicalPort: "cr-lrp-a", Type: "chassisredirect", Chassis: strPtr("ch-a"),
+	})
+
+	err := c.EnsureActivePriorityLead(context.Background(),
+		[]LocalRouterInfo{{LRPName: "lrp-a", CRPort: "cr-lrp-a"}}, "host-a")
+	if err != nil {
+		t.Fatalf("EnsureActivePriorityLead: %v", err)
+	}
+
+	updates := gatewayChassisUpdates(nb.recordedTransacts())
+	if len(updates) != 1 {
+		t.Fatalf("expected one boost when the port is locally bound, got %d: %+v", len(updates), updates)
+	}
+	if got, ok := updates[0].Row["priority"].(int); !ok || got != 6 {
+		t.Errorf("expected boost to 6 (max peer 5 + 1), got %#v", updates[0].Row["priority"])
+	}
+}
+
 // =============================================================================
 // RemoveManagedNBEntries
 // =============================================================================


### PR DESCRIPTION
## Problem

The HA-failover FIP-reachability loss that #123 set out to fix still
reproduces after repeated gateway-agent stop/start cycles. A deep review
of the merged fixes found that the residual cause is a *shared root*
#123 only partially addressed: every cache-consistency defence added by
#115 / #116 / #123 detects a **missing row**, never a **stale row**, and
one failover-path reader has no defence at all.

## Root cause

- **`RestoreDrainedGateways` had no cache fallback.** It lifts a drained
  chassis off `Gateway_Chassis` priority 0 on startup — exactly in the
  issue #115 INSERT-drop window — but #115's affected-code list never
  named it, so #116/#123 left it reading the raw cache. A dropped local
  row means the chassis stays at priority 0 forever; nothing else lifts
  a standby off 0, so redundancy is permanently lost and a later drain
  strands the chassisredirect port on a node that cannot forward.

- **The consistency guard compared only `_uuid` sets.** The whole
  HA-failover signal lives in reference/set columns (`Port_Binding.chassis`,
  `Logical_Router.nat`/`.ports`, `Logical_Router_Port.networks`). A
  dropped UPDATE leaves the `_uuid` set identical, so the guard reports
  "in sync" and `refreshState` computes a short desired-IP set —
  `ensureRoutes` then withdraws the FRR `/32` of a FIP OVN is still
  serving. The periodic reconcile cannot recover because every cycle
  re-reads the same stale cache.

- **Other failover-path reads were never guarded** — `countLocalCRPorts`
  (drain poll), `RemoveManagedNBEntries`, `ListManagedRouteChassis`,
  `CleanupStaleChassisManagedEntries`.

- **`EnsureActivePriorityLead` boosted from a reconcile snapshot**, which
  can race a chassisredirect migration into a self-sustaining priority
  ratchet.

## Changes (one per commit, bisectable)

1. **`agent: fall back to NB select when restore-drain misses the local
   row`** — `RestoreDrainedGateways` gets the same direct-NB-select
   fallback #116 gave `DrainGateways`/`EnsureActivePriorityLead`, via a
   new `filterRestoreCandidates` mirroring `filterDrainCandidates`.

2. **`agent: make the OVN cache consistency check content-aware`** — the
   guard now cross-checks a per-row *content key* built from the
   failover-critical columns, so a dropped UPDATE (stale column, same
   `_uuid`) triggers the existing full-select rebuild. The check select
   stays cheap (a handful of small columns, one round-trip per table).
   `_version` in the model was evaluated and rejected — libovsdb v0.8.1
   fails schema validation on a `_version`-tagged field.

3. **`agent: route the remaining failover-path NB/SB reads through the
   guard`** — `countLocalCRPorts` and the NB cleanup readers now use
   `cachedList`; adds decoders/keys for `Logical_Router_Static_Route`
   and `Static_MAC_Binding`, and `decodeNBLogicalRouter` now decodes
   `static_routes`.

4. **`agent: confirm the chassisredirect binding before an active-lead
   boost`** — `EnsureActivePriorityLead` re-confirms via a direct SB
   select that this chassis still owns the LRP's chassisredirect port
   before boosting; a boost is skipped when SB shows the port bound
   elsewhere, closing the priority-ratchet.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l`, `golangci-lint run` — clean.
- `go test ./...` and `go test -race` — green, including new regression
  tests: `TestAuthoritativeListRecoversStaleColumn`,
  `TestRefreshStateRecoversStaleChassisBinding`,
  `TestRestoreDrainedGateways_FallsBackToServerSelectOnCacheMiss`,
  `TestListManagedRouteChassis_RecoversDroppedRouteFromCache`,
  `TestEnsureActivePriorityLead_SkipsBoostWhenCRPortMovedAway` and its
  positive companion.
- Each commit builds and tests independently (bisectable).
- Not run here: `make test-integration` / E2E (need a live OVN environment).

Follow-up to #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)