### PR TITLE
Support multiple public provider networks per gateway node (VLAN localnet segments)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -204,6 +204,68 @@ jobs:
         if: always()
         run: make e2e-down
 
+  multi-vlan:
+    name: Multi-VLAN provider networks (two segments on master)
+    runs-on: ubuntu-latest
+    # Runs in parallel with failover and hairpin (all gate on baseline)
+    # so a multi-segment regression is reported in isolation. Same
+    # 15-minute budget — the scenario adds the cost of one bootstrap,
+    # the baseline gate, plus a ≤60s convergence wait per segment check
+    # and three 5-packet probes.
+    needs: baseline
+    timeout-minutes: 15
+
+    env:
+      E2E_TOPOLOGY: test/e2e/topology.clab.yml
+      LAB: ovn-e2e
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install containerlab
+        run: bash -c "$(curl -sL https://get.containerlab.dev)"
+
+      # See the baseline job for the rationale; same modules required.
+      - name: Load required kernel modules
+        run: |
+          set -euo pipefail
+          sudo modprobe openvswitch
+          if ! sudo modprobe vrf 2>/dev/null; then
+            sudo apt-get update -qq
+            sudo apt-get install -y "linux-modules-extra-$(uname -r)"
+            sudo modprobe vrf
+          fi
+
+      - name: Bring the lab up
+        run: make e2e-up
+
+      - name: Run multi-VLAN scenario
+        # Direct the scenario's flow/link/route snapshots into the same
+        # artifact root so collect-artifacts.sh and the uploader both
+        # pick them up. `runner.temp` is only available at step scope,
+        # not the job-level env block.
+        env:
+          ARTIFACTS_DIR: ${{ runner.temp }}/e2e-artifacts/multi-vlan
+        run: ./test/e2e/scenarios/multi-vlan.sh
+
+      - name: Collect failure artifacts
+        if: failure()
+        run: |
+          ./test/e2e/scenarios/collect-artifacts.sh "${RUNNER_TEMP}/e2e-artifacts"
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: e2e-artifacts-multi-vlan-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/e2e-artifacts
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Tear the lab down
+        if: always()
+        run: make e2e-down
+
   pf-external:
     name: Port-forward DNAT (external client, source IP preserved)
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION   ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "d
 LDFLAGS   := -s -w -X main.version=$(VERSION)
 GOFLAGS   := -trimpath
 
-.PHONY: all build build-static clean fmt vet test test-integration install docs-gen docs-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-hairpin e2e-pf-external e2e-pf-hairpin e2e-stale-chassis
+.PHONY: all build build-static clean fmt vet test test-integration install docs-gen docs-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-hairpin e2e-multi-vlan e2e-pf-external e2e-pf-hairpin e2e-stale-chassis
 
 # Containerlab E2E harness. See test/e2e/README.md for the topology and
 # acceptance criteria (issue #44).
@@ -12,6 +12,7 @@ E2E_BOOTSTRAP   := test/e2e/bootstrap.sh
 E2E_BASELINE    := test/e2e/scenarios/baseline.sh
 E2E_FAILOVER    := test/e2e/scenarios/failover.sh
 E2E_HAIRPIN     := test/e2e/scenarios/hairpin.sh
+E2E_MULTI_VLAN  := test/e2e/scenarios/multi-vlan.sh
 E2E_PF_EXTERNAL := test/e2e/scenarios/pf-external.sh
 E2E_PF_HAIRPIN  := test/e2e/scenarios/pf-hairpin.sh
 E2E_STALE       := test/e2e/scenarios/stale-chassis.sh
@@ -148,6 +149,19 @@ e2e-failover:
 # `make e2e-baseline` works without tearing the lab down.
 e2e-hairpin:
 	$(E2E_HAIRPIN)
+
+# Run the multi-VLAN provider-network scenario (issue #147) against a
+# lab that is already up. Adds two VLAN provider networks (tags 101/102
+# on physnet1), each with a gatewayless public subnet, a router pinned
+# to gateway-1, and a netns workload behind a FIP. Asserts the agent
+# creates one kernel subinterface per segment (br-ex.101/br-ex.102),
+# routes each FIP /32 over its own segment interface, installs
+# MAC-tweak flows per localnet patch port, and announces both FIPs via
+# BGP — then probes both FIPs plus the flat baseline FIP from client-1.
+# The scenario's own EXIT trap removes the added networks so a
+# subsequent `make e2e-baseline` works without tearing the lab down.
+e2e-multi-vlan:
+	$(E2E_MULTI_VLAN)
 
 # Run the port-forward / DNAT scenario (issue #109) against a lab
 # that is already up. Adds an OVN Load_Balancer for 192.0.2.50:80 →

--- a/agent.go
+++ b/agent.go
@@ -315,6 +315,7 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 	desiredIPs = uniqueIPs(desiredIPs)
 
 	setDesiredState(len(desiredIPs), len(state.LocalRouters), len(a.effectiveFilters))
+	setLocalnetSegments(len(desiredSegments))
 
 	slog.Info("reconciling",
 		"has_local_routers", state.HasLocalRouters,

--- a/agent.go
+++ b/agent.go
@@ -246,16 +246,18 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 	// Compute effective network filters for this cycle.
 	a.effectiveFilters = a.computeEffectiveNetworks(state.DiscoveredNetworks)
 
-	// hairpinMACMap maps each IP that needs a hairpin flow to the MAC of
-	// the router port that owns it. This includes FIPs, SNAT IPs, and
-	// router gateway IPs (LRP networks). Port-forward VIPs are
-	// intentionally excluded because their DNAT is handled by nftables.
+	// hairpinTargets maps each IP that needs a hairpin flow to the MAC of
+	// the router port that owns it and the localnet segment its external
+	// network is on. This includes FIPs, SNAT IPs, and router gateway IPs
+	// (LRP networks). Port-forward VIPs are intentionally excluded because
+	// their DNAT is handled by nftables.
 	//
 	// The MAC is used as mod_dl_dst in the hairpin flow so that OVN's
-	// L2 lookup delivers the reflected packet to the correct router.
-	hairpinMACMap := make(map[string]string, len(state.NATIPToRouterMAC))
+	// L2 lookup delivers the reflected packet to the correct router; the
+	// segment selects the patch port the flow binds to.
+	hairpinTargets := make(map[string]HairpinTarget, len(state.NATIPToRouterMAC))
 	for ip, mac := range state.NATIPToRouterMAC {
-		hairpinMACMap[ip] = mac
+		hairpinTargets[ip] = HairpinTarget{RouterMAC: mac, Segment: state.NATIPToSegment[ip]}
 	}
 	// Router gateway IPs (LRP networks) are included so that VMs on a
 	// same-chassis router can reach other routers' gateway addresses,
@@ -267,15 +269,38 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 				continue
 			}
 			if lr.LRPMAC != "" {
-				hairpinMACMap[ip.String()] = lr.LRPMAC
+				hairpinTargets[ip.String()] = HairpinTarget{RouterMAC: lr.LRPMAC, Segment: segmentName(lr.Segment)}
 			}
 		}
 	}
 
+	// desiredSegments is the deduplicated set of localnet segments the
+	// locally-active routers need a data plane for. Routers whose segment
+	// is unresolved contribute the "" fallback segment.
+	segmentSet := make(map[string]DesiredSegment)
+	for _, lr := range state.LocalRouters {
+		key := segmentName(lr.Segment)
+		if _, ok := segmentSet[key]; ok {
+			continue
+		}
+		d := DesiredSegment{LocalnetPort: key}
+		if lr.Segment != nil {
+			d.VLANTag = lr.Segment.VLANTag
+		}
+		segmentSet[key] = d
+	}
+	desiredSegments := make([]DesiredSegment, 0, len(segmentSet))
+	for _, d := range segmentSet {
+		desiredSegments = append(desiredSegments, d)
+	}
+	sort.Slice(desiredSegments, func(i, j int) bool {
+		return desiredSegments[i].LocalnetPort < desiredSegments[j].LocalnetPort
+	})
+
 	// hairpinIPs is the flat list of IPs for kernel routes and FRR.
 	// Map keys are already unique; just sort for deterministic ordering.
