### PR TITLE
test/e2e: raise the reconcile window to 60s to de-flake reachability

### DIFF
--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -212,8 +212,14 @@ make e2e-baseline
 
 [`baseline.sh`](https://github.com/osism/ovn-network-agent/blob/main/test/e2e/scenarios/baseline.sh)
 pings the FIP `192.0.2.10` from `clab-ovn-e2e-client-1` and waits up to
-30 s for the agent's reconcile loop to install the routes. The
-scenario's exit code mirrors `ping`'s — any packet loss fails the run.
+`RECONCILE_TIMEOUT` (default 60 s) for the agent's reconcile loop to
+install the routes. The scenario's exit code mirrors `ping`'s — any
+packet loss fails the run. The window was raised from the 30 s
+originally measured on a warm local Docker host because cold CI runners
+regularly need longer for the full data path (OVN BFD/geneve tunnels,
+the `cr-lr0-public` HA election, the agent's FRR FIP routes and BGP
+propagation) to converge — a too-tight window made this gate flaky in
+every scenario that runs it as a sanity pre-check.
 
 **Overrides for triage:** `FIP`, `RECONCILE_TIMEOUT`, `PING_COUNT`,
 `PING_TIMEOUT`.
@@ -280,7 +286,7 @@ The scenario:
    a `vm2` netns + veth on `gateway-3`, so the new FIP has a real
    responder.
 3. Polls `gateway-1` for the new hairpin flow on `br-ex` (default
-   `RECONCILE_TIMEOUT=30s`) and asserts that **both** FIPs carry a
+   `RECONCILE_TIMEOUT=60s`) and asserts that **both** FIPs carry a
    `cookie=0x998` flow with `actions=output:in_port` — matching the
    issue's acceptance criterion of "at least one matching rule per FIP
    on the chassis".
@@ -434,7 +440,7 @@ agent's config:
 2. **Phase 2 (positive).** The scenario rewrites the config with
    `hairpin_masquerade: true`, restarts the gateway again, waits for
    the chassis re-bind and DNAT rule, then polls the same probe for up
-   to `RECONCILE_TIMEOUT` (default 30 s). The probe **must** complete,
+   to `RECONCILE_TIMEOUT` (default 60 s). The probe **must** complete,
    and `nft list table ip ovn-network-agent` on `gateway-1` **must**
    carry a `ct original daddr 198.51.100.50 ... masquerade` rule. Both
    the `phase1-off` and `phase2-on` nft snapshots are written to

--- a/test/e2e/scenarios/baseline.sh
+++ b/test/e2e/scenarios/baseline.sh
@@ -2,7 +2,15 @@
 # Baseline reachability scenario for the containerlab E2E harness.
 #
 # Goal (issue #45): client-1 pings the FIP on the active gateway and
-# observes 100% success after the agent has had ≤30s to reconcile.
+# observes 100% success once the agent has reconciled. The reconcile
+# window (RECONCILE_TIMEOUT) defaults to 60s: on cold CI runners the
+# full data path — OVN BFD/geneve tunnel bring-up, the cr-lr0-public HA
+# election, the agent's FRR FIP routes and BGP propagation to the
+# upstream — regularly needs more than the 30s originally measured on a
+# warm local Docker host. That tight window made this reachability gate
+# flaky across every scenario that runs it as a sanity pre-check
+# (hairpin.sh / pf-hairpin.sh / pf-external.sh). 60s matches
+# pf-external.sh, the one scenario that never flaked here.
 #
 # The bootstrap script seeds the OVN NB DB with a logical switch,
 # logical router and two FIPs (192.0.2.10, 192.0.2.11) distributed
@@ -15,7 +23,7 @@
 #   LAB                container-name prefix (defaults to the topology name "ovn-e2e")
 #   FIP                target FIP to ping (defaults to the priority-30 chassis FIP)
 #   CLIENT             source container (defaults to clab-${LAB}-client-1)
-#   RECONCILE_TIMEOUT  seconds to wait for the agent to reconcile (default 30)
+#   RECONCILE_TIMEOUT  seconds to wait for the agent to reconcile (default 60)
 #   PING_COUNT         packets for the final reachability check (default 5)
 #   PING_TIMEOUT       per-packet wait, passed to ping -W (default 2)
 
@@ -24,7 +32,7 @@ set -euo pipefail
 LAB="${LAB:-ovn-e2e}"
 FIP="${FIP:-192.0.2.10}"
 CLIENT="${CLIENT:-clab-${LAB}-client-1}"
-RECONCILE_TIMEOUT="${RECONCILE_TIMEOUT:-30}"
+RECONCILE_TIMEOUT="${RECONCILE_TIMEOUT:-60}"
 PING_COUNT="${PING_COUNT:-5}"
 PING_TIMEOUT="${PING_TIMEOUT:-2}"
 
@@ -33,8 +41,8 @@ log() { printf '[baseline] %s\n' "$*" >&2; }
 # Poll the reachability check for up to RECONCILE_TIMEOUT seconds. The
 # agent's reconcile loop installs FRR static routes and OVS hairpin
 # flows asynchronously after ovn-controller binds the chassisredirect
