### PR TITLE
build: require Go 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/osism/ovn-network-agent
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0


### PR DESCRIPTION
Bumps the minimum Go version in `go.mod` from 1.26.4 to 1.26.5.

- Only `go.mod` carries the exact version; CI workflows derive it via `go-version-file: go.mod`, so they pick up the bump automatically.
- `test/e2e/Dockerfile.gwnode` (`GO_VERSION=1.26`) and the docs (`Go 1.26+`) are left unchanged since they reference only the minor version / a lower bound.
- `go build ./...` passes on Go 1.26.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)