### PR TITLE
build: require Go 1.26.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ workflow.
 
 ## Quick start
 
-Requires Go 1.25+ (see `go.mod` for the exact minimum). Build the binary,
+Requires Go 1.26+ (see `go.mod` for the exact minimum). Build the binary,
 write a minimal config pointing at your OVN cluster, and run it:
 
 ```bash

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -62,7 +62,7 @@ sudo systemctl enable --now ovn-network-agent
 
 ## From source
 
-Requires Go 1.25+ (see `go.mod` for the exact minimum).
+Requires Go 1.26+ (see `go.mod` for the exact minimum).
 
 ```bash
 make build-static

--- a/docs/tutorials/first-agent.md
+++ b/docs/tutorials/first-agent.md
@@ -40,7 +40,7 @@ configures FRR with a `vrf-provider`. See the
 
 ## Step 1 — Build the binary
 
-Requires Go 1.25+ (see `go.mod` for the exact minimum).
+Requires Go 1.26+ (see `go.mod` for the exact minimum).
 
 ```bash
 # Standard build (linux)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/osism/ovn-network-agent
 
-go 1.25.0
+go 1.26.4
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/test/e2e/Dockerfile.gwnode
+++ b/test/e2e/Dockerfile.gwnode
@@ -12,7 +12,7 @@
 # multi-arch publication, use buildx with --platform=linux/amd64,linux/arm64;
 # the Go build stage honours TARGETARCH set by BuildKit.
 
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 ARG UBUNTU_VERSION=24.04
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Bump the project's Go version to **1.26.4**.

## Changes
- `go.mod` — `go` directive bumped `1.25.0` → `1.26.4`
- `test/e2e/Dockerfile.gwnode` — `ARG GO_VERSION` default `1.25` → `1.26` (golang build image)
- `README.md`, `docs/guides/installation.md`, `docs/tutorials/first-agent.md` — "Requires Go 1.25+" → "Requires Go 1.26+"

## Notes
- All CI workflows resolve the toolchain via `go-version-file: go.mod`, so they pick up the new version automatically — no per-workflow edits needed.
- `go build ./...` passes with Go 1.26.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