-# port; a polling probe matches the issue's "≤30s after reconcile"
-# expectation without hard-coding a sleep.
+# port; a polling probe waits for the data path to come up without
+# hard-coding a sleep.
 wait_for_reachability() {
     local deadline
     deadline=$(( $(date +%s) + RECONCILE_TIMEOUT ))

--- a/test/e2e/scenarios/hairpin.sh
+++ b/test/e2e/scenarios/hairpin.sh
@@ -6,7 +6,8 @@
 # behind FIP_A to FIP_B must traverse the agent's OpenFlow hairpin rule
 # (cookie `0x998`, `actions=output:in_port`) on `br-ex` and complete a
 # round trip with 100% reply rate within `RECONCILE_TIMEOUT` (default
-# 30s).
+# 60s — see baseline.sh for why the cold-runner reconcile window was
+# raised from the original 30s).
 #
 # Why a separate scenario: the baseline only exercises a single FIP on
 # the master chassis. The hairpin path is what kicks in when two FIPs
@@ -67,7 +68,7 @@
 #   WORKLOAD_NETNS      netns the probe runs in — host of FIP_A's workload (default vm1)
 #   WORKLOAD_GW         tenant gateway IP for the new responder (default 192.168.10.1)
 #   WORKLOAD_CIDR_LEN   netmask length for FIP_B_INTERNAL on the responder (default 24)
-#   RECONCILE_TIMEOUT   seconds to wait for the agent to install FIP_B's hairpin flow (default 30)
+#   RECONCILE_TIMEOUT   seconds to wait for the agent to install FIP_B's hairpin flow (default 60)
 #   PING_COUNT          packets for the final reachability check (default 5)
 #   PING_TIMEOUT        per-packet wait, passed to ping -W (default 2)
 #   ARTIFACTS_DIR       directory to write before/after hairpin-flow snapshots (default empty = skip)
@@ -94,7 +95,7 @@ FIP_B_NS_VETH="${FIP_B_NS_VETH:-vm2-eth0}"
 WORKLOAD_NETNS="${WORKLOAD_NETNS:-vm1}"
 WORKLOAD_GW="${WORKLOAD_GW:-192.168.10.1}"
 WORKLOAD_CIDR_LEN="${WORKLOAD_CIDR_LEN:-24}"
-RECONCILE_TIMEOUT="${RECONCILE_TIMEOUT:-30}"
+RECONCILE_TIMEOUT="${RECONCILE_TIMEOUT:-60}"
 PING_COUNT="${PING_COUNT:-5}"
 PING_TIMEOUT="${PING_TIMEOUT:-2}"
 ARTIFACTS_DIR="${ARTIFACTS_DIR:-}"

--- a/test/e2e/scenarios/pf-hairpin.sh
+++ b/test/e2e/scenarios/pf-hairpin.sh
@@ -103,7 +103,7 @@
 #   AGENT_CONFIG_PATH  in-container agent config path (default /etc/ovn-network-agent/config.yaml)
 #   GWNODE_CONFIG      host-side baseline config (defaults to the file next to this script)
 #   PROBE_TIMEOUT      seconds for the `timeout` wrapper around the probe (default 5)
-#   RECONCILE_TIMEOUT  seconds to wait for agent reconcile + DNAT/masquerade rules (default 30)
+#   RECONCILE_TIMEOUT  seconds to wait for agent reconcile + DNAT/masquerade rules (default 60 — see baseline.sh for the cold-runner rationale)
 #   RESTART_TIMEOUT    seconds to wait for the gateway container to come back after `docker restart` (default 90)
 #   ARTIFACTS_DIR      directory to write nft snapshots into (default empty = skip)
 #   SANITY_GATE        run baseline.sh first when 1 (default 1)
@@ -149,7 +149,7 @@ WORKLOAD_CIDR_LEN="${WORKLOAD_CIDR_LEN:-24}"
 
 AGENT_CONFIG_PATH="${AGENT_CONFIG_PATH:-/etc/ovn-network-agent/config.yaml}"
 PROBE_TIMEOUT="${PROBE_TIMEOUT:-5}"
-RECONCILE_TIMEOUT="${RECONCILE_TIMEOUT:-30}"
+RECONCILE_TIMEOUT="${RECONCILE_TIMEOUT:-60}"
 RESTART_TIMEOUT="${RESTART_TIMEOUT:-90}"
 ARTIFACTS_DIR="${ARTIFACTS_DIR:-}"
 SANITY_GATE="${SANITY_GATE:-1}"


### PR DESCRIPTION
## What

Raise the E2E reconcile window from 30 s to 60 s in `baseline.sh`,
`hairpin.sh` and `pf-hairpin.sh`, matching the already-stable
`pf-external.sh`.

Closes #144.

## Why

The reachability sanity gate (`baseline.sh` pings FIP `192.0.2.10`)
allowed only 30 s for the data path to converge. Every scenario runs it
— the standalone baseline job plus the sanity pre-check in `hairpin.sh`,
`pf-hairpin.sh` and `pf-external.sh` — so whichever job drew a slow
runner turned red, **including runs on `main`**.

The bootstrap waits for OVN NB reachability and SB chassis registration
but not for full data-path convergence: OVN BFD/geneve tunnel bring-up,
the `cr-lr0-public` HA election, the agent's FIP `/32` FRR routes and BGP
propagation to the upstream. On cold GitHub-hosted runners that chain
regularly needs more than the 30 s originally measured on a warm local
Docker host. `pf-external.sh` already defaults `RECONCILE_TIMEOUT` to
60 s and never flaked at its reachability probe.

See #144 for the run-by-run evidence.

## Notes

- The green path still returns early via polling — no fixed sleep is
  added. Jobs finish in ~2–3 min against a 15-min budget, so there is
  ample headroom.
- `failover.sh`'s `FAILOVER_TIMEOUT` is a separate concern and is left
  unchanged.
- Docs (`docs/contributing/e2e-tests.md`) updated to match.