-	hairpinIPs := make([]string, 0, len(hairpinMACMap))
-	for ip := range hairpinMACMap {
+	hairpinIPs := make([]string, 0, len(hairpinTargets))
+	for ip := range hairpinTargets {
 		hairpinIPs = append(hairpinIPs, ip)
 	}
 	sort.Strings(hairpinIPs)
@@ -309,8 +334,9 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 		// reconciliation are all OVN-driven and skipped entirely — only
 		// port forwarding and the VIP routes below are managed.
 	case state.HasLocalRouters:
-		// Ensure OVS MAC-tweak flows are in place (only when active).
-		if err := a.routing.EnsureOVSFlows(); err != nil {
+		// Ensure per-segment OVS MAC-tweak flows and kernel interfaces are
+		// in place (only when active).
+		if err := a.routing.EnsureSegments(desiredSegments); err != nil {
 			slog.Error("failed to ensure OVS flows", "error", err)
 		}
 
@@ -318,12 +344,12 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 		// communication. These reflect FIP/SNAT-IP traffic from OVN back
 		// into OVN's external pipeline instead of sending it to the kernel,
 		// fixing the case where two routers share the same gateway chassis.
-		if err := a.routing.ReconcileOVSHairpinFlows(hairpinMACMap); err != nil {
+		if err := a.routing.ReconcileOVSHairpinFlows(hairpinTargets); err != nil {
 			slog.Error("failed to reconcile OVS hairpin flows", "error", err)
 		}
 
 		// Ensure OVN default routes and static MAC bindings for local routers.
-		bridgeMAC := a.routing.cachedBridgeMAC
+		bridgeMAC := a.routing.SegmentMAC("")
 		if bridgeMAC == "" {
 			if mac, err := a.routing.GetBridgeMAC(); err == nil {
 				bridgeMAC = mac.String()

--- a/agent.go
+++ b/agent.go
@@ -395,11 +395,36 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 		slog.Error("failed to reconcile port forwarding", "error", err)
 	}
 
+	// ipDev maps each desired IP to the kernel interface its /32 route
+	// belongs on: the owning segment's interface for FIPs, SNAT IPs, and
+	// router gateway IPs. Port-forward VIPs are absent and default to the
+	// bridge device. Computed after EnsureSegments so the bindings are
+	// fresh for this cycle.
+	//
+	// skipKernelRoute holds IPs whose VLAN segment could not be resolved this
+	// cycle. EnsureSegments leaves such a segment without a binding (a
+	// transient discovery failure nulls the whole map, or a per-segment
+	// interface setup failed), so SegmentDev would report the untagged
+	// provider bridge. Reconciling the /32 onto that fallback would atomically
+	// move a VLAN FIP/SNAT route off its subinterface and mis-deliver the
+	// traffic, so those IPs are skipped and their existing route is left in
+	// place until the segment resolves again. Flat segments legitimately route
+	// on the bridge and are never skipped.
+	ipDev := make(map[string]string, len(hairpinTargets))
+	skipKernelRoute := make(map[string]bool)
+	for ip, target := range hairpinTargets {
+		if a.segmentRouteUnresolved(target.Segment, segmentSet) {
+			skipKernelRoute[ip] = true
+			continue
+		}
+		ipDev[ip] = a.routing.SegmentDev(target.Segment)
+	}
+
 	// Ensure routes for all desired IPs (FIPs, SNATs, and port forward VIPs).
 	// When no local routers are present but port forwards are configured,
 	// this still installs VIP routes on br-ex and in FRR.
 	if len(desiredIPs) > 0 || state.HasLocalRouters {
-		a.ensureRoutes(desiredIPs)
+		a.ensureRoutes(desiredIPs, ipDev, skipKernelRoute)
 	} else {
 		a.removeAllRoutes("no locally active routers and no port forward VIPs")
 	}
@@ -495,30 +520,58 @@ func (a *Agent) computeEffectiveNetworks(discovered []*net.IPNet) []*net.IPNet {
 	return effectiveNetworkFilters(a.cfg.NetworkFilters, discovered)
 }
 
+// segmentRouteUnresolved reports whether an IP on the given localnet segment
+// must keep its existing kernel /32 route this cycle instead of being routed
+// via SegmentDev. It is true only for a VLAN segment (one the desired set
+// tagged) whose per-segment binding did not resolve — the case where SegmentDev
+// would wrongly return the untagged provider bridge and atomically relocate the
+// FIP/SNAT route off its subinterface. Flat segments (bridge is correct),
+// resolved VLAN segments, and unknown segments return false and route normally.
+func (a *Agent) segmentRouteUnresolved(segment string, desired map[string]DesiredSegment) bool {
+	d, ok := desired[segment]
+	return ok && d.VLANTag != nil && !a.routing.SegmentResolved(segment)
+}
+
+// desiredRouteDev returns the kernel interface an IP's /32 route belongs on,
+// defaulting to the provider bridge for IPs without segment information
+// (port-forward VIPs, unresolved segments).
+func (a *Agent) desiredRouteDev(ip string, ipDev map[string]string) string {
+	if dev := ipDev[ip]; dev != "" {
+		return dev
+	}
+	return a.cfg.BridgeDev
+}
+
 // ensureRoutes adds routes for all desired IPs and removes stale ones.
-func (a *Agent) ensureRoutes(desiredIPs []string) {
+// ipDev names the kernel interface each IP's route belongs on; kernel routes
+// are reconciled as (IP, device) pairs so a route that sits on the wrong
+// segment interface is replaced. IPs in skipKernelRoute keep their existing
+// kernel route untouched — their VLAN segment did not resolve this cycle, so
+// moving the /32 to the bridge fallback would mis-deliver the traffic.
+func (a *Agent) ensureRoutes(desiredIPs []string, ipDev map[string]string, skipKernelRoute map[string]bool) {
 	desiredSet := make(map[string]bool, len(desiredIPs))
 	for _, ip := range desiredIPs {
 		desiredSet[ip] = true
 	}
 
-	// Kernel routes live on the provider bridge (br-ex). In
-	// port-forward-only mode the node need not have br-ex, so only FRR
-	// static routes are managed — the VIP is reachable as a local address
-	// on port_forward_dev, and the FRR route handles BGP announcement.
+	// Kernel routes live on the provider bridge (br-ex) or a per-VLAN
+	// segment interface on it. In port-forward-only mode the node need not
+	// have br-ex, so only FRR static routes are managed — the VIP is
+	// reachable as a local address on port_forward_dev, and the FRR route
+	// handles BGP announcement.
 	manageKernel := !a.cfg.PortForwardOnly
 
 	// Collect current state so we only add what is actually missing.
-	currentKernelSet := make(map[string]bool)
-	var currentKernel []string
+	currentKernelSet := make(map[kernelRouteEntry]bool)
+	var currentKernel []kernelRouteEntry
 	if manageKernel {
 		var err error
-		currentKernel, err = a.routing.ListKernelRoutes()
+		currentKernel, err = a.routing.listKernelRoutes()
 		if err != nil {
 			slog.Error("failed to list kernel routes", "error", err)
 		} else {
-			for _, ip := range currentKernel {
-				currentKernelSet[ip] = true
+			for _, e := range currentKernel {
+				currentKernelSet[e] = true
 			}
 		}
 	}
@@ -533,10 +586,15 @@ func (a *Agent) ensureRoutes(desiredIPs []string) {
 		}
 	}
 
-	// Collect missing and stale routes, then apply in batches.
+	// Collect missing and stale routes, then apply in batches. A kernel
+	// route on the wrong device counts as missing: AddKernelRoute uses
+	// route replace, which atomically moves the /32 to the right interface
+	// (one route per destination and table), so no separate delete is
+	// needed for the device change.
 	var addFRR []string
 	for _, ip := range desiredIPs {
-		needsKernel := manageKernel && !currentKernelSet[ip]
+		dev := a.desiredRouteDev(ip, ipDev)
+		needsKernel := manageKernel && !skipKernelRoute[ip] && !currentKernelSet[kernelRouteEntry{IP: ip, Dev: dev}]
 		needsFRR := !currentFRRSet[ip]
 
 		if !needsKernel && !needsFRR {
@@ -544,11 +602,11 @@ func (a *Agent) ensureRoutes(desiredIPs []string) {
 			continue
 		}
 
-		slog.Info("ensuring route", "ip", ip, "needs_kernel", needsKernel, "needs_frr", needsFRR)
+		slog.Info("ensuring route", "ip", ip, "dev", dev, "needs_kernel", needsKernel, "needs_frr", needsFRR)
 
 		if needsKernel {
-			if err := a.routing.AddKernelRoute(ip); err != nil {
-				slog.Error("failed to add kernel route", "ip", ip, "error", err)
+			if err := a.routing.AddKernelRoute(ip, dev); err != nil {
+				slog.Error("failed to add kernel route", "ip", ip, "dev", dev, "error", err)
 			}
 		}
 		if needsFRR {
@@ -563,16 +621,23 @@ func (a *Agent) ensureRoutes(desiredIPs []string) {
 		}
 	}
 
-	// Collect stale routes for batch removal.
+	// Collect stale routes for batch removal. Entries for still-desired IPs
+	// on the wrong device were already moved by the route replace above and
+	// must not withdraw the FRR announcement.
 	var delFRR []string
+	var removedKernel []kernelRouteEntry
 	removedSet := make(map[string]bool)
-	for _, ip := range currentKernel {
-		if !desiredSet[ip] && a.isManaged(ip) {
-			slog.Info("removing stale route", "ip", ip)
-			// Remove FRR first to stop attracting traffic before tearing down the data plane.
-			delFRR = append(delFRR, ip)
-			removedSet[ip] = true
+	for _, e := range currentKernel {
+		if desiredSet[e.IP] || !a.isManaged(e.IP) {
+			continue
 		}
+		slog.Info("removing stale route", "ip", e.IP, "dev", e.Dev)
+		// Remove FRR first to stop attracting traffic before tearing down the data plane.
+		if !removedSet[e.IP] {
+			delFRR = append(delFRR, e.IP)
+			removedSet[e.IP] = true
+		}
+		removedKernel = append(removedKernel, e)
 	}
 
 	// Collect orphaned FRR routes that have no corresponding kernel route.
@@ -591,11 +656,9 @@ func (a *Agent) ensureRoutes(desiredIPs []string) {
 	}
 
 	// Remove stale kernel routes (after FRR withdrawal).
-	for _, ip := range currentKernel {
-		if removedSet[ip] {
-			if err := a.routing.DelKernelRoute(ip); err != nil {
-				slog.Error("failed to remove kernel route", "ip", ip, "error", err)
-			}
+	for _, e := range removedKernel {
+		if err := a.routing.DelKernelRoute(e.IP, e.Dev); err != nil {
+			slog.Error("failed to remove kernel route", "ip", e.IP, "dev", e.Dev, "error", err)
 		}
 	}
 
@@ -617,7 +680,7 @@ func (a *Agent) ensureRoutes(desiredIPs []string) {
 	// are still present. A BGP soft-refresh re-evaluates outbound policy
 	// and could (in edge cases) interact with FRR in unexpected ways.
 	if len(addFRR) > 0 || len(delFRR) > 0 {
-		a.verifyRoutes(desiredIPs)
+		a.verifyRoutes(desiredIPs, ipDev, skipKernelRoute)
 	}
 }
 
@@ -647,15 +710,15 @@ func (a *Agent) removeAllRoutes(reason string) {
 	// Remove kernel routes. Skipped in port-forward-only mode, which does
 	// not manage kernel routes on the provider bridge.
 	if !a.cfg.PortForwardOnly {
-		currentKernel, err := a.routing.ListKernelRoutes()
+		currentKernel, err := a.routing.listKernelRoutes()
 		if err != nil {
 			slog.Error("failed to list kernel routes", "error", err)
 		} else {
-			for _, ip := range currentKernel {
-				if a.isManaged(ip) {
-					slog.Info("removing kernel route", "ip", ip, "reason", reason)
-					if err := a.routing.DelKernelRoute(ip); err != nil {
-						slog.Error("failed to remove kernel route", "ip", ip, "error", err)
+			for _, e := range currentKernel {
+				if a.isManaged(e.IP) {
+					slog.Info("removing kernel route", "ip", e.IP, "dev", e.Dev, "reason", reason)
+					if err := a.routing.DelKernelRoute(e.IP, e.Dev); err != nil {
+						slog.Error("failed to remove kernel route", "ip", e.IP, "dev", e.Dev, "error", err)
 					}
 				}
 			}
@@ -678,14 +741,18 @@ func (a *Agent) cleanup() {
 		slog.Error("failed to cleanup FRR prefix-list", "error", err)
 	}
 
-	// OVS flows and the dedicated kernel routing table are OVN-gateway
-	// specific and never created in port-forward-only mode.
+	// OVS flows, the dedicated kernel routing table, and agent-created
+	// segment VLAN interfaces are OVN-gateway specific and never created
+	// in port-forward-only mode.
 	if !a.cfg.PortForwardOnly {
 		if err := a.routing.RemoveOVSFlows(); err != nil {
 			slog.Error("failed to remove OVS flows", "error", err)
 		}
 		if err := a.routing.CleanupRoutingTable(); err != nil {
 			slog.Error("failed to flush routing table", "error", err)
+		}
+		if err := a.routing.TeardownSegmentInterfaces(); err != nil {
+			slog.Error("failed to remove segment interfaces", "error", err)
 		}
 	}
 	// Tear down port forwarding before veth leak (DNAT return route uses veth).
@@ -714,15 +781,19 @@ func (a *Agent) cleanup() {
 // with route re-adds before logging escalates from Warn to Error.
 const consecutiveReAddThreshold = 3
 
-// verifyRoutes checks that all desired IPs still have both a kernel route and
-// an FRR static route after route mutations. Any route that disappeared
-// (e.g. due to a vtysh race or unexpected FRR behaviour) is re-added
-// immediately so that existing connections are not disrupted.
+// verifyRoutes checks that all desired IPs still have both a kernel route
+// (on the right interface) and an FRR static route after route mutations.
+// Any route that disappeared (e.g. due to a vtysh race or unexpected FRR
+// behaviour) is re-added immediately so that existing connections are not
+// disrupted.
 //
 // Returns the number of routes that had to be re-added (0 means all routes
 // were present). The agent tracks consecutive non-zero results and escalates
-// logging to help operators detect persistent route instability.
-func (a *Agent) verifyRoutes(desiredIPs []string) int {
+// logging to help operators detect persistent route instability. IPs in
+// skipKernelRoute are not re-added at the kernel level: their VLAN segment did
+// not resolve this cycle, so their existing route must be left untouched
+// rather than recreated on the bridge fallback.
+func (a *Agent) verifyRoutes(desiredIPs []string, ipDev map[string]string, skipKernelRoute map[string]bool) int {
 	// Re-read current FRR routes.
 	currentFRR, err := a.routing.ListFRRRoutes()
 	if err != nil {
@@ -737,15 +808,15 @@ func (a *Agent) verifyRoutes(desiredIPs []string) int {
 	// Re-read current kernel routes. In port-forward-only mode kernel
 	// routes are not managed (see ensureRoutes), so this is skipped.
 	manageKernel := !a.cfg.PortForwardOnly
-	kernelSet := make(map[string]bool)
+	kernelSet := make(map[kernelRouteEntry]bool)
 	if manageKernel {
-		currentKernel, err := a.routing.ListKernelRoutes()
+		currentKernel, err := a.routing.listKernelRoutes()
 		if err != nil {
 			slog.Error("post-change kernel route verification failed", "error", err)
 			return 0
 		}
-		for _, ip := range currentKernel {
-			kernelSet[ip] = true
+		for _, e := range currentKernel {
+			kernelSet[e] = true
 		}
 	}
 
@@ -759,10 +830,11 @@ func (a *Agent) verifyRoutes(desiredIPs []string) int {
 			slog.Warn("FRR route missing after route change, re-adding", "ip", ip)
 			reAddFRR = append(reAddFRR, ip)
 		}
-		if manageKernel && !kernelSet[ip] {
-			slog.Warn("kernel route missing after route change, re-adding", "ip", ip)
-			if err := a.routing.AddKernelRoute(ip); err != nil {
-				slog.Error("failed to re-add kernel route", "ip", ip, "error", err)
+		dev := a.desiredRouteDev(ip, ipDev)
+		if manageKernel && !skipKernelRoute[ip] && !kernelSet[kernelRouteEntry{IP: ip, Dev: dev}] {
+			slog.Warn("kernel route missing after route change, re-adding", "ip", ip, "dev", dev)
+			if err := a.routing.AddKernelRoute(ip, dev); err != nil {
+				slog.Error("failed to re-add kernel route", "ip", ip, "dev", dev, "error", err)
 			}
 			reAddKernel++
 		}

--- a/agent.go
+++ b/agent.go
@@ -348,17 +348,26 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 			slog.Error("failed to reconcile OVS hairpin flows", "error", err)
 		}
 
-		// Ensure OVN default routes and static MAC bindings for local routers.
-		bridgeMAC := a.routing.SegmentMAC("")
-		if bridgeMAC == "" {
-			if mac, err := a.routing.GetBridgeMAC(); err == nil {
-				bridgeMAC = mac.String()
+		// Ensure OVN default routes and static MAC bindings for local
+		// routers, each pointing at the MAC of its own segment's kernel
+		// interface. When the segment bindings are not (yet) resolved,
+		// fall back to the bridge MAC — the flat single-network value.
+		macByLRP := make(map[string]string, len(state.LocalRouters))
+		fallbackMAC := ""
+		for _, lr := range state.LocalRouters {
+			mac := a.routing.SegmentMAC(segmentName(lr.Segment))
+			if mac == "" {
+				if fallbackMAC == "" {
+					if m, err := a.routing.GetBridgeMAC(); err == nil {
+						fallbackMAC = m.String()
+					}
+				}
+				mac = fallbackMAC
 			}
+			macByLRP[lr.LRPName] = mac
 		}
-		if bridgeMAC != "" {
-			if err := a.ovn.EnsureGatewayRouting(ctx, state.LocalRouters, bridgeMAC); err != nil {
-				slog.Error("failed to ensure gateway routing", "error", err)
-			}
+		if err := a.ovn.EnsureGatewayRouting(ctx, state.LocalRouters, macByLRP); err != nil {
+			slog.Error("failed to ensure gateway routing", "error", err)
 		}
 
 		// Ensure the active chassis has a strictly higher priority than

--- a/agent_test.go
+++ b/agent_test.go
@@ -157,7 +157,7 @@ func TestVerifyRoutesDryRun(t *testing.T) {
 	// lists (nil, nil). This means verifyRoutes sees every desired IP as
 	// missing and attempts re-adds — but those are also dry-run no-ops.
 	// This is by design: we exercise the full code path without side effects.
-	n := a.verifyRoutes([]string{"10.0.0.1", "10.0.0.2", "10.0.0.3"})
+	n := a.verifyRoutes([]string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}, nil, nil)
 	if n != 6 { // 3 FRR + 3 kernel
 		t.Errorf("expected 6 re-adds in dry-run, got %d", n)
 	}
@@ -177,7 +177,7 @@ func TestVerifyRoutesSkipsUnmanagedIPs(t *testing.T) {
 	}
 
 	// IPs outside the managed CIDR should be skipped — zero re-adds.
-	n := a.verifyRoutes([]string{"192.168.1.1", "172.16.0.1"})
+	n := a.verifyRoutes([]string{"192.168.1.1", "172.16.0.1"}, nil, nil)
 	if n != 0 {
 		t.Errorf("expected 0 re-adds for unmanaged IPs, got %d", n)
 	}
@@ -193,10 +193,10 @@ func TestVerifyRoutesEmptyDesired(t *testing.T) {
 	a := &Agent{routing: rm}
 
 	// Empty desired list should be a no-op.
-	if n := a.verifyRoutes(nil); n != 0 {
+	if n := a.verifyRoutes(nil, nil, nil); n != 0 {
 		t.Errorf("expected 0 re-adds for nil desired, got %d", n)
 	}
-	if n := a.verifyRoutes([]string{}); n != 0 {
+	if n := a.verifyRoutes([]string{}, nil, nil); n != 0 {
 		t.Errorf("expected 0 re-adds for empty desired, got %d", n)
 	}
 }
@@ -218,16 +218,197 @@ func TestVerifyRoutesConsecutiveReAddCounter(t *testing.T) {
 	// always reports all routes as missing since list calls return nil).
 	desired := []string{"10.0.0.1"}
 	for i := 1; i <= 5; i++ {
-		a.verifyRoutes(desired)
+		a.verifyRoutes(desired, nil, nil)
 		if a.consecutiveReAdds != i {
 			t.Errorf("after cycle %d: expected consecutiveReAdds=%d, got %d", i, i, a.consecutiveReAdds)
 		}
 	}
 
 	// A cycle with no managed IPs (nothing to re-add) resets the counter.
-	a.verifyRoutes([]string{"192.168.1.1"}) // unmanaged → 0 re-adds
+	a.verifyRoutes([]string{"192.168.1.1"}, nil, nil) // unmanaged → 0 re-adds
 	if a.consecutiveReAdds != 0 {
 		t.Errorf("expected consecutiveReAdds=0 after clean cycle, got %d", a.consecutiveReAdds)
+	}
+}
+
+// TestEnsureRoutesDevMismatchDoesNotWithdrawFRR covers the (IP, Dev) model:
+// a kernel route that sits on the wrong segment interface is re-replaced on
+// the right device, but the IP is still desired — so its FRR announcement
+// must NOT be withdrawn (a withdraw would blackhole the FIP during a segment
+// move).
+func TestEnsureRoutesDevMismatchDoesNotWithdrawFRR(t *testing.T) {
+	rec := newVtyshRecorder()
+	// FRR already has the desired IP.
+	rec.on(
+		[]string{"vtysh", "-c", "show ip route vrf vrf-provider static"},
+		`S>* 198.51.100.10/32 [1/0] via 169.254.0.1, veth-default, weight 1, 00:00:01
+`,
+		nil,
+	)
+	rm := &RouteManager{
+		bridgeDev:   "ovnagent-nonexistent-br",
+		vrfName:     "vrf-provider",
+		vethNexthop: "169.254.0.1",
+		// The kernel route exists, but on the bridge device instead of the
+		// segment's VLAN interface.
+		listKernelRoutesHook: func() ([]kernelRouteEntry, error) {
+			return []kernelRouteEntry{{IP: "198.51.100.10", Dev: "ovnagent-nonexistent-br"}}, nil
+		},
+		execVtyshHook: rec.hook(),
+	}
+	_, cidr, _ := net.ParseCIDR("198.51.100.0/24")
+	a := &Agent{cfg: Config{BridgeDev: "ovnagent-nonexistent-br"}, routing: rm, effectiveFilters: []*net.IPNet{cidr}}
+
+	a.ensureRoutes([]string{"198.51.100.10"}, map[string]string{"198.51.100.10": "br-ex.101"}, nil)
+
+	for _, c := range rec.calls {
+		joined := strings.Join(c, " ")
+		if strings.Contains(joined, "no ip route 198.51.100.10/32") {
+			t.Errorf("dev mismatch must not withdraw the FRR route, got: %v", rec.calls)
+		}
+		if strings.Contains(joined, "clear ip bgp") {
+			t.Errorf("dev mismatch must not trigger a BGP refresh, got: %v", rec.calls)
+		}
+	}
+}
+
+// TestEnsureRoutesStaleEntryRemovedWithItsDevice verifies that a kernel
+// route whose IP is no longer desired withdraws the FRR route regardless of
+// which segment interface it sits on.
+func TestEnsureRoutesStaleEntryRemovedWithItsDevice(t *testing.T) {
+	rec := newVtyshRecorder()
+	rec.on(
+		[]string{"vtysh", "-c", "show ip route vrf vrf-provider static"},
+		`S>* 198.51.100.99/32 [1/0] via 169.254.0.1, veth-default, weight 1, 00:00:01
+`,
+		nil,
+	)
+	rm := &RouteManager{
+		bridgeDev:   "ovnagent-nonexistent-br",
+		vrfName:     "vrf-provider",
+		vethNexthop: "169.254.0.1",
+		listKernelRoutesHook: func() ([]kernelRouteEntry, error) {
+			return []kernelRouteEntry{{IP: "198.51.100.99", Dev: "br-ex.101"}}, nil
+		},
+		execVtyshHook: rec.hook(),
+	}
+	_, cidr, _ := net.ParseCIDR("198.51.100.0/24")
+	a := &Agent{cfg: Config{BridgeDev: "ovnagent-nonexistent-br"}, routing: rm, effectiveFilters: []*net.IPNet{cidr}}
+
+	a.ensureRoutes(nil, nil, nil)
+
+	sawDel := false
+	for _, c := range rec.calls {
+		if strings.Contains(strings.Join(c, " "), "no ip route 198.51.100.99/32") {
+			sawDel = true
+		}
+	}
+	if !sawDel {
+		t.Errorf("expected FRR withdrawal of stale 198.51.100.99, got calls: %v", rec.calls)
+	}
+}
+
+// TestVerifyRoutesDetectsDevMismatch verifies that the post-change check
+// treats a kernel route on the wrong device as missing and re-adds it on the
+// segment's interface.
+func TestVerifyRoutesDetectsDevMismatch(t *testing.T) {
+	rec := newVtyshRecorder()
+	rec.on(
+		[]string{"vtysh", "-c", "show ip route vrf vrf-provider static"},
+		`S>* 198.51.100.10/32 [1/0] via 169.254.0.1, veth-default, weight 1, 00:00:01
+`,
+		nil,
+	)
+	rm := &RouteManager{
+		bridgeDev:   "ovnagent-nonexistent-br",
+		vrfName:     "vrf-provider",
+		vethNexthop: "169.254.0.1",
+		listKernelRoutesHook: func() ([]kernelRouteEntry, error) {
+			return []kernelRouteEntry{{IP: "198.51.100.10", Dev: "ovnagent-nonexistent-br"}}, nil
+		},
+		execVtyshHook: rec.hook(),
+	}
+	_, cidr, _ := net.ParseCIDR("198.51.100.0/24")
+	a := &Agent{cfg: Config{BridgeDev: "ovnagent-nonexistent-br"}, routing: rm, effectiveFilters: []*net.IPNet{cidr}}
+
+	// The route exists but on the wrong device — one kernel re-add expected
+	// (the AddKernelRoute itself fails on the synthetic bridge, which is
+	// fine: the count is what matters).
+	n := a.verifyRoutes([]string{"198.51.100.10"}, map[string]string{"198.51.100.10": "br-ex.101"}, nil)
+	if n != 1 {
+		t.Errorf("expected 1 re-add for dev mismatch, got %d", n)
+	}
+
+	// With the device matching, no re-adds.
+	n = a.verifyRoutes([]string{"198.51.100.10"}, nil, nil)
+	if n != 0 {
+		t.Errorf("expected 0 re-adds when device matches, got %d", n)
+	}
+}
+
+// TestSegmentRouteUnresolved guards the decision at the heart of the transient
+// segment-resolution fix: only a VLAN segment whose per-segment binding failed
+// to resolve is skipped. A flat segment (bridge is correct), a resolved VLAN
+// segment, and an unknown segment must all route normally — misclassifying any
+// of them would either mis-deliver traffic or needlessly freeze a route.
+func TestSegmentRouteUnresolved(t *testing.T) {
+	tag := 101
+	desired := map[string]DesiredSegment{
+		"seg-101": {LocalnetPort: "seg-101", VLANTag: &tag}, // VLAN segment
+		"":        {LocalnetPort: ""},                       // flat / fallback
+	}
+	rm := &RouteManager{bridgeDev: "br-ex", segments: map[string]*segmentBinding{}}
+	a := &Agent{routing: rm}
+
+	// VLAN segment with no binding this cycle → must be skipped.
+	if !a.segmentRouteUnresolved("seg-101", desired) {
+		t.Error("unresolved VLAN segment must be skipped")
+	}
+	// Flat segment routes on the bridge legitimately → never skipped.
+	if a.segmentRouteUnresolved("", desired) {
+		t.Error("flat segment must not be skipped")
+	}
+	// Unknown segment (not in the desired set) → route normally.
+	if a.segmentRouteUnresolved("seg-999", desired) {
+		t.Error("unknown segment must not be skipped")
+	}
+	// Once the VLAN segment resolves to its own binding → route normally.
+	rm.segments["seg-101"] = &segmentBinding{kernelDev: "br-ex.101", vlanTag: &tag}
+	if a.segmentRouteUnresolved("seg-101", desired) {
+		t.Error("resolved VLAN segment must not be skipped")
+	}
+}
+
+// TestVerifyRoutesLeavesUnresolvedVLANRouteInPlace is a regression guard for
+// the transient failure that would otherwise relocate a VLAN FIP's /32 onto the
+// untagged bridge. The FIP's kernel route sits on its VLAN subinterface
+// (br-ex.101); its segment did not resolve this cycle, so the IP is flagged
+// skip-kernel and ipDev carries no entry for it. verifyRoutes must leave the
+// route untouched — zero re-adds — rather than re-add it on the bridge fallback
+// (the exact move TestVerifyRoutesDetectsDevMismatch shows for an unskipped IP).
+func TestVerifyRoutesLeavesUnresolvedVLANRouteInPlace(t *testing.T) {
+	rec := newVtyshRecorder()
+	rec.on(
+		[]string{"vtysh", "-c", "show ip route vrf vrf-provider static"},
+		`S>* 198.51.100.10/32 [1/0] via 169.254.0.1, veth-default, weight 1, 00:00:01
+`,
+		nil,
+	)
+	rm := &RouteManager{
+		bridgeDev:   "ovnagent-nonexistent-br",
+		vrfName:     "vrf-provider",
+		vethNexthop: "169.254.0.1",
+		listKernelRoutesHook: func() ([]kernelRouteEntry, error) {
+			return []kernelRouteEntry{{IP: "198.51.100.10", Dev: "br-ex.101"}}, nil
+		},
+		execVtyshHook: rec.hook(),
+	}
+	_, cidr, _ := net.ParseCIDR("198.51.100.0/24")
+	a := &Agent{cfg: Config{BridgeDev: "ovnagent-nonexistent-br"}, routing: rm, effectiveFilters: []*net.IPNet{cidr}}
+
+	skip := map[string]bool{"198.51.100.10": true}
+	if n := a.verifyRoutes([]string{"198.51.100.10"}, nil, skip); n != 0 {
+		t.Errorf("unresolved VLAN segment must leave the FIP route in place, got %d re-adds", n)
 	}
 }
 
@@ -298,7 +479,7 @@ S>* 198.51.100.99/32 [1/0] via 169.254.0.1, veth-default, weight 1, 00:00:01
 	a := &Agent{routing: rm, effectiveFilters: []*net.IPNet{cidr}}
 
 	// Desired: 198.51.100.10 (new) and 198.51.100.20 (already in FRR).
-	a.ensureRoutes([]string{"198.51.100.10", "198.51.100.20"})
+	a.ensureRoutes([]string{"198.51.100.10", "198.51.100.20"}, nil, nil)
 
 	var sawAdd, sawDel, sawRefresh bool
 	for _, c := range rec.calls {

--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -35,6 +35,7 @@ test/e2e/
     baseline.sh             — baseline reachability scenario (issue #45)
     failover.sh             — HA failover scenario, master chassis loss (issue #105)
     hairpin.sh              — same-chassis hairpin scenario, two FIPs on master (issue #108)
+    multi-vlan.sh           — multi-VLAN provider networks, two segments on master (issue #147)
     pf-external.sh          — port-forward / DNAT scenario, source IP preserved (issue #109)
     pf-hairpin.sh           — port-forward hairpin masquerade scenario (issue #110)
     stale-chassis.sh        — stale chassis cleanup scenario, hard kill (issue #111)
@@ -195,6 +196,7 @@ Between bring-up and teardown, each scenario is its own `make` target:
 | [Baseline](#baseline) | `e2e-baseline` | An external client reaches a FIP once the agent reconciles. | [#45](https://github.com/osism/ovn-network-agent/issues/45) |
 | [Failover](#failover) | `e2e-failover` | `cr-lr0-public` re-elects to a surviving chassis after the master is lost. | [#105](https://github.com/osism/ovn-network-agent/issues/105) |
 | [Hairpin](#hairpin) | `e2e-hairpin` | The `cookie=0x998` hairpin flow reflects FIP-to-FIP traffic on `br-ex`. | [#108](https://github.com/osism/ovn-network-agent/issues/108) |
+| [Multi-VLAN](#multi-vlan) | `e2e-multi-vlan` | Two VLAN provider networks on one node get per-segment kernel interfaces, flows, and BGP-announced FIPs. | [#147](https://github.com/osism/ovn-network-agent/issues/147) |
 | [Port-forward (external client)](#port-forward-external-client) | `e2e-pf-external` | Inbound DNAT preserves the external client's source IP. | [#109](https://github.com/osism/ovn-network-agent/issues/109) |
 | [Port-forward hairpin masquerade](#port-forward-hairpin-masquerade) | `e2e-pf-hairpin` | The `hairpin_masquerade` flag is load-bearing for a co-located FIP. | [#110](https://github.com/osism/ovn-network-agent/issues/110) |
 | [Stale chassis](#stale-chassis) | `e2e-stale-chassis` | Surviving peers garbage-collect the NB rows of a hard-killed chassis. | [#111](https://github.com/osism/ovn-network-agent/issues/111) |
@@ -329,6 +331,45 @@ nothing behind for other scenarios to trip over.
 
 **Overrides for triage:** `FIP_B`, `FIP_B_INTERNAL`, `MASTER`,
 `WORKLOAD_HOST`, `RECONCILE_TIMEOUT`, `SANITY_GATE`.
+
+### Multi-VLAN
+
+```sh
+make e2e-multi-vlan
+```
+
+[`multi-vlan.sh`](https://github.com/osism/ovn-network-agent/blob/main/test/e2e/scenarios/multi-vlan.sh)
+exercises the multi-network data path from issue #147: one gateway node
+serving FIPs from **two VLAN provider networks** on the same physnet,
+alongside the flat baseline network.
+
+The scenario:
+
+1. Runs the baseline first as a sanity gate.
+2. Adds — scenario-locally — two VLAN provider networks on `physnet1`
+   (localnet ports with `tag=101` / `tag=102`, public subnets
+   `198.51.100.0/24` and `203.0.113.0/24`), each with its own router
+   pinned to `gateway-1`, a tenant switch, a netns workload on
+   `gateway-3`, and one FIP (`198.51.100.10`, `203.0.113.10`).
+3. Waits for the agent on `gateway-1` to create the per-segment kernel
+   subinterfaces `br-ex.101` / `br-ex.102`, land each FIP's `/32` route
+   on its own subinterface, install a `cookie=0x999` MAC-tweak flow on
+   each network's localnet patch port, and announce both FIPs as `/32`
+   via BGP (checked on the upstream router).
+4. Probes both VLAN FIPs from `client-1` and finally re-probes the flat
+   baseline FIP `192.0.2.10`, proving the flat and VLAN data paths
+   coexist on the same node.
+
+No underlay change is required: the fabric routes the `/32`s via BGP
+into `vrf-provider`, so the VLAN frames never leave the node. The EXIT
+trap removes the routers, switches, and workloads; the agent itself
+prunes the subinterfaces and per-segment flows on its next reconcile.
+The CI workflow runs this scenario as its own `multi-vlan` job gating
+on `baseline`.
+
+**Overrides for triage:** `MASTER`, `MASTER_UNDERLAY_IP`,
+`WORKLOAD_HOST`, `BASELINE_FIP`, `RECONCILE_TIMEOUT`, `PING_COUNT`,
+`PING_TIMEOUT`, `SANITY_GATE`.
 
 ### Port-forward (external client)
 

--- a/docs/contributing/integration-tests.md
+++ b/docs/contributing/integration-tests.md
@@ -26,6 +26,7 @@ test/integration/
   scenario_vethleak_test.go                   — SetupVethLeak / ReconcileVethLeakNetworks / TeardownVethLeak (#56)
   scenario_ipv6_test.go                       — IPv6-capable OVS flow plumbing on br-ex (#54; kernel/FRR paths are v4-only today)
   scenario_metrics_test.go                    — Prometheus /metrics scrapes (reconcile counter, drain outcome, stale-chassis, desired-state gauges)
+  scenario_multi_segment_test.go              — multi-VLAN localnet segments: per-segment interfaces/routes/flows, failover isolation, same-segment hairpin, restart re-adoption (#147)
   scenario_failure_injection_test.go          — mid-cycle vtysh/nft/ovs-ofctl failures + self-heal (#88 item 1)
   scenario_route_tables_test.go               — non-overlapping route_table_id / port_forward_table_id / veth_leak_table_id (#88 item 2)
   scenario_cleanup_no_drain_test.go           — RemoveManagedNBEntries with drain_on_shutdown=false (#88 item 3)
@@ -58,6 +59,13 @@ Scenario tests pause `ovn-northd` for the duration of each test (via
 `testenv.PauseOVNNorthd`) so the test driver can write SB Port_Binding rows
 directly without northd garbage-collecting them. `ovn-controller` keeps
 running. `setup.sh` is unchanged from the harness foundation.
+
+The multi-segment scenarios use `testenv.LocalRouterOpts.SegmentOpts` to
+seed the SB rows of a router's localnet segment (external-switch
+`Datapath_Binding`, `localnet` and peer patch `Port_Binding`) and
+`testenv.EnsureSegmentPatchPort` to create the tagged provider-bridge patch
+port (`external_ids:ovn-localnet-port`) that ovn-controller would create in
+a real deployment.
 
 ## Local prerequisites
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -62,21 +62,25 @@ For each locally-active router the agent:
 1. Writes a **default route** (`0.0.0.0/0 via <virtual-gw>`) and **static
    MAC binding** into OVN NB — the
    [virtual gateway](gatewayless-networks) makes reply traffic exit the
-   logical router without a real upstream gateway.
+   logical router without a real upstream gateway. The binding carries the
+   MAC of the router's own segment interface (`br-ex` for flat networks,
+   `br-ex.<tag>` for VLAN networks).
 2. Boosts the **active `Gateway_Chassis` priority** to `max(max peer + 1, 2)`
    so a previously-drained peer that returns at priority 1 cannot trigger
    a reverse failover (see [gateway drain](gateway-drain#priority-semantics)).
-3. Installs **OVS MAC-tweak flows** on `br-ex` — rewrites the destination
-   MAC on packets arriving from OVN's patch port so the kernel accepts them.
+3. Installs **OVS MAC-tweak flows** on `br-ex`, one pair per localnet patch
+   port — rewrites the destination MAC on packets arriving from OVN to the
+   MAC of that segment's kernel interface so the kernel accepts them.
 4. Installs **OVS hairpin flows** on `br-ex` — reflects same-chassis
    cross-router traffic back into OVN via `output:in_port` with rewritten
-   MACs.
+   MACs, each flow bound to the patch port of the segment the target FIP's
+   external network is on.
 5. Reconciles **per-network veth-leak routes and policy rules** so the
    provider subnet's reply traffic crosses from the default VRF into
    `vrf-provider` for BGP delivery.
 6. Creates `/32` **kernel routes** (with `ip rule` entries when using a
-   dedicated routing table) on `br-ex` for every FIP, SNAT IP, router LRP
-   gateway IP, and configured port-forward VIP.
+   dedicated routing table) on the segment's kernel interface for every
+   FIP, SNAT IP, router LRP gateway IP, and configured port-forward VIP.
 7. Creates `/32` **FRR static routes** in `vrf-provider` for the same set
    so BGP announces them to the external fabric.
 8. Triggers a **BGP outbound soft-refresh** only when routes are removed
@@ -192,3 +196,18 @@ The agent creates the veth pair and assigns link-local addresses at startup
 are reconciled dynamically — networks are either auto-discovered from OVN
 `Logical_Router_Port.Networks` or taken from the static `network_cidr`
 configuration. On shutdown, all resources are cleaned up.
+
+### VLAN provider networks
+
+The diagram above shows a single flat provider network, where the kernel
+side of the data path lives on the bridge device itself. When a node serves
+**multiple provider networks** as VLAN localnet segments on the same
+physnet, each segment gets its own kernel path: the agent creates an 802.1Q
+subinterface `br-ex.<tag>` per VLAN segment, carrying that segment's bridge
+IP, proxy ARP, and per-IP `/32` routes. Traffic that OVN emits tagged on
+the provider bridge reaches the kernel through the matching subinterface,
+and the per-patch-port MAC-tweak flows rewrite the destination MAC to that
+subinterface's MAC. Flat segments keep the untagged path on `br-ex`
+unchanged. See
+[gatewayless networks](gatewayless-networks#multiple-provider-networks-vlan-segments)
+for the segment discovery and lifecycle details.

--- a/docs/explanation/gatewayless-networks.md
+++ b/docs/explanation/gatewayless-networks.md
@@ -34,9 +34,12 @@ Northbound database:
 
 1. **Default route** — `0.0.0.0/0 via <virtual-gw>` on the logical router,
    so OVN knows where to send reply traffic after SNAT.
-2. **Static MAC binding** — maps the virtual gateway IP to the local `br-ex`
-   MAC address, so OVN can resolve the nexthop without sending ARP requests
-   that nobody would answer.
+2. **Static MAC binding** — maps the virtual gateway IP to the MAC of that
+   router's segment kernel interface (the `br-ex` MAC for flat networks,
+   the `br-ex.<tag>` MAC for VLAN networks — see
+   [multiple provider networks](#multiple-provider-networks-vlan-segments)),
+   so OVN can resolve the nexthop without sending ARP requests that nobody
+   would answer.
 
 Together, these two entries trick OVN into forwarding SNAT reply packets out
 of the logical router's external port onto `br-ex`, where the kernel and FRR
@@ -60,24 +63,28 @@ For the OpenStack-side configuration that triggers the gatewayless path
 
 On HA failover (chassisredirect port moves to a different chassis), the agent
 on the new active node **updates the static MAC binding** to point to its
-own `br-ex` MAC. This ensures reply traffic is forwarded to the correct
-physical node without requiring any change to the logical route itself.
+own segment interface MAC. This ensures reply traffic is forwarded to the
+correct physical node without requiring any change to the logical route
+itself.
 
 ## MAC-tweak flows on br-ex
 
-Packets leaving OVN via `br-int` arrive on the patch port of `br-ex` with a
-destination MAC set by OVN's logical pipeline — not the bridge's own MAC.
-The Linux kernel would drop these packets because the destination MAC does
-not match any local interface. To fix this, the agent installs OVS flows
-(cookie `0x999`, priority 900) on `br-ex` that **rewrite the destination
-MAC** to the bridge's own MAC for all packets arriving on the patch port:
+Packets leaving OVN via `br-int` arrive on a patch port of `br-ex` with a
+destination MAC set by OVN's logical pipeline — not the MAC of any kernel
+interface. The Linux kernel would drop these packets because the
+destination MAC does not match a local interface. To fix this, the agent
+installs OVS flows (cookie `0x999`, priority 900) on `br-ex` **per localnet
+patch port** that **rewrite the destination MAC** to the MAC of that
+segment's kernel interface for all packets arriving on the port:
 
 ```
-cookie=0x999,priority=900,ip,in_port=<patch-port>,actions=mod_dl_dst:<br-ex-mac>,NORMAL
+cookie=0x999,priority=900,ip,in_port=<patch-port>,actions=mod_dl_dst:<segment-iface-mac>,NORMAL
 ```
 
 This allows the kernel to accept and route the packets normally (via the
 `/32` kernel routes and policy rules into `vrf-provider` for BGP delivery).
+With a single flat network there is exactly one patch port and the segment
+interface is `br-ex` itself, which is the pre-multi-network behavior.
 
 ## Hairpin OVS flows on br-ex
 
@@ -94,18 +101,20 @@ that intercept packets from OVN destined for a locally-managed FIP and
 **reflect them back through the same patch port** using `output:in_port`.
 OVN then processes the reflected packet as if it arrived from the external
 network, applying the correct DNAT/ICMP handling on the destination router.
+Each flow is bound to the localnet patch port of the segment the target
+FIP's external network is on, so the reflection stays within that segment.
 
 Both source and destination MACs are rewritten:
 
-- **`dl_src`** is set to the `br-ex` MAC so the reflected packet appears as
-  external traffic to OVN, avoiding loop detection.
+- **`dl_src`** is set to the segment interface's MAC so the reflected packet
+  appears as external traffic to OVN, avoiding loop detection.
 - **`dl_dst`** is set to the owning router port's MAC so OVN's L2 lookup on
   the external logical switch delivers the packet to the correct router
   (without this, the original destination MAC may be unresolved when OVN's
   ARP resolution between co-located routers has not completed).
 
 ```
-cookie=0x998,priority=910,ip,in_port=<patch-port>,ip_dst=<fip>/32,actions=mod_dl_src:<br-ex-mac>,mod_dl_dst:<router-port-mac>,output:in_port
+cookie=0x998,priority=910,ip,in_port=<patch-port>,ip_dst=<fip>/32,actions=mod_dl_src:<segment-iface-mac>,mod_dl_dst:<router-port-mac>,output:in_port
 ```
 
 Priority 910 ensures hairpin fires **before** the MAC-tweak flow (priority
@@ -113,3 +122,80 @@ Priority 910 ensures hairpin fires **before** the MAC-tweak flow (priority
 still falls through to MAC-tweak and exits to the physical network normally.
 The hairpin flows are reconciled alongside the MAC-tweak flows and removed
 when no routers are locally active.
+
+## Multiple provider networks (VLAN segments)
+
+A gateway node can announce FIPs from **more than one provider network** at
+the same time, using VLAN-tagged localnet networks on the same physnet
+(e.g. an operator-owned provider network per customer pool, each shared to
+selected projects via Neutron RBAC `access_as_external`). No configuration
+is needed — multi-network support activates automatically from discovery,
+and a deployment with a single flat network behaves exactly as before.
+
+### Segment discovery
+
+For every locally-active router, the agent resolves the **localnet
+segment** of its external network from the OVN Southbound database: the
+gateway port's peer patch `Port_Binding` shares a datapath with the
+external switch's `localnet` port, whose `options:network_name` names the
+physnet and whose `tag` carries the optional VLAN ID. On the OVS side, the
+segment's localnet port name is matched to the provider-bridge patch port
+via the `external_ids:ovn-localnet-port` key that ovn-controller stamps on
+the `Port` row.
+
+Neutron RBAC (`access_as_external`) is transparent to this mechanism: the
+agent only reads OVN NB/SB and never the Neutron API, so a non-shared,
+RBAC-shared provider network behaves identically to an admin-created
+`--external` network.
+
+### Per-segment data path
+
+For each **VLAN segment**, the agent creates a kernel 802.1Q subinterface
+`<bridge_dev>.<tag>` (e.g. `br-ex.101`) on the provider bridge and moves
+the segment's kernel path onto it: the bridge IP, proxy ARP, and the
+per-IP `/32` routes. VLAN-tagged traffic that OVN emits on the provider
+bridge reaches the kernel through this subinterface — on the untagged
+bridge device it would bypass the kernel routing path entirely. **Flat
+segments** keep the pre-existing behavior on the bridge device itself.
+
+Subinterfaces created by the agent are marked with the link alias
+`ovn-network-agent` so that pruning (failover, network removal, restart)
+and shutdown teardown only ever delete links the agent owns. A
+pre-provisioned subinterface with the right name is adopted as-is and
+never deleted. Because `<bridge_dev>.<tag>` must fit the kernel's
+15-character interface-name limit, an over-long combination causes the
+segment to be skipped with an error log (the default `br-ex` is always
+safe).
+
+MAC-tweak and hairpin flows are installed per localnet patch port as
+described above, and each router's virtual-gateway MAC binding is written
+with the MAC of its own segment interface. Note that a VLAN subinterface
+inherits the bridge MAC, so the per-segment MACs are typically identical —
+the agent still resolves them per segment. Failover of one router tears
+down only that router's segment resources; other segments on the node are
+untouched.
+
+A router whose segment cannot be resolved (no localnet row, or no patch
+port carrying the `ovn-localnet-port` key) falls back to the legacy
+single-patch-port data path — the first patch port on the bridge with the
+kernel path on the bridge device — which keeps flat single-network
+deployments bit-compatible. With several patch ports on the bridge this
+fallback is ambiguous; the agent logs an error and proceeds, which is no
+worse than the pre-multi-network nondeterminism but now visible. Note that
+a deployment that already had two patch ports on the bridge (where the
+agent nondeterministically served only one network) starts serving both
+after an upgrade — that is the intended fix.
+
+### Scope
+
+- **Cross-segment hairpin** (FIP on VLAN 101 → FIP on VLAN 102 on the same
+  chassis) is out of scope: hairpin flows are installed per segment only.
+  Cross-segment same-chassis traffic falls through MAC-tweak into the
+  kernel, which can route between the segment interfaces via the per-IP
+  `/32` routes, but this path is not asserted by tests.
+- The **IPv6 kernel path** is out of scope (status quo): bridge IP, proxy
+  ARP, `/32` routes, and the virtual gateway are IPv4-only; the per-port
+  IPv6 MAC-tweak flow variant is kept.
+
+The `localnet_segments` gauge reports how many segments are currently
+bound — see the [metrics reference](../reference/metrics).

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -31,6 +31,7 @@ regenerate it with `go generate ./...`.
 | `ovn_network_agent_desired_ips` | gauge | — | Number of unique IPs the agent currently wants routes for (FIPs, SNATs, port-forward VIPs). |
 | `ovn_network_agent_local_routers` | gauge | — | Number of OVN logical routers whose chassisredirect port is currently active on this chassis. |
 | `ovn_network_agent_effective_networks` | gauge | — | Number of effective network filters (manual config or auto-discovered). |
+| `ovn_network_agent_localnet_segments` | gauge | — | Number of localnet segments (patch ports) currently bound for locally-active routers. |
 | `ovn_network_agent_route_readds_total` | counter (vec) | `plane`={`kernel`,`frr`} | Total routes re-added by post-change verification, labelled by route plane. |
 | `ovn_network_agent_consecutive_readds` | gauge | — | Number of consecutive reconcile cycles that required route re-adds. Sustained non-zero indicates persistent route instability. |
 | `ovn_network_agent_inactive_routes` | gauge | — | Number of desired FIP/VIP routes that exist as FRR static routes but are not selected/installed — i.e. not advertised via BGP. Non-zero means those FIPs are unreachable from outside. |

--- a/metrics.go
+++ b/metrics.go
@@ -30,6 +30,7 @@ type metricsRegistry struct {
 	desiredIPs        prometheus.Gauge
 	localRouters      prometheus.Gauge
 	effectiveNetworks prometheus.Gauge
+	localnetSegments  prometheus.Gauge
 
 	// Route stability metrics
 	routeReAddsTotal  *prometheus.CounterVec
@@ -106,6 +107,12 @@ func newMetricsRegistry() *metricsRegistry {
 			Help:      "Number of effective network filters (manual config or auto-discovered).",
 		}),
 
+		localnetSegments: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "localnet_segments",
+			Help:      "Number of localnet segments (patch ports) currently bound for locally-active routers.",
+		}),
+
 		routeReAddsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Name:      "route_readds_total",
@@ -163,6 +170,7 @@ func newMetricsRegistry() *metricsRegistry {
 		m.desiredIPs,
 		m.localRouters,
 		m.effectiveNetworks,
+		m.localnetSegments,
 		m.routeReAddsTotal,
 		m.consecutiveReAdds,
 		m.inactiveRoutes,
@@ -270,6 +278,13 @@ func setDesiredState(desiredIPs, localRouters, effectiveNetworks int) {
 	metrics.desiredIPs.Set(float64(desiredIPs))
 	metrics.localRouters.Set(float64(localRouters))
 	metrics.effectiveNetworks.Set(float64(effectiveNetworks))
+}
+
+func setLocalnetSegments(n int) {
+	if metrics == nil {
+		return
+	}
+	metrics.localnetSegments.Set(float64(n))
 }
 
 func recordRouteReAdds(frr, kernel int) {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -32,6 +32,7 @@ func TestRecordingHelpersAreNilSafe(t *testing.T) {
 	setReconcileInProgress(true)
 	setReconcileInProgress(false)
 	setDesiredState(5, 2, 3)
+	setLocalnetSegments(2)
 	recordRouteReAdds(1, 2)
 	setConsecutiveReAdds(4)
 	setOVNConnectionState("nb", true)
@@ -54,6 +55,7 @@ func TestNewMetricsRegistryRegistersAllCollectors(t *testing.T) {
 		"ovn_network_agent_reconcile_duration_seconds",
 		"ovn_network_agent_desired_ips",
 		"ovn_network_agent_local_routers",
+		"ovn_network_agent_localnet_segments",
 		"ovn_network_agent_route_readds_total",
 		"ovn_network_agent_consecutive_readds",
 		"ovn_network_agent_inactive_routes",
@@ -238,6 +240,25 @@ func TestSetDesiredStateUpdatesGauges(t *testing.T) {
 		}
 		if v := mf.GetMetric()[0].GetGauge().GetValue(); v != want {
 			t.Errorf("%s = %v, want %v", mf.GetName(), v, want)
+		}
+	}
+}
+
+// TestSetLocalnetSegmentsSetsGauge verifies the gauge tracks the current
+// segment count, including the reset back to zero when the last local
+// router (and with it every bound segment) disappears.
+func TestSetLocalnetSegmentsSetsGauge(t *testing.T) {
+	m := withTestMetrics(t)
+	setLocalnetSegments(2)
+	setLocalnetSegments(0)
+
+	got, _ := m.registry.Gather()
+	for _, mf := range got {
+		if mf.GetName() != "ovn_network_agent_localnet_segments" {
+			continue
+		}
+		if v := mf.GetMetric()[0].GetGauge().GetValue(); v != 0 {
+			t.Errorf("localnet_segments = %v after reset, want 0", v)
 		}
 	}
 }

--- a/ovn.go
+++ b/ovn.go
@@ -143,15 +143,34 @@ type ovsdbClient interface {
 	Transact(ctx context.Context, ops ...ovsdb.Operation) ([]ovsdb.OperationResult, error)
 }
 
+// LocalnetSegment describes the localnet segment (provider network) that a
+// locally-active router's external network is attached to. A nil VLANTag
+// means a flat (untagged) network.
+type LocalnetSegment struct {
+	LocalnetPort string // SB localnet Port_Binding logical_port name
+	NetworkName  string // options:network_name of the localnet port (the physnet)
+	VLANTag      *int   // SB Port_Binding tag; nil = flat
+}
+
 // LocalRouterInfo describes a logical router whose gateway is active on this chassis.
 type LocalRouterInfo struct {
-	RouterName  string   // NB Logical_Router name
-	RouterUUID  string   // NB Logical_Router UUID
-	LRPName     string   // NB Logical_Router_Port name (e.g. "lrp-abc123")
-	LRPUUID     string   // NB Logical_Router_Port UUID
-	LRPMAC      string   // NB Logical_Router_Port MAC (e.g. "fa:16:3e:xx:xx:xx")
-	LRPNetworks []string // NB Logical_Router_Port networks (e.g. ["198.51.100.11/24"])
-	CRPort      string   // SB chassisredirect logical_port (e.g. "cr-lrp-abc123")
+	RouterName  string           // NB Logical_Router name
+	RouterUUID  string           // NB Logical_Router UUID
+	LRPName     string           // NB Logical_Router_Port name (e.g. "lrp-abc123")
+	LRPUUID     string           // NB Logical_Router_Port UUID
+	LRPMAC      string           // NB Logical_Router_Port MAC (e.g. "fa:16:3e:xx:xx:xx")
+	LRPNetworks []string         // NB Logical_Router_Port networks (e.g. ["198.51.100.11/24"])
+	CRPort      string           // SB chassisredirect logical_port (e.g. "cr-lrp-abc123")
+	Segment     *LocalnetSegment // localnet segment of the external network; nil = unresolved
+}
+
+// segmentName returns the localnet port name of a router's segment, or ""
+// (the fallback segment) when the segment is unresolved.
+func segmentName(seg *LocalnetSegment) string {
+	if seg == nil {
+		return ""
+	}
+	return seg.LocalnetPort
 }
 
 type OVNState struct {
@@ -174,6 +193,11 @@ type OVNState struct {
 	// that OVN's L2 lookup delivers the reflected packet to the correct
 	// router port.
 	NATIPToRouterMAC map[string]string
+
+	// NATIPToSegment maps each FIP/SNAT external IP to the localnet port
+	// name of the segment its external network is on. IPs whose segment
+	// is unresolved are absent from the map (the "" fallback segment).
+	NATIPToSegment map[string]string
 
 	// Networks auto-discovered from Logical_Router_Port.Networks of locally-active routers.
 	DiscoveredNetworks []*net.IPNet
@@ -398,6 +422,10 @@ func (o *OVNClient) GetState() OVNState {
 	for k, v := range o.state.NATIPToRouterMAC {
 		natIPToMAC[k] = v
 	}
+	natIPToSegment := make(map[string]string, len(o.state.NATIPToSegment))
+	for k, v := range o.state.NATIPToSegment {
+		natIPToSegment[k] = v
+	}
 	return OVNState{
 		LocalChassisName:   o.state.LocalChassisName,
 		LocalRouters:       localRouters,
@@ -405,6 +433,7 @@ func (o *OVNClient) GetState() OVNState {
 		FIPs:               append([]string{}, o.state.FIPs...),
 		SNATIPs:            append([]string{}, o.state.SNATIPs...),
 		NATIPToRouterMAC:   natIPToMAC,
+		NATIPToSegment:     natIPToSegment,
 		DiscoveredNetworks: discoveredNets,
 		AllChassisNames:    allChassis,
 	}
@@ -466,6 +495,47 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 		}
 	}
 
+	// Step 1b: Resolve each local LRP's localnet segment. A gateway LRP's
+	// peer logical switch (the external network) carries a localnet port
+	// whose SB Port_Binding holds the physnet name (options:network_name)
+	// and the optional VLAN tag. Two joins over the Port_Binding table:
+	// localnet rows indexed by datapath, then the switch-side patch rows
+	// (options:peer == LRP name) sharing that datapath. Deliberately no
+	// neutron:device_owner filter: the join must also work for non-Neutron
+	// topologies (e.g. the E2E lab) that set no external_ids.
+	localnetByDatapath := make(map[string]SBPortBinding)
+	for _, pb := range portBindings {
+		if pb.Type == "localnet" {
+			localnetByDatapath[pb.Datapath] = pb
+		}
+	}
+	segmentByLRP := make(map[string]*LocalnetSegment)
+	for _, pb := range portBindings {
+		if pb.Type != "patch" {
+			continue
+		}
+		peer := pb.Options["peer"]
+		if peer == "" {
+			continue
+		}
+		if _, isLocal := localLRPNames[peer]; !isLocal {
+			continue
+		}
+		ln, ok := localnetByDatapath[pb.Datapath]
+		if !ok {
+			continue
+		}
+		seg := &LocalnetSegment{
+			LocalnetPort: ln.LogicalPort,
+			NetworkName:  ln.Options["network_name"],
+		}
+		if ln.Tag != nil {
+			tag := *ln.Tag
+			seg.VLANTag = &tag
+		}
+		segmentByLRP[peer] = seg
+	}
+
 	// Step 2: Build NB Logical_Router_Port name → UUID map.
 	lrps, err := cachedList(ctx, o.nbClient, "Logical_Router_Port",
 		lrpCheckColumns, keyOfNBLogicalRouterPort, decodeNBLogicalRouterPort)
@@ -500,7 +570,10 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 
 	// natUUIDToRouterMAC maps each NAT UUID to the MAC of the router port
 	// that owns it, so hairpin flows can set the correct dl_dst.
+	// natUUIDToSegment records the owning router's localnet segment
+	// alongside, so per-IP state lands on the right patch port/interface.
 	natUUIDToRouterMAC := make(map[string]string)
+	natUUIDToSegment := make(map[string]string)
 	var localRouters []LocalRouterInfo
 	for _, router := range routers {
 		var matchedLRP *NBLogicalRouterPort
@@ -514,6 +587,7 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 		if matchedLRP == nil {
 			continue
 		}
+		segment := segmentByLRP[matchedLRP.Name]
 		localRouters = append(localRouters, LocalRouterInfo{
 			RouterName:  router.Name,
 			RouterUUID:  router.UUID,
@@ -522,10 +596,14 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 			LRPMAC:      matchedLRP.MAC,
 			LRPNetworks: matchedLRP.Networks,
 			CRPort:      localLRPNames[matchedLRP.Name],
+			Segment:     segment,
 		})
 		for _, natUUID := range router.Nat {
 			if matchedLRP.MAC != "" {
 				natUUIDToRouterMAC[natUUID] = matchedLRP.MAC
+			}
+			if segment != nil {
+				natUUIDToSegment[natUUID] = segment.LocalnetPort
 			}
 		}
 	}
@@ -557,6 +635,7 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 
 	var fips, snatIPs []string
 	natIPToRouterMAC := make(map[string]string)
+	natIPToSegment := make(map[string]string)
 	for _, nat := range nats {
 		routerMAC, ok := natUUIDToRouterMAC[nat.UUID]
 		if !ok {
@@ -570,6 +649,9 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 			}
 		}
 		natIPToRouterMAC[ip] = routerMAC
+		if seg, ok := natUUIDToSegment[nat.UUID]; ok {
+			natIPToSegment[ip] = seg
+		}
 		switch nat.Type {
 		case "dnat_and_snat":
 			fips = append(fips, ip)
@@ -611,6 +693,9 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 				if routerMAC != "" {
 					natIPToRouterMAC[ip] = routerMAC
 				}
+				if seg := segmentByLRP[peer]; seg != nil {
+					natIPToSegment[ip] = seg.LocalnetPort
+				}
 			}
 		}
 	}
@@ -622,6 +707,7 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 	o.state.FIPs = fips
 	o.state.SNATIPs = snatIPs
 	o.state.NATIPToRouterMAC = natIPToRouterMAC
+	o.state.NATIPToSegment = natIPToSegment
 	o.state.DiscoveredNetworks = discoveredNets
 	o.state.AllChassisNames = allChassisNames
 	o.state.mu.Unlock()
@@ -637,6 +723,7 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 			"router", lr.RouterName,
 			"lrp", lr.LRPName,
 			"cr_port", lr.CRPort,
+			"segment", segmentName(lr.Segment),
 		)
 	}
 }

--- a/ovn_cache.go
+++ b/ovn_cache.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
@@ -46,7 +47,7 @@ import (
 // selects exactly these — keeping the common in-sync round-trip cheap — and
 // the matching keyOf* helper must read only the model fields they back.
 var (
-	pbCheckColumns   = []string{"_uuid", "type", "chassis", "nat_addresses"}
+	pbCheckColumns   = []string{"_uuid", "type", "chassis", "nat_addresses", "datapath", "tag", "options"}
 	chCheckColumns   = []string{"_uuid", "hostname"}
 	lrCheckColumns   = []string{"_uuid", "ports", "nat", "static_routes"}
 	lrpCheckColumns  = []string{"_uuid", "mac", "networks"}
@@ -60,7 +61,13 @@ func keyOfSBPortBinding(p SBPortBinding) string {
 	if p.Chassis != nil {
 		chassis = *p.Chassis
 	}
-	return contentKey(p.UUID, p.Type, chassis, sortedJoin(p.NatAddresses))
+	tag := ""
+	if p.Tag != nil {
+		tag = strconv.Itoa(*p.Tag)
+	}
+	// fmt %v renders a map with its keys sorted, so the key stays stable.
+	return contentKey(p.UUID, p.Type, chassis, sortedJoin(p.NatAddresses),
+		p.Datapath, tag, fmt.Sprintf("%v", p.Options))
 }
 
 func keyOfSBChassis(c SBChassis) string {
@@ -250,6 +257,8 @@ func decodeSBPortBinding(row ovsdb.Row) SBPortBinding {
 		Type:         rowString(row, "type"),
 		LogicalPort:  rowString(row, "logical_port"),
 		Chassis:      rowOptString(row, "chassis"),
+		Datapath:     rowUUIDRef(row, "datapath"),
+		Tag:          rowOptInt(row, "tag"),
 		Options:      rowStringMap(row, "options"),
 		ExternalIDs:  rowStringMap(row, "external_ids"),
 		NatAddresses: rowStringSet(row, "nat_addresses"),
@@ -338,6 +347,41 @@ func rowOptString(row ovsdb.Row, col string) *string {
 		if vals := ovsSetToStrings(v); len(vals) > 0 {
 			return &vals[0]
 		}
+	}
+	return nil
+}
+
+// rowUUIDRef returns a strong UUID-reference column flattened to its GoUUID
+// string, or "" when absent. The monitor cache stores such columns as plain
+// strings, so both encodings are accepted.
+func rowUUIDRef(row ovsdb.Row, col string) string {
+	switch v := row[col].(type) {
+	case ovsdb.UUID:
+		return v.GoUUID
+	case string:
+		return v
+	}
+	return ""
+}
+
+// rowOptInt returns an optional integer column as a pointer. OVSDB sends an
+// absent optional as an empty set and a present one as the bare number;
+// JSON-RPC delivers integers as float64, while an in-process fake may pass int.
+func rowOptInt(row ovsdb.Row, col string) *int {
+	v := row[col]
+	if s, ok := v.(ovsdb.OvsSet); ok {
+		if len(s.GoSet) == 0 {
+			return nil
+		}
+		v = s.GoSet[0]
+	}
+	switch n := v.(type) {
+	case int:
+		i := n
+		return &i
+	case float64:
+		i := int(n)
+		return &i
 	}
 	return nil
 }

--- a/ovn_cache_test.go
+++ b/ovn_cache_test.go
@@ -263,6 +263,74 @@ func TestDecodeSBPortBindingSetsAndMaps(t *testing.T) {
 	}
 }
 
+// TestKeyOfSBPortBindingIncludesSegmentColumns guards the segment-resolution
+// inputs: a dropped UPDATE to datapath, tag, or options must register as
+// content drift, or a stale cache could silently program the wrong VLAN.
+func TestKeyOfSBPortBindingIncludesSegmentColumns(t *testing.T) {
+	tag101, tag102 := 101, 102
+	base := SBPortBinding{
+		UUID: "pb-1", Type: "localnet", Datapath: "dp-1",
+		Tag:     &tag101,
+		Options: map[string]string{"network_name": "physnet1"},
+	}
+
+	variants := map[string]SBPortBinding{
+		"datapath changed": func() SBPortBinding { v := base; v.Datapath = "dp-2"; return v }(),
+		"tag changed":      func() SBPortBinding { v := base; v.Tag = &tag102; return v }(),
+		"tag cleared":      func() SBPortBinding { v := base; v.Tag = nil; return v }(),
+		"options changed": func() SBPortBinding {
+			v := base
+			v.Options = map[string]string{"network_name": "physnet2"}
+			return v
+		}(),
+	}
+	baseKey := keyOfSBPortBinding(base)
+	for name, v := range variants {
+		if keyOfSBPortBinding(v) == baseKey {
+			t.Errorf("%s: content key did not change", name)
+		}
+	}
+}
+
+// TestDecodeSBPortBindingSegmentColumns round-trips the columns the segment
+// resolution reads from a direct server select: the datapath UUID reference
+// and the optional VLAN tag, including the OVSDB empty-set encoding for an
+// absent tag.
+func TestDecodeSBPortBindingSegmentColumns(t *testing.T) {
+	row := ovsdb.Row{
+		"_uuid":        ovsdb.UUID{GoUUID: "pb-ln"},
+		"type":         "localnet",
+		"logical_port": "seg-vlan",
+		"datapath":     ovsdb.UUID{GoUUID: "dp-1"},
+		// JSON-RPC delivers integers as float64.
+		"tag":     float64(101),
+		"options": ovsdb.OvsMap{GoMap: map[any]any{"network_name": "physnet1"}},
+	}
+	got := decodeSBPortBinding(row)
+	if got.Datapath != "dp-1" {
+		t.Errorf("Datapath = %q, want dp-1", got.Datapath)
+	}
+	if got.Tag == nil || *got.Tag != 101 {
+		t.Errorf("Tag = %v, want 101", got.Tag)
+	}
+
+	// Absent tag arrives as an empty set and must decode to nil.
+	flatRow := ovsdb.Row{
+		"_uuid":    ovsdb.UUID{GoUUID: "pb-flat"},
+		"type":     "localnet",
+		"datapath": ovsdb.UUID{GoUUID: "dp-2"},
+		"tag":      ovsdb.OvsSet{},
+	}
+	if got := decodeSBPortBinding(flatRow); got.Tag != nil {
+		t.Errorf("flat Tag = %v, want nil", *got.Tag)
+	}
+
+	// A row without the columns at all decodes to zero values.
+	if got := decodeSBPortBinding(ovsdb.Row{"_uuid": ovsdb.UUID{GoUUID: "pb-x"}}); got.Datapath != "" || got.Tag != nil {
+		t.Errorf("empty row: Datapath=%q Tag=%v, want zero values", got.Datapath, got.Tag)
+	}
+}
+
 func TestRowHelpers(t *testing.T) {
 	t.Run("ovsSetToStrings", func(t *testing.T) {
 		cases := []struct {

--- a/ovn_fake_test.go
+++ b/ovn_fake_test.go
@@ -163,6 +163,13 @@ func modelToRow(m model.Model) ovsdb.Row {
 			} else {
 				row[tag] = fv.Elem().String()
 			}
+		case fv.Kind() == reflect.Pointer && fv.Type().Elem().Kind() == reflect.Int:
+			// Optional integer (e.g. Port_Binding.tag) — same set encoding.
+			if fv.IsNil() {
+				row[tag] = ovsdb.OvsSet{}
+			} else {
+				row[tag] = int(fv.Elem().Int())
+			}
 		case fv.Kind() == reflect.Slice && fv.Type().Elem().Kind() == reflect.String:
 			set := make([]any, fv.Len())
 			for j := 0; j < fv.Len(); j++ {

--- a/ovn_gateway.go
+++ b/ovn_gateway.go
@@ -61,11 +61,22 @@ func virtualGatewayIP(lrpNetworks []string) (net.IP, error) {
 }
 
 // EnsureGatewayRouting ensures that each locally-active router has a default
-// route and a static MAC binding pointing to the local br-ex interface.
-// This allows OVN to route reply traffic out the external port and into
-// the kernel for further routing via the VRF.
-func (o *OVNClient) EnsureGatewayRouting(ctx context.Context, localRouters []LocalRouterInfo, bridgeMAC string) error {
+// route and a static MAC binding pointing to the kernel interface of that
+// router's localnet segment (the bridge device for flat segments, the VLAN
+// subinterface for tagged ones). This allows OVN to route reply traffic out
+// the external port and into the kernel for further routing via the VRF.
+//
+// macForLRP maps each router's LRP name to its segment interface MAC. A
+// router whose MAC is unknown (empty or absent) is skipped entirely — route
+// and binding — preserving the "no MAC → no write" contract per router.
+func (o *OVNClient) EnsureGatewayRouting(ctx context.Context, localRouters []LocalRouterInfo, macForLRP map[string]string) error {
 	for _, lr := range localRouters {
+		mac := macForLRP[lr.LRPName]
+		if mac == "" {
+			slog.Error("no segment interface MAC for router, skipping gateway routing",
+				"router", lr.RouterName, "lrp", lr.LRPName)
+			continue
+		}
 		vgwIP, err := virtualGatewayIP(lr.LRPNetworks)
 		if err != nil {
 			slog.Error("cannot compute virtual gateway IP", "router", lr.RouterName, "error", err)
@@ -77,7 +88,7 @@ func (o *OVNClient) EnsureGatewayRouting(ctx context.Context, localRouters []Loc
 			slog.Error("failed to ensure default route", "router", lr.RouterName, "vgw", vgwStr, "error", err)
 			continue
 		}
-		if err := o.ensureStaticMACBinding(ctx, lr.LRPName, vgwStr, bridgeMAC); err != nil {
+		if err := o.ensureStaticMACBinding(ctx, lr.LRPName, vgwStr, mac); err != nil {
 			slog.Error("failed to ensure static MAC binding", "router", lr.RouterName, "lrp", lr.LRPName, "error", err)
 		}
 	}

--- a/ovn_gateway_writes_test.go
+++ b/ovn_gateway_writes_test.go
@@ -291,7 +291,8 @@ func TestEnsureGatewayRouting_SkipsRouterWithoutIPv4(t *testing.T) {
 		LRPName:     "lrp-v6",
 		LRPNetworks: []string{"fe80::1/64"}, // no IPv4 — virtualGatewayIP must fail
 	}}
-	if err := c.EnsureGatewayRouting(context.Background(), routers, "aa:bb:cc:dd:ee:ff"); err != nil {
+	macs := map[string]string{"lrp-v6": "aa:bb:cc:dd:ee:ff"}
+	if err := c.EnsureGatewayRouting(context.Background(), routers, macs); err != nil {
 		t.Fatalf("EnsureGatewayRouting: %v", err)
 	}
 	if got := nb.recordedTransacts(); len(got) != 0 {
@@ -311,7 +312,11 @@ func TestEnsureGatewayRouting_ProcessesEachRouter(t *testing.T) {
 		{RouterName: "router1", RouterUUID: "lr-1", LRPName: "lrp-1", LRPNetworks: []string{"198.51.100.11/24"}},
 		{RouterName: "router2", RouterUUID: "lr-2", LRPName: "lrp-2", LRPNetworks: []string{"203.0.113.1/24"}},
 	}
-	if err := c.EnsureGatewayRouting(context.Background(), routers, "aa:bb:cc:dd:ee:ff"); err != nil {
+	macs := map[string]string{
+		"lrp-1": "aa:bb:cc:dd:ee:ff",
+		"lrp-2": "aa:bb:cc:dd:ee:ff",
+	}
+	if err := c.EnsureGatewayRouting(context.Background(), routers, macs); err != nil {
 		t.Fatalf("EnsureGatewayRouting: %v", err)
 	}
 
@@ -320,6 +325,140 @@ func TestEnsureGatewayRouting_ProcessesEachRouter(t *testing.T) {
 	tx := nb.recordedTransacts()
 	if len(tx) != 4 {
 		t.Fatalf("expected 4 transacts (2 routers × {route, mac}), got %d: %+v", len(tx), tx)
+	}
+}
+
+// TestEnsureGatewayRouting_UsesPerRouterMAC verifies that each router's
+// static MAC binding is written with that router's own segment interface
+// MAC — two routers on different VLAN segments get two distinct bindings.
+func TestEnsureGatewayRouting_UsesPerRouterMAC(t *testing.T) {
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+
+	nb.setRows("Logical_Router",
+		&NBLogicalRouter{UUID: "lr-1", Name: "router1"},
+		&NBLogicalRouter{UUID: "lr-2", Name: "router2"},
+	)
+
+	routers := []LocalRouterInfo{
+		{RouterName: "router1", RouterUUID: "lr-1", LRPName: "lrp-1", LRPNetworks: []string{"198.51.100.11/24"}},
+		{RouterName: "router2", RouterUUID: "lr-2", LRPName: "lrp-2", LRPNetworks: []string{"203.0.113.11/24"}},
+	}
+	macs := map[string]string{
+		"lrp-1": "aa:bb:cc:dd:ee:65",
+		"lrp-2": "aa:bb:cc:dd:ee:66",
+	}
+	if err := c.EnsureGatewayRouting(context.Background(), routers, macs); err != nil {
+		t.Fatalf("EnsureGatewayRouting: %v", err)
+	}
+
+	// Collect the Static_MAC_Binding inserts across all transacts and check
+	// each LRP got its own MAC. The fake's Create records only table +
+	// UUIDName, so assert per-router write counts via transact shape: each
+	// router produces one route transact (insert+mutate) and one MAC-binding
+	// transact (single insert on Static_MAC_Binding).
+	tx := nb.recordedTransacts()
+	macInserts := 0
+	for _, batch := range tx {
+		for _, op := range batch {
+			if op.Op == ovsdb.OperationInsert && op.Table == "Static_MAC_Binding" {
+				macInserts++
+			}
+		}
+	}
+	if macInserts != 2 {
+		t.Fatalf("expected 2 Static_MAC_Binding inserts (one per router), got %d: %+v", macInserts, tx)
+	}
+}
+
+// TestEnsureGatewayRouting_UpdatesBindingToSegmentMAC drives the per-router
+// MAC through an existing binding: router1's binding carries the old global
+// bridge MAC and must be updated to its segment MAC, while router2's binding
+// already matches its own segment MAC and must be left alone.
+func TestEnsureGatewayRouting_UpdatesBindingToSegmentMAC(t *testing.T) {
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+
+	nb.setRows("Logical_Router",
+		&NBLogicalRouter{UUID: "lr-1", Name: "router1", StaticRoutes: []string{"rt-1"}},
+		&NBLogicalRouter{UUID: "lr-2", Name: "router2", StaticRoutes: []string{"rt-2"}},
+	)
+	// Both default routes already exist and are correct, so the only writes
+	// left are MAC-binding updates.
+	nb.setRows("Logical_Router_Static_Route",
+		&NBLogicalRouterStaticRoute{
+			UUID: "rt-1", IPPrefix: "0.0.0.0/0", Nexthop: "198.51.100.254",
+			ExternalIDs: map[string]string{"ovn-network-agent": "managed", "ovn-network-agent-chassis": "host-a"},
+		},
+		&NBLogicalRouterStaticRoute{
+			UUID: "rt-2", IPPrefix: "0.0.0.0/0", Nexthop: "203.0.113.254",
+			ExternalIDs: map[string]string{"ovn-network-agent": "managed", "ovn-network-agent-chassis": "host-a"},
+		},
+	)
+	nb.setRows("Static_MAC_Binding",
+		&NBStaticMACBinding{UUID: "mb-1", LogicalPort: "lrp-1", IP: "198.51.100.254", MAC: "aa:bb:cc:dd:ee:ff"},
+		&NBStaticMACBinding{UUID: "mb-2", LogicalPort: "lrp-2", IP: "203.0.113.254", MAC: "aa:bb:cc:dd:ee:66"},
+	)
+
+	routers := []LocalRouterInfo{
+		{RouterName: "router1", RouterUUID: "lr-1", LRPName: "lrp-1", LRPNetworks: []string{"198.51.100.11/24"}},
+		{RouterName: "router2", RouterUUID: "lr-2", LRPName: "lrp-2", LRPNetworks: []string{"203.0.113.11/24"}},
+	}
+	macs := map[string]string{
+		"lrp-1": "aa:bb:cc:dd:ee:65",
+		"lrp-2": "aa:bb:cc:dd:ee:66",
+	}
+	if err := c.EnsureGatewayRouting(context.Background(), routers, macs); err != nil {
+		t.Fatalf("EnsureGatewayRouting: %v", err)
+	}
+
+	tx := nb.recordedTransacts()
+	if len(tx) != 1 || len(tx[0]) != 1 {
+		t.Fatalf("expected exactly one update transact (router1's binding), got %+v", tx)
+	}
+	op := tx[0][0]
+	if op.Op != ovsdb.OperationUpdate || op.Table != "Static_MAC_Binding" || op.UUID != "mb-1" {
+		t.Fatalf("expected update on mb-1, got %+v", op)
+	}
+	if got := op.Row["mac"]; got != "aa:bb:cc:dd:ee:65" {
+		t.Errorf("updated MAC = %v, want aa:bb:cc:dd:ee:65", got)
+	}
+}
+
+// TestEnsureGatewayRouting_SkipsRouterWithoutMAC pins the per-router
+// "no MAC → no write" contract: a router with an empty (or absent) MAC in
+// macForLRP is skipped entirely — neither default route nor MAC binding —
+// while other routers proceed.
+func TestEnsureGatewayRouting_SkipsRouterWithoutMAC(t *testing.T) {
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+
+	nb.setRows("Logical_Router",
+		&NBLogicalRouter{UUID: "lr-1", Name: "router1"},
+		&NBLogicalRouter{UUID: "lr-2", Name: "router2"},
+	)
+
+	routers := []LocalRouterInfo{
+		{RouterName: "router1", RouterUUID: "lr-1", LRPName: "lrp-1", LRPNetworks: []string{"198.51.100.11/24"}},
+		{RouterName: "router2", RouterUUID: "lr-2", LRPName: "lrp-2", LRPNetworks: []string{"203.0.113.11/24"}},
+	}
+	// lrp-1 has no MAC at all; lrp-2 resolves normally.
+	macs := map[string]string{"lrp-2": "aa:bb:cc:dd:ee:66"}
+	if err := c.EnsureGatewayRouting(context.Background(), routers, macs); err != nil {
+		t.Fatalf("EnsureGatewayRouting: %v", err)
+	}
+
+	// Only router2 writes: one route transact (insert+mutate) and one
+	// MAC-binding transact. Nothing may reference router1.
+	tx := nb.recordedTransacts()
+	if len(tx) != 2 {
+		t.Fatalf("expected 2 transacts (router2 only), got %d: %+v", len(tx), tx)
+	}
+	for _, batch := range tx {
+		for _, op := range batch {
+			if op.Op == ovsdb.OperationMutate && op.Table == "Logical_Router" {
+				if uuid, ok := op.Where[0].Value.(ovsdb.UUID); !ok || uuid.GoUUID != "lr-2" {
+					t.Errorf("route mutate must target lr-2 only, got %+v", op)
+				}
+			}
+		}
 	}
 }
 

--- a/ovn_test.go
+++ b/ovn_test.go
@@ -880,6 +880,133 @@ func TestRefreshStatePopulatesLocalRoutersAndNATs(t *testing.T) {
 	}
 }
 
+// TestRefreshStateResolvesLocalnetSegments verifies the SB-driven segment
+// resolution: each locally-active router is associated with the localnet
+// segment (localnet port + physnet + optional VLAN tag) of its external
+// network, and NAT IPs inherit the owning router's segment. A router whose
+// external switch has no localnet row keeps a nil segment — the trigger for
+// the legacy single-patch-port fallback.
+func TestRefreshStateResolvesLocalnetSegments(t *testing.T) {
+	c, nb, sb := newOVNClientWithFakes(t, "host-a")
+
+	sb.setRows("Chassis", &SBChassis{UUID: "ch-a", Name: "ch-a", Hostname: "host-a"})
+
+	chA := "ch-a"
+	tag101 := 101
+	sb.setRows("Port_Binding",
+		// Three locally-active routers.
+		&SBPortBinding{UUID: "pb-cr-vlan", LogicalPort: "cr-lrp-vlan", Type: "chassisredirect", Chassis: &chA},
+		&SBPortBinding{UUID: "pb-cr-flat", LogicalPort: "cr-lrp-flat", Type: "chassisredirect", Chassis: &chA},
+		&SBPortBinding{UUID: "pb-cr-none", LogicalPort: "cr-lrp-none", Type: "chassisredirect", Chassis: &chA},
+		// VLAN segment: switch-side patch row + localnet row share dp-vlan.
+		// The patch row also carries a NatAddresses SNAT IP (step 5b) that
+		// must inherit the segment.
+		&SBPortBinding{
+			UUID: "pb-patch-vlan", LogicalPort: "ext-vlan", Type: "patch",
+			Datapath:    "dp-vlan",
+			Options:     map[string]string{"peer": "lrp-vlan"},
+			ExternalIDs: map[string]string{"neutron:device_owner": "network:router_gateway"},
+			NatAddresses: []string{
+				"fa:16:3e:11:22:33 198.51.100.60 is_chassis_resident(\"cr-lrp-vlan\")",
+			},
+		},
+		&SBPortBinding{
+			UUID: "pb-ln-vlan", LogicalPort: "seg-vlan", Type: "localnet",
+			Datapath: "dp-vlan",
+			Tag:      &tag101,
+			Options:  map[string]string{"network_name": "physnet1"},
+		},
+		// Flat segment: localnet row without a tag.
+		&SBPortBinding{
+			UUID: "pb-patch-flat", LogicalPort: "ext-flat", Type: "patch",
+			Datapath: "dp-flat",
+			Options:  map[string]string{"peer": "lrp-flat"},
+		},
+		&SBPortBinding{
+			UUID: "pb-ln-flat", LogicalPort: "seg-flat", Type: "localnet",
+			Datapath: "dp-flat",
+			Options:  map[string]string{"network_name": "physnet1"},
+		},
+		// No localnet row at all for lrp-none's external switch.
+		&SBPortBinding{
+			UUID: "pb-patch-none", LogicalPort: "ext-none", Type: "patch",
+			Datapath: "dp-none",
+			Options:  map[string]string{"peer": "lrp-none"},
+		},
+	)
+
+	nb.setRows("Logical_Router_Port",
+		&NBLogicalRouterPort{UUID: "lrp-uuid-vlan", Name: "lrp-vlan", MAC: "fa:16:3e:aa:aa:01", Networks: []string{"198.51.100.1/24"}},
+		&NBLogicalRouterPort{UUID: "lrp-uuid-flat", Name: "lrp-flat", MAC: "fa:16:3e:aa:aa:02", Networks: []string{"192.0.2.1/24"}},
+		&NBLogicalRouterPort{UUID: "lrp-uuid-none", Name: "lrp-none", MAC: "fa:16:3e:aa:aa:03", Networks: []string{"203.0.113.1/24"}},
+	)
+	nb.setRows("Logical_Router",
+		&NBLogicalRouter{UUID: "lr-vlan", Name: "router-vlan", Ports: []string{"lrp-uuid-vlan"}, Nat: []string{"nat-vlan"}},
+		&NBLogicalRouter{UUID: "lr-flat", Name: "router-flat", Ports: []string{"lrp-uuid-flat"}, Nat: []string{"nat-flat"}},
+		&NBLogicalRouter{UUID: "lr-none", Name: "router-none", Ports: []string{"lrp-uuid-none"}, Nat: []string{"nat-none"}},
+	)
+	nb.setRows("NAT",
+		&NBNAT{UUID: "nat-vlan", Type: "dnat_and_snat", ExternalIP: "198.51.100.50"},
+		&NBNAT{UUID: "nat-flat", Type: "dnat_and_snat", ExternalIP: "192.0.2.50"},
+		&NBNAT{UUID: "nat-none", Type: "dnat_and_snat", ExternalIP: "203.0.113.50"},
+	)
+
+	c.state.LocalChassisName = "host-a"
+	c.refreshState(context.Background())
+	snap := c.GetState()
+
+	if len(snap.LocalRouters) != 3 {
+		t.Fatalf("LocalRouters length = %d, want 3", len(snap.LocalRouters))
+	}
+	segByRouter := map[string]*LocalnetSegment{}
+	for i := range snap.LocalRouters {
+		segByRouter[snap.LocalRouters[i].RouterName] = snap.LocalRouters[i].Segment
+	}
+
+	vlanSeg := segByRouter["router-vlan"]
+	if vlanSeg == nil {
+		t.Fatal("router-vlan has no segment")
+	}
+	if vlanSeg.LocalnetPort != "seg-vlan" || vlanSeg.NetworkName != "physnet1" {
+		t.Errorf("router-vlan segment = %+v, want seg-vlan/physnet1", vlanSeg)
+	}
+	if vlanSeg.VLANTag == nil || *vlanSeg.VLANTag != 101 {
+		t.Errorf("router-vlan VLANTag = %v, want 101", vlanSeg.VLANTag)
+	}
+
+	flatSeg := segByRouter["router-flat"]
+	if flatSeg == nil {
+		t.Fatal("router-flat has no segment")
+	}
+	if flatSeg.LocalnetPort != "seg-flat" || flatSeg.VLANTag != nil {
+		t.Errorf("router-flat segment = %+v, want seg-flat with nil tag", flatSeg)
+	}
+
+	if segByRouter["router-none"] != nil {
+		t.Errorf("router-none segment = %+v, want nil (no localnet row)", segByRouter["router-none"])
+	}
+
+	wantSegments := map[string]string{
+		"198.51.100.50": "seg-vlan",
+		"192.0.2.50":    "seg-flat",
+		"198.51.100.60": "seg-vlan", // SB NatAddresses SNAT IP (step 5b)
+	}
+	for ip, want := range wantSegments {
+		if got := snap.NATIPToSegment[ip]; got != want {
+			t.Errorf("NATIPToSegment[%s] = %q, want %q", ip, got, want)
+		}
+	}
+	if got, ok := snap.NATIPToSegment["203.0.113.50"]; ok {
+		t.Errorf("NATIPToSegment[203.0.113.50] = %q, want absent (unresolved segment)", got)
+	}
+
+	// The snapshot must be a copy, not a reference.
+	snap.NATIPToSegment["198.51.100.50"] = "modified"
+	if c.state.NATIPToSegment["198.51.100.50"] == "modified" {
+		t.Error("GetState should return a copy of NATIPToSegment, not a reference")
+	}
+}
+
 func TestRefreshStateNoLocalRouters(t *testing.T) {
 	c, nb, sb := newOVNClientWithFakes(t, "host-a")
 

--- a/ovs.go
+++ b/ovs.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net"
 	"os/exec"
+	"sort"
 	"strings"
 )
 
@@ -12,6 +13,39 @@ const (
 	ovsCookieMACTweak = "0x999"
 	ovsCookieHairpin  = "0x998"
 )
+
+// ovsLocalnetPortKey is the external_ids key ovn-controller sets on the
+// provider-bridge patch Port row, naming the localnet logical port the
+// patch carries. It is how a localnet segment is mapped to its patch port.
+const ovsLocalnetPortKey = "ovn-localnet-port"
+
+// DesiredSegment identifies a localnet segment the reconcile loop wants OVS
+// flows and a kernel path for. An empty LocalnetPort requests the legacy
+// single-patch-port fallback (routers whose segment is unresolved).
+type DesiredSegment struct {
+	LocalnetPort string
+	VLANTag      *int
+}
+
+// segmentBinding is the resolved data-plane state of one localnet segment:
+// the OVS patch port (and its OpenFlow port number) carrying the segment's
+// traffic on the provider bridge, and the kernel interface (and its MAC)
+// carrying the segment's /32 routes, bridge IP, and proxy ARP.
+type segmentBinding struct {
+	patchPort string
+	ofport    string
+	kernelDev string
+	kernelMAC string
+	vlanTag   *int
+}
+
+// HairpinTarget describes one locally-managed IP that needs a hairpin flow:
+// the MAC of the router port that owns it, and the localnet segment its
+// external network is on ("" = the fallback segment).
+type HairpinTarget struct {
+	RouterMAC string
+	Segment   string
+}
 
 // MACTweakFlow returns the OpenFlow rule string for a MAC-tweak flow.
 func MACTweakFlow(cookie, ofport, mac string, ipv6 bool) string {
@@ -44,20 +78,35 @@ func (rm *RouteManager) runOVS(binary string, args ...string) ([]byte, error) {
 	return cmd.CombinedOutput()
 }
 
-// EnsureOVSFlows installs MAC-tweak flows on the bridge device.
-// These flows rewrite the destination MAC of packets arriving from OVN's
-// integration bridge (via the patch-provnet port) to the bridge device's own
-// MAC, so the kernel can properly receive and route them.
+// EnsureSegments resolves the desired localnet segments to their patch ports
+// and kernel interfaces, prunes kernel interfaces of segments that are gone,
+// and installs MAC-tweak flows per patch port. Each flow rewrites the
+// destination MAC of packets arriving from OVN's integration bridge (via the
+// segment's patch port) to the MAC of that segment's kernel interface, so
+// the kernel can properly receive and route them.
 //
-// The patch port is re-validated on every call via refreshOVSDiscovery.
-func (rm *RouteManager) EnsureOVSFlows() error {
+// Every binding is re-validated on every call via refreshSegmentBindings.
+func (rm *RouteManager) EnsureSegments(desired []DesiredSegment) error {
 	if rm.dryRun {
-		slog.Info("[dry-run] would ensure OVS MAC-tweak flows", "dev", rm.bridgeDev)
+		slog.Info("[dry-run] would ensure OVS MAC-tweak flows", "dev", rm.bridgeDev, "segments", len(desired))
 		return nil
 	}
 
-	if err := rm.refreshOVSDiscovery(); err != nil {
+	if err := rm.refreshSegmentBindings(desired); err != nil {
 		return err
+	}
+
+	// Remove agent-created VLAN interfaces whose segment is no longer
+	// desired, so a failover or network removal does not leave a stale
+	// kernel path behind.
+	keepTags := make(map[int]bool)
+	for _, b := range rm.segments {
+		if b.vlanTag != nil {
+			keepTags[*b.vlanTag] = true
+		}
+	}
+	if err := rm.PruneSegmentInterfaces(keepTags); err != nil {
+		slog.Warn("failed to prune stale segment interfaces", "error", err)
 	}
 
 	// Delete existing agent-managed flows (idempotent replace).
@@ -66,62 +115,253 @@ func (rm *RouteManager) EnsureOVSFlows() error {
 		slog.Warn("failed to delete old OVS flows", "error", err, "output", strings.TrimSpace(string(out)))
 	}
 
-	// Add IPv4 and IPv6 MAC-tweak flows.
-	ipv4Flow := MACTweakFlow(ovsCookieMACTweak, rm.cachedOfport, rm.cachedBridgeMAC, false)
-	if err := rm.addOVSFlow(ipv4Flow); err != nil {
-		return fmt.Errorf("add IPv4 MAC-tweak flow: %w", err)
+	// Add IPv4 and IPv6 MAC-tweak flows per patch port. Several segments
+	// may share one binding (fallback), so dedup by ofport.
+	seenOfports := make(map[string]bool, len(rm.segments))
+	for _, key := range sortedSegmentKeys(rm.segments) {
+		b := rm.segments[key]
+		if seenOfports[b.ofport] {
+			continue
+		}
+		seenOfports[b.ofport] = true
+
+		// Install both flows best-effort: the up-front del-flows already
+		// swept every segment's old flows, so a failed re-add on one patch
+		// port must not abort the loop and leave the remaining segments
+		// without any MAC-tweak flow at all. Log and move on.
+		ipv4Flow := MACTweakFlow(ovsCookieMACTweak, b.ofport, b.kernelMAC, false)
+		if err := rm.addOVSFlow(ipv4Flow); err != nil {
+			slog.Warn("failed to add IPv4 MAC-tweak flow, skipping",
+				"patch_port", b.patchPort, "ofport", b.ofport, "error", err)
+		}
+
+		ipv6Flow := MACTweakFlow(ovsCookieMACTweak, b.ofport, b.kernelMAC, true)
+		if err := rm.addOVSFlow(ipv6Flow); err != nil {
+			slog.Warn("failed to add IPv6 MAC-tweak flow, skipping",
+				"patch_port", b.patchPort, "ofport", b.ofport, "error", err)
+		}
 	}
 
-	ipv6Flow := MACTweakFlow(ovsCookieMACTweak, rm.cachedOfport, rm.cachedBridgeMAC, true)
-	if err := rm.addOVSFlow(ipv6Flow); err != nil {
-		return fmt.Errorf("add IPv6 MAC-tweak flow: %w", err)
-	}
-
-	slog.Debug("OVS MAC-tweak flows ensured", "dev", rm.bridgeDev)
+	slog.Debug("OVS MAC-tweak flows ensured", "dev", rm.bridgeDev, "segments", len(rm.segments))
 	return nil
 }
 
-// refreshOVSDiscovery makes sure cachedPatchPort, cachedOfport and
-// cachedBridgeMAC reflect the current br-ex state.
+// sortedSegmentKeys returns the segment map keys in deterministic order.
+func sortedSegmentKeys(segments map[string]*segmentBinding) []string {
+	keys := make([]string, 0, len(segments))
+	for k := range segments {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// refreshSegmentBindings makes sure rm.segments reflects the current br-ex
+// state for exactly the desired segments.
 //
 // The discovery results cannot be cached for the process lifetime:
-// ovn-controller can delete and recreate the br-ex patch port — on a
-// bridge-mapping change, an OVS resync, or its own restart — which assigns
-// the port a new OpenFlow port number. A stale cached ofport makes every
-// MAC-tweak and hairpin flow match a dead in_port, silently breaking the
-// OVN↔kernel data path until the agent is restarted.
+// ovn-controller can delete and recreate a patch port — on a bridge-mapping
+// change, an OVS resync, or its own restart — which assigns the port a new
+// OpenFlow port number. A stale cached ofport makes every MAC-tweak and
+// hairpin flow match a dead in_port, silently breaking the OVN↔kernel data
+// path until the agent is restarted.
 //
-// The fast path keeps the cache whenever the cached patch port still resolves
-// to the cached ofport; otherwise (first call, or the port was recreated) it
-// rediscovers from scratch.
-func (rm *RouteManager) refreshOVSDiscovery() error {
-	if rm.cachedPatchPort != "" {
-		if ofport, err := rm.getOFPort(rm.cachedPatchPort); err == nil && ofport == rm.cachedOfport {
-			return nil
+// The fast path keeps the cache whenever every desired segment already has a
+// binding whose patch port still resolves to the cached ofport; otherwise
+// (first call, segment set changed, or a port was recreated) it rediscovers
+// from scratch.
+func (rm *RouteManager) refreshSegmentBindings(desired []DesiredSegment) error {
+	if rm.segmentsCurrent(desired) {
+		return nil
+	}
+	// Drop the stale bindings up front: if rediscovery aborts half-way, the
+	// hairpin reconcile must see "no bindings" rather than reuse dead
+	// ofports.
+	rm.segments = nil
+
+	// Map localnet port name → provider-bridge patch port, from the
+	// external_ids ovn-controller stamps on the patch Port rows.
+	out, err := rm.runOVS("ovs-vsctl", "list-ports", rm.bridgeDev)
+	if err != nil {
+		return fmt.Errorf("list-ports %s: %w (output: %s)", rm.bridgeDev, err, strings.TrimSpace(string(out)))
+	}
+	patchByLocalnet := make(map[string]string)
+	for _, port := range strings.Fields(strings.TrimSpace(string(out))) {
+		val, err := rm.runOVS("ovs-vsctl", "--if-exists", "get", "Port", port,
+			"external_ids:"+ovsLocalnetPortKey)
+		if err != nil {
+			continue
 		}
-		slog.Info("br-ex patch port changed or gone, rediscovering OVS flow target",
-			"cached_patch_port", rm.cachedPatchPort, "cached_ofport", rm.cachedOfport)
-		rm.cachedPatchPort = ""
-		rm.cachedOfport = ""
+		name := strings.Trim(strings.TrimSpace(string(val)), "\"")
+		if name != "" {
+			patchByLocalnet[name] = port
+		}
 	}
 
+	segments := make(map[string]*segmentBinding, len(desired))
+	var fallback *segmentBinding
+	for _, d := range desired {
+		patchPort := ""
+		if d.LocalnetPort != "" {
+			patchPort = patchByLocalnet[d.LocalnetPort]
+		}
+		if patchPort == "" {
+			// Legacy fallback: first patch port on the bridge, kernel path
+			// on the bridge device itself. Keeps single-network flat
+			// deployments bit-compatible with the pre-segment behavior.
+			if d.LocalnetPort != "" {
+				slog.Warn("localnet segment has no matching patch port on the provider bridge, using single-patch fallback",
+					"localnet_port", d.LocalnetPort, "dev", rm.bridgeDev)
+			}
+			if fallback == nil {
+				fallback, err = rm.fallbackBinding()
+				if err != nil {
+					return err
+				}
+			}
+			segments[d.LocalnetPort] = fallback
+			continue
+		}
+
+		ofport, err := rm.getOFPort(patchPort)
+		if err != nil {
+			return fmt.Errorf("get ofport for %s: %w", patchPort, err)
+		}
+		binding := &segmentBinding{patchPort: patchPort, ofport: ofport}
+		if d.VLANTag == nil {
+			// Flat segment: the kernel path lives on the bridge device.
+			mac, err := rm.GetBridgeMAC()
+			if err != nil {
+				return fmt.Errorf("get bridge MAC: %w", err)
+			}
+			binding.kernelDev = rm.bridgeDev
+			binding.kernelMAC = mac.String()
+		} else {
+			tag := *d.VLANTag
+			dev, mac, err := rm.ensureSegmentInterface(tag)
+			if err != nil {
+				slog.Error("cannot ensure kernel interface for VLAN segment, skipping segment",
+					"localnet_port", d.LocalnetPort, "tag", tag, "error", err)
+				continue
+			}
+			binding.kernelDev = dev
+			binding.kernelMAC = mac
+			binding.vlanTag = &tag
+		}
+		segments[d.LocalnetPort] = binding
+		slog.Info("localnet segment bound",
+			"localnet_port", d.LocalnetPort,
+			"patch_port", binding.patchPort,
+			"ofport", binding.ofport,
+			"kernel_dev", binding.kernelDev,
+			"mac", binding.kernelMAC,
+		)
+	}
+
+	rm.segments = segments
+	return nil
+}
+
+// segmentsCurrent reports whether the cached bindings cover exactly the
+// desired segments (same keys, same VLAN tags) and every cached patch port
+// still resolves to its cached ofport.
+func (rm *RouteManager) segmentsCurrent(desired []DesiredSegment) bool {
+	if len(rm.segments) == 0 {
+		return false
+	}
+	byKey := make(map[string]DesiredSegment, len(desired))
+	for _, d := range desired {
+		byKey[d.LocalnetPort] = d
+	}
+	if len(byKey) != len(rm.segments) {
+		return false
+	}
+	for key, d := range byKey {
+		b, ok := rm.segments[key]
+		if !ok || !tagsEqual(b.vlanTag, d.VLANTag) {
+			return false
+		}
+		if ofport, err := rm.getOFPort(b.patchPort); err != nil || ofport != b.ofport {
+			slog.Info("segment patch port changed or gone, rediscovering OVS flow targets",
+				"localnet_port", key, "cached_patch_port", b.patchPort, "cached_ofport", b.ofport)
+			return false
+		}
+	}
+	return true
+}
+
+// tagsEqual compares two optional VLAN tags. A binding that fell back to the
+// single-patch path has a nil tag regardless of the desired tag, so a
+// still-unresolvable VLAN segment keeps re-triggering rediscovery until its
+// patch port appears — which is intended.
+func tagsEqual(a, b *int) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
+}
+
+// ensureSegmentInterface dispatches to the platform implementation, or to
+// the test hook when one is set.
+func (rm *RouteManager) ensureSegmentInterface(tag int) (string, string, error) {
+	if rm.segmentIfaceHook != nil {
+		return rm.segmentIfaceHook(tag)
+	}
+	return rm.EnsureSegmentInterface(tag)
+}
+
+// fallbackBinding resolves the legacy single-patch-port binding: the first
+// type=patch port on the bridge device, with the kernel path on the bridge
+// device itself. Used for segments that cannot be mapped to a patch port.
+func (rm *RouteManager) fallbackBinding() (*segmentBinding, error) {
 	patchPort, err := rm.discoverPatchPort()
 	if err != nil {
-		return fmt.Errorf("discover patch port on %s: %w", rm.bridgeDev, err)
+		return nil, fmt.Errorf("discover patch port on %s: %w", rm.bridgeDev, err)
 	}
 	ofport, err := rm.getOFPort(patchPort)
 	if err != nil {
-		return fmt.Errorf("get ofport for %s: %w", patchPort, err)
+		return nil, fmt.Errorf("get ofport for %s: %w", patchPort, err)
 	}
 	mac, err := rm.GetBridgeMAC()
 	if err != nil {
-		return fmt.Errorf("get bridge MAC: %w", err)
+		return nil, fmt.Errorf("get bridge MAC: %w", err)
 	}
-	rm.cachedPatchPort = patchPort
-	rm.cachedOfport = ofport
-	rm.cachedBridgeMAC = mac.String()
-	slog.Info("OVS discovery complete", "patch_port", patchPort, "ofport", ofport, "mac", rm.cachedBridgeMAC)
-	return nil
+	return &segmentBinding{
+		patchPort: patchPort,
+		ofport:    ofport,
+		kernelDev: rm.bridgeDev,
+		kernelMAC: mac.String(),
+	}, nil
+}
+
+// segmentBinding returns the binding for a localnet port name, falling back
+// to the legacy "" binding when the segment is unknown. Returns nil when
+// neither exists.
+func (rm *RouteManager) segmentBindingFor(localnetPort string) *segmentBinding {
+	if b, ok := rm.segments[localnetPort]; ok {
+		return b
+	}
+	return rm.segments[""]
+}
+
+// SegmentDev returns the kernel interface that carries the given localnet
+// segment's /32 routes, falling back to the provider bridge device when the
+// segment (and the fallback binding) is not yet discovered.
+func (rm *RouteManager) SegmentDev(localnetPort string) string {
+	if b := rm.segmentBindingFor(localnetPort); b != nil {
+		return b.kernelDev
+	}
+	return rm.bridgeDev
+}
+
+// SegmentMAC returns the MAC of the given localnet segment's kernel
+// interface, or "" when the segment (and the fallback binding) is not yet
+// discovered.
+func (rm *RouteManager) SegmentMAC(localnetPort string) string {
+	if b := rm.segmentBindingFor(localnetPort); b != nil {
+		return b.kernelMAC
+	}
+	return ""
 }
 
 // HairpinFlow returns the OpenFlow rule string for a same-chassis hairpin flow.
@@ -161,23 +401,25 @@ func HairpinFlow(cookie, ofport, ip, bridgeMAC, routerMAC string, ipv6 bool) str
 // From a different chassis the same traffic arrives via the physical network
 // and OVN processes it correctly — explaining the asymmetric failure.
 //
-// ipToRouterMAC maps each IP to the MAC of the router port that owns it.
-// The MAC is written into the flow as mod_dl_dst so that OVN's L2 lookup
-// delivers the reflected packet to the correct router port.
+// targets maps each IP to the MAC of the router port that owns it and the
+// localnet segment its external network is on. The MAC is written into the
+// flow as mod_dl_dst so that OVN's L2 lookup delivers the reflected packet
+// to the correct router port; the segment selects the patch port the flow
+// matches on, so reflection (output:in_port) stays within the segment.
 //
-// EnsureOVSFlows must be called before this method so that cachedOfport is
-// populated. If cachedOfport is empty this method is a no-op.
+// EnsureSegments must be called before this method so that the segment
+// bindings are populated. With no bindings this method is a no-op.
 //
 // Pass nil or an empty map to remove all hairpin flows (e.g. when no
 // locally-active routers remain).
-func (rm *RouteManager) ReconcileOVSHairpinFlows(ipToRouterMAC map[string]string) error {
+func (rm *RouteManager) ReconcileOVSHairpinFlows(targets map[string]HairpinTarget) error {
 	if rm.dryRun {
-		slog.Info("[dry-run] would reconcile OVS hairpin flows", "count", len(ipToRouterMAC))
+		slog.Info("[dry-run] would reconcile OVS hairpin flows", "count", len(targets))
 		return nil
 	}
-	if rm.cachedOfport == "" {
-		// Patch port not yet discovered; EnsureOVSFlows must run first.
-		slog.Warn("skipping OVS hairpin flow reconcile: patch port ofport not yet cached")
+	if len(rm.segments) == 0 {
+		// Segments not yet discovered; EnsureSegments must run first.
+		slog.Warn("skipping OVS hairpin flow reconcile: segment bindings not yet discovered")
 		return nil
 	}
 
@@ -188,19 +430,25 @@ func (rm *RouteManager) ReconcileOVSHairpinFlows(ipToRouterMAC map[string]string
 		return fmt.Errorf("del hairpin OVS flows on %s: %w (output: %s)", rm.bridgeDev, err, strings.TrimSpace(string(out)))
 	}
 
-	for ip, routerMAC := range ipToRouterMAC {
+	for ip, target := range targets {
 		parsed := net.ParseIP(ip)
 		if parsed == nil {
 			return fmt.Errorf("invalid IP %q", ip)
 		}
+		b := rm.segmentBindingFor(target.Segment)
+		if b == nil {
+			slog.Warn("no segment binding for hairpin IP, skipping",
+				"ip", ip, "segment", target.Segment)
+			continue
+		}
 		isIPv6 := parsed.To4() == nil
-		flow := HairpinFlow(ovsCookieHairpin, rm.cachedOfport, ip, rm.cachedBridgeMAC, routerMAC, isIPv6)
+		flow := HairpinFlow(ovsCookieHairpin, b.ofport, ip, b.kernelMAC, target.RouterMAC, isIPv6)
 		if err := rm.addOVSFlow(flow); err != nil {
 			return fmt.Errorf("add hairpin flow for %s: %w", ip, err)
 		}
 	}
 
-	slog.Debug("OVS hairpin flows reconciled", "count", len(ipToRouterMAC))
+	slog.Debug("OVS hairpin flows reconciled", "count", len(targets))
 	return nil
 }
 

--- a/ovs.go
+++ b/ovs.go
@@ -354,6 +354,19 @@ func (rm *RouteManager) SegmentDev(localnetPort string) string {
 	return rm.bridgeDev
 }
 
+// SegmentResolved reports whether the given localnet segment has its own
+// binding this cycle. It is false when EnsureSegments could not resolve the
+// segment (a transient discovery failure nulls the whole map, or a per-segment
+// interface setup failed), in which case SegmentDev returns the provider-bridge
+// fallback. Callers routing a VLAN segment's /32 use this to leave the existing
+// route in place rather than move it onto the untagged bridge. A segment that
+// deliberately fell back to the single-patch path keeps its own (fallback)
+// binding and so still reports true.
+func (rm *RouteManager) SegmentResolved(localnetPort string) bool {
+	_, ok := rm.segments[localnetPort]
+	return ok
+}
+
 // SegmentMAC returns the MAC of the given localnet segment's kernel
 // interface, or "" when the segment (and the fallback binding) is not yet
 // discovered.

--- a/ovs_test.go
+++ b/ovs_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os/exec"
 	"reflect"
 	"sort"
@@ -51,6 +52,16 @@ func (r *ovsRecorder) findAddFlows() []string {
 		}
 	}
 	return flows
+}
+
+// containsFlow reports whether want is one of the recorded flow strings.
+func containsFlow(flows []string, want string) bool {
+	for _, f := range flows {
+		if f == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestHairpinFlow(t *testing.T) {
@@ -160,24 +171,36 @@ func TestOVSCmdNoWrapper(t *testing.T) {
 	}
 }
 
-func TestEnsureOVSFlowsWithCachedDiscovery(t *testing.T) {
+// fallbackSegments returns a segment map holding only the legacy
+// single-patch-port fallback binding, as EnsureSegments resolves it for a
+// flat single-network deployment.
+func fallbackSegments(patchPort, ofport, mac string) map[string]*segmentBinding {
+	return map[string]*segmentBinding{
+		"": {patchPort: patchPort, ofport: ofport, kernelDev: "br-ex", kernelMAC: mac},
+	}
+}
+
+// TestEnsureSegmentsWithCachedFallbackKeepsFlatFlowSet locks the flat
+// single-network behavior: with a cached fallback binding that still
+// resolves to its ofport, EnsureSegments issues exactly the pre-segment
+// command sequence — one ofport validation, one cookie sweep, and the
+// IPv4+IPv6 MAC-tweak pair for the single patch port and bridge MAC.
+func TestEnsureSegmentsWithCachedFallbackKeepsFlatFlowSet(t *testing.T) {
 	rec := newOVSRecorder()
-	// EnsureOVSFlows re-validates the cached patch port on every call; here
-	// it still resolves to ofport 42, so no full rediscovery (list-ports) runs.
+	// EnsureSegments re-validates every cached binding on each call; here
+	// the patch port still resolves to ofport 42, so no rediscovery runs.
 	rec.on(
 		[]string{"ovs-vsctl", "get", "Interface", "patch-provnet-0", "ofport"},
 		"42\n", nil,
 	)
 	rm := &RouteManager{
-		bridgeDev:       "br-ex",
-		cachedPatchPort: "patch-provnet-0",
-		cachedOfport:    "42",
-		cachedBridgeMAC: "aa:bb:cc:dd:ee:ff",
-		execOVSHook:     rec.hook(),
+		bridgeDev:   "br-ex",
+		segments:    fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"),
+		execOVSHook: rec.hook(),
 	}
 
-	if err := rm.EnsureOVSFlows(); err != nil {
-		t.Fatalf("EnsureOVSFlows() error: %v", err)
+	if err := rm.EnsureSegments([]DesiredSegment{{LocalnetPort: ""}}); err != nil {
+		t.Fatalf("EnsureSegments() error: %v", err)
 	}
 
 	// Expect: 1 ofport validation + 1 del-flows + 2 add-flows (IPv4 + IPv6).
@@ -204,16 +227,165 @@ func TestEnsureOVSFlowsWithCachedDiscovery(t *testing.T) {
 	}
 }
 
-// TestEnsureOVSFlowsRunsDiscoveryWhenUncached exercises the first-call
-// discovery path: with no cached values, EnsureOVSFlows calls
-// discoverPatchPort and getOFPort via the OVS hook and only falls over at
-// GetBridgeMAC (which has no hook). The discovery branches are covered up
-// to that point, and the function returns the wrapped MAC error.
-func TestEnsureOVSFlowsRunsDiscoveryWhenUncached(t *testing.T) {
+// TestEnsureSegmentsInstallsFlowsPerPatchPort covers the multi-VLAN path:
+// two localnet segments resolve to their own patch ports (via the
+// external_ids ovn-controller stamps on the Port rows) and their own kernel
+// interfaces (via the segment-interface hook), and the MAC-tweak flows are
+// installed per patch port with the per-segment MACs after a single
+// bridge-wide cookie sweep.
+func TestEnsureSegmentsInstallsFlowsPerPatchPort(t *testing.T) {
+	rec := newOVSRecorder()
+	rec.on(
+		[]string{"ovs-vsctl", "list-ports", "br-ex"},
+		"patch-seg101\npatch-seg102\nphy-eth0\n", nil,
+	)
+	rec.on(
+		[]string{"ovs-vsctl", "--if-exists", "get", "Port", "patch-seg101", "external_ids:ovn-localnet-port"},
+		"\"seg-101\"\n", nil,
+	)
+	rec.on(
+		[]string{"ovs-vsctl", "--if-exists", "get", "Port", "patch-seg102", "external_ids:ovn-localnet-port"},
+		"\"seg-102\"\n", nil,
+	)
+	rec.on(
+		[]string{"ovs-vsctl", "--if-exists", "get", "Port", "phy-eth0", "external_ids:ovn-localnet-port"},
+		"\n", nil,
+	)
+	rec.on(
+		[]string{"ovs-vsctl", "get", "Interface", "patch-seg101", "ofport"},
+		"5\n", nil,
+	)
+	rec.on(
+		[]string{"ovs-vsctl", "get", "Interface", "patch-seg102", "ofport"},
+		"6\n", nil,
+	)
+	rm := &RouteManager{
+		bridgeDev:   "br-ex",
+		execOVSHook: rec.hook(),
+		segmentIfaceHook: func(tag int) (string, string, error) {
+			return fmt.Sprintf("br-ex.%d", tag), fmt.Sprintf("aa:bb:cc:dd:ee:%02x", tag), nil
+		},
+	}
+
+	tag101, tag102 := 101, 102
+	desired := []DesiredSegment{
+		{LocalnetPort: "seg-101", VLANTag: &tag101},
+		{LocalnetPort: "seg-102", VLANTag: &tag102},
+	}
+	if err := rm.EnsureSegments(desired); err != nil {
+		t.Fatalf("EnsureSegments() error: %v", err)
+	}
+
+	flows := rec.findAddFlows()
+	wantFlows := []string{
+		"cookie=0x999,priority=900,ip,in_port=5,actions=mod_dl_dst:aa:bb:cc:dd:ee:65,NORMAL",
+		"cookie=0x999,priority=900,ipv6,in_port=5,actions=mod_dl_dst:aa:bb:cc:dd:ee:65,NORMAL",
+		"cookie=0x999,priority=900,ip,in_port=6,actions=mod_dl_dst:aa:bb:cc:dd:ee:66,NORMAL",
+		"cookie=0x999,priority=900,ipv6,in_port=6,actions=mod_dl_dst:aa:bb:cc:dd:ee:66,NORMAL",
+	}
+	if !reflect.DeepEqual(flows, wantFlows) {
+		t.Errorf("add-flow flows = %v, want %v", flows, wantFlows)
+	}
+
+	// Exactly one cookie sweep, bridge-wide.
+	dels := 0
+	for _, c := range rec.calls {
+		if len(c) >= 4 && c[1] == "del-flows" && c[3] == "cookie=0x999/-1" {
+			dels++
+		}
+	}
+	if dels != 1 {
+		t.Errorf("expected 1 del-flows sweep, got %d", dels)
+	}
+
+	// The kernel devices are recorded per segment for the routing side.
+	if got := rm.SegmentDev("seg-101"); got != "br-ex.101" {
+		t.Errorf("SegmentDev(seg-101) = %q, want br-ex.101", got)
+	}
+	if got := rm.SegmentMAC("seg-102"); got != "aa:bb:cc:dd:ee:66" {
+		t.Errorf("SegmentMAC(seg-102) = %q, want aa:bb:cc:dd:ee:66", got)
+	}
+}
+
+// TestEnsureSegmentsSkipsSegmentWhenIfaceFails exercises the error path of
+// the kernel-interface resolution (e.g. an interface name over the IFNAMSIZ
+// limit): the failing segment is skipped with an error log, and the other
+// segment's flows are still installed.
+func TestEnsureSegmentsSkipsSegmentWhenIfaceFails(t *testing.T) {
+	rec := newOVSRecorder()
+	rec.on(
+		[]string{"ovs-vsctl", "list-ports", "br-ex"},
+		"patch-seg101\npatch-seg102\n", nil,
+	)
+	rec.on(
+		[]string{"ovs-vsctl", "--if-exists", "get", "Port", "patch-seg101", "external_ids:ovn-localnet-port"},
+		"\"seg-101\"\n", nil,
+	)
+	rec.on(
+		[]string{"ovs-vsctl", "--if-exists", "get", "Port", "patch-seg102", "external_ids:ovn-localnet-port"},
+		"\"seg-102\"\n", nil,
+	)
+	rec.on(
+		[]string{"ovs-vsctl", "get", "Interface", "patch-seg101", "ofport"},
+		"5\n", nil,
+	)
+	rec.on(
+		[]string{"ovs-vsctl", "get", "Interface", "patch-seg102", "ofport"},
+		"6\n", nil,
+	)
+	rm := &RouteManager{
+		bridgeDev:   "br-ex",
+		execOVSHook: rec.hook(),
+		segmentIfaceHook: func(tag int) (string, string, error) {
+			if tag == 102 {
+				return "", "", errors.New("interface name too long")
+			}
+			return fmt.Sprintf("br-ex.%d", tag), "aa:bb:cc:dd:ee:65", nil
+		},
+	}
+
+	tag101, tag102 := 101, 102
+	desired := []DesiredSegment{
+		{LocalnetPort: "seg-101", VLANTag: &tag101},
+		{LocalnetPort: "seg-102", VLANTag: &tag102},
+	}
+	if err := rm.EnsureSegments(desired); err != nil {
+		t.Fatalf("EnsureSegments() error: %v", err)
+	}
+
+	flows := rec.findAddFlows()
+	if len(flows) != 2 {
+		t.Fatalf("expected 2 flows (healthy segment only), got %v", flows)
+	}
+	for _, f := range flows {
+		if !strings.Contains(f, "in_port=5") {
+			t.Errorf("flow %q should target the healthy segment's in_port=5", f)
+		}
+	}
+	if _, ok := rm.segments["seg-102"]; ok {
+		t.Error("failing segment must not be recorded as bound")
+	}
+}
+
+// TestEnsureSegmentsFallbackDiscoveryWhenUncached exercises the first-call
+// fallback path: no cached bindings and no external_ids on any port, so the
+// desired segment falls back to the legacy single-patch-port discovery
+// (discoverPatchPort + getOFPort) and only falls over at GetBridgeMAC
+// (which has no hook). The discovery branches are covered up to that point,
+// and the function returns the wrapped MAC error.
+func TestEnsureSegmentsFallbackDiscoveryWhenUncached(t *testing.T) {
 	rec := newOVSRecorder()
 	rec.on(
 		[]string{"ovs-vsctl", "list-ports", "ovnagent-nonexistent-br"},
 		"phy-eth0\npatch-provnet-0\n", nil,
+	)
+	rec.on(
+		[]string{"ovs-vsctl", "--if-exists", "get", "Port", "phy-eth0", "external_ids:ovn-localnet-port"},
+		"\n", nil,
+	)
+	rec.on(
+		[]string{"ovs-vsctl", "--if-exists", "get", "Port", "patch-provnet-0", "external_ids:ovn-localnet-port"},
+		"\n", nil,
 	)
 	rec.on(
 		[]string{"ovs-vsctl", "--if-exists", "get", "Interface", "phy-eth0", "type"},
@@ -232,7 +404,7 @@ func TestEnsureOVSFlowsRunsDiscoveryWhenUncached(t *testing.T) {
 		execOVSHook: rec.hook(),
 	}
 
-	err := rm.EnsureOVSFlows()
+	err := rm.EnsureSegments([]DesiredSegment{{LocalnetPort: ""}})
 	if err == nil {
 		t.Fatal("expected GetBridgeMAC error in absence of a real bridge")
 	}
@@ -240,13 +412,12 @@ func TestEnsureOVSFlowsRunsDiscoveryWhenUncached(t *testing.T) {
 		t.Errorf("expected 'get bridge MAC' wrapped error, got: %v", err)
 	}
 	// Discovery commands must have been dispatched before the MAC lookup failed.
-	if rm.cachedPatchPort != "" || rm.cachedOfport != "" {
-		t.Errorf("cache should remain empty when discovery aborts: patch=%q ofport=%q",
-			rm.cachedPatchPort, rm.cachedOfport)
+	if len(rm.segments) != 0 {
+		t.Errorf("bindings should remain empty when discovery aborts: %v", rm.segments)
 	}
 }
 
-func TestEnsureOVSFlowsTolersDelFailure(t *testing.T) {
+func TestEnsureSegmentsTolersDelFailure(t *testing.T) {
 	// del-flows is treated as best-effort; a failure must not abort the
 	// subsequent add-flow calls.
 	rec := newOVSRecorder()
@@ -259,15 +430,13 @@ func TestEnsureOVSFlowsTolersDelFailure(t *testing.T) {
 		"some output", errors.New("transient ofctl error"),
 	)
 	rm := &RouteManager{
-		bridgeDev:       "br-ex",
-		cachedPatchPort: "patch-provnet-0",
-		cachedOfport:    "42",
-		cachedBridgeMAC: "aa:bb:cc:dd:ee:ff",
-		execOVSHook:     rec.hook(),
+		bridgeDev:   "br-ex",
+		segments:    fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"),
+		execOVSHook: rec.hook(),
 	}
 
-	if err := rm.EnsureOVSFlows(); err != nil {
-		t.Fatalf("EnsureOVSFlows() should swallow del-flows error, got: %v", err)
+	if err := rm.EnsureSegments([]DesiredSegment{{LocalnetPort: ""}}); err != nil {
+		t.Fatalf("EnsureSegments() should swallow del-flows error, got: %v", err)
 	}
 
 	if got := len(rec.findAddFlows()); got != 2 {
@@ -275,43 +444,79 @@ func TestEnsureOVSFlowsTolersDelFailure(t *testing.T) {
 	}
 }
 
-func TestEnsureOVSFlowsAddFailurePropagates(t *testing.T) {
+// TestEnsureSegmentsAddFailureDoesNotStarveOthers verifies that a per-segment
+// add-flow failure is logged and skipped rather than aborting the whole loop.
+// All flows are deleted up front, so returning on the first failure would
+// leave every later segment with no MAC-tweak flow at all. Here the first
+// segment's IPv4 add-flow fails; the second segment's flows must still be
+// installed and EnsureSegments must not report a hard error.
+func TestEnsureSegmentsAddFailureDoesNotStarveOthers(t *testing.T) {
 	rec := newOVSRecorder()
 	rec.on(
-		[]string{"ovs-vsctl", "get", "Interface", "patch-provnet-0", "ofport"},
-		"42\n", nil,
+		[]string{"ovs-vsctl", "list-ports", "br-ex"},
+		"patch-seg101\npatch-seg102\n", nil,
 	)
-	// First add-flow (IPv4) fails — function must return an error.
+	rec.on(
+		[]string{"ovs-vsctl", "--if-exists", "get", "Port", "patch-seg101", "external_ids:ovn-localnet-port"},
+		"\"seg-101\"\n", nil,
+	)
+	rec.on(
+		[]string{"ovs-vsctl", "--if-exists", "get", "Port", "patch-seg102", "external_ids:ovn-localnet-port"},
+		"\"seg-102\"\n", nil,
+	)
+	rec.on(
+		[]string{"ovs-vsctl", "get", "Interface", "patch-seg101", "ofport"},
+		"5\n", nil,
+	)
+	rec.on(
+		[]string{"ovs-vsctl", "get", "Interface", "patch-seg102", "ofport"},
+		"6\n", nil,
+	)
+	// The first segment's IPv4 add-flow fails.
 	rec.on(
 		[]string{"ovs-ofctl", "add-flow", "br-ex",
-			"cookie=0x999,priority=900,ip,in_port=42,actions=mod_dl_dst:aa:bb:cc:dd:ee:ff,NORMAL"},
+			"cookie=0x999,priority=900,ip,in_port=5,actions=mod_dl_dst:aa:bb:cc:dd:ee:65,NORMAL"},
 		"add-flow failed", errors.New("bad flow"),
 	)
 	rm := &RouteManager{
-		bridgeDev:       "br-ex",
-		cachedPatchPort: "patch-provnet-0",
-		cachedOfport:    "42",
-		cachedBridgeMAC: "aa:bb:cc:dd:ee:ff",
-		execOVSHook:     rec.hook(),
+		bridgeDev:   "br-ex",
+		execOVSHook: rec.hook(),
+		segmentIfaceHook: func(tag int) (string, string, error) {
+			return fmt.Sprintf("br-ex.%d", tag), fmt.Sprintf("aa:bb:cc:dd:ee:%02x", tag), nil
+		},
 	}
 
-	err := rm.EnsureOVSFlows()
-	if err == nil {
-		t.Fatal("expected error from EnsureOVSFlows when add-flow fails")
+	tag101, tag102 := 101, 102
+	desired := []DesiredSegment{
+		{LocalnetPort: "seg-101", VLANTag: &tag101},
+		{LocalnetPort: "seg-102", VLANTag: &tag102},
 	}
-	if !strings.Contains(err.Error(), "add IPv4 MAC-tweak flow") {
-		t.Errorf("expected wrapped IPv4 error, got: %v", err)
+	if err := rm.EnsureSegments(desired); err != nil {
+		t.Fatalf("EnsureSegments() should tolerate a per-segment add-flow failure, got: %v", err)
+	}
+
+	// The healthy second segment's flows must still have been installed.
+	flows := rec.findAddFlows()
+	wantSurviving := []string{
+		"cookie=0x999,priority=900,ip,in_port=6,actions=mod_dl_dst:aa:bb:cc:dd:ee:66,NORMAL",
+		"cookie=0x999,priority=900,ipv6,in_port=6,actions=mod_dl_dst:aa:bb:cc:dd:ee:66,NORMAL",
+	}
+	for _, want := range wantSurviving {
+		if !containsFlow(flows, want) {
+			t.Errorf("healthy segment flow %q not installed after earlier failure; got %v", want, flows)
+		}
 	}
 }
 
-// TestEnsureOVSFlowsRediscoversWhenOfportChanges covers the core of the
+// TestEnsureSegmentsRediscoversWhenOfportChanges covers the core of the
 // patch-port staleness fix: the cached patch port now resolves to a different
-// ofport (as if ovn-controller had recreated it). EnsureOVSFlows must drop the
-// stale cache and rediscover, rather than keep installing flows for a dead
-// in_port. Rediscovery runs through discoverPatchPort + getOFPort and then
-// fails at GetBridgeMAC (no real bridge in a unit test) — which proves the
-// stale cache was abandoned instead of trusted.
-func TestEnsureOVSFlowsRediscoversWhenOfportChanges(t *testing.T) {
+// ofport (as if ovn-controller had recreated it). EnsureSegments must drop
+// the stale bindings and rediscover, rather than keep installing flows for a
+// dead in_port. Rediscovery runs through the external_ids mapping, falls
+// back to discoverPatchPort + getOFPort, and then fails at GetBridgeMAC (no
+// real bridge in a unit test) — which proves the stale cache was abandoned
+// instead of trusted.
+func TestEnsureSegmentsRediscoversWhenOfportChanges(t *testing.T) {
 	rec := newOVSRecorder()
 	rec.on(
 		[]string{"ovs-vsctl", "get", "Interface", "patch-provnet-0", "ofport"},
@@ -322,43 +527,80 @@ func TestEnsureOVSFlowsRediscoversWhenOfportChanges(t *testing.T) {
 		"patch-provnet-0\n", nil,
 	)
 	rec.on(
+		[]string{"ovs-vsctl", "--if-exists", "get", "Port", "patch-provnet-0", "external_ids:ovn-localnet-port"},
+		"\n", nil,
+	)
+	rec.on(
 		[]string{"ovs-vsctl", "--if-exists", "get", "Interface", "patch-provnet-0", "type"},
 		"patch\n", nil,
 	)
 	rm := &RouteManager{
-		bridgeDev:       "br-ex",
-		cachedPatchPort: "patch-provnet-0",
-		cachedOfport:    "42",
-		cachedBridgeMAC: "aa:bb:cc:dd:ee:ff",
-		execOVSHook:     rec.hook(),
+		bridgeDev:   "br-ex",
+		segments:    fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"),
+		execOVSHook: rec.hook(),
 	}
 
-	err := rm.EnsureOVSFlows()
+	err := rm.EnsureSegments([]DesiredSegment{{LocalnetPort: ""}})
 	if err == nil || !strings.Contains(err.Error(), "get bridge MAC") {
 		t.Fatalf("expected rediscovery to reach GetBridgeMAC, got: %v", err)
 	}
-	if rm.cachedPatchPort != "" || rm.cachedOfport != "" {
-		t.Errorf("stale cache must be cleared on rediscovery: patch=%q ofport=%q",
-			rm.cachedPatchPort, rm.cachedOfport)
+	if len(rm.segments) != 0 {
+		t.Errorf("stale bindings must be cleared on rediscovery: %v", rm.segments)
+	}
+}
+
+// TestEnsureSegmentsRediscoversWhenSegmentSetChanges verifies that a change
+// in the desired segment set (a second network appearing on the node)
+// triggers rediscovery even though the cached binding's ofport is unchanged.
+func TestEnsureSegmentsRediscoversWhenSegmentSetChanges(t *testing.T) {
+	rec := newOVSRecorder()
+	rec.on(
+		[]string{"ovs-vsctl", "list-ports", "br-ex"},
+		"patch-seg101\n", nil,
+	)
+	rec.on(
+		[]string{"ovs-vsctl", "--if-exists", "get", "Port", "patch-seg101", "external_ids:ovn-localnet-port"},
+		"\"seg-101\"\n", nil,
+	)
+	rec.on(
+		[]string{"ovs-vsctl", "get", "Interface", "patch-seg101", "ofport"},
+		"5\n", nil,
+	)
+	rm := &RouteManager{
+		bridgeDev:   "br-ex",
+		segments:    fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"),
+		execOVSHook: rec.hook(),
+		segmentIfaceHook: func(tag int) (string, string, error) {
+			return fmt.Sprintf("br-ex.%d", tag), "aa:bb:cc:dd:ee:65", nil
+		},
+	}
+
+	tag101 := 101
+	if err := rm.EnsureSegments([]DesiredSegment{{LocalnetPort: "seg-101", VLANTag: &tag101}}); err != nil {
+		t.Fatalf("EnsureSegments() error: %v", err)
+	}
+	if _, ok := rm.segments["seg-101"]; !ok {
+		t.Errorf("expected binding for seg-101 after set change, got %v", rm.segments)
+	}
+	if _, ok := rm.segments[""]; ok {
+		t.Errorf("stale fallback binding should be gone, got %v", rm.segments)
 	}
 }
 
 func TestReconcileOVSHairpinFlowsInstallsExpectedFlows(t *testing.T) {
 	rec := newOVSRecorder()
 	rm := &RouteManager{
-		bridgeDev:       "br-ex",
-		cachedPatchPort: "patch-provnet-0",
-		cachedOfport:    "42",
-		cachedBridgeMAC: "aa:bb:cc:dd:ee:ff",
-		execOVSHook:     rec.hook(),
+		bridgeDev:   "br-ex",
+		segments:    fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"),
+		execOVSHook: rec.hook(),
 	}
 
-	mapping := map[string]string{
-		"5.182.234.199": "fa:16:3e:6f:a1:64",
-		"2001:db8::1":   "fa:16:3e:00:00:01",
+	targets := map[string]HairpinTarget{
+		"5.182.234.199": {RouterMAC: "fa:16:3e:6f:a1:64"},
+		"2001:db8::1":   {RouterMAC: "fa:16:3e:00:00:01"},
 	}
 
-	if err := rm.ReconcileOVSHairpinFlows(mapping); err != nil {
+	if err := rm.ReconcileOVSHairpinFlows(targets); err != nil {
 		t.Fatalf("ReconcileOVSHairpinFlows() error: %v", err)
 	}
 
@@ -382,13 +624,51 @@ func TestReconcileOVSHairpinFlowsInstallsExpectedFlows(t *testing.T) {
 	}
 }
 
+// TestReconcileOVSHairpinFlowsPerSegment verifies that each IP's hairpin
+// flow binds to its own segment's patch port and rewrites dl_src to that
+// segment's kernel MAC, so reflection stays within the segment. An IP whose
+// segment has no binding (and no fallback exists) is skipped rather than
+// bound to the wrong port.
+func TestReconcileOVSHairpinFlowsPerSegment(t *testing.T) {
+	rec := newOVSRecorder()
+	tag101, tag102 := 101, 102
+	rm := &RouteManager{
+		bridgeDev: "br-ex",
+		segments: map[string]*segmentBinding{
+			"seg-101": {patchPort: "patch-seg101", ofport: "5", kernelDev: "br-ex.101", kernelMAC: "aa:bb:cc:dd:ee:65", vlanTag: &tag101},
+			"seg-102": {patchPort: "patch-seg102", ofport: "6", kernelDev: "br-ex.102", kernelMAC: "aa:bb:cc:dd:ee:66", vlanTag: &tag102},
+		},
+		execOVSHook: rec.hook(),
+	}
+
+	targets := map[string]HairpinTarget{
+		"198.51.100.50": {RouterMAC: "fa:16:3e:00:01:01", Segment: "seg-101"},
+		"203.0.113.50":  {RouterMAC: "fa:16:3e:00:01:02", Segment: "seg-102"},
+		// Unresolved segment and no "" fallback binding — must be skipped.
+		"192.0.2.50": {RouterMAC: "fa:16:3e:00:01:03", Segment: ""},
+	}
+
+	if err := rm.ReconcileOVSHairpinFlows(targets); err != nil {
+		t.Fatalf("ReconcileOVSHairpinFlows() error: %v", err)
+	}
+
+	got := rec.findAddFlows()
+	sort.Strings(got)
+	want := []string{
+		"cookie=0x998,priority=910,ip,in_port=5,ip_dst=198.51.100.50/32,actions=mod_dl_src:aa:bb:cc:dd:ee:65,mod_dl_dst:fa:16:3e:00:01:01,output:in_port",
+		"cookie=0x998,priority=910,ip,in_port=6,ip_dst=203.0.113.50/32,actions=mod_dl_src:aa:bb:cc:dd:ee:66,mod_dl_dst:fa:16:3e:00:01:02,output:in_port",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("add-flow flows = %v, want %v", got, want)
+	}
+}
+
 func TestReconcileOVSHairpinFlowsEmptyMapClearsAll(t *testing.T) {
 	rec := newOVSRecorder()
 	rm := &RouteManager{
-		bridgeDev:       "br-ex",
-		cachedOfport:    "42",
-		cachedBridgeMAC: "aa:bb:cc:dd:ee:ff",
-		execOVSHook:     rec.hook(),
+		bridgeDev:   "br-ex",
+		segments:    fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"),
+		execOVSHook: rec.hook(),
 	}
 
 	if err := rm.ReconcileOVSHairpinFlows(nil); err != nil {
@@ -403,32 +683,31 @@ func TestReconcileOVSHairpinFlowsEmptyMapClearsAll(t *testing.T) {
 	}
 }
 
-func TestReconcileOVSHairpinFlowsNoCacheIsNoOp(t *testing.T) {
+func TestReconcileOVSHairpinFlowsNoBindingsIsNoOp(t *testing.T) {
 	rec := newOVSRecorder()
 	rm := &RouteManager{
 		bridgeDev:   "br-ex",
 		execOVSHook: rec.hook(),
-		// cachedOfport intentionally empty.
+		// segments intentionally empty.
 	}
 
-	if err := rm.ReconcileOVSHairpinFlows(map[string]string{"10.0.0.1": "aa:aa:aa:aa:aa:aa"}); err != nil {
-		t.Fatalf("expected no-op when cache is empty, got: %v", err)
+	if err := rm.ReconcileOVSHairpinFlows(map[string]HairpinTarget{"10.0.0.1": {RouterMAC: "aa:aa:aa:aa:aa:aa"}}); err != nil {
+		t.Fatalf("expected no-op when bindings are empty, got: %v", err)
 	}
 	if len(rec.calls) != 0 {
-		t.Errorf("expected no OVS commands when cache empty, got: %v", rec.calls)
+		t.Errorf("expected no OVS commands when bindings empty, got: %v", rec.calls)
 	}
 }
 
 func TestReconcileOVSHairpinFlowsRejectsInvalidIP(t *testing.T) {
 	rec := newOVSRecorder()
 	rm := &RouteManager{
-		bridgeDev:       "br-ex",
-		cachedOfport:    "42",
-		cachedBridgeMAC: "aa:bb:cc:dd:ee:ff",
-		execOVSHook:     rec.hook(),
+		bridgeDev:   "br-ex",
+		segments:    fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"),
+		execOVSHook: rec.hook(),
 	}
 
-	err := rm.ReconcileOVSHairpinFlows(map[string]string{"not-an-ip": "aa:aa:aa:aa:aa:aa"})
+	err := rm.ReconcileOVSHairpinFlows(map[string]HairpinTarget{"not-an-ip": {RouterMAC: "aa:aa:aa:aa:aa:aa"}})
 	if err == nil {
 		t.Fatal("expected error for invalid IP, got nil")
 	}
@@ -445,7 +724,7 @@ func TestReconcileOVSHairpinFlowsDryRun(t *testing.T) {
 		execOVSHook: rec.hook(),
 	}
 
-	if err := rm.ReconcileOVSHairpinFlows(map[string]string{"10.0.0.1": "aa:aa:aa:aa:aa:aa"}); err != nil {
+	if err := rm.ReconcileOVSHairpinFlows(map[string]HairpinTarget{"10.0.0.1": {RouterMAC: "aa:aa:aa:aa:aa:aa"}}); err != nil {
 		t.Fatalf("dry-run should not error: %v", err)
 	}
 	if len(rec.calls) != 0 {

--- a/routing.go
+++ b/routing.go
@@ -65,6 +65,11 @@ type RouteManager struct {
 	// synthetic kernel interfaces without touching netlink.
 	segmentIfaceHook func(tag int) (dev, mac string, err error)
 
+	// listKernelRoutesHook, when non-nil, replaces ListKernelRoutes in the
+	// agent's route reconciliation. Tests set this to inject kernel route
+	// state without touching netlink.
+	listKernelRoutesHook func() ([]kernelRouteEntry, error)
+
 	// execVtyshHook, when non-nil, replaces the real exec.Cmd runner used by
 	// FRR/vtysh helpers. Tests set this to capture commands without executing them.
 	execVtyshHook ovsExecFunc
@@ -104,6 +109,23 @@ func NewRouteManager(cfg Config) *RouteManager {
 		rm.ovsWrapper = strings.Fields(cfg.OVSWrapper)
 	}
 	return rm
+}
+
+// kernelRouteEntry is one agent-managed /32 kernel route: the destination IP
+// and the kernel interface it is bound to (the bridge device or a per-VLAN
+// segment interface).
+type kernelRouteEntry struct {
+	IP  string
+	Dev string
+}
+
+// listKernelRoutes dispatches to the platform ListKernelRoutes, or to the
+// test hook when one is set.
+func (rm *RouteManager) listKernelRoutes() ([]kernelRouteEntry, error) {
+	if rm.listKernelRoutesHook != nil {
+		return rm.listKernelRoutesHook()
+	}
+	return rm.ListKernelRoutes()
 }
 
 // validateIP checks that the given string is a valid IPv4 address.

--- a/routing.go
+++ b/routing.go
@@ -24,6 +24,7 @@ const (
 // RouteManager handles kernel routes on the provider bridge and FRR static routes.
 type RouteManager struct {
 	bridgeDev    string
+	bridgeIP     string
 	vrfName      string
 	vethNexthop  string
 	routeTableID int
@@ -48,14 +49,21 @@ type RouteManager struct {
 	portForwardCTZone       int
 	portForwards            []PortForwardVIP
 
-	// Cached OVS discovery results (populated on first use).
-	cachedPatchPort string
-	cachedOfport    string
-	cachedBridgeMAC string
+	// segments maps each localnet port name to its resolved OVS/kernel
+	// binding (populated on first use, revalidated every reconcile). The
+	// "" key is the legacy single-patch-port fallback binding used when a
+	// segment cannot be resolved — flat deployments, or an OVN version
+	// that does not set external_ids:ovn-localnet-port on patch ports.
+	segments map[string]*segmentBinding
 
 	// execOVSHook, when non-nil, replaces the real exec.Cmd runner used by
 	// OVS helpers. Tests set this to capture commands without executing them.
 	execOVSHook ovsExecFunc
+
+	// segmentIfaceHook, when non-nil, replaces EnsureSegmentInterface in
+	// refreshSegmentBindings. Tests set this to resolve VLAN segments to
+	// synthetic kernel interfaces without touching netlink.
+	segmentIfaceHook func(tag int) (dev, mac string, err error)
 
 	// execVtyshHook, when non-nil, replaces the real exec.Cmd runner used by
 	// FRR/vtysh helpers. Tests set this to capture commands without executing them.
@@ -74,6 +82,7 @@ func (rm *RouteManager) runVtysh(args ...string) ([]byte, error) {
 func NewRouteManager(cfg Config) *RouteManager {
 	rm := &RouteManager{
 		bridgeDev:               cfg.BridgeDev,
+		bridgeIP:                cfg.BridgeIP,
 		vrfName:                 cfg.VRFName,
 		vethNexthop:             cfg.VethNexthop,
 		routeTableID:            cfg.RouteTableID,

--- a/routing_linux.go
+++ b/routing_linux.go
@@ -320,14 +320,14 @@ func (rm *RouteManager) agentSegmentLinks() ([]*netlink.Vlan, error) {
 // Kernel routes via netlink (Linux only)
 // =============================================================================
 
-func (rm *RouteManager) AddKernelRoute(ip string) error {
+func (rm *RouteManager) AddKernelRoute(ip, dev string) error {
 	if rm.dryRun {
-		slog.Info("[dry-run] would add kernel route", "ip", ip, "dev", rm.bridgeDev, "table", rm.routeTableID)
+		slog.Info("[dry-run] would add kernel route", "ip", ip, "dev", dev, "table", rm.routeTableID)
 		return nil
 	}
-	link, err := netlink.LinkByName(rm.bridgeDev)
+	link, err := netlink.LinkByName(dev)
 	if err != nil {
-		return fmt.Errorf("find bridge %s: %w", rm.bridgeDev, err)
+		return fmt.Errorf("find bridge %s: %w", dev, err)
 	}
 
 	dst := &net.IPNet{
@@ -348,7 +348,7 @@ func (rm *RouteManager) AddKernelRoute(ip string) error {
 	}
 
 	if err := netlink.RouteReplace(route); err != nil {
-		return fmt.Errorf("add kernel route %s/32 dev %s: %w", ip, rm.bridgeDev, err)
+		return fmt.Errorf("add kernel route %s/32 dev %s: %w", ip, dev, err)
 	}
 
 	// Add ip rule when using a dedicated routing table.
@@ -360,18 +360,18 @@ func (rm *RouteManager) AddKernelRoute(ip string) error {
 		}
 	}
 
-	slog.Info("kernel route ensured", "ip", ip, "dev", rm.bridgeDev, "table", rm.routeTableID)
+	slog.Info("kernel route ensured", "ip", ip, "dev", dev, "table", rm.routeTableID)
 	return nil
 }
 
-func (rm *RouteManager) DelKernelRoute(ip string) error {
+func (rm *RouteManager) DelKernelRoute(ip, dev string) error {
 	if rm.dryRun {
-		slog.Info("[dry-run] would remove kernel route", "ip", ip, "dev", rm.bridgeDev)
+		slog.Info("[dry-run] would remove kernel route", "ip", ip, "dev", dev)
 		return nil
 	}
-	link, err := netlink.LinkByName(rm.bridgeDev)
+	link, err := netlink.LinkByName(dev)
 	if err != nil {
-		return fmt.Errorf("find bridge %s: %w", rm.bridgeDev, err)
+		return fmt.Errorf("find bridge %s: %w", dev, err)
 	}
 
 	dst := &net.IPNet{
@@ -398,51 +398,98 @@ func (rm *RouteManager) DelKernelRoute(ip string) error {
 
 	if err := netlink.RouteDel(route); err != nil {
 		if isNoSuchRoute(err) {
-			slog.Debug("kernel route already absent", "ip", ip, "dev", rm.bridgeDev)
+			slog.Debug("kernel route already absent", "ip", ip, "dev", dev)
 			return nil
 		}
-		return fmt.Errorf("del kernel route %s/32 dev %s: %w", ip, rm.bridgeDev, err)
+		return fmt.Errorf("del kernel route %s/32 dev %s: %w", ip, dev, err)
 	}
 
-	slog.Info("kernel route removed", "ip", ip, "dev", rm.bridgeDev)
+	slog.Info("kernel route removed", "ip", ip, "dev", dev)
 	return nil
 }
 
-// ListKernelRoutes returns all /32 routes on the bridge device.
-// When a dedicated routing table is configured, only routes from that table are returned.
-func (rm *RouteManager) ListKernelRoutes() ([]string, error) {
+// ListKernelRoutes returns all agent-relevant /32 routes as (IP, device)
+// pairs. When a dedicated routing table is configured, the whole table is
+// listed — routes on any interface — so per-segment leftovers survive an
+// agent restart; otherwise routes on the bridge device and its VLAN
+// subinterfaces are listed.
+func (rm *RouteManager) ListKernelRoutes() ([]kernelRouteEntry, error) {
 	if rm.dryRun {
 		return nil, nil
 	}
-	link, err := netlink.LinkByName(rm.bridgeDev)
-	if err != nil {
-		return nil, fmt.Errorf("find bridge %s: %w", rm.bridgeDev, err)
-	}
 
-	var routes []netlink.Route
 	if rm.routeTableID > 0 {
-		filter := &netlink.Route{
-			LinkIndex: link.Attrs().Index,
-			Table:     rm.routeTableID,
+		filter := &netlink.Route{Table: rm.routeTableID}
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, filter, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return nil, fmt.Errorf("list routes in table %d: %w", rm.routeTableID, err)
 		}
-		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V4, filter, netlink.RT_FILTER_OIF|netlink.RT_FILTER_TABLE)
-	} else {
-		routes, err = netlink.RouteList(link, netlink.FAMILY_V4)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("list routes on %s: %w", rm.bridgeDev, err)
+		devByIndex := make(map[int]string)
+		var entries []kernelRouteEntry
+		for _, r := range routes {
+			if r.Dst == nil {
+				continue
+			}
+			if ones, _ := r.Dst.Mask.Size(); ones != 32 {
+				continue
+			}
+			dev, ok := devByIndex[r.LinkIndex]
+			if !ok {
+				link, err := netlink.LinkByIndex(r.LinkIndex)
+				if err != nil {
+					slog.Warn("cannot resolve link for kernel route, skipping",
+						"ip", r.Dst.IP, "link_index", r.LinkIndex, "error", err)
+					continue
+				}
+				dev = link.Attrs().Name
+				devByIndex[r.LinkIndex] = dev
+			}
+			entries = append(entries, kernelRouteEntry{IP: r.Dst.IP.String(), Dev: dev})
+		}
+		return entries, nil
 	}
 
-	var ips []string
-	for _, r := range routes {
-		if r.Dst != nil {
-			ones, _ := r.Dst.Mask.Size()
-			if ones == 32 {
-				ips = append(ips, r.Dst.IP.String())
+	links, err := rm.segmentCandidateLinks()
+	if err != nil {
+		return nil, err
+	}
+	var entries []kernelRouteEntry
+	for _, link := range links {
+		routes, err := netlink.RouteList(link, netlink.FAMILY_V4)
+		if err != nil {
+			return nil, fmt.Errorf("list routes on %s: %w", link.Attrs().Name, err)
+		}
+		for _, r := range routes {
+			if r.Dst == nil {
+				continue
+			}
+			if ones, _ := r.Dst.Mask.Size(); ones == 32 {
+				entries = append(entries, kernelRouteEntry{IP: r.Dst.IP.String(), Dev: link.Attrs().Name})
 			}
 		}
 	}
-	return ips, nil
+	return entries, nil
+}
+
+// segmentCandidateLinks returns the bridge device plus every VLAN
+// subinterface parented on it — agent-created or operator-provisioned —
+// i.e. all interfaces that may carry agent-managed /32 routes.
+func (rm *RouteManager) segmentCandidateLinks() ([]netlink.Link, error) {
+	parent, err := netlink.LinkByName(rm.bridgeDev)
+	if err != nil {
+		return nil, fmt.Errorf("find bridge %s: %w", rm.bridgeDev, err)
+	}
+	links, err := netlink.LinkList()
+	if err != nil {
+		return nil, fmt.Errorf("list links: %w", err)
+	}
+	out := []netlink.Link{parent}
+	for _, l := range links {
+		if vlan, ok := l.(*netlink.Vlan); ok && vlan.Attrs().ParentIndex == parent.Attrs().Index {
+			out = append(out, l)
+		}
+	}
+	return out, nil
 }
 
 // =============================================================================

--- a/routing_linux.go
+++ b/routing_linux.go
@@ -49,14 +49,21 @@ func (rm *RouteManager) EnsureBridgeIP(ip string) error {
 		slog.Info("[dry-run] would add bridge IP", "ip", ip, "dev", rm.bridgeDev)
 		return nil
 	}
+	return rm.ensureIPOnDev(ip, rm.bridgeDev)
+}
+
+// ensureIPOnDev adds a /32 IP address to the named device if not already
+// present. Shared by the bridge device (EnsureBridgeIP) and the per-VLAN
+// segment interfaces (EnsureSegmentInterface).
+func (rm *RouteManager) ensureIPOnDev(ip, dev string) error {
 	parsedIP := net.ParseIP(ip)
 	if parsedIP == nil {
 		return fmt.Errorf("invalid IP: %s", ip)
 	}
 
-	link, err := netlink.LinkByName(rm.bridgeDev)
+	link, err := netlink.LinkByName(dev)
 	if err != nil {
-		return fmt.Errorf("find bridge %s: %w", rm.bridgeDev, err)
+		return fmt.Errorf("find bridge %s: %w", dev, err)
 	}
 
 	addr := &netlink.Addr{
@@ -65,19 +72,19 @@ func (rm *RouteManager) EnsureBridgeIP(ip string) error {
 
 	addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
 	if err != nil {
-		return fmt.Errorf("list addrs on %s: %w", rm.bridgeDev, err)
+		return fmt.Errorf("list addrs on %s: %w", dev, err)
 	}
 	for _, a := range addrs {
 		if a.IP.Equal(parsedIP) {
-			slog.Debug("bridge IP already present", "ip", ip, "dev", rm.bridgeDev)
+			slog.Debug("bridge IP already present", "ip", ip, "dev", dev)
 			return nil
 		}
 	}
 
 	if err := netlink.AddrAdd(link, addr); err != nil {
-		return fmt.Errorf("add IP %s/32 to %s: %w", ip, rm.bridgeDev, err)
+		return fmt.Errorf("add IP %s/32 to %s: %w", ip, dev, err)
 	}
-	slog.Info("bridge IP added", "ip", ip, "dev", rm.bridgeDev)
+	slog.Info("bridge IP added", "ip", ip, "dev", dev)
 	return nil
 }
 
@@ -115,11 +122,17 @@ func (rm *RouteManager) EnableProxyARP() error {
 		slog.Info("[dry-run] would enable proxy ARP", "dev", rm.bridgeDev)
 		return nil
 	}
-	path := filepath.Join("/proc/sys/net/ipv4/conf", rm.bridgeDev, "proxy_arp")
+	return rm.enableProxyARPOnDev(rm.bridgeDev)
+}
+
+// enableProxyARPOnDev enables proxy ARP on the named device. Shared by the
+// bridge device and the per-VLAN segment interfaces.
+func (rm *RouteManager) enableProxyARPOnDev(dev string) error {
+	path := filepath.Join("/proc/sys/net/ipv4/conf", dev, "proxy_arp")
 	if err := os.WriteFile(path, []byte("1\n"), 0644); err != nil {
-		return fmt.Errorf("enable proxy ARP on %s: %w", rm.bridgeDev, err)
+		return fmt.Errorf("enable proxy ARP on %s: %w", dev, err)
 	}
-	slog.Info("proxy ARP enabled", "dev", rm.bridgeDev)
+	slog.Info("proxy ARP enabled", "dev", dev)
 	return nil
 }
 
@@ -130,6 +143,177 @@ func (rm *RouteManager) GetBridgeMAC() (net.HardwareAddr, error) {
 		return nil, fmt.Errorf("find bridge %s: %w", rm.bridgeDev, err)
 	}
 	return link.Attrs().HardwareAddr, nil
+}
+
+// =============================================================================
+// Per-VLAN segment interfaces (Linux only)
+// =============================================================================
+
+// segmentLinkAlias marks kernel VLAN links created by the agent, so restart
+// pruning and shutdown teardown can tell them apart from operator-provisioned
+// interfaces (which are adopted for use but never deleted).
+const segmentLinkAlias = "ovn-network-agent"
+
+// ifNameSize is the kernel's usable interface-name length (IFNAMSIZ minus
+// the trailing NUL).
+const ifNameSize = 15
+
+// segmentIfaceName returns the kernel interface name for a VLAN segment on
+// the provider bridge (<bridge>.<tag>), rejecting names that exceed the
+// kernel's IFNAMSIZ limit.
+func segmentIfaceName(bridgeDev string, tag int) (string, error) {
+	name := fmt.Sprintf("%s.%d", bridgeDev, tag)
+	if len(name) > ifNameSize {
+		return "", fmt.Errorf("segment interface name %q exceeds the kernel's %d-character limit", name, ifNameSize)
+	}
+	return name, nil
+}
+
+// EnsureSegmentInterface makes sure a kernel-visible 802.1Q subinterface for
+// the given VLAN tag exists on the provider bridge, is up, carries the bridge
+// IP, and answers proxy ARP — the per-segment equivalent of the flat bridge
+// setup in Agent.Run. An existing interface (agent-created on a previous run,
+// or operator-provisioned) is adopted as-is; freshly created ones are marked
+// with the agent's link alias so pruning and teardown only ever touch links
+// the agent owns. Returns the interface name and its MAC address.
+func (rm *RouteManager) EnsureSegmentInterface(tag int) (string, string, error) {
+	name, err := segmentIfaceName(rm.bridgeDev, tag)
+	if err != nil {
+		return "", "", err
+	}
+
+	parent, err := netlink.LinkByName(rm.bridgeDev)
+	if err != nil {
+		return "", "", fmt.Errorf("find bridge %s: %w", rm.bridgeDev, err)
+	}
+
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		vlan := &netlink.Vlan{
+			LinkAttrs: netlink.LinkAttrs{Name: name, ParentIndex: parent.Attrs().Index},
+			VlanId:    tag,
+		}
+		if err := netlink.LinkAdd(vlan); err != nil {
+			return "", "", fmt.Errorf("create VLAN interface %s: %w", name, err)
+		}
+		link, err = netlink.LinkByName(name)
+		if err != nil {
+			return "", "", fmt.Errorf("find %s after creation: %w", name, err)
+		}
+		if err := netlink.LinkSetAlias(link, segmentLinkAlias); err != nil {
+			slog.Warn("failed to set ownership alias on segment interface", "dev", name, "error", err)
+		}
+		slog.Info("segment VLAN interface created", "dev", name, "tag", tag)
+	} else {
+		// Adopt a pre-existing interface only after confirming it really is
+		// this segment's 802.1Q subinterface. Keying adoption on the name
+		// alone would silently reuse a colliding link — a different VLAN id,
+		// a non-VLAN device, or a subinterface of another bridge — and steer
+		// the segment's routes, bridge IP, and proxy ARP onto the wrong path.
+		if err := verifyAdoptedSegmentLink(link, tag, parent.Attrs().Index); err != nil {
+			return "", "", err
+		}
+		slog.Debug("segment VLAN interface already exists, adopting", "dev", name, "tag", tag)
+	}
+
+	if link.Attrs().Flags&net.FlagUp == 0 {
+		if err := netlink.LinkSetUp(link); err != nil {
+			return "", "", fmt.Errorf("bring up %s: %w", name, err)
+		}
+	}
+	if rm.bridgeIP != "" {
+		if err := rm.ensureIPOnDev(rm.bridgeIP, name); err != nil {
+			return "", "", fmt.Errorf("ensure bridge IP on %s: %w", name, err)
+		}
+	}
+	if err := rm.enableProxyARPOnDev(name); err != nil {
+		return "", "", err
+	}
+	return name, link.Attrs().HardwareAddr.String(), nil
+}
+
+// verifyAdoptedSegmentLink checks that an existing interface
+// EnsureSegmentInterface is about to adopt is genuinely the expected VLAN
+// subinterface: a *netlink.Vlan carrying VLAN id tag on the parent bridge
+// (parentIndex). It returns a descriptive error on any mismatch so the caller
+// refuses the adoption rather than reusing a wrong interface.
+func verifyAdoptedSegmentLink(link netlink.Link, tag, parentIndex int) error {
+	name := link.Attrs().Name
+	vlan, ok := link.(*netlink.Vlan)
+	if !ok {
+		return fmt.Errorf("refusing to adopt %s: existing interface is type %q, not an 802.1Q VLAN subinterface", name, link.Type())
+	}
+	if vlan.VlanId != tag {
+		return fmt.Errorf("refusing to adopt %s: existing interface carries VLAN id %d, want %d", name, vlan.VlanId, tag)
+	}
+	if vlan.Attrs().ParentIndex != parentIndex {
+		return fmt.Errorf("refusing to adopt %s: existing interface has parent index %d, want %d", name, vlan.Attrs().ParentIndex, parentIndex)
+	}
+	return nil
+}
+
+// PruneSegmentInterfaces removes agent-created VLAN interfaces on the
+// provider bridge whose tag is not in keepTags. Links without the agent's
+// ownership alias (operator-provisioned) are never touched.
+func (rm *RouteManager) PruneSegmentInterfaces(keepTags map[int]bool) error {
+	if rm.dryRun {
+		slog.Info("[dry-run] would prune stale segment interfaces", "keep", len(keepTags))
+		return nil
+	}
+	vlans, err := rm.agentSegmentLinks()
+	if err != nil {
+		return err
+	}
+	for _, vlan := range vlans {
+		if keepTags[vlan.VlanId] {
+			continue
+		}
+		if err := netlink.LinkDel(vlan); err != nil {
+			slog.Warn("failed to remove stale segment interface", "dev", vlan.Attrs().Name, "error", err)
+			continue
+		}
+		slog.Info("stale segment VLAN interface removed", "dev", vlan.Attrs().Name, "tag", vlan.VlanId)
+	}
+	return nil
+}
+
+// TeardownSegmentInterfaces removes all agent-created VLAN interfaces on the
+// provider bridge. Called on shutdown cleanup.
+func (rm *RouteManager) TeardownSegmentInterfaces() error {
+	if rm.dryRun {
+		slog.Info("[dry-run] would remove agent-created segment interfaces")
+		return nil
+	}
+	return rm.PruneSegmentInterfaces(nil)
+}
+
+// agentSegmentLinks returns the VLAN links on the provider bridge that carry
+// the agent's ownership alias. Adopted (operator-provisioned) links are
+// deliberately excluded so they are never deleted.
+func (rm *RouteManager) agentSegmentLinks() ([]*netlink.Vlan, error) {
+	parent, err := netlink.LinkByName(rm.bridgeDev)
+	if err != nil {
+		return nil, fmt.Errorf("find bridge %s: %w", rm.bridgeDev, err)
+	}
+	links, err := netlink.LinkList()
+	if err != nil {
+		return nil, fmt.Errorf("list links: %w", err)
+	}
+	var vlans []*netlink.Vlan
+	for _, l := range links {
+		vlan, ok := l.(*netlink.Vlan)
+		if !ok {
+			continue
+		}
+		if vlan.Attrs().ParentIndex != parent.Attrs().Index {
+			continue
+		}
+		if vlan.Attrs().Alias != segmentLinkAlias {
+			continue
+		}
+		vlans = append(vlans, vlan)
+	}
+	return vlans, nil
 }
 
 // =============================================================================

--- a/routing_linux_test.go
+++ b/routing_linux_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+
+	"github.com/vishvananda/netlink"
 )
 
 // nonexistentBridge is a synthetic interface name that is guaranteed not to
@@ -106,6 +108,129 @@ func TestCheckBridgeDeviceDryRunSkips(t *testing.T) {
 	rm := &RouteManager{bridgeDev: nonexistentBridge, dryRun: true}
 	if err := rm.CheckBridgeDevice(); err != nil {
 		t.Errorf("CheckBridgeDevice in dry-run should not error, got: %v", err)
+	}
+}
+
+func TestSegmentIfaceNameLength(t *testing.T) {
+	tests := []struct {
+		name      string
+		bridgeDev string
+		tag       int
+		want      string
+		wantErr   bool
+	}{
+		{"default bridge fits with max tag", "br-ex", 4094, "br-ex.4094", false},
+		{"short bridge and tag", "br-ex", 101, "br-ex.101", false},
+		{"long bridge with 4-digit tag exceeds IFNAMSIZ", "br-provider", 4094, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := segmentIfaceName(tt.bridgeDev, tt.tag)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("segmentIfaceName(%q, %d) should error", tt.bridgeDev, tt.tag)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("segmentIfaceName(%q, %d) error: %v", tt.bridgeDev, tt.tag, err)
+			}
+			if got != tt.want {
+				t.Errorf("segmentIfaceName(%q, %d) = %q, want %q", tt.bridgeDev, tt.tag, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnsureSegmentInterfaceWrapsLinkLookupError(t *testing.T) {
+	rm := &RouteManager{bridgeDev: nonexistentBridge}
+	_, _, err := rm.EnsureSegmentInterface(101)
+	if err == nil {
+		t.Fatal("EnsureSegmentInterface should error when the bridge device is missing")
+	}
+	if !strings.Contains(err.Error(), nonexistentBridge) {
+		t.Errorf("error should mention the bridge name, got: %v", err)
+	}
+}
+
+func TestEnsureSegmentInterfaceRejectsOverlongName(t *testing.T) {
+	rm := &RouteManager{bridgeDev: "br-provider-x"}
+	_, _, err := rm.EnsureSegmentInterface(4094)
+	if err == nil {
+		t.Fatal("EnsureSegmentInterface should reject a name over the kernel limit")
+	}
+	if !strings.Contains(err.Error(), "limit") {
+		t.Errorf("error should mention the length limit, got: %v", err)
+	}
+}
+
+// TestVerifyAdoptedSegmentLink guards the adoption check: an interface named
+// <bridge>.<tag> that already exists is only reused when it is really a VLAN
+// subinterface with the matching tag and parent. A name collision (wrong tag,
+// non-VLAN device, or a subinterface of a different bridge) must be refused so
+// the segment's traffic is not steered onto the wrong interface.
+func TestVerifyAdoptedSegmentLink(t *testing.T) {
+	const parentIndex = 7
+	tests := []struct {
+		name    string
+		link    netlink.Link
+		tag     int
+		wantErr string
+	}{
+		{
+			name: "matching vlan is adopted",
+			link: &netlink.Vlan{LinkAttrs: netlink.LinkAttrs{Name: "br-ex.101", ParentIndex: parentIndex}, VlanId: 101},
+			tag:  101,
+		},
+		{
+			name:    "wrong vlan id refused",
+			link:    &netlink.Vlan{LinkAttrs: netlink.LinkAttrs{Name: "br-ex.101", ParentIndex: parentIndex}, VlanId: 999},
+			tag:     101,
+			wantErr: "VLAN id",
+		},
+		{
+			name:    "wrong parent refused",
+			link:    &netlink.Vlan{LinkAttrs: netlink.LinkAttrs{Name: "br-ex.101", ParentIndex: parentIndex + 1}, VlanId: 101},
+			tag:     101,
+			wantErr: "parent index",
+		},
+		{
+			name:    "non-vlan device refused",
+			link:    &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "br-ex.101", ParentIndex: parentIndex}},
+			tag:     101,
+			wantErr: "not an 802.1Q",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := verifyAdoptedSegmentLink(tt.link, tt.tag, parentIndex)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("verifyAdoptedSegmentLink() unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("verifyAdoptedSegmentLink() = nil, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("verifyAdoptedSegmentLink() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPruneSegmentInterfacesWrapsLinkLookupError(t *testing.T) {
+	rm := &RouteManager{bridgeDev: nonexistentBridge}
+	if err := rm.PruneSegmentInterfaces(nil); err == nil {
+		t.Fatal("PruneSegmentInterfaces should error when the bridge device is missing")
+	}
+}
+
+func TestTeardownSegmentInterfacesDryRun(t *testing.T) {
+	rm := &RouteManager{bridgeDev: nonexistentBridge, dryRun: true}
+	if err := rm.TeardownSegmentInterfaces(); err != nil {
+		t.Errorf("TeardownSegmentInterfaces in dry-run should not error, got: %v", err)
 	}
 }
 

--- a/routing_linux_test.go
+++ b/routing_linux_test.go
@@ -50,7 +50,7 @@ func TestRemoveBridgeIPWrapsLinkLookupError(t *testing.T) {
 
 func TestAddKernelRouteWrapsLinkLookupError(t *testing.T) {
 	rm := &RouteManager{bridgeDev: nonexistentBridge}
-	err := rm.AddKernelRoute("10.0.0.1")
+	err := rm.AddKernelRoute("10.0.0.1", nonexistentBridge)
 	if err == nil {
 		t.Fatal("AddKernelRoute should error when the bridge device is missing")
 	}
@@ -66,7 +66,7 @@ func TestAddKernelRouteRejectsInvalidIP(t *testing.T) {
 
 func TestDelKernelRouteWrapsLinkLookupError(t *testing.T) {
 	rm := &RouteManager{bridgeDev: nonexistentBridge}
-	err := rm.DelKernelRoute("10.0.0.1")
+	err := rm.DelKernelRoute("10.0.0.1", nonexistentBridge)
 	if err == nil {
 		t.Fatal("DelKernelRoute should error when the bridge device is missing")
 	}

--- a/routing_notlinux.go
+++ b/routing_notlinux.go
@@ -64,23 +64,23 @@ func (rm *RouteManager) TeardownSegmentInterfaces() error {
 	return fmt.Errorf("segment interface management is only supported on Linux")
 }
 
-func (rm *RouteManager) AddKernelRoute(ip string) error {
+func (rm *RouteManager) AddKernelRoute(ip, dev string) error {
 	if rm.dryRun {
-		slog.Info("[dry-run] would add kernel route", "ip", ip, "dev", rm.bridgeDev)
+		slog.Info("[dry-run] would add kernel route", "ip", ip, "dev", dev)
 		return nil
 	}
 	return fmt.Errorf("kernel route management is only supported on Linux")
 }
 
-func (rm *RouteManager) DelKernelRoute(ip string) error {
+func (rm *RouteManager) DelKernelRoute(ip, dev string) error {
 	if rm.dryRun {
-		slog.Info("[dry-run] would remove kernel route", "ip", ip, "dev", rm.bridgeDev)
+		slog.Info("[dry-run] would remove kernel route", "ip", ip, "dev", dev)
 		return nil
 	}
 	return fmt.Errorf("kernel route management is only supported on Linux")
 }
 
-func (rm *RouteManager) ListKernelRoutes() ([]string, error) {
+func (rm *RouteManager) ListKernelRoutes() ([]kernelRouteEntry, error) {
 	if rm.dryRun {
 		return nil, nil
 	}

--- a/routing_notlinux.go
+++ b/routing_notlinux.go
@@ -44,6 +44,26 @@ func (rm *RouteManager) GetBridgeMAC() (net.HardwareAddr, error) {
 	return nil, fmt.Errorf("bridge MAC lookup is only supported on Linux")
 }
 
+func (rm *RouteManager) EnsureSegmentInterface(tag int) (string, string, error) {
+	return "", "", fmt.Errorf("segment interface management is only supported on Linux")
+}
+
+func (rm *RouteManager) PruneSegmentInterfaces(keepTags map[int]bool) error {
+	if rm.dryRun {
+		slog.Info("[dry-run] would prune stale segment interfaces", "keep", len(keepTags))
+		return nil
+	}
+	return fmt.Errorf("segment interface management is only supported on Linux")
+}
+
+func (rm *RouteManager) TeardownSegmentInterfaces() error {
+	if rm.dryRun {
+		slog.Info("[dry-run] would remove agent-created segment interfaces")
+		return nil
+	}
+	return fmt.Errorf("segment interface management is only supported on Linux")
+}
+
 func (rm *RouteManager) AddKernelRoute(ip string) error {
 	if rm.dryRun {
 		slog.Info("[dry-run] would add kernel route", "ip", ip, "dev", rm.bridgeDev)

--- a/routing_test.go
+++ b/routing_test.go
@@ -118,8 +118,8 @@ func TestDryRunOVSFlows(t *testing.T) {
 		dryRun:    true,
 	}
 
-	if err := rm.EnsureOVSFlows(); err != nil {
-		t.Errorf("EnsureOVSFlows() in dry-run should not error, got: %v", err)
+	if err := rm.EnsureSegments([]DesiredSegment{{LocalnetPort: ""}}); err != nil {
+		t.Errorf("EnsureSegments() in dry-run should not error, got: %v", err)
 	}
 	if err := rm.RemoveOVSFlows(); err != nil {
 		t.Errorf("RemoveOVSFlows() in dry-run should not error, got: %v", err)

--- a/test/e2e/scenarios/multi-vlan.sh
+++ b/test/e2e/scenarios/multi-vlan.sh
@@ -1,0 +1,412 @@
+#!/usr/bin/env bash
+# Multi-VLAN provider-network scenario for the containerlab E2E harness.
+#
+# Goal (issue #147): a single gateway node announces FIPs from TWO
+# VLAN-tagged provider networks on the same physnet. Two routers — each
+# with its own VLAN localnet network (tags 101/102 on physnet1) and a
+# gatewayless public subnet — are pinned to gateway-1. The agent must:
+#
+#   * create one kernel 802.1Q subinterface per segment (br-ex.101,
+#     br-ex.102) carrying the bridge IP and the per-FIP /32 routes,
+#   * install MAC-tweak flows (cookie 0x999) per localnet patch port —
+#     two distinct in_ports, which the old single-patch-port data path
+#     could not do,
+#   * announce both FIPs as /32 via BGP from the same node,
+#
+# and both FIPs must be reachable end-to-end from client-1 while the
+# flat baseline FIP (192.0.2.10) keeps working (issue #147 AC 1 + 2).
+#
+# Why no underlay change is needed: the fabric routes each FIP /32 via
+# BGP into gateway-1's vrf-provider, and the agent hands the packet to
+# OVN through the node-local kernel path (br-ex.<tag> → tagged patch
+# port). The VLAN frames never leave the node, so the /30 underlay
+# links stay untouched.
+#
+# Pre-condition: the lab is up. When SANITY_GATE=1 (default) this
+# scenario runs `baseline.sh` first so a broken green path is reported
+# as a baseline regression instead of being attributed to multi-VLAN.
+#
+# Teardown: the routers, switches, netns workloads and MAC bindings
+# added here are removed on EXIT (via trap), returning the lab to
+# baseline state. The agent itself prunes the br-ex.<tag> subinterfaces
+# and per-segment flows on its next reconcile once the routers are
+# gone. The CI workflow additionally invokes the teardown step with
+# `if: always()`.
+#
+# Environment overrides (used by the CI workflow):
+#   LAB                 container-name prefix (defaults to the topology name "ovn-e2e")
+#   MASTER              chassis both routers are pinned to (defaults to gateway-1)
+#   MASTER_UNDERLAY_IP  MASTER's vrf-provider /30 address as seen by upstream (default 100.64.1.2)
+#   WORKLOAD_HOST       chassis hosting the two workloads (defaults to gateway-3)
+#   CENTRAL             OVN central container (defaults to clab-${LAB}-central)
+#   UPSTREAM            upstream router container (defaults to clab-${LAB}-upstream)
+#   CLIENT              probe source container (defaults to clab-${LAB}-client-1)
+#   BASELINE_FIP        flat-network FIP that must stay green (default 192.0.2.10)
+#   RECONCILE_TIMEOUT   seconds to wait for agent/OVN convergence per check (default 60)
+#   PING_COUNT          packets for the final reachability checks (default 5)
+#   PING_TIMEOUT        per-packet wait, passed to ping -W (default 2)
+#   ARTIFACTS_DIR       directory for flow/route snapshots (default empty = skip)
+#   SANITY_GATE         run baseline.sh first when 1 (default 1)
+
+set -euo pipefail
+
+LAB="${LAB:-ovn-e2e}"
+MASTER="${MASTER:-gateway-1}"
+MASTER_NODE="clab-${LAB}-${MASTER}"
+MASTER_UNDERLAY_IP="${MASTER_UNDERLAY_IP:-100.64.1.2}"
+WORKLOAD_HOST="${WORKLOAD_HOST:-gateway-3}"
+WORKLOAD_NODE="clab-${LAB}-${WORKLOAD_HOST}"
+CENTRAL="${CENTRAL:-clab-${LAB}-central}"
+UPSTREAM="${UPSTREAM:-clab-${LAB}-upstream}"
+CLIENT="${CLIENT:-clab-${LAB}-client-1}"
+BASELINE_FIP="${BASELINE_FIP:-192.0.2.10}"
+RECONCILE_TIMEOUT="${RECONCILE_TIMEOUT:-60}"
+PING_COUNT="${PING_COUNT:-5}"
+PING_TIMEOUT="${PING_TIMEOUT:-2}"
+ARTIFACTS_DIR="${ARTIFACTS_DIR:-}"
+SANITY_GATE="${SANITY_GATE:-1}"
+
+PHYSNET="${PHYSNET:-physnet1}"
+BRIDGE_DEV="${BRIDGE_DEV:-br-ex}"
+
+# Per-network table: "<vlan-tag> <public-prefix> <tenant-prefix> <mac-octet>"
+# Everything else (switch/router/port/netns names, FIPs, MACs) is derived
+# from these four fields — see net_vars().
+NETWORKS=(
+    "101 198.51.100 192.168.101 65"
+    "102 203.0.113 192.168.102 66"
+)
+
+SCENARIOS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASELINE="${BASELINE:-${SCENARIOS_DIR}/baseline.sh}"
+
+log() { printf '[multi-vlan] %s\n' "$*" >&2; }
+
+nbctl() { docker exec "${CENTRAL}" ovn-nbctl "$@"; }
+
+# Derive all per-network names from a NETWORKS entry into globals. Called
+# at the top of every per-network function so the naming lives in exactly
+# one place.
+#
+#   tag=101 pub=198.51.100 tenant=192.168.101 hex=65 →
+#     LS_PUB=ls-vlan101       LN_LSP=ln-vlan101
+#     LS_TENANT=ls-vlan101-t  LR=lr-vlan101
+#     LRP_PUB=lr-vlan101-public (198.51.100.1/24, 02:00:00:65:02:01)
+#     LRP_TEN=lr-vlan101-tenant (192.168.101.1/24, 02:00:00:65:01:01)
+#     FIP=198.51.100.10 → FIP_INTERNAL=192.168.101.10
+#     VM_LSP/VM_NETNS=vm101, VM_MAC=02:00:00:65:0a:0a
+#     SEG_DEV=br-ex.101
+net_vars() {
+    local tag="$1" pub="$2" tenant="$3" hex="$4"
+    TAG="${tag}"
+    LS_PUB="ls-vlan${tag}"
+    LN_LSP="ln-vlan${tag}"
+    LS_TENANT="ls-vlan${tag}-t"
+    LR="lr-vlan${tag}"
+    LRP_PUB="lr-vlan${tag}-public"
+    LRP_PUB_MAC="02:00:00:${hex}:02:01"
+    LRP_PUB_CIDR="${pub}.1/24"
+    LRP_TEN="lr-vlan${tag}-tenant"
+    LRP_TEN_MAC="02:00:00:${hex}:01:01"
+    LRP_TEN_CIDR="${tenant}.1/24"
+    VGW_IP="${pub}.254"
+    FIP="${pub}.10"
+    FIP_INTERNAL="${tenant}.10"
+    VM_LSP="vm${tag}"
+    VM_NETNS="vm${tag}"
+    VM_MAC="02:00:00:${hex}:0a:0a"
+    VM_HOST_VETH="vm${tag}-host"
+    VM_NS_VETH="vm${tag}-eth0"
+    WORKLOAD_GW="${tenant}.1"
+    SEG_DEV="${BRIDGE_DEV}.${tag}"
+}
+
+# Write `content` (read from stdin) to `path` under ARTIFACTS_DIR when
+# it is set; quietly no-op otherwise. Mirrors hairpin.sh.
+write_artifact() {
+    local path="$1"
+    if [ -z "${ARTIFACTS_DIR}" ]; then
+        cat >/dev/null
+        return 0
+    fi
+    mkdir -p "${ARTIFACTS_DIR}"
+    cat >"${ARTIFACTS_DIR}/${path}"
+}
+
+sanity_gate() {
+    if [ "${SANITY_GATE}" != "1" ]; then
+        log "SANITY_GATE=${SANITY_GATE}: skipping baseline pre-check"
+        return 0
+    fi
+    if [ ! -x "${BASELINE}" ]; then
+        log "baseline script not executable at ${BASELINE} — skipping pre-check"
+        return 0
+    fi
+    log "running baseline.sh as a sanity gate (set SANITY_GATE=0 to skip)"
+    "${BASELINE}"
+}
+
+# Dump the agent's MAC-tweak flows on MASTER's br-ex.
+dump_mactweak_flows() {
+    docker exec "${MASTER_NODE}" \
+        ovs-ofctl --no-stats dump-flows "${BRIDGE_DEV}" 2>/dev/null \
+        | grep 'cookie=0x999' || true
+}
+
+# Provision one VLAN provider network + router + tenant network +
+# workload. All NB calls are idempotent (--may-exist / value-replacing).
+#
+# Deliberately NO default route and NO nexthop MAC binding are seeded
+# here (unlike bootstrap.sh's flat network): the networks are
+# gatewayless, and providing 0.0.0.0/0 via <pub>.254 plus the matching
+# Static_MAC_Binding with the segment interface's MAC is exactly the
+# agent behaviour this scenario exercises.
+ensure_network() {
+    net_vars "$@"
+
+    log "ensuring VLAN network ${LS_PUB} (tag ${TAG} on ${PHYSNET}) + router ${LR}"
+    nbctl --may-exist ls-add "${LS_PUB}"
+    nbctl --may-exist lsp-add "${LS_PUB}" "${LN_LSP}"
+    nbctl lsp-set-type      "${LN_LSP}" localnet
+    nbctl lsp-set-addresses "${LN_LSP}" unknown
+    nbctl lsp-set-options   "${LN_LSP}" network_name="${PHYSNET}"
+    # Neutron's OVN driver sets the segmentation ID on the localnet
+    # port's `tag` column; ovn-northd propagates it to the SB
+    # Port_Binding, where the agent reads it.
+    nbctl set Logical_Switch_Port "${LN_LSP}" tag="${TAG}"
+
+    nbctl --may-exist ls-add "${LS_TENANT}"
+    nbctl --may-exist lr-add "${LR}"
+
+    nbctl --may-exist lrp-add "${LR}" "${LRP_TEN}" "${LRP_TEN_MAC}" "${LRP_TEN_CIDR}"
+    nbctl --may-exist lsp-add "${LS_TENANT}" "${LS_TENANT}-${LR}"
+    nbctl lsp-set-type      "${LS_TENANT}-${LR}" router
+    nbctl lsp-set-addresses "${LS_TENANT}-${LR}" router
+    nbctl lsp-set-options   "${LS_TENANT}-${LR}" router-port="${LRP_TEN}"
+
+    nbctl --may-exist lrp-add "${LR}" "${LRP_PUB}" "${LRP_PUB_MAC}" "${LRP_PUB_CIDR}"
+    nbctl --may-exist lsp-add "${LS_PUB}" "${LS_PUB}-${LR}"
+    nbctl lsp-set-type      "${LS_PUB}-${LR}" router
+    nbctl lsp-set-addresses "${LS_PUB}-${LR}" router
+    nbctl lsp-set-options   "${LS_PUB}-${LR}" router-port="${LRP_PUB}"
+
+    log "pinning ${LRP_PUB} to ${MASTER}"
+    nbctl lrp-set-gateway-chassis "${LRP_PUB}" "${MASTER}" 30
+
+    log "ensuring FIP ${FIP} → ${FIP_INTERNAL} on ${LR}"
+    nbctl --may-exist lr-nat-add "${LR}" dnat_and_snat "${FIP}" "${FIP_INTERNAL}"
+
+    log "ensuring workload LSP ${VM_LSP} on ${LS_TENANT}"
+    nbctl --may-exist lsp-add "${LS_TENANT}" "${VM_LSP}"
+    nbctl lsp-set-addresses "${VM_LSP}" "${VM_MAC} ${FIP_INTERNAL}"
+}
+
+# Provision the netns responder for one network on WORKLOAD_HOST —
+# the ensure_workload_netns pattern from bootstrap.sh.
+ensure_responder() {
+    net_vars "$@"
+    log "provisioning ${VM_NETNS} responder on ${WORKLOAD_HOST} (${FIP_INTERNAL}/24)"
+    docker exec -i \
+        --env "VM_NETNS=${VM_NETNS}" \
+        --env "VM_LSP=${VM_LSP}" \
+        --env "VM_MAC=${VM_MAC}" \
+        --env "VM_IP_CIDR=${FIP_INTERNAL}/24" \
+        --env "VM_GW=${WORKLOAD_GW}" \
+        --env "VM_HOST_VETH=${VM_HOST_VETH}" \
+        --env "VM_NS_VETH=${VM_NS_VETH}" \
+        "${WORKLOAD_NODE}" sh -eu <<'EOSH'
+if ! ip link show "${VM_HOST_VETH}" >/dev/null 2>&1; then
+    ip link add "${VM_HOST_VETH}" type veth peer name "${VM_NS_VETH}"
+fi
+ovs-vsctl --may-exist add-port br-int "${VM_HOST_VETH}" \
+    -- set Interface "${VM_HOST_VETH}" external_ids:iface-id="${VM_LSP}"
+ip link set "${VM_HOST_VETH}" up
+
+if ! ip netns list | awk '{print $1}' | grep -qx "${VM_NETNS}"; then
+    ip netns add "${VM_NETNS}"
+fi
+if ! ip -n "${VM_NETNS}" link show "${VM_NS_VETH}" >/dev/null 2>&1; then
+    ip link set "${VM_NS_VETH}" netns "${VM_NETNS}"
+fi
+ip -n "${VM_NETNS}" link set lo up
+ip -n "${VM_NETNS}" link set "${VM_NS_VETH}" address "${VM_MAC}"
+ip -n "${VM_NETNS}" link set "${VM_NS_VETH}" up
+ip -n "${VM_NETNS}" addr replace "${VM_IP_CIDR}" dev "${VM_NS_VETH}"
+ip -n "${VM_NETNS}" route replace default via "${VM_GW}"
+EOSH
+}
+
+# Remove everything ensure_network/ensure_responder added for one
+# network. Best-effort and idempotent.
+teardown_network() {
+    net_vars "$@"
+    log "teardown: removing ${LR}, ${LS_PUB}, ${LS_TENANT}, ${VM_NETNS}"
+    docker exec -i \
+        --env "VM_NETNS=${VM_NETNS}" \
+        --env "VM_HOST_VETH=${VM_HOST_VETH}" \
+        "${WORKLOAD_NODE}" sh -u <<'EOSH' || true
+ovs-vsctl --if-exists del-port br-int "${VM_HOST_VETH}" || true
+if ip link show "${VM_HOST_VETH}" >/dev/null 2>&1; then
+    ip link delete "${VM_HOST_VETH}" || true
+fi
+if ip netns list | awk '{print $1}' | grep -qx "${VM_NETNS}"; then
+    ip netns delete "${VM_NETNS}" || true
+fi
+EOSH
+    # lr-del cascades the NAT rows and the agent's managed default route;
+    # ls-del cascades the LSPs (incl. the localnet port). The agent's MAC
+    # binding for the virtual gateway is a root-table row and must go
+    # explicitly. The agent prunes br-ex.<tag>, its routes and flows on
+    # MASTER on the next reconcile once the router is gone.
+    nbctl --if-exists lr-del "${LR}" || true
+    nbctl --if-exists ls-del "${LS_PUB}" || true
+    nbctl --if-exists ls-del "${LS_TENANT}" || true
+    nbctl static-mac-binding-del "${LRP_PUB}" "${VGW_IP}" >/dev/null 2>&1 || true
+}
+
+teardown_all() {
+    local entry
+    for entry in "${NETWORKS[@]}"; do
+        # shellcheck disable=SC2086  # word-splitting the table row is intended
+        teardown_network ${entry}
+    done
+}
+
+# Poll until `docker exec MASTER_NODE <cmd...>` succeeds or the
+# reconcile window expires.
+wait_on_master() {
+    local desc="$1"; shift
+    local deadline
+    deadline=$(( $(date +%s) + RECONCILE_TIMEOUT ))
+    log "waiting up to ${RECONCILE_TIMEOUT}s for ${desc}"
+    while (( $(date +%s) < deadline )); do
+        if "$@" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 2
+    done
+    log "ERROR: ${desc} did not materialise within ${RECONCILE_TIMEOUT}s"
+    return 1
+}
+
+check_segment_link() {
+    docker exec "${MASTER_NODE}" ip link show dev "$1"
+}
+
+check_kernel_route() {
+    docker exec "${MASTER_NODE}" ip -4 route show "$1/32" dev "$2" \
+        | grep -q "$1"
+}
+
+# ovn-controller stamps external_ids:ovn-localnet-port=<lsp> on BOTH
+# Port rows of the patch pair it creates for a localnet port — the
+# br-int side as well as the provider-bridge side — so an unscoped
+# `find Port` returns two rows. Scope the lookup to the provider
+# bridge's ports, exactly like the agent's segment discovery does.
+segment_patch_port() {
+    docker exec --env LSP="$1" --env BRIDGE="${BRIDGE_DEV}" "${MASTER_NODE}" sh -eu -c '
+        for port in $(ovs-vsctl list-ports "${BRIDGE}"); do
+            val="$(ovs-vsctl --if-exists get Port "${port}" \
+                external_ids:ovn-localnet-port 2>/dev/null | tr -d "[:space:]\"")" || val=""
+            if [ "${val}" = "${LSP}" ]; then
+                printf "%s" "${port}"
+                exit 0
+            fi
+        done
+        exit 1
+    '
+}
+
+check_mactweak_flow_for_segment() {
+    local lsp="$1"
+    local port ofport
+    port="$(segment_patch_port "${lsp}")"
+    [ -n "${port}" ] || return 1
+    ofport="$(docker exec "${MASTER_NODE}" ovs-vsctl get Interface "${port}" ofport | tr -d '[:space:]')"
+    [ -n "${ofport}" ] && [ "${ofport}" != "-1" ] || return 1
+    dump_mactweak_flows | grep -Eq "in_port=(${ofport}|\"?${port}\"?)([, ]|$)"
+}
+
+check_bgp_announcement() {
+    docker exec "${UPSTREAM}" vtysh -c "show bgp ipv4 unicast $1/32" 2>/dev/null \
+        | grep -q "${MASTER_UNDERLAY_IP}"
+}
+
+# Final reachability probe per FIP — non-zero on any packet loss.
+probe() {
+    local fip="$1"
+    log "ping -c ${PING_COUNT} -W ${PING_TIMEOUT} ${fip} from ${CLIENT}"
+    docker exec "${CLIENT}" ping -c "${PING_COUNT}" -W "${PING_TIMEOUT}" "${fip}"
+}
+
+wait_for_reachability() {
+    local fip="$1"
+    local deadline
+    deadline=$(( $(date +%s) + RECONCILE_TIMEOUT ))
+    log "waiting up to ${RECONCILE_TIMEOUT}s for ${CLIENT} → ${fip} to come up"
+    while (( $(date +%s) < deadline )); do
+        if docker exec "${CLIENT}" ping -c 1 -W 1 "${fip}" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 2
+    done
+    log "no reply from ${fip} within ${RECONCILE_TIMEOUT}s — falling through to the final probe so its output appears in the log"
+    return 0
+}
+
+snapshot_artifacts() {
+    local phase="$1"
+    {
+        printf '# cookie=0x999 flows on %s:%s (%s)\n\n' "${MASTER}" "${BRIDGE_DEV}" "${phase}"
+        dump_mactweak_flows
+        printf '\n# links on %s (%s)\n\n' "${MASTER}" "${phase}"
+        docker exec "${MASTER_NODE}" ip -d link show type vlan 2>/dev/null || true
+        printf '\n# ipv4 routes on %s (%s)\n\n' "${MASTER}" "${phase}"
+        docker exec "${MASTER_NODE}" ip -4 route show 2>/dev/null || true
+    } | write_artifact "multi-vlan-${phase}.txt"
+}
+
+main() {
+    sanity_gate
+    snapshot_artifacts "before"
+
+    trap teardown_all EXIT
+    local entry
+    for entry in "${NETWORKS[@]}"; do
+        # shellcheck disable=SC2086
+        ensure_network ${entry}
+        # shellcheck disable=SC2086
+        ensure_responder ${entry}
+    done
+
+    # Per-segment kernel + OVS state on the master chassis.
+    for entry in "${NETWORKS[@]}"; do
+        # shellcheck disable=SC2086
+        net_vars ${entry}
+        wait_on_master "segment interface ${SEG_DEV} on ${MASTER}" \
+            check_segment_link "${SEG_DEV}"
+        wait_on_master "kernel route ${FIP}/32 on ${SEG_DEV}" \
+            check_kernel_route "${FIP}" "${SEG_DEV}"
+        wait_on_master "MAC-tweak flow on ${LN_LSP}'s patch port" \
+            check_mactweak_flow_for_segment "${LN_LSP}"
+        wait_on_master "BGP announcement of ${FIP}/32 via ${MASTER_UNDERLAY_IP}" \
+            check_bgp_announcement "${FIP}"
+    done
+
+    snapshot_artifacts "after"
+
+    # End-to-end reachability for both VLAN FIPs.
+    for entry in "${NETWORKS[@]}"; do
+        # shellcheck disable=SC2086
+        net_vars ${entry}
+        wait_for_reachability "${FIP}"
+        probe "${FIP}"
+    done
+
+    # AC 2 coexistence: the flat baseline FIP must still be green while
+    # both VLAN networks are active on the same node.
+    log "verifying flat baseline FIP ${BASELINE_FIP} still works alongside the VLAN segments"
+    probe "${BASELINE_FIP}"
+}
+
+main "$@"

--- a/test/integration/scenario_multi_segment_test.go
+++ b/test/integration/scenario_multi_segment_test.go
@@ -1,0 +1,354 @@
+//go:build integration
+
+package integration
+
+import (
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/osism/ovn-network-agent/test/integration/testenv"
+)
+
+// multiSegmentCIDRs covers both provider networks used by the multi-segment
+// scenarios. The failover and restart cases pass it as manual network_cidr:
+// after one router leaves, auto-discovery no longer covers the departed
+// network, and the agent's isManaged guard would then (deliberately) refuse
+// to withdraw the departed FIP's FRR route. Operators running multiple
+// provider networks are expected to list them, and so do these tests.
+var multiSegmentCIDRs = []string{"198.51.100.0/24", "203.0.113.0/24"}
+
+// readLinkMAC returns the MAC of the named interface. VLAN subinterfaces
+// inherit the bridge MAC, so per-segment values are identical across
+// segments — the assertions still resolve them per interface, mirroring
+// what the agent does.
+func readLinkMAC(t *testing.T, dev string) string {
+	t.Helper()
+	link, err := net.InterfaceByName(dev)
+	if err != nil {
+		t.Fatalf("lookup %s: %v", dev, err)
+	}
+	mac := link.HardwareAddr.String()
+	if mac == "" {
+		t.Fatalf("link %s has no MAC", dev)
+	}
+	return mac
+}
+
+// hasInPort reports whether a dump-flows line matches the given OpenFlow
+// port. ovs-ofctl renders in_port as a number when its output is piped (as
+// here) but as the port name on a terminal — tolerate both.
+func hasInPort(line, ofport, patchPort string) bool {
+	for _, tok := range []string{
+		"in_port=" + ofport + ",",
+		"in_port=" + ofport + " ",
+		"in_port=" + patchPort + ",",
+		"in_port=" + patchPort + " ",
+		`in_port="` + patchPort + `"`,
+	} {
+		if strings.Contains(line, tok) {
+			return true
+		}
+	}
+	return false
+}
+
+// segmentPatchName is the br-ex side of the pair EnsureSegmentPatchPort creates.
+func segmentPatchName(localnetPort string) string {
+	return "patch-" + localnetPort + "-to-br-int"
+}
+
+// TestScenario_MultiSegmentTwoVLANNetworks (#147 AC 1, control/data plane):
+//
+// Two routers, each on its own VLAN provider network (tags 101/102 on the
+// same physnet), both active on this chassis. The agent must create one
+// kernel VLAN subinterface per segment, land each FIP's /32 on its own
+// segment interface, install MAC-tweak and hairpin flows per patch port, and
+// write each router's MAC binding at its own network's virtual gateway IP.
+func TestScenario_MultiSegmentTwoVLANNetworks(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	tag101, tag102 := 101, 102
+	testenv.EnsureSegmentPatchPort(t, "ln-v101")
+	testenv.EnsureSegmentPatchPort(t, "ln-v102")
+
+	r101 := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "seg101",
+		LRPMAC:      "fa:16:3e:01:01:01",
+		LRPNetworks: []string{"198.51.100.11/24"},
+		SegmentOpts: &testenv.SegmentOpts{LocalnetPort: "ln-v101", Tag: &tag101},
+	})
+	r102 := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "seg102",
+		LRPMAC:      "fa:16:3e:02:02:02",
+		LRPNetworks: []string{"203.0.113.11/24"},
+		SegmentOpts: &testenv.SegmentOpts{LocalnetPort: "ln-v102", Tag: &tag102},
+	})
+
+	const fip101 = "198.51.100.77"
+	const fip102 = "203.0.113.77"
+	testenv.AddFIP(t, ctx, nb, r101, fip101, "10.0.1.7")
+	testenv.AddFIP(t, ctx, nb, r102, fip102, "10.0.2.7")
+
+	a := readyAgent(t, testenv.Defaults())
+	defer a.Stop(15 * time.Second)
+
+	// One kernel VLAN subinterface per segment.
+	testenv.AssertLinkExists(t, "br-ex.101", 20*time.Second)
+	testenv.AssertLinkExists(t, "br-ex.102", 20*time.Second)
+
+	// Each FIP's /32 lands on its own segment interface, and both are
+	// announced via FRR.
+	testenv.AssertKernelRouteOnDev(t, fip101, "br-ex.101", 20*time.Second)
+	testenv.AssertKernelRouteOnDev(t, fip102, "br-ex.102", 20*time.Second)
+	testenv.AssertFRRRoute(t, fip101, 20*time.Second)
+	testenv.AssertFRRRoute(t, fip102, 20*time.Second)
+
+	// MAC-tweak flows exist for both patch ports — two distinct in_ports,
+	// which is exactly what the single-patch-port data path could not do.
+	of101 := testenv.SegmentPatchOfport(t, "ln-v101")
+	of102 := testenv.SegmentPatchOfport(t, "ln-v102")
+	testenv.AssertOVSFlowMatches(t, "0x999",
+		func(line string) bool { return hasInPort(line, of101, segmentPatchName("ln-v101")) },
+		20*time.Second, "MAC-tweak flow on segment 101's patch port")
+	testenv.AssertOVSFlowMatches(t, "0x999",
+		func(line string) bool { return hasInPort(line, of102, segmentPatchName("ln-v102")) },
+		20*time.Second, "MAC-tweak flow on segment 102's patch port")
+
+	// Hairpin flows bind each FIP to its own segment's patch port with the
+	// owning router-port MAC as mod_dl_dst.
+	testenv.AssertOVSFlowMatches(t, "0x998",
+		func(line string) bool {
+			return strings.Contains(line, "nw_dst="+fip101) &&
+				strings.Contains(line, "mod_dl_dst:"+r101.LRPMAC) &&
+				hasInPort(line, of101, segmentPatchName("ln-v101"))
+		}, 20*time.Second, "hairpin flow for FIP 101 on segment 101's patch port")
+	testenv.AssertOVSFlowMatches(t, "0x998",
+		func(line string) bool {
+			return strings.Contains(line, "nw_dst="+fip102) &&
+				strings.Contains(line, "mod_dl_dst:"+r102.LRPMAC) &&
+				hasInPort(line, of102, segmentPatchName("ln-v102"))
+		}, 20*time.Second, "hairpin flow for FIP 102 on segment 102's patch port")
+
+	// Per-router MAC bindings at each network's virtual gateway IP (.254),
+	// carrying the MAC of that router's own segment interface.
+	mac101 := readLinkMAC(t, "br-ex.101")
+	mac102 := readLinkMAC(t, "br-ex.102")
+	testenv.Eventually(t, func() bool {
+		b, ok := testenv.FindMACBinding(t, ctx, nb, r101.LRPName, "198.51.100.254")
+		return ok && b.MAC == mac101
+	}, 20*time.Second, 200*time.Millisecond,
+		"MAC binding for router 101 at 198.51.100.254 with segment 101's interface MAC")
+	testenv.Eventually(t, func() bool {
+		b, ok := testenv.FindMACBinding(t, ctx, nb, r102.LRPName, "203.0.113.254")
+		return ok && b.MAC == mac102
+	}, 20*time.Second, 200*time.Millisecond,
+		"MAC binding for router 102 at 203.0.113.254 with segment 102's interface MAC")
+
+	// veth-leak routes cover both discovered provider networks.
+	testenv.AssertVethRouteInVRF(t, "198.51.100.0/24", 20*time.Second)
+	testenv.AssertVethRouteInVRF(t, "203.0.113.0/24", 20*time.Second)
+}
+
+// TestScenario_MultiSegmentFailoverIsolation (#147 AC 3):
+//
+// With two VLAN routers active, moving one router's chassisredirect port to
+// a peer chassis must tear down only that router's segment resources —
+// kernel VLAN interface, /32 routes, FRR announcement, MAC-tweak flow —
+// while the other segment keeps serving untouched.
+func TestScenario_MultiSegmentFailoverIsolation(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	tag101, tag102 := 101, 102
+	testenv.EnsureSegmentPatchPort(t, "ln-v101")
+	testenv.EnsureSegmentPatchPort(t, "ln-v102")
+
+	r101 := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "fov101",
+		LRPMAC:      "fa:16:3e:01:01:01",
+		LRPNetworks: []string{"198.51.100.11/24"},
+		SegmentOpts: &testenv.SegmentOpts{LocalnetPort: "ln-v101", Tag: &tag101},
+	})
+	r102 := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "fov102",
+		LRPMAC:      "fa:16:3e:02:02:02",
+		LRPNetworks: []string{"203.0.113.11/24"},
+		SegmentOpts: &testenv.SegmentOpts{LocalnetPort: "ln-v102", Tag: &tag102},
+	})
+
+	const fip101 = "198.51.100.77"
+	const fip102 = "203.0.113.77"
+	testenv.AddFIP(t, ctx, nb, r101, fip101, "10.0.1.7")
+	testenv.AddFIP(t, ctx, nb, r102, fip102, "10.0.2.7")
+
+	cfg := testenv.Defaults()
+	cfg.NetworkCIDRs = multiSegmentCIDRs
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// Both segments fully in place before the failover, so the assertions
+	// below prove removal rather than "never installed".
+	testenv.AssertKernelRouteOnDev(t, fip101, "br-ex.101", 20*time.Second)
+	testenv.AssertKernelRouteOnDev(t, fip102, "br-ex.102", 20*time.Second)
+	testenv.AssertFRRRoute(t, fip101, 20*time.Second)
+	testenv.AssertFRRRoute(t, fip102, 20*time.Second)
+
+	of101 := testenv.SegmentPatchOfport(t, "ln-v101")
+	of102 := testenv.SegmentPatchOfport(t, "ln-v102")
+
+	// Move only router 101 to a peer chassis.
+	peerChassis := testenv.MakeChassis(t, ctx, sb, "peer-host")
+	testenv.SetCRPortChassis(t, ctx, sb, r101.CRPortUUID, &peerChassis)
+
+	// Segment 101's resources are gone: VLAN interface pruned (taking its
+	// /32 with it), FRR route withdrawn, flows removed from its patch port.
+	testenv.AssertNoLink(t, "br-ex.101", 30*time.Second)
+	testenv.AssertNoFRRRoute(t, fip101, 30*time.Second)
+	testenv.AssertNoOVSFlowMatches(t, "0x999",
+		func(line string) bool { return hasInPort(line, of101, segmentPatchName("ln-v101")) },
+		30*time.Second, "MAC-tweak flow on departed segment 101's patch port")
+	testenv.AssertNoOVSFlowMatches(t, "0x998",
+		func(line string) bool { return strings.Contains(line, "nw_dst="+fip101) },
+		30*time.Second, "hairpin flow for departed FIP 101")
+
+	// Segment 102 is untouched.
+	testenv.AssertLinkExists(t, "br-ex.102", 5*time.Second)
+	testenv.AssertKernelRouteOnDev(t, fip102, "br-ex.102", 5*time.Second)
+	testenv.AssertFRRRoute(t, fip102, 5*time.Second)
+	testenv.AssertOVSFlowMatches(t, "0x999",
+		func(line string) bool { return hasInPort(line, of102, segmentPatchName("ln-v102")) },
+		5*time.Second, "MAC-tweak flow on surviving segment 102's patch port")
+	mac102 := readLinkMAC(t, "br-ex.102")
+	if b, ok := testenv.FindMACBinding(t, ctx, nb, r102.LRPName, "203.0.113.254"); !ok || b.MAC != mac102 {
+		t.Fatalf("surviving router 102's MAC binding disturbed by failover (present=%v)", ok)
+	}
+}
+
+// TestScenario_MultiSegmentSameSegmentHairpin (#147 AC 4, same-segment):
+//
+// Two routers sharing one VLAN segment (same localnet port, same external
+// switch datapath): both FIPs' hairpin flows must land on the SAME patch
+// port, each with its own router-port MAC, so same-segment cross-router
+// hairpin reflection works. Also exercises the segment dedup path — one
+// desired segment despite two routers.
+func TestScenario_MultiSegmentSameSegmentHairpin(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	tag := 101
+	testenv.EnsureSegmentPatchPort(t, "ln-shared")
+
+	rA := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "sharea",
+		LRPMAC:      "fa:16:3e:aa:00:01",
+		LRPNetworks: []string{"198.51.100.11/24"},
+		SegmentOpts: &testenv.SegmentOpts{LocalnetPort: "ln-shared", Tag: &tag},
+	})
+	rB := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "shareb",
+		LRPMAC:      "fa:16:3e:bb:00:02",
+		LRPNetworks: []string{"198.51.100.12/24"},
+		// Attach to router A's external switch instead of creating a second
+		// localnet segment.
+		SegmentOpts: &testenv.SegmentOpts{DatapathUUID: rA.SegmentDatapathID},
+	})
+
+	const fipA = "198.51.100.81"
+	const fipB = "198.51.100.82"
+	testenv.AddFIP(t, ctx, nb, rA, fipA, "10.0.1.8")
+	testenv.AddFIP(t, ctx, nb, rB, fipB, "10.0.2.8")
+
+	a := readyAgent(t, testenv.Defaults())
+	defer a.Stop(15 * time.Second)
+
+	// One shared segment: one VLAN interface, both /32s on it.
+	testenv.AssertLinkExists(t, "br-ex.101", 20*time.Second)
+	testenv.AssertKernelRouteOnDev(t, fipA, "br-ex.101", 20*time.Second)
+	testenv.AssertKernelRouteOnDev(t, fipB, "br-ex.101", 20*time.Second)
+
+	// Both hairpin flows sit on the same patch port, each targeting its own
+	// router's MAC.
+	of := testenv.SegmentPatchOfport(t, "ln-shared")
+	testenv.AssertOVSFlowMatches(t, "0x998",
+		func(line string) bool {
+			return strings.Contains(line, "nw_dst="+fipA) &&
+				strings.Contains(line, "mod_dl_dst:"+rA.LRPMAC) &&
+				hasInPort(line, of, segmentPatchName("ln-shared"))
+		}, 20*time.Second, "hairpin flow for FIP A on the shared patch port")
+	testenv.AssertOVSFlowMatches(t, "0x998",
+		func(line string) bool {
+			return strings.Contains(line, "nw_dst="+fipB) &&
+				strings.Contains(line, "mod_dl_dst:"+rB.LRPMAC) &&
+				hasInPort(line, of, segmentPatchName("ln-shared"))
+		}, 20*time.Second, "hairpin flow for FIP B on the shared patch port")
+}
+
+// TestScenario_MultiSegmentAgentRestart (#147 AC 5):
+//
+// The agent stops without cleanup (cleanup_on_shutdown=false, simulating a
+// restart that keeps routes in place). While it is down, one of the two
+// routers disappears from NB. On restart the agent must re-adopt the
+// surviving segment's VLAN interface and routes, and prune the departed
+// segment's interface and FRR announcement.
+func TestScenario_MultiSegmentAgentRestart(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	tag101, tag102 := 101, 102
+	testenv.EnsureSegmentPatchPort(t, "ln-v101")
+	testenv.EnsureSegmentPatchPort(t, "ln-v102")
+
+	r101 := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "rst101",
+		LRPMAC:      "fa:16:3e:01:01:01",
+		LRPNetworks: []string{"198.51.100.11/24"},
+		SegmentOpts: &testenv.SegmentOpts{LocalnetPort: "ln-v101", Tag: &tag101},
+	})
+	r102 := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "rst102",
+		LRPMAC:      "fa:16:3e:02:02:02",
+		LRPNetworks: []string{"203.0.113.11/24"},
+		SegmentOpts: &testenv.SegmentOpts{LocalnetPort: "ln-v102", Tag: &tag102},
+	})
+
+	const fip101 = "198.51.100.77"
+	const fip102 = "203.0.113.77"
+	testenv.AddFIP(t, ctx, nb, r101, fip101, "10.0.1.7")
+	testenv.AddFIP(t, ctx, nb, r102, fip102, "10.0.2.7")
+
+	cfg := testenv.Defaults()
+	cfg.NetworkCIDRs = multiSegmentCIDRs
+	off := false
+	cfg.CleanupOnShutdown = &off
+
+	a := readyAgent(t, cfg)
+	testenv.AssertKernelRouteOnDev(t, fip101, "br-ex.101", 20*time.Second)
+	testenv.AssertKernelRouteOnDev(t, fip102, "br-ex.102", 20*time.Second)
+
+	// Stop without cleanup: segment interfaces, routes, and flows survive.
+	if err := a.Stop(15 * time.Second); err != nil {
+		t.Fatalf("agent stop: %v", err)
+	}
+	testenv.AssertLinkExists(t, "br-ex.101", 2*time.Second)
+	testenv.AssertLinkExists(t, "br-ex.102", 2*time.Second)
+
+	// While the agent is down, router 102 disappears from NB.
+	deleteRouter(t, ctx, nb, r102.RouterUUID)
+
+	a2 := readyAgent(t, cfg)
+	defer a2.Stop(15 * time.Second)
+
+	// The surviving segment is re-adopted: interface still there, /32 and
+	// FRR announcement intact.
+	testenv.AssertLinkExists(t, "br-ex.101", 20*time.Second)
+	testenv.AssertKernelRouteOnDev(t, fip101, "br-ex.101", 20*time.Second)
+	testenv.AssertFRRRoute(t, fip101, 20*time.Second)
+
+	// The departed segment is pruned: agent-created interface removed
+	// (taking its kernel route with it) and the stale FRR route withdrawn.
+	testenv.AssertNoLink(t, "br-ex.102", 30*time.Second)
+	testenv.AssertNoFRRRoute(t, fip102, 30*time.Second)
+}

--- a/test/integration/testenv/assert.go
+++ b/test/integration/testenv/assert.go
@@ -59,6 +59,68 @@ func AssertNoKernelRoute(t *testing.T, ip string, timeout time.Duration) {
 	}
 }
 
+// AssertKernelRouteOnDev fails the test if no /32 route for ip exists on the
+// named interface within timeout. The multi-segment scenarios use it to pin
+// each FIP's route to its segment's VLAN subinterface rather than just "some
+// interface on the host".
+func AssertKernelRouteOnDev(t *testing.T, ip, dev string, timeout time.Duration) {
+	t.Helper()
+	if net.ParseIP(ip) == nil {
+		t.Fatalf("AssertKernelRouteOnDev: invalid IP %q", ip)
+	}
+	deadline := time.Now().Add(timeout)
+	var lastOut string
+	var lastErr error
+	for {
+		out, err := exec.Command("ip", "-4", "route", "show", ip+"/32", "dev", dev).CombinedOutput()
+		lastOut = strings.TrimSpace(string(out))
+		lastErr = err
+		if err == nil && strings.Contains(string(out), ip) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("kernel route %s/32 on %s not present after %s (last output: %q, err: %v)",
+				ip, dev, timeout, lastOut, lastErr)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// AssertLinkExists fails the test if the named link does not appear within
+// timeout. Used for the agent-created per-VLAN segment interfaces.
+func AssertLinkExists(t *testing.T, dev string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		if _, err := net.InterfaceByName(dev); err == nil {
+			return
+		} else {
+			lastErr = err
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("link %s not present after %s (last error: %v)", dev, timeout, lastErr)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// AssertNoLink fails the test if the named link persists past timeout.
+// Mirrors AssertLinkExists for the negative case (segment pruning, teardown).
+func AssertNoLink(t *testing.T, dev string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if _, err := net.InterfaceByName(dev); err != nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("link %s still present after %s", dev, timeout)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
 // AssertBridgeAddress fails the test if cidr is not present on bridge within
 // timeout. cidr is matched against `ip -j -4 addr show dev <bridge>` as the
 // (local, prefixlen) pair extracted from each addr_info entry, so the caller
@@ -405,6 +467,11 @@ func scrubLocalState(t *testing.T) {
 		_ = exec.Command("ovs-ofctl", "del-flows", DefaultBridgeDev,
 			fmt.Sprintf("cookie=%s/-1", cookie)).Run()
 	}
+
+	// Agent-created per-VLAN segment interfaces on the bridge. Deleting a
+	// link also drops the /32 routes riding on it, so no per-device route
+	// flush is needed here.
+	scrubSegmentLinks(t)
 
 	// Port-forward residue: managed VIPs on loopback1, fwmark ip rules,
 	// the port-forward reply table. Calls into portforward.go.

--- a/test/integration/testenv/fixtures.go
+++ b/test/integration/testenv/fixtures.go
@@ -101,6 +101,12 @@ type RouterRef struct {
 	CRPort      string // "cr-lrp-router1"
 	CRPortUUID  string
 	DatapathID  string // SB Datapath_Binding UUID
+
+	// SegmentDatapathID is the SB Datapath_Binding UUID of the external
+	// switch inserted for LocalRouterOpts.SegmentOpts ("" when no segment
+	// was requested). A second router can attach to the same segment by
+	// passing it as SegmentOpts.DatapathUUID.
+	SegmentDatapathID string
 }
 
 // LocalRouterOpts configures MakeLocalRouter. ChassisUUID defaults to the
@@ -119,6 +125,31 @@ type LocalRouterOpts struct {
 	// into NB Gateway_Chassis. If nil, a single entry is created for the
 	// local hostname at priority DefaultLocalPriority.
 	GatewayChassis []GatewayChassisEntry
+
+	// SegmentOpts, when set, additionally inserts the SB rows describing the
+	// router's external network as a localnet segment: an external-switch
+	// Datapath_Binding, a type=patch Port_Binding peering with the router's
+	// LRP, and a type=localnet Port_Binding carrying the physnet name and
+	// optional VLAN tag. Nil reproduces the legacy fixture (no segment rows),
+	// which exercises the agent's single-patch-port fallback.
+	SegmentOpts *SegmentOpts
+}
+
+// SegmentOpts configures the localnet segment rows inserted by MakeLocalRouter.
+type SegmentOpts struct {
+	// LocalnetPort is the logical_port name of the type=localnet
+	// Port_Binding. Required unless DatapathUUID is set.
+	LocalnetPort string
+	// NetworkName is options:network_name of the localnet port (the
+	// physnet). Defaults to "physnet1".
+	NetworkName string
+	// Tag is the segment's VLAN tag; nil = flat (untagged).
+	Tag *int
+	// DatapathUUID, when set, attaches the router to an existing external
+	// switch (from another router's SegmentDatapathID) instead of inserting
+	// a new Datapath_Binding and localnet row — only the patch row peering
+	// with this router's LRP is added. Used by same-segment scenarios.
+	DatapathUUID string
 }
 
 // GatewayChassisEntry is one row in NB Gateway_Chassis seeded by MakeLocalRouter.
@@ -267,7 +298,7 @@ func MakeLocalRouter(t *testing.T, ctx context.Context, nb, sb client.Client, op
 	pbResults := Transact(t, ctx, sb, []ovsdb.Operation{pbInsertOp})
 	pbUUID := pbResults[0].UUID.GoUUID
 
-	return RouterRef{
+	ref := RouterRef{
 		Name:        opts.Name,
 		RouterUUID:  lrUUID,
 		LRPName:     lrpName,
@@ -278,6 +309,73 @@ func MakeLocalRouter(t *testing.T, ctx context.Context, nb, sb client.Client, op
 		CRPortUUID:  pbUUID,
 		DatapathID:  dpUUID,
 	}
+	if opts.SegmentOpts != nil {
+		ref.SegmentDatapathID = insertSegment(t, ctx, sb, lrpName, *opts.SegmentOpts)
+	}
+	return ref
+}
+
+// insertSegment inserts the SB rows the agent's segment resolution joins on:
+// the external switch's Datapath_Binding, its type=localnet Port_Binding
+// (options:network_name + optional tag), and the type=patch Port_Binding
+// whose options:peer names the router's LRP. Returns the external-switch
+// datapath UUID. When seg.DatapathUUID is set, only the patch row is added.
+func insertSegment(t *testing.T, ctx context.Context, sb client.Client, lrpName string, seg SegmentOpts) string {
+	t.Helper()
+	if seg.DatapathUUID == "" && seg.LocalnetPort == "" {
+		t.Fatal("insertSegment: SegmentOpts.LocalnetPort required")
+	}
+	if seg.NetworkName == "" {
+		seg.NetworkName = "physnet1"
+	}
+
+	dpUUID := seg.DatapathUUID
+	if dpUUID == "" {
+		dpRow := &SBDatapathBinding{
+			UUID:        "extdp_named",
+			TunnelKey:   nextTunnelKey(),
+			ExternalIDs: map[string]string{"name": "ext-" + seg.LocalnetPort},
+		}
+		dpOps, err := sb.Create(dpRow)
+		if err != nil {
+			t.Fatalf("create external datapath op: %v", err)
+		}
+		dpResults := Transact(t, ctx, sb, dpOps)
+		dpUUID = dpResults[0].UUID.GoUUID
+
+		// The localnet Port_Binding is inserted as a raw op: `tag` is an
+		// optional integer column, which OVSDB encodes as a 0/1-element set.
+		lnRow := ovsdb.Row{
+			"datapath":     realUUID(dpUUID),
+			"tunnel_key":   nextTunnelKey(),
+			"logical_port": seg.LocalnetPort,
+			"type":         "localnet",
+			"options":      ovsdb.OvsMap{GoMap: map[any]any{"network_name": seg.NetworkName}},
+		}
+		if seg.Tag != nil {
+			lnRow["tag"] = ovsdb.OvsSet{GoSet: []any{*seg.Tag}}
+		}
+		Transact(t, ctx, sb, []ovsdb.Operation{{
+			Op:    ovsdb.OperationInsert,
+			Table: "Port_Binding",
+			Row:   lnRow,
+		}})
+	}
+
+	// Switch-side patch row peering with the router's gateway LRP — the row
+	// refreshState joins with the localnet row via the shared datapath.
+	Transact(t, ctx, sb, []ovsdb.Operation{{
+		Op:    ovsdb.OperationInsert,
+		Table: "Port_Binding",
+		Row: ovsdb.Row{
+			"datapath":     realUUID(dpUUID),
+			"tunnel_key":   nextTunnelKey(),
+			"logical_port": lrpName + "-attachment",
+			"type":         "patch",
+			"options":      ovsdb.OvsMap{GoMap: map[any]any{"peer": lrpName}},
+		},
+	}})
+	return dpUUID
 }
 
 // AddFIP inserts a dnat_and_snat NAT entry on the given router for externalIP

--- a/test/integration/testenv/services.go
+++ b/test/integration/testenv/services.go
@@ -42,6 +42,60 @@ func EnsureBridgePatchPort(t *testing.T) {
 	addPort("br-int", testenvPatchOnBrInt, testenvPatchOnBrEx)
 }
 
+// EnsureSegmentPatchPort creates a patch-port pair between br-ex and br-int
+// whose br-ex Port row carries external_ids:ovn-localnet-port=<localnetPort>,
+// mirroring what ovn-controller stamps on the provider-bridge patch port of
+// each localnet network. The agent's per-segment discovery maps the localnet
+// port name to this patch port. Idempotent; the ports are removed at test
+// cleanup so leftover tagged ports cannot skew single-network scenarios'
+// first-patch-port fallback.
+func EnsureSegmentPatchPort(t *testing.T, localnetPort string) {
+	t.Helper()
+
+	brexPort := "patch-" + localnetPort + "-to-br-int"
+	brintPort := "patch-br-int-to-" + localnetPort
+
+	addPort := func(bridge, port, peer string) {
+		out, err := exec.Command("ovs-vsctl",
+			"--may-exist", "add-port", bridge, port, "--",
+			"set", "Interface", port, "type=patch", "options:peer="+peer,
+		).CombinedOutput()
+		if err != nil {
+			t.Fatalf("create patch port %s on %s: %v (output: %s)",
+				port, bridge, err, strings.TrimSpace(string(out)))
+		}
+	}
+	addPort(DefaultBridgeDev, brexPort, brintPort)
+	addPort("br-int", brintPort, brexPort)
+
+	if out, err := exec.Command("ovs-vsctl", "set", "Port", brexPort,
+		"external_ids:ovn-localnet-port="+localnetPort).CombinedOutput(); err != nil {
+		t.Fatalf("set ovn-localnet-port on %s: %v (output: %s)",
+			brexPort, err, strings.TrimSpace(string(out)))
+	}
+
+	t.Cleanup(func() {
+		_ = exec.Command("ovs-vsctl", "--if-exists", "del-port", DefaultBridgeDev, brexPort).Run()
+		_ = exec.Command("ovs-vsctl", "--if-exists", "del-port", "br-int", brintPort).Run()
+	})
+}
+
+// SegmentPatchOfport returns the OpenFlow port number of the br-ex patch port
+// created by EnsureSegmentPatchPort for the given localnet port name.
+func SegmentPatchOfport(t *testing.T, localnetPort string) string {
+	t.Helper()
+	port := "patch-" + localnetPort + "-to-br-int"
+	out, err := exec.Command("ovs-vsctl", "get", "Interface", port, "ofport").CombinedOutput()
+	if err != nil {
+		t.Fatalf("get ofport for %s: %v (output: %s)", port, err, strings.TrimSpace(string(out)))
+	}
+	ofport := strings.TrimSpace(string(out))
+	if ofport == "" || ofport == "-1" {
+		t.Fatalf("invalid ofport %q for %s", ofport, port)
+	}
+	return ofport
+}
+
 // PauseOVNNorthd suspends the ovn-northd processing loop for the duration of
 // the test, registering a Cleanup that resumes it.
 //

--- a/test/integration/testenv/testenv.go
+++ b/test/integration/testenv/testenv.go
@@ -37,6 +37,7 @@
 package testenv
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -159,6 +160,42 @@ func Teardown(t *testing.T) {
 	// startScenario / ResetOVNState still rely on this safety net to keep
 	// the next run from inheriting an enslaved veth pair.
 	scrubVethLeakState(t)
+
+	// Agent-created per-VLAN segment interfaces on the bridge. A SIGKILL'd
+	// agent skips TeardownSegmentInterfaces, so without this scrub the next
+	// scenario would inherit stale VLAN links (and the routes riding on them).
+	scrubSegmentLinks(t)
+}
+
+// segmentLinkAlias mirrors the ownership marker the agent sets on VLAN links
+// it creates on the provider bridge (segmentLinkAlias in routing_linux.go).
+const segmentLinkAlias = "ovn-network-agent"
+
+// scrubSegmentLinks deletes VLAN links parented on the bridge that carry the
+// agent's ownership alias. Operator-provisioned links (no alias) are left
+// alone — the same contract the agent's own pruning honours.
+func scrubSegmentLinks(t *testing.T) {
+	t.Helper()
+	out, err := exec.Command("ip", "-j", "link", "show", "type", "vlan").CombinedOutput()
+	if err != nil {
+		return
+	}
+	var links []struct {
+		Ifname  string `json:"ifname"`
+		Link    string `json:"link"`
+		Ifalias string `json:"ifalias"`
+	}
+	if json.Unmarshal(out, &links) != nil {
+		return
+	}
+	for _, l := range links {
+		if l.Link != DefaultBridgeDev || l.Ifalias != segmentLinkAlias {
+			continue
+		}
+		if err := exec.Command("ip", "link", "del", l.Ifname).Run(); err != nil {
+			t.Logf("teardown: failed to delete segment link %s: %v", l.Ifname, err)
+		}
+	}
 }
 
 // frrStaticRoutes returns the /32 static routes currently present in the


### PR DESCRIPTION
## Summary

Teaches the agent to serve **multiple public provider networks per gateway node** by giving each locally-active router its own localnet segment (patch port + optional VLAN tag + kernel interface) and building a per-segment data plane on top of it. Flat single-network deployments are unchanged and need no config change.

Closes #147

## Background

Previously the data plane was hard-wired to a single flat (untagged) localnet network on a single bridge: `discoverPatchPort` returned the first `type=patch` port, VLAN-tagged traffic never reached the kernel, and `EnsureGatewayRouting` stamped one global bridge MAC on every local router. The control plane was already multi-router aware; this branch closes the data-plane gap so two VLAN provider networks (same physnet, different tags) can be announced from the same node.

## Change set (in commit order)

1. **`299c8bb` ovn: discover localnet segments and attach them to local routers**
   Resolves, per locally-active router, the localnet segment (localnet port name, physnet, optional VLAN tag) by joining SB `Port_Binding` rows — `type=localnet` rows indexed by datapath against the switch-side `type=patch` rows whose `options:peer` names the router's gateway LRP. Records the segment on `LocalRouterInfo` and maps each NAT external IP to its segment (`NATIPToSegment`). Extends the monitor-cache consistency guard so the `Port_Binding` content key/decoder cover `datapath`, `tag`, and `options` (a dropped UPDATE would otherwise program the wrong VLAN undetected). No downstream behavior change yet — nothing consumes the segment info in this commit.

2. **`fe539d9` ovs: install MAC-tweak and hairpin flows per localnet patch port**
   Replaces "first patch port wins" with per-segment bindings: each desired segment maps to its provider-bridge patch port via the `external_ids:ovn-localnet-port` key ovn-controller stamps, and to a kernel interface (the bridge device for flat segments; an agent-created or adopted 802.1Q `<bridge>.<tag>` subinterface carrying the bridge IP + proxy ARP for VLAN segments). MAC-tweak flows (cookie `0x999`) install per patch port with that segment's kernel MAC; hairpin flows (cookie `0x998`) take a per-IP segment so reflection via `output:in_port` stays within the segment. Bindings are revalidated each reconcile; a recreated patch port or a changed segment set triggers full rediscovery, and stale agent-created VLAN interfaces are pruned. Segments that cannot be resolved fall back to the legacy single-patch binding, keeping flat deployments bit-compatible.

3. **`955d25a` routing: route FIP /32s over each segment's kernel interface**
   Makes the kernel route API device-aware: `AddKernelRoute`/`DelKernelRoute` take the target interface and `ListKernelRoutes` returns `(IP, device)` pairs (listing the dedicated table when `route_table_id` is set, else the bridge device plus its VLAN subinterfaces, so per-segment leftovers are found after a restart). The reconcile loop derives each desired IP's device from its segment binding and compares routes as `(IP, device)` pairs: a route on the wrong interface is atomically moved with `route replace` (no FRR withdrawal), while genuinely stale entries withdraw FRR first and are then deleted. Shutdown cleanup tears down the agent-created segment VLAN interfaces.

4. **`8c32375` ovn: write per-router MAC bindings from the segment interface**
   `EnsureGatewayRouting` now takes a per-LRP MAC map instead of one global bridge MAC; each locally-active router's virtual-gateway MAC binding is written with the MAC of its own segment interface. A router whose MAC cannot be resolved is skipped entirely (route and binding, loudly), preserving the previous no-MAC-no-write semantics per router. Also removes the multi-instance failure mode where two agents serving different bridges would fight over the bindings.

5. **`c913d91` metrics: add localnet_segments gauge**
   Exposes the number of localnet segments the reconcile loop currently wants a data plane for, so operators can see multi-network activation per node — a single gauge with bounded cardinality and no per-segment labels on existing series (no dashboard breakage).

6. **`42e4048` test/integration: cover multi-VLAN segments, failover and restart**
   New fixtures insert the SB rows segment resolution joins on (external-switch `Datapath_Binding`, localnet and patch `Port_Binding`) and a services helper that creates the tagged provider-bridge patch port ovn-controller would stamp with `external_ids:ovn-localnet-port`. Scenarios cover: two VLAN networks on one node (per-segment interfaces, routes, flows, MAC bindings); failover isolation (only the departed router's segment resources torn down); same-segment hairpin for two routers sharing one localnet port; and agent restart that re-adopts surviving segments and prunes departed ones. Teardown scrubs leftover agent-created VLAN links so a killed agent cannot poison the next scenario.

7. **`d0de321` test/e2e: add multi-vlan scenario with two VLAN networks on one node**
   Provisions two VLAN provider networks (tags 101/102 on `physnet1`), each with a gatewayless public subnet, a router pinned to `gateway-1`, and a netns workload behind a FIP. Asserts the agent creates `br-ex.101`/`br-ex.102`, routes each FIP /32 over its own segment interface, installs MAC-tweak flows per localnet patch port, and announces both FIPs as /32 via BGP — then probes both FIPs end-to-end from `client-1` and re-probes the flat baseline FIP to prove flat and VLAN data paths coexist on the same node. Wired into the `Makefile` (`e2e-multi-vlan`) and the E2E workflow as a job gating on baseline.

8. **`fafafad` docs: describe multi-network VLAN segment support**
   Documents the per-segment data plane in the architecture and gatewayless-networks pages (SB-driven discovery, per-patch-port MAC-tweak/hairpin flows, agent-created/adopted `<bridge>.<tag>` subinterfaces and the interface-name length constraint, the per-router MAC binding, the RBAC `access_as_external` transparency note) and picks up the new integration scenario, segment fixtures, and e2e scenario in the contributing pages.

## Decisions on the issue's open questions

The issue left several open questions for the plan; the branch resolves them as follows (reviewers should confirm these are acceptable):

- **VLAN interface ownership** → agent-created (or adopted) 802.1Q `<bridge>.<tag>` kernel subinterfaces, *not* OVS internal ports. This carries the bridge IP and proxy ARP the same way the flat setup does, and cleanup prunes agent-created links. Note the interface-name length constraint (`<bridge>.<tag>` must fit the kernel `IFNAMSIZ` limit).
- **Cross-segment hairpin** (FIP on VLAN 101 → FIP on VLAN 102 on the same chassis) → explicitly **out of scope** for this iteration; same-segment hairpin is covered and tested.
- **IPv6** (RA/ND instead of proxy ARP) → the IPv6 kernel path is explicitly **out of scope** for the first iteration.
- **Config / opt-in flag** → no new `multi-network` flag or physnet allowlist was added. Discovery is automatic and falls back to the legacy single-patch binding when segments cannot be resolved, so flat single-network deployments stay bit-compatible with no config change.
- **Metrics** → a single bounded-cardinality `localnet_segments` gauge instead of per-segment labels on existing series.

## Verification

- Integration: `test/integration/scenario_multi_segment_test.go` (multi-VLAN, failover isolation, same-segment hairpin, restart re-adoption/pruning).
- E2E: `test/e2e/scenarios/multi-vlan.sh`, run via `make e2e-multi-vlan` and the new E2E CI job (gates on the baseline job).

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 0986627 with Claude:claude-opus-4-8_
