### PR TITLE
bfd: BFD visibility and optional management for faster failover detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Full documentation is published at
   - [Gatewayless provider networks](https://osism.github.io/ovn-network-agent/explanation/gatewayless-networks)
   - [Port forwarding (DNAT)](https://osism.github.io/ovn-network-agent/explanation/port-forwarding)
   - [Gateway drain mode](https://osism.github.io/ovn-network-agent/explanation/gateway-drain)
+  - [BFD failover detection](https://osism.github.io/ovn-network-agent/explanation/bfd-failover-detection)
 - Contributing:
   - [Integration tests](https://osism.github.io/ovn-network-agent/contributing/integration-tests)
   - [Containerlab E2E harness](https://osism.github.io/ovn-network-agent/contributing/e2e-tests)

--- a/agent.go
+++ b/agent.go
@@ -443,6 +443,11 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 	// advertised via BGP — ensureRoutes alone cannot detect this.
 	a.checkFRRRouteActivity(desiredIPs)
 
+	// Surface (and optionally lower) the BFD failure-detection floor that
+	// bounds ungraceful failover. Runs after route programming so it never
+	// delays the failover hot path.
+	a.reconcileBFD()
+
 	// Check for stale chassis entries from dead nodes (runs on every agent).
 	// This runs after gateway routing reconciliation so that a surviving agent
 	// creates its own routes before removing entries from dead chassis.

--- a/bfd.go
+++ b/bfd.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -244,6 +246,7 @@ func worstTunnelDetectTime(tunnels []bfdTunnel) (time.Duration, string) {
 // "unknown" and is never compared.
 type frrBFDPeer struct {
 	Peer                   string `json:"peer"`
+	Interface              string `json:"interface"`
 	VRF                    string `json:"vrf"`
 	ReceiveInterval        int    `json:"receive-interval"`
 	TransmitInterval       int    `json:"transmit-interval"`
@@ -299,6 +302,337 @@ func (rm *RouteManager) ListFRRBFDPeers() ([]frrBFDPeer, error) {
 		return nil, fmt.Errorf("parse vtysh bfd peers json: %w", err)
 	}
 	return peers, nil
+}
+
+// frrBFDProfileName is the bfd profile the agent owns. Neighbors are attached
+// to it by name so its timers can be retuned in one place.
+const frrBFDProfileName = "ovn-network-agent"
+
+// isValidBGPNeighbor guards the neighbor identifier before it is interpolated
+// into a vtysh command. FRR identifies a neighbor by IP address, or by
+// interface name for unnumbered peering.
+func isValidBGPNeighbor(addr string) bool {
+	if net.ParseIP(addr) != nil {
+		return true
+	}
+	return isValidIdentifier(addr)
+}
+
+// VRFBGPNeighbors returns the addresses of the VRF's configured BGP neighbors,
+// sorted. A VRF with no BGP instance makes vtysh print a "% …" notice, or
+// nothing at all, instead of JSON, which yields no neighbors rather than an
+// error. Output that is neither is an error: reading it as "no neighbors" would
+// silently disable BFD management on a VRF that has peering.
+//
+// Only the object keys are read. Whether a neighbor already carries the agent's
+// bfd profile is decided from the running configuration instead — see
+// parseFRRBGPInstance.
+//
+// Safety: vrfName is validated by isValidIdentifier in config validation, and
+// every neighbor key is validated by isValidBGPNeighbor before use.
+func (rm *RouteManager) VRFBGPNeighbors() ([]string, error) {
+	output, err := rm.runVtysh("-c", fmt.Sprintf("show bgp vrf %s neighbors json", rm.vrfName))
+	if err != nil {
+		return nil, fmt.Errorf("vtysh show bgp neighbors: %w (output: %s)", err, strings.TrimSpace(string(output)))
+	}
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" || strings.HasPrefix(trimmed, "%") {
+		slog.Debug("vtysh returned no BGP neighbor JSON", "vrf", rm.vrfName, "output", trimmed)
+		return nil, nil
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(trimmed), &raw); err != nil {
+		return nil, fmt.Errorf("parse vtysh bgp neighbors json: %w", err)
+	}
+
+	var neighbors []string
+	for addr := range raw {
+		if !isValidBGPNeighbor(addr) {
+			slog.Warn("skipping BGP neighbor with an unexpected identifier", "neighbor", addr, "vrf", rm.vrfName)
+			continue
+		}
+		neighbors = append(neighbors, addr)
+	}
+	// Walk the neighbors in a stable order so the emitted command sequence does
+	// not depend on Go's map iteration order.
+	sort.Strings(neighbors)
+	return neighbors, nil
+}
+
+// frrBGPInstance is the VRF's `router bgp` stanza as it stands in FRR's running
+// configuration.
+type frrBGPInstance struct {
+	// AS is the number the stanza is keyed on. 0 means the VRF has no BGP
+	// instance: `router bgp <as> vrf <vrf>` is a create-or-enter command, and
+	// the agent's contract is to add the bfd knob to peering an operator
+	// declared — never to instantiate a BGP instance itself.
+	//
+	// A neighbor's reported localAs is not a substitute: `neighbor <addr>
+	// local-as <asn>` overrides it per session — a routine pattern for AS
+	// migration — and entering `router bgp` with the wrong AS makes FRR reject
+	// the block and run the remaining commands in the wrong CLI node.
+	AS int64
+	// Profiled holds the neighbors the stanza already attaches to the agent's
+	// bfd profile.
+	Profiled map[string]bool
+}
+
+// parseFRRBGPInstance extracts the VRF's `router bgp` stanza from an FRR running
+// configuration. An AS written in asdot notation (`1.10`) does not parse and
+// yields AS 0, so the agent declines to configure rather than emit a command FRR
+// would reject.
+//
+// The stanza's own neighbor lines are the authority on which neighbors carry the
+// agent's profile. `show bgp … neighbors json` reports that a neighbor has BFD,
+// but a neighbor can have BFD and no profile — an operator's plain `neighbor
+// <addr> bfd`, or a vtysh the command timeout killed between the two commands
+// that attach it. Such a neighbor runs at bgpd's session defaults, and treating
+// it as configured would leave it there forever. The key an attached profile is
+// reported under has also changed across FRR releases, whereas `neighbor <addr>
+// bfd profile <name>` is the line the agent writes and FRR renders back verbatim.
+func parseFRRBGPInstance(runningConfig, vrf string) frrBGPInstance {
+	instance := frrBGPInstance{Profiled: make(map[string]bool)}
+	const header = "router bgp "
+	vrfSuffix := " vrf " + vrf
+	profileSuffix := " bfd profile " + frrBFDProfileName
+
+	inStanza := false
+	for _, raw := range strings.Split(runningConfig, "\n") {
+		line := strings.TrimSpace(raw)
+		// The stanza body is indented; `exit`, `!` and the next `router bgp` all
+		// start at column 0.
+		if inStanza && (line == "" || raw != line) {
+			if addr, ok := strings.CutPrefix(line, "neighbor "); ok {
+				if addr, ok := strings.CutSuffix(addr, profileSuffix); ok {
+					instance.Profiled[addr] = true
+				}
+			}
+			continue
+		}
+		inStanza = false
+		if !strings.HasPrefix(line, header) || !strings.HasSuffix(line, vrfSuffix) {
+			continue
+		}
+		as, err := strconv.ParseInt(strings.TrimSuffix(strings.TrimPrefix(line, header), vrfSuffix), 10, 64)
+		if err != nil || as <= 0 {
+			continue
+		}
+		instance.AS = as
+		inStanza = true
+	}
+	return instance
+}
+
+// frrBFDProfileConfigured reports whether the agent's bfd profile still exists
+// in FRR's running configuration.
+//
+// FRR holds the profile only in its running state. A `systemctl reload frr` or
+// an frr-reload.py run reapplies frr.conf, which carries the agent's `neighbor
+// <addr> bfd profile <name>` lines once an operator has written them to memory,
+// but not the profile stanza the agent never persisted. The neighbors then
+// reference a profile that no longer exists, bfdd silently falls back to its own
+// defaults, and every neighbor still reports BFD — so nothing else notices.
+func frrBFDProfileConfigured(runningConfig string) bool {
+	want := "profile " + frrBFDProfileName
+	for _, line := range strings.Split(runningConfig, "\n") {
+		if strings.TrimSpace(line) == want {
+			return true
+		}
+	}
+	return false
+}
+
+// frrRunningConfig returns FRR's running configuration.
+func (rm *RouteManager) frrRunningConfig() (string, error) {
+	output, err := rm.runVtysh("-c", "show running-config")
+	if err != nil {
+		return "", fmt.Errorf("vtysh show running-config: %w (output: %s)", err, strings.TrimSpace(string(output)))
+	}
+	return string(output), nil
+}
+
+// applyFRRBFDProfile writes the agent's bfd profile, which carries the timers
+// every attached neighbor then uses.
+func (rm *RouteManager) applyFRRBFDProfile(minRxMs, minTxMs, multiplier int) error {
+	output, err := rm.runVtysh(
+		"-c", "conf t",
+		"-c", "bfd",
+		"-c", fmt.Sprintf("profile %s", frrBFDProfileName),
+		"-c", fmt.Sprintf("receive-interval %d", minRxMs),
+		"-c", fmt.Sprintf("transmit-interval %d", minTxMs),
+		"-c", fmt.Sprintf("detect-multiplier %d", multiplier),
+		"-c", "exit",
+		"-c", "exit",
+		"-c", "end")
+	if err != nil {
+		return fmt.Errorf("vtysh write bfd profile: %w (output: %s)", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// attachFRRBFDNeighbor enables BFD on one BGP neighbor and points it at the
+// agent's profile.
+//
+// One vtysh invocation per neighbor, not one batch for all of them: vtysh stops
+// at the first command FRR rejects, so a single neighbor bgpd refuses to
+// configure — a dynamic peer from `bgp listen range`, which `show bgp …
+// neighbors json` reports but no `neighbor <addr>` line configures — would keep
+// every neighbor sorted after it from ever getting BFD, and leave the agent
+// unable to tell which of them had already been attached. A neighbor is attached
+// once per process, so the extra invocations are paid on the first reconcile.
+//
+// Safety: addr is validated by isValidBGPNeighbor before it reaches here.
+func (rm *RouteManager) attachFRRBFDNeighbor(as int64, addr string) error {
+	output, err := rm.runVtysh(
+		"-c", "conf t",
+		"-c", fmt.Sprintf("router bgp %d vrf %s", as, rm.vrfName),
+		"-c", fmt.Sprintf("neighbor %s bfd", addr),
+		"-c", fmt.Sprintf("neighbor %s bfd profile %s", addr, frrBFDProfileName),
+		"-c", "end")
+	if err != nil {
+		return fmt.Errorf("vtysh enable BFD on neighbor %s: %w (output: %s)", addr, err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// EnsureFRRBFD enables BFD on the VRF's already-configured BGP neighbors,
+// attaching each to the agent's bfd profile, which carries the timers. Only
+// neighbors the running configuration does not already attach to that profile
+// are configured, so once the fleet has settled a reconcile issues no vtysh
+// configuration at all. That matters: every `conf t` takes FRR's configuration
+// lock, and re-issuing `neighbor <addr> bfd` can reinstall the session —
+// bouncing the very fabric BFD session this feature exists to keep up.
+//
+// Nothing guarantees that a neighbor `show bgp … neighbors json` reports can be
+// rendered back as `neighbor <addr> bfd profile <name>`: a peer-group member
+// whose BFD FRR writes under the group never appears attached, however often it
+// is configured. Such a neighbor would keep the set non-empty forever, so each
+// neighbor is attached at most once per process — frrBFDAttached remembers the
+// attempt, and a neighbor still unattached on the next reconcile is reported and
+// left alone rather than reconfigured every 60 s for the life of the node.
+//
+// The profile is written on the first reconcile of the process and whenever
+// FRR's running configuration no longer carries it. The first case applies a
+// changed timer configuration, which the agent only ever reads at startup; the
+// second restores a profile an frr-reload dropped out from under the neighbors
+// still pointing at it.
+//
+// The running configuration is read once per call and answers all three
+// questions — profile present, instance AS, neighbors already attached — from
+// one snapshot. `router bgp <as> vrf <vrf>` is still create-or-enter, so an
+// operator who deletes the instance between that read and the write below has a
+// window in which the agent recreates it; one read makes the window as small as
+// two separate vtysh processes allow.
+//
+// This closes the "stale /32 from the dead node" gap: without BFD the fabric
+// keeps the crashed node's routes until the BGP hold timer expires. The fabric
+// side must enable BFD too — see docs/explanation/bfd-failover-detection.md.
+func (rm *RouteManager) EnsureFRRBFD(minRxMs, minTxMs, multiplier int) error {
+	if rm.dryRun {
+		slog.Info("[dry-run] would enable BFD on the VRF's BGP neighbors",
+			"vrf", rm.vrfName, "min_rx_ms", minRxMs, "min_tx_ms", minTxMs, "multiplier", multiplier)
+		return nil
+	}
+
+	neighbors, err := rm.VRFBGPNeighbors()
+	if err != nil {
+		return err
+	}
+	if len(neighbors) == 0 {
+		return nil // no BGP peering in this VRF — nothing to attach a profile to
+	}
+
+	runningConfig, err := rm.frrRunningConfig()
+	if err != nil {
+		return err
+	}
+	instance := parseFRRBGPInstance(runningConfig, rm.vrfName)
+
+	var needing, unrendered []string
+	for _, addr := range neighbors {
+		switch {
+		case instance.Profiled[addr]:
+			// An operator who removed the line gets it back on the next cycle.
+			delete(rm.frrBFDAttached, addr)
+		case rm.frrBFDAttached[addr]:
+			unrendered = append(unrendered, addr)
+		default:
+			needing = append(needing, addr)
+		}
+	}
+	if len(unrendered) > 0 {
+		slog.Warn("BGP neighbors took the bfd profile but FRR does not render it back; not attaching them again",
+			"vrf", rm.vrfName, "neighbors", strings.Join(unrendered, " "))
+	}
+	if len(needing) > 0 && instance.AS == 0 {
+		return fmt.Errorf("cannot configure BFD: no router bgp instance for vrf %s", rm.vrfName)
+	}
+
+	if !rm.frrBFDProfileApplied || !frrBFDProfileConfigured(runningConfig) {
+		if err := rm.applyFRRBFDProfile(minRxMs, minTxMs, multiplier); err != nil {
+			return err
+		}
+		rm.frrBFDProfileApplied = true
+	}
+	if len(needing) == 0 {
+		return nil
+	}
+	if rm.frrBFDAttached == nil {
+		rm.frrBFDAttached = make(map[string]bool, len(needing))
+	}
+
+	var failed []string
+	for _, addr := range needing {
+		if err := rm.attachFRRBFDNeighbor(instance.AS, addr); err != nil {
+			// A neighbor FRR rejects installs nothing, so retrying it costs one
+			// vtysh invocation and bounces no session. Only a neighbor the
+			// command succeeded on is remembered, so a vtysh the configuration
+			// lock defeated is tried again.
+			slog.Warn("failed to enable BFD on a BGP neighbor", "vrf", rm.vrfName, "neighbor", addr, "error", err)
+			failed = append(failed, addr)
+			continue
+		}
+		rm.frrBFDAttached[addr] = true
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("enable BFD on bgp neighbors %s of vrf %s", strings.Join(failed, " "), rm.vrfName)
+	}
+	slog.Info("BFD profile applied to the VRF's BGP neighbors",
+		"vrf", rm.vrfName, "attached", len(needing), "min_rx_ms", minRxMs, "min_tx_ms", minTxMs, "multiplier", multiplier)
+	return nil
+}
+
+// neighborsWithoutBFD returns the VRF's BGP neighbors that run no BFD session
+// at all.
+//
+// `show bfd peers json` lists the sessions that exist, so a neighbor that was
+// never attached to a profile is simply absent and contributes nothing to
+// worstPeerDetectTime. Three fast sessions and one missing one would report the
+// fast estimate, while the missing neighbor still withdraws a crashed node's
+// /32s only when the BGP hold timer expires — 180 s by default. That is the
+// half-took-effect state frr_bfd_manage can leave behind, and precisely the one
+// the check exists to catch.
+//
+// An unnumbered neighbor is named by its interface, which bfdd reports as
+// `interface` next to the link-local `peer` address, so both identify a session.
+func neighborsWithoutBFD(neighbors []string, peers []frrBFDPeer, vrf string) []string {
+	sessions := make(map[string]bool, 2*len(peers))
+	for _, p := range peers {
+		if !p.inVRF(vrf) {
+			continue
+		}
+		sessions[p.Peer] = true
+		if p.Interface != "" {
+			sessions[p.Interface] = true
+		}
+	}
+	var missing []string
+	for _, n := range neighbors {
+		if !sessions[n] {
+			missing = append(missing, n)
+		}
+	}
+	return missing
 }
 
 // worstPeerDetectTime returns the longest detection time across the BFD
@@ -387,6 +721,16 @@ func (a *Agent) reconcileOVNBFD() {
 }
 
 func (a *Agent) reconcileFRRBFD() {
+	if !a.cfg.BFDCheckEnabled && !a.cfg.FRRBFDManage {
+		return
+	}
+
+	if a.cfg.FRRBFDManage {
+		if err := a.routing.EnsureFRRBFD(a.cfg.FRRBFDMinRxMs, a.cfg.FRRBFDMinTxMs, a.cfg.FRRBFDMultiplier); err != nil {
+			slog.Warn("failed to enable BFD on the VRF's BGP neighbors", "error", err)
+		}
+	}
+
 	if !a.cfg.BFDCheckEnabled {
 		return
 	}
@@ -394,6 +738,22 @@ func (a *Agent) reconcileFRRBFD() {
 	if err != nil {
 		slog.Warn("failed to list FRR BFD peers for the BFD check", "error", err)
 		reportBFDUnknown("frr")
+		return
+	}
+	neighbors, err := a.routing.VRFBGPNeighbors()
+	if err != nil {
+		slog.Warn("failed to list the VRF's BGP neighbors for the BFD check", "error", err)
+		reportBFDUnknown("frr")
+		return
+	}
+
+	if missing := neighborsWithoutBFD(neighbors, peers, a.cfg.VRFName); len(missing) > 0 {
+		// One neighbor without a session is enough: the fabric withdraws this
+		// node's /32s over every session, and the slowest one bounds the
+		// failover. The other sessions' timers say nothing about that neighbor.
+		setBFDDetectSeconds("frr", math.Inf(1))
+		slog.Warn("BGP neighbors run no BFD session; their route withdrawal is bounded only by the BGP hold timer",
+			"layer", "frr", "vrf", a.cfg.VRFName, "neighbors", strings.Join(missing, " "))
 		return
 	}
 

--- a/bfd.go
+++ b/bfd.go
@@ -1,0 +1,364 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Ungraceful failover (node crash, partition, ovn-controller crash) is
+// dominated by BFD's detection of the dead gateway chassis: OVN cannot move a
+// chassisredirect Port_Binding before BFD declares the tunnel down, and the
+// fabric keeps sending traffic to a crashed node until its BGP session drops.
+// This file estimates that detection floor per layer, and optionally lowers it.
+
+// OVS BFD timer defaults from ovs-vswitchd.conf.db(5). ovn-controller sets
+// only bfd:enable=true, so an untuned tunnel negotiates 3 × 1000 ms — the
+// ~3 s floor documented in docs/explanation/gateway-drain.md.
+const (
+	ovsBFDDefaultMinRxMs = 1000
+	ovsBFDDefaultMinTxMs = 100
+	ovsBFDDefaultMult    = 3
+)
+
+// maxBFDDetectTime saturates an estimate that would otherwise overflow.
+// time.Duration is int64 nanoseconds, while the timers arrive as free-form
+// integers — OVSDB's bfd column is a map<string,string> and bfdd reports plain
+// JSON numbers. An out-of-range interval must not wrap to a negative duration,
+// because every worst-case comparison below would then silently discard the
+// session with the longest detection time.
+const (
+	maxBFDDetectTime       = time.Duration(1<<63 - 1)
+	maxBFDDetectIntervalMs = int64(maxBFDDetectTime) / int64(time.Millisecond)
+)
+
+// bfdDetectTime is how long a BFD session takes to declare its peer dead: the
+// detect multiplier times the negotiated interval. An unreported multiplier or
+// interval (0) yields no estimate.
+func bfdDetectTime(mult, intervalMs int) time.Duration {
+	if mult <= 0 || intervalMs <= 0 {
+		return 0
+	}
+	if int64(intervalMs) > maxBFDDetectIntervalMs/int64(mult) {
+		return maxBFDDetectTime
+	}
+	return time.Duration(mult) * time.Duration(intervalMs) * time.Millisecond
+}
+
+// =============================================================================
+// OVN Geneve tunnel BFD
+// =============================================================================
+
+// bfdTunnel is one local Geneve tunnel interface with its BFD configuration,
+// as read from the Interface table's bfd column.
+type bfdTunnel struct {
+	Name    string
+	Enabled bool // bfd:enable=true — ovn-controller runs a BFD session here
+	MinRxMs int
+	MinTxMs int
+	Mult    int
+}
+
+// detectTime estimates how long this tunnel takes to declare the remote
+// endpoint dead: the detect multiplier times the slower of the two intervals.
+// Only the local side's configuration is visible, so this is a lower bound —
+// the negotiated interval is the maximum across both endpoints, which is why
+// timers must be lowered fleet-wide to take effect.
+func (t bfdTunnel) detectTime() time.Duration {
+	interval := t.MinRxMs
+	if t.MinTxMs > interval {
+		interval = t.MinTxMs
+	}
+	return bfdDetectTime(t.Mult, interval)
+}
+
+// ovsFindResult is the `ovs-vsctl --format=json find` envelope: one row per
+// record, with the columns positioned by Headings.
+type ovsFindResult struct {
+	Data     [][]json.RawMessage `json:"data"`
+	Headings []string            `json:"headings"`
+}
+
+// ovsdbMap decodes the OVSDB JSON map notation `["map",[["k","v"],…]]`.
+func ovsdbMap(raw json.RawMessage) (map[string]string, error) {
+	var wrapper []json.RawMessage
+	if err := json.Unmarshal(raw, &wrapper); err != nil {
+		return nil, fmt.Errorf("decode map wrapper: %w", err)
+	}
+	if len(wrapper) != 2 {
+		return nil, fmt.Errorf("expected a 2-element OVSDB map, got %d elements", len(wrapper))
+	}
+	var kind string
+	if err := json.Unmarshal(wrapper[0], &kind); err != nil {
+		return nil, fmt.Errorf("decode map kind: %w", err)
+	}
+	if kind != "map" {
+		return nil, fmt.Errorf("expected an OVSDB map, got %q", kind)
+	}
+	var pairs [][2]string
+	if err := json.Unmarshal(wrapper[1], &pairs); err != nil {
+		return nil, fmt.Errorf("decode map pairs: %w", err)
+	}
+	m := make(map[string]string, len(pairs))
+	for _, p := range pairs {
+		m[p[0]] = p[1]
+	}
+	return m, nil
+}
+
+// bfdIntOr returns the integer value of key, falling back to the OVS default
+// when the key is absent or unusable — which is exactly what OVS itself does.
+func bfdIntOr(m map[string]string, key string, fallback int) int {
+	v, ok := m[key]
+	if !ok {
+		return fallback
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return fallback
+	}
+	return n
+}
+
+// parseGeneveTunnels decodes the output of findGeneveInterfaces.
+func parseGeneveTunnels(out []byte) ([]bfdTunnel, error) {
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return nil, nil
+	}
+	var result ovsFindResult
+	if err := json.Unmarshal([]byte(trimmed), &result); err != nil {
+		return nil, fmt.Errorf("parse ovs-vsctl find json: %w", err)
+	}
+
+	nameIdx, bfdIdx := -1, -1
+	for i, h := range result.Headings {
+		switch h {
+		case "name":
+			nameIdx = i
+		case "bfd":
+			bfdIdx = i
+		}
+	}
+	if nameIdx < 0 || bfdIdx < 0 {
+		return nil, fmt.Errorf("ovs-vsctl find json is missing the name or bfd column")
+	}
+
+	var tunnels []bfdTunnel
+	for _, row := range result.Data {
+		if nameIdx >= len(row) || bfdIdx >= len(row) {
+			return nil, fmt.Errorf("ovs-vsctl find json row has only %d columns", len(row))
+		}
+		var name string
+		if err := json.Unmarshal(row[nameIdx], &name); err != nil {
+			return nil, fmt.Errorf("decode interface name: %w", err)
+		}
+		bfd, err := ovsdbMap(row[bfdIdx])
+		if err != nil {
+			return nil, fmt.Errorf("decode bfd column of %s: %w", name, err)
+		}
+		tunnels = append(tunnels, bfdTunnel{
+			Name:    name,
+			Enabled: bfd["enable"] == "true",
+			MinRxMs: bfdIntOr(bfd, "min_rx", ovsBFDDefaultMinRxMs),
+			MinTxMs: bfdIntOr(bfd, "min_tx", ovsBFDDefaultMinTxMs),
+			Mult:    bfdIntOr(bfd, "mult", ovsBFDDefaultMult),
+		})
+	}
+	return tunnels, nil
+}
+
+// GeneveTunnels returns the local Geneve tunnel interfaces.
+func (rm *RouteManager) GeneveTunnels() ([]bfdTunnel, error) {
+	out, err := rm.findGeneveInterfaces()
+	if err != nil {
+		return nil, err
+	}
+	return parseGeneveTunnels(out)
+}
+
+// worstTunnelDetectTime returns the longest detection time across the tunnels
+// that actually run a BFD session, and the tunnel it belongs to. Tunnels
+// without bfd:enable=true contribute nothing.
+func worstTunnelDetectTime(tunnels []bfdTunnel) (time.Duration, string) {
+	var worst time.Duration
+	var name string
+	for _, t := range tunnels {
+		if !t.Enabled {
+			continue
+		}
+		if d := t.detectTime(); d > worst {
+			worst, name = d, t.Name
+		}
+	}
+	return worst, name
+}
+
+// =============================================================================
+// FRR BGP-session BFD
+// =============================================================================
+
+// frrBFDPeer is the subset of a `show bfd peers json` entry the agent
+// inspects. bfdd omits fields it has not negotiated, so the zero value means
+// "unknown" and is never compared.
+type frrBFDPeer struct {
+	Peer                   string `json:"peer"`
+	VRF                    string `json:"vrf"`
+	ReceiveInterval        int    `json:"receive-interval"`
+	TransmitInterval       int    `json:"transmit-interval"`
+	RemoteTransmitInterval int    `json:"remote-transmit-interval"`
+	DetectMultiplier       int    `json:"detect-multiplier"`
+}
+
+// detectTime estimates how long this session takes to declare the peer dead:
+// the detect multiplier times the negotiated interval, which is the slower of
+// our receive interval and the peer's transmit interval. Before the session
+// comes up the peer has reported nothing, so our own transmit interval stands
+// in for theirs.
+func (p frrBFDPeer) detectTime() time.Duration {
+	remoteTx := p.RemoteTransmitInterval
+	if remoteTx <= 0 {
+		remoteTx = p.TransmitInterval
+	}
+	interval := p.ReceiveInterval
+	if remoteTx > interval {
+		interval = remoteTx
+	}
+	return bfdDetectTime(p.DetectMultiplier, interval)
+}
+
+// inVRF reports whether the peer belongs to the given VRF. Per the type's
+// contract an unreported vrf means "unknown", not "some other VRF": a bfdd
+// release that omits the field would otherwise make every session look foreign,
+// and a node whose BFD is entirely healthy would report running none at all.
+func (p frrBFDPeer) inVRF(vrf string) bool {
+	return p.VRF == "" || p.VRF == vrf
+}
+
+// ListFRRBFDPeers returns the BFD sessions FRR knows about. A fabric without
+// BFD — or a node where bfdd is not running — makes vtysh print a "% …"
+// notice, or nothing at all, instead of JSON. For a check that is on by default
+// that is an expected state, not an error, so it yields no peers.
+//
+// Output that is neither is an error, not an empty peer list: reading it as "no
+// BFD anywhere" would flip the gauge to +Inf and page an operator over a fabric
+// whose BFD is healthy.
+func (rm *RouteManager) ListFRRBFDPeers() ([]frrBFDPeer, error) {
+	output, err := rm.runVtysh("-c", "show bfd peers json")
+	if err != nil {
+		return nil, fmt.Errorf("vtysh show bfd peers: %w (output: %s)", err, strings.TrimSpace(string(output)))
+	}
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" || strings.HasPrefix(trimmed, "%") {
+		slog.Debug("vtysh returned no BFD peer JSON", "output", trimmed)
+		return nil, nil
+	}
+	var peers []frrBFDPeer
+	if err := json.Unmarshal([]byte(trimmed), &peers); err != nil {
+		return nil, fmt.Errorf("parse vtysh bfd peers json: %w", err)
+	}
+	return peers, nil
+}
+
+// worstPeerDetectTime returns the longest detection time across the BFD
+// sessions in the given VRF, and the peer it belongs to.
+func worstPeerDetectTime(peers []frrBFDPeer, vrf string) (time.Duration, string) {
+	var worst time.Duration
+	var name string
+	for _, p := range peers {
+		if !p.inVRF(vrf) {
+			continue
+		}
+		if d := p.detectTime(); d > worst {
+			worst, name = d, p.Peer
+		}
+	}
+	return worst, name
+}
+
+// =============================================================================
+// Reconcile integration
+// =============================================================================
+
+// reportBFDUnknown records that a layer's BFD state could not be read. The
+// gauge goes to NaN rather than 0: a layer the agent cannot see has an unknown
+// detection time, and 0 is the healthiest value the gauge can take — every
+// threshold alert would go quiet on the one reading that means "I do not know".
+// The error counter carries the signal that NaN cannot.
+func reportBFDUnknown(layer string) {
+	setBFDDetectSeconds(layer, math.NaN())
+	recordBFDCheckError(layer)
+}
+
+// reconcileBFD estimates the BFD failure-detection time per layer, exports it
+// and warns when it exceeds bfd_check_max_detect. It runs at the end of a
+// reconcile cycle so it never delays route programming on the failover hot
+// path, and every failure is logged rather than aborting the cycle.
+func (a *Agent) reconcileBFD() {
+	// There is no OVS — and so no Geneve tunnel — in port-forward-only mode.
+	// FRR still announces the VIP /32s there, so its layer always runs.
+	if !a.cfg.PortForwardOnly {
+		a.reconcileOVNBFD()
+	}
+	a.reconcileFRRBFD()
+}
+
+func (a *Agent) reconcileOVNBFD() {
+	if !a.cfg.BFDCheckEnabled {
+		return
+	}
+	tunnels, err := a.routing.GeneveTunnels()
+	if err != nil {
+		slog.Warn("failed to enumerate Geneve tunnels for the BFD check", "error", err)
+		reportBFDUnknown("ovn")
+		return
+	}
+
+	worst, tunnel := worstTunnelDetectTime(tunnels)
+	if worst == 0 {
+		// No tunnel runs a BFD session, so nothing bounds how long OVN takes to
+		// notice a dead chassis. That is the worst state this check can find —
+		// it must not share the gauge value of the best one.
+		setBFDDetectSeconds("ovn", math.Inf(1))
+		slog.Warn("no Geneve tunnel runs a BFD session; OVN's gateway failover is not bounded by BFD", "layer", "ovn")
+		return
+	}
+	setBFDDetectSeconds("ovn", worst.Seconds())
+	if worst > a.cfg.BFDCheckMaxDetect {
+		slog.Warn("estimated BFD detection time exceeds bfd_check_max_detect",
+			"layer", "ovn", "estimate", worst, "max_detect", a.cfg.BFDCheckMaxDetect, "tunnel", tunnel)
+	}
+}
+
+func (a *Agent) reconcileFRRBFD() {
+	if !a.cfg.BFDCheckEnabled {
+		return
+	}
+	peers, err := a.routing.ListFRRBFDPeers()
+	if err != nil {
+		slog.Warn("failed to list FRR BFD peers for the BFD check", "error", err)
+		reportBFDUnknown("frr")
+		return
+	}
+
+	worst, peer := worstPeerDetectTime(peers, a.cfg.VRFName)
+	if worst == 0 {
+		// No BFD session exists in this VRF, so the fabric withdraws a crashed
+		// node's /32s only when the BGP hold timer expires — the state every
+		// node is in before frr_bfd_manage is enabled, and the one an operator
+		// most needs to see.
+		setBFDDetectSeconds("frr", math.Inf(1))
+		slog.Warn("no BGP neighbor in the VRF runs a BFD session; route withdrawal is bounded only by the BGP hold timer",
+			"layer", "frr", "vrf", a.cfg.VRFName)
+		return
+	}
+	setBFDDetectSeconds("frr", worst.Seconds())
+	if worst > a.cfg.BFDCheckMaxDetect {
+		slog.Warn("estimated BFD detection time exceeds bfd_check_max_detect",
+			"layer", "frr", "estimate", worst, "max_detect", a.cfg.BFDCheckMaxDetect, "peer", peer)
+	}
+}

--- a/bfd.go
+++ b/bfd.go
@@ -181,6 +181,43 @@ func (rm *RouteManager) GeneveTunnels() ([]bfdTunnel, error) {
 	return parseGeneveTunnels(out)
 }
 
+// EnsureOVNBFDTimers sets bfd:min_rx and bfd:min_tx on the Geneve tunnel
+// interfaces whose timers differ from the desired values. A reconcile that finds
+// nothing drifted issues no OVS command at all, and one that finds N drifted
+// tunnels issues exactly one — see setInterfaceBFDTimers for why the count
+// matters.
+//
+// tunnels is read, never updated: what the agent writes is not necessarily what
+// OVS keeps, so the effective timers are the ones the next reconcile reads back
+// from the bfd column.
+//
+// bfd:enable is never touched: ovn-controller owns it. Whether ovn-controller
+// preserves operator-set timer keys depends on the deployed OVN version — if
+// it reverts them, the next reconcile re-applies them. See
+// docs/explanation/bfd-failover-detection.md.
+func (rm *RouteManager) EnsureOVNBFDTimers(tunnels []bfdTunnel, minRxMs, minTxMs int) error {
+	if rm.dryRun {
+		slog.Info("[dry-run] would set BFD timers on Geneve tunnels",
+			"tunnels", len(tunnels), "min_rx_ms", minRxMs, "min_tx_ms", minTxMs)
+		return nil
+	}
+	var drifted []string
+	for _, t := range tunnels {
+		if t.MinRxMs != minRxMs || t.MinTxMs != minTxMs {
+			drifted = append(drifted, t.Name)
+		}
+	}
+	if len(drifted) == 0 {
+		return nil
+	}
+	if err := rm.setInterfaceBFDTimers(drifted, minRxMs, minTxMs); err != nil {
+		return err
+	}
+	slog.Info("BFD timers set on Geneve tunnels",
+		"tunnels", len(drifted), "min_rx_ms", minRxMs, "min_tx_ms", minTxMs)
+	return nil
+}
+
 // worstTunnelDetectTime returns the longest detection time across the tunnels
 // that actually run a BFD session, and the tunnel it belongs to. Tunnels
 // without bfd:enable=true contribute nothing.
@@ -308,16 +345,31 @@ func (a *Agent) reconcileBFD() {
 }
 
 func (a *Agent) reconcileOVNBFD() {
-	if !a.cfg.BFDCheckEnabled {
+	if !a.cfg.BFDCheckEnabled && !a.cfg.OVNBFDManage {
 		return
 	}
 	tunnels, err := a.routing.GeneveTunnels()
 	if err != nil {
 		slog.Warn("failed to enumerate Geneve tunnels for the BFD check", "error", err)
-		reportBFDUnknown("ovn")
+		if a.cfg.BFDCheckEnabled {
+			reportBFDUnknown("ovn")
+		}
 		return
 	}
 
+	if a.cfg.OVNBFDManage {
+		if err := a.routing.EnsureOVNBFDTimers(tunnels, a.cfg.OVNBFDMinRxMs, a.cfg.OVNBFDMinTxMs); err != nil {
+			slog.Warn("failed to set BFD timers on Geneve tunnels", "error", err)
+		}
+	}
+
+	if !a.cfg.BFDCheckEnabled {
+		return
+	}
+	// The estimate comes from the bfd column as OVSDB reported it above, never
+	// from the values just written: an ovn-controller that reclaims the column
+	// would otherwise be invisible to the very check meant to prove that
+	// ovn_bfd_manage took effect.
 	worst, tunnel := worstTunnelDetectTime(tunnels)
 	if worst == 0 {
 		// No tunnel runs a BFD session, so nothing bounds how long OVN takes to

--- a/bfd_test.go
+++ b/bfd_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"math"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -786,5 +787,618 @@ func TestReconcileBFDOVNManageWithoutCheck(t *testing.T) {
 	}
 	if v, _ := bfdDetectValue(t, m, "ovn"); !math.IsNaN(v) {
 		t.Errorf("bfd_detect_seconds{layer=ovn} = %v, want NaN — the check is disabled", v)
+	}
+}
+
+// =============================================================================
+// FRR BGP-session BFD management (frr_bfd_manage)
+// =============================================================================
+
+func TestVRFBGPNeighbors(t *testing.T) {
+	tests := []struct {
+		name      string
+		out       string
+		execErr   error
+		wantAddrs []string
+		wantErr   bool
+	}{
+		{
+			name:      "neighbor without BFD",
+			out:       `{"192.0.2.1":{"localAs":64512,"remoteAs":65001}}`,
+			wantAddrs: []string{"192.0.2.1"},
+		},
+		{
+			name:      "neighbor with BFD",
+			out:       `{"192.0.2.1":{"peerBfdInfo":{"detectMultiplier":3,"rxMinInterval":300,"txMinInterval":300}}}`,
+			wantAddrs: []string{"192.0.2.1"},
+		},
+		{
+			name:      "neighbors are sorted so the command sequence is deterministic",
+			out:       `{"192.0.2.9":{},"192.0.2.1":{},"192.0.2.5":{}}`,
+			wantAddrs: []string{"192.0.2.1", "192.0.2.5", "192.0.2.9"},
+		},
+		{
+			name:      "interface-named neighbor (unnumbered peering)",
+			out:       `{"swp1":{}}`,
+			wantAddrs: []string{"swp1"},
+		},
+		{
+			// A neighbor key is interpolated into a vtysh command, so anything
+			// that is neither an IP nor a plain interface name is dropped.
+			name:      "hostile neighbor identifier is skipped",
+			out:       `{"192.0.2.1":{},"x\nrouter bgp 1":{}}`,
+			wantAddrs: []string{"192.0.2.1"},
+		},
+		{"no BGP instance for the VRF", "% No BGP process is configured\n", nil, nil, false},
+		{"empty output", "", nil, nil, false},
+		{"empty neighbor set", `{}`, nil, nil, false},
+		{"malformed json", `{"192.0.2.1":`, nil, nil, true},
+		{"exec failure", "vtysh: connect failed", errors.New("exit status 1"), nil, true},
+		{
+			// Reading unparseable output as "no neighbors" would silently skip
+			// BFD management on a VRF that has peering.
+			name:    "contaminated json is an error, not an empty neighbor set",
+			out:     "vtysh: warning\n" + `{"192.0.2.1":{}}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := newVtyshRecorder()
+			rec.on([]string{"vtysh", "-c", "show bgp vrf vrf-provider neighbors json"}, tt.out, tt.execErr)
+			rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+
+			neighbors, err := rm.VRFBGPNeighbors()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("VRFBGPNeighbors() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(neighbors, tt.wantAddrs) {
+				t.Errorf("neighbors = %v, want %v", neighbors, tt.wantAddrs)
+			}
+		})
+	}
+}
+
+func TestParseFRRBGPInstance(t *testing.T) {
+	tests := []struct {
+		name         string
+		conf         string
+		wantAS       int64
+		wantProfiled []string
+	}{
+		{
+			// The instance ASN is 65000; 64999 is a per-session local-as
+			// override, which is exactly what must not be picked up.
+			name:   "the stanza header wins over a neighbor local-as override",
+			conf:   "router bgp 65000 vrf vrf-provider\n neighbor 192.0.2.1 remote-as 65001\n neighbor 192.0.2.1 local-as 64999\nexit\n",
+			wantAS: 65000,
+		},
+		{
+			name:   "the default-VRF instance is not the VRF instance",
+			conf:   "router bgp 64512\n neighbor 10.0.0.1 remote-as 64513\nexit\n",
+			wantAS: 0,
+		},
+		{
+			name:   "another VRF's instance is not matched on a name prefix",
+			conf:   "router bgp 65000 vrf vrf-prov\nexit\n",
+			wantAS: 0,
+		},
+		{
+			name:   "the right instance is found among several",
+			conf:   "router bgp 64512\nexit\nrouter bgp 65000 vrf vrf-other\nexit\nrouter bgp 65001 vrf vrf-provider\nexit\n",
+			wantAS: 65001,
+		},
+		{
+			name: "an attached neighbor is recognised",
+			conf: "router bgp 65000 vrf vrf-provider\n neighbor 192.0.2.1 remote-as 65001\n" +
+				" neighbor 192.0.2.1 bfd\n neighbor 192.0.2.1 bfd profile ovn-network-agent\nexit\n",
+			wantAS:       65000,
+			wantProfiled: []string{"192.0.2.1"},
+		},
+		{
+			// A neighbor with BFD but no profile runs at bgpd's session
+			// defaults. It is exactly the neighbor that still needs attaching.
+			name:   "a neighbor with plain bfd is not attached",
+			conf:   "router bgp 65000 vrf vrf-provider\n neighbor 192.0.2.1 bfd\nexit\n",
+			wantAS: 65000,
+		},
+		{
+			name:   "a neighbor attached to somebody else's profile is not attached",
+			conf:   "router bgp 65000 vrf vrf-provider\n neighbor 192.0.2.1 bfd profile fabric\nexit\n",
+			wantAS: 65000,
+		},
+		{
+			// Another instance's neighbors say nothing about this VRF's.
+			name: "an attachment in another BGP instance does not count",
+			conf: "router bgp 64512\n neighbor 192.0.2.1 bfd profile ovn-network-agent\nexit\n" +
+				"router bgp 65000 vrf vrf-provider\n neighbor 192.0.2.1 remote-as 65001\nexit\n",
+			wantAS: 65000,
+		},
+		{
+			name: "an unnumbered neighbor is recognised",
+			conf: "router bgp 65000 vrf vrf-provider\n neighbor swp1 interface remote-as external\n" +
+				" neighbor swp1 bfd profile ovn-network-agent\n!\nexit\n",
+			wantAS:       65000,
+			wantProfiled: []string{"swp1"},
+		},
+		{"no bgp at all", "frr version 9.1\nhostname node1\n", 0, nil},
+		{"asdot notation is not parsed", "router bgp 1.10 vrf vrf-provider\n", 0, nil},
+		{"empty running config", "", 0, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseFRRBGPInstance(tt.conf, "vrf-provider")
+			if got.AS != tt.wantAS {
+				t.Errorf("AS = %d, want %d", got.AS, tt.wantAS)
+			}
+			if len(got.Profiled) != len(tt.wantProfiled) {
+				t.Fatalf("Profiled = %v, want %v", got.Profiled, tt.wantProfiled)
+			}
+			for _, addr := range tt.wantProfiled {
+				if !got.Profiled[addr] {
+					t.Errorf("Profiled = %v, want it to contain %q", got.Profiled, addr)
+				}
+			}
+		})
+	}
+}
+
+func TestFRRBFDProfileConfigured(t *testing.T) {
+	tests := []struct {
+		name string
+		conf string
+		want bool
+	}{
+		{"the profile stanza is present", "bfd\n profile ovn-network-agent\n  receive-interval 150\n exit\nexit\n", true},
+		{"another profile is not ours", "bfd\n profile fabric\n exit\nexit\n", false},
+		{
+			// frr-reload reapplies frr.conf, which carries the neighbor lines an
+			// operator wrote to memory but not the profile the agent never
+			// persisted. bfdd then silently falls back to its own defaults.
+			name: "neighbors referencing a profile FRR no longer has",
+			conf: "router bgp 65000 vrf vrf-provider\n neighbor 192.0.2.1 bfd profile ovn-network-agent\nexit\n",
+			want: false,
+		},
+		{"empty running config", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := frrBFDProfileConfigured(tt.conf); got != tt.want {
+				t.Errorf("frrBFDProfileConfigured() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// frrConfigCalls returns the recorded vtysh calls that enter configuration mode.
+func frrConfigCalls(calls [][]string) []string {
+	var found []string
+	for _, c := range calls {
+		joined := strings.Join(c, " ")
+		if strings.Contains(joined, "conf t") {
+			found = append(found, joined)
+		}
+	}
+	return found
+}
+
+// frrNeighborsCmd and frrRunningConfigCmd are the two read commands EnsureFRRBFD
+// issues before it decides whether anything must be configured. frrProfileCmd is
+// the write that lays down the profile carrying the timers.
+var (
+	frrNeighborsCmd     = []string{"vtysh", "-c", "show bgp vrf vrf-provider neighbors json"}
+	frrRunningConfigCmd = []string{"vtysh", "-c", "show running-config"}
+	frrProfileCmd       = []string{
+		"vtysh", "-c", "conf t", "-c", "bfd", "-c", "profile ovn-network-agent",
+		"-c", "receive-interval 150", "-c", "transmit-interval 150", "-c", "detect-multiplier 3",
+		"-c", "exit", "-c", "exit", "-c", "end",
+	}
+)
+
+// frrAttachCmd is the per-neighbor write that enables BFD on one BGP neighbor.
+func frrAttachCmd(addr string) []string {
+	return []string{
+		"vtysh", "-c", "conf t", "-c", "router bgp 64512 vrf vrf-provider",
+		"-c", "neighbor " + addr + " bfd",
+		"-c", "neighbor " + addr + " bfd profile ovn-network-agent",
+		"-c", "end",
+	}
+}
+
+// frrConfigWithProfile is a running configuration in which FRR still holds the
+// agent's bfd profile and 192.0.2.1 is attached to it — the settled state.
+const frrConfigWithProfile = "bfd\n profile ovn-network-agent\n  receive-interval 150\n exit\nexit\n" +
+	"router bgp 64512 vrf vrf-provider\n neighbor 192.0.2.1 bfd\n neighbor 192.0.2.1 bfd profile ovn-network-agent\nexit\n"
+
+func TestEnsureFRRBFD(t *testing.T) {
+	t.Run("only the neighbor the running config does not attach is configured", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		rec.on(frrNeighborsCmd, `{"192.0.2.1":{},"192.0.2.2":{}}`, nil)
+		rec.on(frrRunningConfigCmd, frrConfigWithProfile, nil)
+		rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+
+		if err := rm.EnsureFRRBFD(150, 150, 3); err != nil {
+			t.Fatalf("EnsureFRRBFD() error: %v", err)
+		}
+
+		cfgCalls := frrConfigCalls(rec.calls)
+		if len(cfgCalls) != 2 {
+			t.Fatalf("config calls = %v, want the profile and one neighbor", cfgCalls)
+		}
+		for _, want := range []string{
+			"profile ovn-network-agent",
+			"receive-interval 150",
+			"transmit-interval 150",
+			"detect-multiplier 3",
+		} {
+			if !strings.Contains(cfgCalls[0], want) {
+				t.Errorf("profile call missing %q; got: %s", want, cfgCalls[0])
+			}
+		}
+		for _, want := range []string{
+			"router bgp 64512 vrf vrf-provider",
+			"neighbor 192.0.2.2 bfd",
+			"neighbor 192.0.2.2 bfd profile ovn-network-agent",
+		} {
+			if !strings.Contains(cfgCalls[1], want) {
+				t.Errorf("neighbor call missing %q; got: %s", want, cfgCalls[1])
+			}
+		}
+		if got := strings.Join(cfgCalls, " "); strings.Contains(got, "neighbor 192.0.2.1 bfd") {
+			t.Errorf("already-attached neighbor was reconfigured; got: %s", got)
+		}
+	})
+
+	// bgpd reports BFD for a neighbor an operator gave a plain `neighbor <addr>
+	// bfd`, and for one whose vtysh the command timeout killed between the two
+	// commands that attach the profile. Both run at bgpd's session defaults
+	// (3/300/300, ~900 ms) rather than the configured timers, and taking BFD's
+	// presence for the profile's presence leaves them there forever.
+	t.Run("a neighbor with BFD but no profile is attached", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		rec.on(frrNeighborsCmd,
+			`{"192.0.2.1":{"peerBfdInfo":{"detectMultiplier":3,"rxMinInterval":300,"txMinInterval":300}}}`, nil)
+		rec.on(frrRunningConfigCmd, "router bgp 64512 vrf vrf-provider\n neighbor 192.0.2.1 bfd\nexit\n", nil)
+		rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+
+		if err := rm.EnsureFRRBFD(150, 150, 3); err != nil {
+			t.Fatalf("EnsureFRRBFD() error: %v", err)
+		}
+		cfgCalls := frrConfigCalls(rec.calls)
+		if len(cfgCalls) != 2 {
+			t.Fatalf("config calls = %v, want the neighbor attached", cfgCalls)
+		}
+		if !strings.Contains(cfgCalls[1], "neighbor 192.0.2.1 bfd profile ovn-network-agent") {
+			t.Errorf("a neighbor with BFD but no profile was left unattached; got: %s", cfgCalls[1])
+		}
+	})
+
+	// FRR keeps the profile only in its running state. A reload reapplies
+	// frr.conf, which carries the neighbor's `bfd profile` line but not the
+	// profile stanza the agent never persisted — leaving every session at bfdd's
+	// defaults. A process-lifetime flag cannot see that; the running config can.
+	t.Run("a profile FRR lost is written again", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		rec.on(frrNeighborsCmd, `{"192.0.2.1":{}}`, nil)
+		rec.on(frrRunningConfigCmd, frrConfigWithProfile, nil)
+		rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+
+		// The first reconcile writes the profile once — that is what applies a
+		// changed timer configuration. Every later one issues nothing.
+		if err := rm.EnsureFRRBFD(150, 150, 3); err != nil {
+			t.Fatalf("EnsureFRRBFD() error: %v", err)
+		}
+		for range 3 {
+			if err := rm.EnsureFRRBFD(150, 150, 3); err != nil {
+				t.Fatalf("EnsureFRRBFD() error: %v", err)
+			}
+		}
+		if got := frrConfigCalls(rec.calls); len(got) != 1 {
+			t.Fatalf("config calls = %v, want the profile written exactly once while FRR keeps it", got)
+		}
+
+		// `systemctl reload frr`: the neighbor still references the profile, the
+		// profile is gone.
+		rec.on(frrRunningConfigCmd,
+			"router bgp 64512 vrf vrf-provider\n neighbor 192.0.2.1 bfd profile ovn-network-agent\nexit\n", nil)
+
+		if err := rm.EnsureFRRBFD(150, 150, 3); err != nil {
+			t.Fatalf("EnsureFRRBFD() error: %v", err)
+		}
+		cfgCalls := frrConfigCalls(rec.calls)
+		if len(cfgCalls) != 2 {
+			t.Fatalf("config calls = %v, want the vanished profile rewritten", cfgCalls)
+		}
+		if !strings.Contains(cfgCalls[1], "profile ovn-network-agent") {
+			t.Errorf("rewrite did not carry the profile; got: %s", cfgCalls[1])
+		}
+		if strings.Contains(cfgCalls[1], "router bgp") {
+			t.Errorf("re-attached an already-attached neighbor; got: %s", cfgCalls[1])
+		}
+	})
+
+	// Nothing to attach means nothing to enter `router bgp` for — the command
+	// that would otherwise create a BGP instance no operator declared.
+	t.Run("the profile is written without entering router bgp", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		rec.on(frrNeighborsCmd, `{"192.0.2.1":{}}`, nil)
+		rec.on(frrRunningConfigCmd,
+			"router bgp 64512 vrf vrf-provider\n neighbor 192.0.2.1 bfd profile ovn-network-agent\nexit\n", nil)
+		rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+
+		if err := rm.EnsureFRRBFD(150, 150, 3); err != nil {
+			t.Fatalf("EnsureFRRBFD() error: %v", err)
+		}
+		cfgCalls := frrConfigCalls(rec.calls)
+		if len(cfgCalls) != 1 {
+			t.Fatalf("config calls = %v, want the profile written once", cfgCalls)
+		}
+		if strings.Contains(cfgCalls[0], "router bgp") {
+			t.Errorf("entered router bgp with nothing to attach; got: %s", cfgCalls[0])
+		}
+	})
+
+	// FRR reports a neighbor's effective local AS, which `neighbor <addr>
+	// local-as` overrides. Keying `router bgp` on it makes FRR reject the block.
+	t.Run("the instance AS comes from the running config, not from a neighbor", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		rec.on(frrNeighborsCmd, `{"192.0.2.1":{"localAs":64999}}`, nil)
+		rec.on(frrRunningConfigCmd,
+			"router bgp 65000 vrf vrf-provider\n neighbor 192.0.2.1 local-as 64999\nexit\n", nil)
+		rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+
+		if err := rm.EnsureFRRBFD(150, 150, 3); err != nil {
+			t.Fatalf("EnsureFRRBFD() error: %v", err)
+		}
+		cfgCalls := frrConfigCalls(rec.calls)
+		if len(cfgCalls) != 2 {
+			t.Fatalf("config calls = %v, want the profile and one neighbor", cfgCalls)
+		}
+		if !strings.Contains(cfgCalls[1], "router bgp 65000 vrf vrf-provider") {
+			t.Errorf("wrong instance AS; got: %s", cfgCalls[1])
+		}
+	})
+
+	t.Run("no neighbors is a no-op", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		rec.on(frrNeighborsCmd, "% No BGP process is configured\n", nil)
+		rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+
+		if err := rm.EnsureFRRBFD(150, 150, 3); err != nil {
+			t.Fatalf("EnsureFRRBFD() error: %v", err)
+		}
+		if got := frrConfigCalls(rec.calls); len(got) != 0 {
+			t.Errorf("config calls = %v, want none", got)
+		}
+	})
+
+	// The instance vanished between the neighbor read and the write (frr-reload).
+	// Configuring anyway would create an empty `router bgp` stanza the agent
+	// never owned.
+	t.Run("a VRF without a router bgp stanza is an error, not a created instance", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		rec.on(frrNeighborsCmd, `{"192.0.2.1":{}}`, nil)
+		rec.on(frrRunningConfigCmd, "router bgp 64512\nexit\n", nil)
+		rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+
+		if err := rm.EnsureFRRBFD(150, 150, 3); err == nil {
+			t.Fatal("EnsureFRRBFD() = nil error, want a missing-instance failure")
+		}
+		if got := frrConfigCalls(rec.calls); len(got) != 0 {
+			t.Errorf("config calls = %v, want none", got)
+		}
+	})
+
+	t.Run("neighbor discovery failure is propagated", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		rec.on(frrNeighborsCmd, "vtysh: connect failed", errors.New("exit status 1"))
+		rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+
+		if err := rm.EnsureFRRBFD(150, 150, 3); err == nil {
+			t.Fatal("EnsureFRRBFD() = nil error, want the exec failure")
+		}
+	})
+
+	t.Run("running config failure is propagated", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		rec.on(frrNeighborsCmd, `{"192.0.2.1":{}}`, nil)
+		rec.on(frrRunningConfigCmd, "vtysh: connect failed", errors.New("exit status 1"))
+		rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+
+		if err := rm.EnsureFRRBFD(150, 150, 3); err == nil {
+			t.Fatal("EnsureFRRBFD() = nil error, want the exec failure")
+		}
+		if got := frrConfigCalls(rec.calls); len(got) != 0 {
+			t.Errorf("config calls = %v, want none", got)
+		}
+	})
+
+	// A failed write must not mark the profile as applied, or the retry on the
+	// next reconcile would be skipped.
+	t.Run("configuration failure is propagated and retried", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		rec.on(frrNeighborsCmd, `{"192.0.2.1":{}}`, nil)
+		rec.on(frrRunningConfigCmd, "router bgp 64512 vrf vrf-provider\nexit\n", nil)
+		rec.on(frrProfileCmd, "% Unknown command", errors.New("exit status 1"))
+		rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+
+		if err := rm.EnsureFRRBFD(150, 150, 3); err == nil {
+			t.Fatal("EnsureFRRBFD() = nil error, want the config failure")
+		}
+		if rm.frrBFDProfileApplied {
+			t.Error("a failed write marked the profile as applied")
+		}
+	})
+
+	// vtysh stops at the first command FRR rejects. Batching every neighbor into
+	// one invocation would let a dynamic peer — reported by `show bgp neighbors`
+	// but configured by no `neighbor <addr>` line — keep every neighbor sorted
+	// after it from ever getting BFD.
+	t.Run("a neighbor FRR rejects does not starve the neighbors after it", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		rec.on(frrNeighborsCmd, `{"192.0.2.1":{},"192.0.2.2":{}}`, nil)
+		rec.on(frrRunningConfigCmd, "router bgp 64512 vrf vrf-provider\nexit\n", nil)
+		rec.on(frrAttachCmd("192.0.2.1"), "% Specify remote-as or peer-group commands first",
+			errors.New("exit status 1"))
+		rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+
+		if err := rm.EnsureFRRBFD(150, 150, 3); err == nil {
+			t.Fatal("EnsureFRRBFD() = nil error, want the rejected neighbor reported")
+		}
+		if got := strings.Join(frrConfigCalls(rec.calls), " "); !strings.Contains(got, "neighbor 192.0.2.2 bfd") {
+			t.Errorf("the neighbor after the rejected one was never attached; got: %s", got)
+		}
+		// The rejected neighbor installed nothing, so it stays retryable.
+		if rm.frrBFDAttached["192.0.2.1"] {
+			t.Error("a rejected neighbor was recorded as attached")
+		}
+	})
+
+	// `needing` diffs operational state against configuration state. A neighbor
+	// that FRR accepts but never renders back — a peer-group member whose BFD is
+	// written under the group — would otherwise stay in the set forever, and
+	// `neighbor <addr> bfd` would reinstall its BGP session on every reconcile.
+	t.Run("a neighbor FRR never renders back is attached once, not forever", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		// 192.0.2.9 peers, and the running configuration never grows its
+		// `bfd profile` line no matter how often the agent writes it.
+		rec.on(frrNeighborsCmd, `{"192.0.2.9":{}}`, nil)
+		rec.on(frrRunningConfigCmd, frrConfigWithProfile, nil)
+		rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+
+		for range 3 {
+			if err := rm.EnsureFRRBFD(150, 150, 3); err != nil {
+				t.Fatalf("EnsureFRRBFD() error: %v", err)
+			}
+		}
+		var attaches int
+		for _, c := range frrConfigCalls(rec.calls) {
+			if strings.Contains(c, "neighbor 192.0.2.9 bfd") {
+				attaches++
+			}
+		}
+		if attaches != 1 {
+			t.Errorf("attached the unrenderable neighbor %d times, want exactly 1 — every retry reinstalls its BGP session", attaches)
+		}
+	})
+
+	t.Run("dry-run reads and writes nothing", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		rm := &RouteManager{vrfName: "vrf-provider", dryRun: true, execVtyshHook: rec.hook()}
+
+		if err := rm.EnsureFRRBFD(150, 150, 3); err != nil {
+			t.Fatalf("EnsureFRRBFD() error: %v", err)
+		}
+		if len(rec.calls) != 0 {
+			t.Errorf("dry-run issued %v, want no commands", rec.calls)
+		}
+	})
+}
+
+// AC 4: the two manage flags are independently toggleable and default off.
+func TestReconcileBFDManageFlagsIndependent(t *testing.T) {
+	tests := []struct {
+		name          string
+		ovnManage     bool
+		frrManage     bool
+		wantOVSWrites bool
+		wantFRRWrites bool
+	}{
+		{"both off — read-only", false, false, false, false},
+		{"only OVN", true, false, true, false},
+		{"only FRR", false, true, false, true},
+		{"both", true, true, true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTestMetrics(t)
+			a, ovsRec, vtyshRec := bfdTestAgent(t, Config{
+				BFDCheckEnabled: true, BFDCheckMaxDetect: time.Second,
+				OVNBFDManage: tt.ovnManage, OVNBFDMinRxMs: 150, OVNBFDMinTxMs: 150,
+				FRRBFDManage: tt.frrManage, FRRBFDMinRxMs: 150, FRRBFDMinTxMs: 150, FRRBFDMultiplier: 3,
+			})
+			vtyshRec.on(frrNeighborsCmd, `{"192.0.2.1":{}}`, nil)
+			vtyshRec.on(frrRunningConfigCmd, "router bgp 64512 vrf vrf-provider\nexit\n", nil)
+
+			a.reconcileBFD()
+
+			if got := len(setTimerCommands(ovsRec.calls)) > 0; got != tt.wantOVSWrites {
+				t.Errorf("OVS writes = %v, want %v (calls: %v)", got, tt.wantOVSWrites, ovsRec.calls)
+			}
+			if got := len(frrConfigCalls(vtyshRec.calls)) > 0; got != tt.wantFRRWrites {
+				t.Errorf("FRR writes = %v, want %v (calls: %v)", got, tt.wantFRRWrites, vtyshRec.calls)
+			}
+		})
+	}
+}
+
+// `show bfd peers json` lists only the sessions that exist, so a BGP neighbor
+// that never got a session contributes nothing to the estimate. Reporting the
+// surviving sessions' 450 ms would promise a failover bound the missing neighbor
+// does not honour: it withdraws this node's /32s on the BGP hold timer, 180 s
+// later. This is the half-took-effect state frr_bfd_manage can leave behind.
+func TestReconcileBFDFRRNeighborWithoutSessionIsUnbounded(t *testing.T) {
+	m := withTestMetrics(t)
+	vtyshRec := newVtyshRecorder()
+	vtyshRec.on([]string{"vtysh", "-c", "show bfd peers json"},
+		`[{"peer":"192.0.2.1","vrf":"vrf-provider","receive-interval":150,"transmit-interval":150,"detect-multiplier":3}]`, nil)
+	// Two ToRs peer; only one carries a BFD session.
+	vtyshRec.on(frrNeighborsCmd, `{"192.0.2.1":{},"192.0.2.2":{}}`, nil)
+
+	rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: vtyshRec.hook()}
+	a := &Agent{cfg: Config{BFDCheckEnabled: true, BFDCheckMaxDetect: time.Second, VRFName: "vrf-provider",
+		PortForwardOnly: true}, routing: rm}
+
+	a.reconcileBFD()
+
+	if v, _ := bfdDetectValue(t, m, "frr"); !math.IsInf(v, 1) {
+		t.Errorf("bfd_detect_seconds{layer=frr} = %v, want +Inf — a neighbor without a BFD session bounds nothing", v)
+	}
+}
+
+// An unnumbered neighbor is named by its interface, while bfdd names the session
+// by the link-local peer address and reports the interface alongside. Matching
+// on the peer address alone would report every unnumbered fabric as running no
+// BFD at all.
+func TestReconcileBFDFRRUnnumberedNeighborIsMatchedByInterface(t *testing.T) {
+	m := withTestMetrics(t)
+	vtyshRec := newVtyshRecorder()
+	vtyshRec.on([]string{"vtysh", "-c", "show bfd peers json"},
+		`[{"peer":"fe80::1","interface":"swp1","vrf":"vrf-provider",`+
+			`"receive-interval":150,"transmit-interval":150,"detect-multiplier":3}]`, nil)
+	vtyshRec.on(frrNeighborsCmd, `{"swp1":{}}`, nil)
+
+	rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: vtyshRec.hook()}
+	a := &Agent{cfg: Config{BFDCheckEnabled: true, BFDCheckMaxDetect: time.Second, VRFName: "vrf-provider",
+		PortForwardOnly: true}, routing: rm}
+
+	a.reconcileBFD()
+
+	if v, _ := bfdDetectValue(t, m, "frr"); v != 0.45 {
+		t.Errorf("bfd_detect_seconds{layer=frr} = %v, want 0.45 — the unnumbered neighbor's session was not recognised", v)
+	}
+}
+
+// The FRR manager runs even when the check is off — the two are independent.
+func TestReconcileBFDFRRManageWithoutCheck(t *testing.T) {
+	m := withTestMetrics(t)
+	a, _, vtyshRec := bfdTestAgent(t, Config{
+		BFDCheckEnabled: false,
+		FRRBFDManage:    true, FRRBFDMinRxMs: 150, FRRBFDMinTxMs: 150, FRRBFDMultiplier: 3,
+	})
+	vtyshRec.on(frrNeighborsCmd, `{"192.0.2.1":{}}`, nil)
+	vtyshRec.on(frrRunningConfigCmd, "router bgp 64512 vrf vrf-provider\nexit\n", nil)
+
+	a.reconcileBFD()
+
+	if got := frrConfigCalls(vtyshRec.calls); len(got) != 2 {
+		t.Errorf("config calls = %v, want the profile and one neighbor", got)
+	}
+	if v, _ := bfdDetectValue(t, m, "frr"); !math.IsNaN(v) {
+		t.Errorf("bfd_detect_seconds{layer=frr} = %v, want NaN — the check is disabled", v)
 	}
 }

--- a/bfd_test.go
+++ b/bfd_test.go
@@ -538,3 +538,253 @@ func TestReconcileBFDClearsTheEstimateWhenMeasurementStops(t *testing.T) {
 		t.Errorf("bfd_detect_seconds{layer=frr} = %v, want +Inf — a stale estimate must not survive a vanished session", v)
 	}
 }
+
+// =============================================================================
+// OVN tunnel BFD timer management (ovn_bfd_manage)
+// =============================================================================
+
+// setTimerCommands returns the recorded `ovs-vsctl set Interface … bfd:…` calls.
+func setTimerCommands(calls [][]string) []string {
+	var found []string
+	for _, c := range calls {
+		joined := strings.Join(c, " ")
+		if strings.Contains(joined, "set Interface") && strings.Contains(joined, "bfd:min_rx") {
+			found = append(found, joined)
+		}
+	}
+	return found
+}
+
+func TestEnsureOVNBFDTimers(t *testing.T) {
+	t.Run("a drifted tunnel is written, and the caller's slice is left alone", func(t *testing.T) {
+		rec := newOVSRecorder()
+		rm := &RouteManager{execOVSHook: rec.hook()}
+		tunnels := []bfdTunnel{{Name: "genev_sys_6081", Enabled: true, MinRxMs: 1000, MinTxMs: 100, Mult: 3}}
+
+		if err := rm.EnsureOVNBFDTimers(tunnels, 150, 150); err != nil {
+			t.Fatalf("EnsureOVNBFDTimers() error: %v", err)
+		}
+		want := "ovs-vsctl --if-exists set Interface genev_sys_6081 bfd:min_rx=150 bfd:min_tx=150"
+		if got := setTimerCommands(rec.calls); len(got) != 1 || got[0] != want {
+			t.Fatalf("commands = %v, want exactly [%q]", got, want)
+		}
+
+		// A successful write is not proof that OVS kept the value: ovn-controller
+		// may reclaim the bfd column. Only a fresh read knows the effective
+		// timers, so the slice must still hold what OVSDB reported.
+		if tunnels[0].MinRxMs != 1000 || tunnels[0].MinTxMs != 100 {
+			t.Errorf("tunnel = %+v, want the timers OVS reported, not the ones written", tunnels[0])
+		}
+	})
+
+	t.Run("a tunnel already at the desired timers is not written", func(t *testing.T) {
+		rec := newOVSRecorder()
+		rm := &RouteManager{execOVSHook: rec.hook()}
+		tunnels := []bfdTunnel{{Name: "genev_sys_6081", Enabled: true, MinRxMs: 150, MinTxMs: 150, Mult: 3}}
+
+		if err := rm.EnsureOVNBFDTimers(tunnels, 150, 150); err != nil {
+			t.Fatalf("EnsureOVNBFDTimers() error: %v", err)
+		}
+		if got := setTimerCommands(rec.calls); len(got) != 0 {
+			t.Errorf("commands = %v, want none", got)
+		}
+	})
+
+	// ovsCommandTimeout bounds one ovs-vsctl invocation, not one reconcile. A
+	// per-tunnel loop over a cluster's worth of drifted tunnels therefore has no
+	// bound at all: a wedged ovsdb-server would hold the agent's only loop
+	// goroutine for 30 s per remote chassis, blocking route programming and the
+	// SIGTERM drain for hours. Every drifted tunnel goes into one transaction,
+	// and --if-exists keeps a tunnel ovn-controller destroyed since the
+	// enumeration from failing it.
+	t.Run("every drifted tunnel is written by a single ovs-vsctl invocation", func(t *testing.T) {
+		rec := newOVSRecorder()
+		rm := &RouteManager{execOVSHook: rec.hook()}
+		tunnels := []bfdTunnel{
+			{Name: "gone", Enabled: true, MinRxMs: 1000, MinTxMs: 100, Mult: 3},
+			{Name: "survivor", Enabled: true, MinRxMs: 1000, MinTxMs: 100, Mult: 3},
+		}
+
+		if err := rm.EnsureOVNBFDTimers(tunnels, 150, 150); err != nil {
+			t.Fatalf("EnsureOVNBFDTimers() error: %v", err)
+		}
+		if len(rec.calls) != 1 {
+			t.Fatalf("issued %d ovs-vsctl calls, want exactly one: %v", len(rec.calls), rec.calls)
+		}
+		want := "ovs-vsctl --if-exists set Interface gone bfd:min_rx=150 bfd:min_tx=150 " +
+			"-- --if-exists set Interface survivor bfd:min_rx=150 bfd:min_tx=150"
+		if got := strings.Join(rec.calls[0], " "); got != want {
+			t.Errorf("command = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("only the drifted tunnel is written", func(t *testing.T) {
+		rec := newOVSRecorder()
+		rm := &RouteManager{execOVSHook: rec.hook()}
+		tunnels := []bfdTunnel{
+			{Name: "correct", Enabled: true, MinRxMs: 150, MinTxMs: 150, Mult: 3},
+			{Name: "drifted", Enabled: true, MinRxMs: 1000, MinTxMs: 100, Mult: 3},
+		}
+
+		if err := rm.EnsureOVNBFDTimers(tunnels, 150, 150); err != nil {
+			t.Fatalf("EnsureOVNBFDTimers() error: %v", err)
+		}
+		got := setTimerCommands(rec.calls)
+		if len(got) != 1 || !strings.Contains(got[0], "Interface drifted") {
+			t.Errorf("commands = %v, want only the drifted tunnel written", got)
+		}
+	})
+
+	t.Run("a disabled tunnel is still pre-staged", func(t *testing.T) {
+		// ovn-controller flips bfd:enable when a gateway lands here; having
+		// the timers already set means the session starts out fast.
+		rec := newOVSRecorder()
+		rm := &RouteManager{execOVSHook: rec.hook()}
+		tunnels := []bfdTunnel{{Name: "idle", Enabled: false, MinRxMs: 1000, MinTxMs: 100, Mult: 3}}
+
+		if err := rm.EnsureOVNBFDTimers(tunnels, 150, 150); err != nil {
+			t.Fatalf("EnsureOVNBFDTimers() error: %v", err)
+		}
+		if got := setTimerCommands(rec.calls); len(got) != 1 {
+			t.Errorf("commands = %v, want the idle tunnel pre-staged", got)
+		}
+	})
+
+	// `--` is ovs-vsctl's own clause separator: an Interface row named `--`, or
+	// anything starting with `-`, re-partitions the command line and fails the
+	// transaction, leaving every tunnel in the batch untuned.
+	t.Run("an interface whose name would re-partition the command line is skipped", func(t *testing.T) {
+		rec := newOVSRecorder()
+		rm := &RouteManager{execOVSHook: rec.hook()}
+		tunnels := []bfdTunnel{
+			{Name: "--", Enabled: true, MinRxMs: 1000, MinTxMs: 100, Mult: 3},
+			{Name: "genev_sys_6081", Enabled: true, MinRxMs: 1000, MinTxMs: 100, Mult: 3},
+		}
+
+		if err := rm.EnsureOVNBFDTimers(tunnels, 150, 150); err != nil {
+			t.Fatalf("EnsureOVNBFDTimers() error: %v", err)
+		}
+		want := "ovs-vsctl --if-exists set Interface genev_sys_6081 bfd:min_rx=150 bfd:min_tx=150"
+		if got := setTimerCommands(rec.calls); len(got) != 1 || got[0] != want {
+			t.Fatalf("commands = %v, want exactly [%q] — the poisoned row must not disable the whole batch", got, want)
+		}
+	})
+
+	t.Run("nothing is issued when every name is unusable", func(t *testing.T) {
+		rec := newOVSRecorder()
+		rm := &RouteManager{execOVSHook: rec.hook()}
+		tunnels := []bfdTunnel{{Name: "-x", Enabled: true, MinRxMs: 1000, MinTxMs: 100, Mult: 3}}
+
+		if err := rm.EnsureOVNBFDTimers(tunnels, 150, 150); err != nil {
+			t.Fatalf("EnsureOVNBFDTimers() error: %v", err)
+		}
+		if len(rec.calls) != 0 {
+			t.Errorf("issued %v, want no ovs-vsctl invocation at all", rec.calls)
+		}
+	})
+
+	t.Run("exec error is propagated", func(t *testing.T) {
+		rec := newOVSRecorder()
+		rec.on(strings.Fields("ovs-vsctl --if-exists set Interface genev_sys_6081 bfd:min_rx=150 bfd:min_tx=150"),
+			"ovs-vsctl: unix socket error", errors.New("exit status 1"))
+		rm := &RouteManager{execOVSHook: rec.hook()}
+		tunnels := []bfdTunnel{{Name: "genev_sys_6081", Enabled: true, MinRxMs: 1000, MinTxMs: 100, Mult: 3}}
+
+		if err := rm.EnsureOVNBFDTimers(tunnels, 150, 150); err == nil {
+			t.Fatal("EnsureOVNBFDTimers() = nil error, want the exec failure")
+		}
+	})
+
+	t.Run("dry-run writes nothing", func(t *testing.T) {
+		rec := newOVSRecorder()
+		rm := &RouteManager{dryRun: true, execOVSHook: rec.hook()}
+		tunnels := []bfdTunnel{{Name: "genev_sys_6081", Enabled: true, MinRxMs: 1000, MinTxMs: 100, Mult: 3}}
+
+		if err := rm.EnsureOVNBFDTimers(tunnels, 150, 150); err != nil {
+			t.Fatalf("EnsureOVNBFDTimers() error: %v", err)
+		}
+		if len(rec.calls) != 0 {
+			t.Errorf("dry-run issued %v, want no commands", rec.calls)
+		}
+	})
+}
+
+// The exported estimate must describe the timers OVS holds, not the ones the
+// agent asked for — otherwise the check that exists to prove ovn_bfd_manage
+// took effect is structurally incapable of observing that it did not.
+func TestReconcileBFDOVNManageEstimatesFromOVSDBNotFromIntent(t *testing.T) {
+	m := withTestMetrics(t)
+	a, ovsRec, vtyshRec := bfdTestAgent(t, Config{
+		BFDCheckEnabled: true, BFDCheckMaxDetect: time.Second,
+		OVNBFDManage: true, OVNBFDMinRxMs: 150, OVNBFDMinTxMs: 150,
+	})
+
+	a.reconcileBFD()
+
+	if got := setTimerCommands(ovsRec.calls); len(got) != 1 {
+		t.Fatalf("OVS timer commands = %v, want exactly one", got)
+	}
+	// OVS still reported the untuned timers this cycle, so 3 s is the floor
+	// that was actually in force.
+	if v, _ := bfdDetectValue(t, m, "ovn"); v != 3 {
+		t.Errorf("bfd_detect_seconds{layer=ovn} = %v, want 3 — the estimate must follow OVSDB, not the write", v)
+	}
+	// FRR must stay untouched: the manage flags are independent.
+	if got := mutatingCommands(vtyshRec.calls); len(got) > 0 {
+		t.Errorf("ovn_bfd_manage modified FRR state: %v", got)
+	}
+
+	// Once OVS reports the timers that were written, the next reconcile finds
+	// nothing drifted, writes nothing, and the estimate follows.
+	ovsRec.on(strings.Fields("ovs-vsctl --format=json --columns=name,bfd find Interface type=geneve"),
+		geneveFindTunedTimers, nil)
+	before := len(setTimerCommands(ovsRec.calls))
+	a.reconcileBFD()
+	if got := setTimerCommands(ovsRec.calls); len(got) != before {
+		t.Errorf("second reconcile issued %d timer commands, want 0", len(got)-before)
+	}
+	if v, _ := bfdDetectValue(t, m, "ovn"); v != 0.45 {
+		t.Errorf("bfd_detect_seconds{layer=ovn} = %v, want 0.45 once OVS reports the tuned timers", v)
+	}
+}
+
+// An OVN version that reclaims the bfd column reverts the timers after every
+// write. The metric must keep reporting the real 3 s floor rather than the
+// 450 ms the agent keeps asking for.
+func TestReconcileBFDOVNManageReportsRevertedTimers(t *testing.T) {
+	m := withTestMetrics(t)
+	a, ovsRec, _ := bfdTestAgent(t, Config{
+		BFDCheckEnabled: true, BFDCheckMaxDetect: time.Second,
+		OVNBFDManage: true, OVNBFDMinRxMs: 150, OVNBFDMinTxMs: 150,
+	})
+
+	// The recorder keeps answering the find with the OVS defaults: whatever the
+	// agent writes, ovn-controller puts them back.
+	a.reconcileBFD()
+	a.reconcileBFD()
+
+	if got := setTimerCommands(ovsRec.calls); len(got) != 2 {
+		t.Errorf("OVS timer commands = %v, want one per reconcile", got)
+	}
+	if v, _ := bfdDetectValue(t, m, "ovn"); v != 3 {
+		t.Errorf("bfd_detect_seconds{layer=ovn} = %v, want 3 — a reverted write must stay visible", v)
+	}
+}
+
+// The manager runs even when the check is off — the two are independent.
+func TestReconcileBFDOVNManageWithoutCheck(t *testing.T) {
+	m := withTestMetrics(t)
+	a, ovsRec, _ := bfdTestAgent(t, Config{
+		BFDCheckEnabled: false,
+		OVNBFDManage:    true, OVNBFDMinRxMs: 150, OVNBFDMinTxMs: 150,
+	})
+
+	a.reconcileBFD()
+
+	if got := setTimerCommands(ovsRec.calls); len(got) != 1 {
+		t.Errorf("OVS timer commands = %v, want exactly one", got)
+	}
+	if v, _ := bfdDetectValue(t, m, "ovn"); !math.IsNaN(v) {
+		t.Errorf("bfd_detect_seconds{layer=ovn} = %v, want NaN — the check is disabled", v)
+	}
+}

--- a/bfd_test.go
+++ b/bfd_test.go
@@ -1,0 +1,540 @@
+package main
+
+import (
+	"errors"
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A tunnel with the OVS default timers (ovn-controller sets only
+// bfd:enable=true) and one with the timers this agent can manage.
+const (
+	geneveFindDefaultTimers = `{"data":[["genev_sys_6081",["map",[["enable","true"]]]]],"headings":["name","bfd"]}`
+	geneveFindTunedTimers   = `{"data":[["genev_sys_6081",["map",[["enable","true"],["min_rx","150"],["min_tx","150"]]]]],"headings":["name","bfd"]}`
+)
+
+func TestParseGeneveTunnels(t *testing.T) {
+	tests := []struct {
+		name    string
+		out     string
+		want    []bfdTunnel
+		wantErr bool
+	}{
+		{
+			name: "explicit timers",
+			out:  geneveFindTunedTimers,
+			want: []bfdTunnel{{Name: "genev_sys_6081", Enabled: true, MinRxMs: 150, MinTxMs: 150, Mult: 3}},
+		},
+		{
+			name: "absent keys fall back to OVS defaults",
+			out:  geneveFindDefaultTimers,
+			want: []bfdTunnel{{Name: "genev_sys_6081", Enabled: true, MinRxMs: 1000, MinTxMs: 100, Mult: 3}},
+		},
+		{
+			name: "explicit mult overrides the default",
+			out:  `{"data":[["genev_sys_6081",["map",[["enable","true"],["mult","5"]]]]],"headings":["name","bfd"]}`,
+			want: []bfdTunnel{{Name: "genev_sys_6081", Enabled: true, MinRxMs: 1000, MinTxMs: 100, Mult: 5}},
+		},
+		{
+			name: "enable absent means no BFD session",
+			out:  `{"data":[["genev_sys_6081",["map",[]]]],"headings":["name","bfd"]}`,
+			want: []bfdTunnel{{Name: "genev_sys_6081", Enabled: false, MinRxMs: 1000, MinTxMs: 100, Mult: 3}},
+		},
+		{
+			name: "non-integer timer falls back to the OVS default",
+			out:  `{"data":[["genev_sys_6081",["map",[["enable","true"],["min_rx","fast"],["min_tx","0"]]]]],"headings":["name","bfd"]}`,
+			want: []bfdTunnel{{Name: "genev_sys_6081", Enabled: true, MinRxMs: 1000, MinTxMs: 100, Mult: 3}},
+		},
+		{
+			name: "several tunnels",
+			out: `{"data":[["genev_sys_6081",["map",[["enable","true"]]]],` +
+				`["genev_sys_6082",["map",[["enable","true"],["min_rx","150"],["min_tx","150"]]]]],"headings":["name","bfd"]}`,
+			want: []bfdTunnel{
+				{Name: "genev_sys_6081", Enabled: true, MinRxMs: 1000, MinTxMs: 100, Mult: 3},
+				{Name: "genev_sys_6082", Enabled: true, MinRxMs: 150, MinTxMs: 150, Mult: 3},
+			},
+		},
+		{
+			name: "no geneve tunnels",
+			out:  `{"data":[],"headings":["name","bfd"]}`,
+			want: nil,
+		},
+		{"empty output", "", nil, false},
+		{"blank output", "   \n", nil, false},
+		{"malformed json", `{"data":`, nil, true},
+		{"missing bfd column", `{"data":[["genev_sys_6081"]],"headings":["name"]}`, nil, true},
+		{"row shorter than headings", `{"data":[["genev_sys_6081"]],"headings":["name","bfd"]}`, nil, true},
+		{"bfd column is not a map", `{"data":[["genev_sys_6081",["set",[]]]],"headings":["name","bfd"]}`, nil, true},
+		{"bfd column is a bare scalar", `{"data":[["genev_sys_6081","nope"]],"headings":["name","bfd"]}`, nil, true},
+		{"interface name is not a string", `{"data":[[42,["map",[]]]],"headings":["name","bfd"]}`, nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseGeneveTunnels([]byte(tt.out))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseGeneveTunnels() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d tunnels, want %d (%+v)", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("tunnel[%d] = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBFDTunnelDetectTime(t *testing.T) {
+	tests := []struct {
+		name   string
+		tunnel bfdTunnel
+		want   time.Duration
+	}{
+		{"OVS defaults are the documented 3s floor", bfdTunnel{MinRxMs: 1000, MinTxMs: 100, Mult: 3}, 3 * time.Second},
+		{"tuned 150/150 with mult 3", bfdTunnel{MinRxMs: 150, MinTxMs: 150, Mult: 3}, 450 * time.Millisecond},
+		{"the slower interval wins", bfdTunnel{MinRxMs: 150, MinTxMs: 900, Mult: 3}, 2700 * time.Millisecond},
+		{"higher multiplier extends detection", bfdTunnel{MinRxMs: 150, MinTxMs: 150, Mult: 5}, 750 * time.Millisecond},
+		{"an unreported multiplier yields no estimate", bfdTunnel{MinRxMs: 150, MinTxMs: 150}, 0},
+		// The bfd column accepts any integer literal, so a fat-fingered timer
+		// reaches this code. The nanosecond product must saturate rather than
+		// wrap to a negative duration.
+		{
+			"an out-of-range interval saturates",
+			bfdTunnel{MinRxMs: 1_000_000_000, MinTxMs: 1, Mult: 1_000_000},
+			maxBFDDetectTime,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.tunnel.detectTime(); got != tt.want {
+				t.Errorf("detectTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Only tunnels running a BFD session bound the failover floor; a disabled
+// tunnel with terrible timers must not be reported.
+func TestWorstTunnelDetectTime(t *testing.T) {
+	tests := []struct {
+		name     string
+		tunnels  []bfdTunnel
+		want     time.Duration
+		wantName string
+	}{
+		{"no tunnels", nil, 0, ""},
+		{
+			"disabled tunnels are ignored",
+			[]bfdTunnel{{Name: "a", Enabled: false, MinRxMs: 5000, MinTxMs: 5000, Mult: 3}},
+			0, "",
+		},
+		{
+			"worst enabled tunnel wins",
+			[]bfdTunnel{
+				{Name: "fast", Enabled: true, MinRxMs: 150, MinTxMs: 150, Mult: 3},
+				{Name: "slow", Enabled: true, MinRxMs: 1000, MinTxMs: 100, Mult: 3},
+			},
+			3 * time.Second, "slow",
+		},
+		{
+			"a disabled slow tunnel does not mask an enabled fast one",
+			[]bfdTunnel{
+				{Name: "slow", Enabled: false, MinRxMs: 5000, MinTxMs: 5000, Mult: 3},
+				{Name: "fast", Enabled: true, MinRxMs: 150, MinTxMs: 150, Mult: 3},
+			},
+			450 * time.Millisecond, "fast",
+		},
+		{
+			// A tunnel whose timers overflow the nanosecond product has an
+			// effectively infinite detection time — it is exactly the one the
+			// check must report, not the one it silently drops.
+			"a tunnel with out-of-range timers is not discarded",
+			[]bfdTunnel{
+				{Name: "fast", Enabled: true, MinRxMs: 150, MinTxMs: 150, Mult: 3},
+				{Name: "broken", Enabled: true, MinRxMs: 1_000_000_000, MinTxMs: 1, Mult: 1_000_000},
+			},
+			maxBFDDetectTime, "broken",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, name := worstTunnelDetectTime(tt.tunnels)
+			if got != tt.want || name != tt.wantName {
+				t.Errorf("worstTunnelDetectTime() = (%v, %q), want (%v, %q)", got, name, tt.want, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestGeneveTunnels(t *testing.T) {
+	const findCmd = "ovs-vsctl --format=json --columns=name,bfd find Interface type=geneve"
+
+	t.Run("enumerates the local tunnels", func(t *testing.T) {
+		rec := newOVSRecorder()
+		rec.on(strings.Fields(findCmd), geneveFindTunedTimers, nil)
+		rm := &RouteManager{execOVSHook: rec.hook()}
+
+		tunnels, err := rm.GeneveTunnels()
+		if err != nil {
+			t.Fatalf("GeneveTunnels() error: %v", err)
+		}
+		if len(tunnels) != 1 || tunnels[0].Name != "genev_sys_6081" {
+			t.Fatalf("got %+v, want one genev_sys_6081 tunnel", tunnels)
+		}
+		if len(rec.calls) != 1 || strings.Join(rec.calls[0], " ") != findCmd {
+			t.Fatalf("calls = %v, want exactly %q", rec.calls, findCmd)
+		}
+	})
+
+	t.Run("a node with no tunnels yields none", func(t *testing.T) {
+		rec := newOVSRecorder()
+		rec.on(strings.Fields(findCmd), `{"data":[],"headings":["name","bfd"]}`, nil)
+		rm := &RouteManager{execOVSHook: rec.hook()}
+
+		tunnels, err := rm.GeneveTunnels()
+		if err != nil {
+			t.Fatalf("GeneveTunnels() error: %v", err)
+		}
+		if len(tunnels) != 0 {
+			t.Errorf("tunnels = %+v, want none", tunnels)
+		}
+	})
+
+	t.Run("exec error is propagated", func(t *testing.T) {
+		rec := newOVSRecorder()
+		rec.on(strings.Fields(findCmd), "ovs-vsctl: unix socket error", errors.New("exit status 1"))
+		rm := &RouteManager{execOVSHook: rec.hook()}
+
+		if _, err := rm.GeneveTunnels(); err == nil {
+			t.Fatal("GeneveTunnels() = nil error, want the exec failure")
+		}
+	})
+
+	t.Run("malformed output is an error", func(t *testing.T) {
+		rec := newOVSRecorder()
+		rec.on(strings.Fields(findCmd), `{"data":`, nil)
+		rm := &RouteManager{execOVSHook: rec.hook()}
+
+		if _, err := rm.GeneveTunnels(); err == nil {
+			t.Fatal("GeneveTunnels() = nil error, want a parse failure")
+		}
+	})
+}
+
+func TestFRRBFDPeerDetectTime(t *testing.T) {
+	tests := []struct {
+		name string
+		peer frrBFDPeer
+		want time.Duration
+	}{
+		{
+			"remote transmit interval refines the estimate",
+			frrBFDPeer{ReceiveInterval: 300, TransmitInterval: 300, RemoteTransmitInterval: 1000, DetectMultiplier: 3},
+			3 * time.Second,
+		},
+		{
+			"falls back to our transmit interval before the session is up",
+			frrBFDPeer{ReceiveInterval: 150, TransmitInterval: 150, DetectMultiplier: 3},
+			450 * time.Millisecond,
+		},
+		{
+			"our receive interval wins when it is the slower side",
+			frrBFDPeer{ReceiveInterval: 900, TransmitInterval: 150, RemoteTransmitInterval: 150, DetectMultiplier: 3},
+			2700 * time.Millisecond,
+		},
+		{
+			"an unreported multiplier yields no estimate",
+			frrBFDPeer{ReceiveInterval: 300, TransmitInterval: 300},
+			0,
+		},
+		{
+			"an out-of-range interval saturates",
+			frrBFDPeer{ReceiveInterval: 1_000_000_000, TransmitInterval: 1, DetectMultiplier: 1_000_000},
+			maxBFDDetectTime,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.peer.detectTime(); got != tt.want {
+				t.Errorf("detectTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestListFRRBFDPeers(t *testing.T) {
+	const peersCmd = "vtysh -c show bfd peers json"
+	peersJSON := `[{"peer":"192.0.2.1","vrf":"vrf-provider","status":"up",` +
+		`"receive-interval":300,"transmit-interval":300,"remote-transmit-interval":300,"detect-multiplier":3}]`
+
+	tests := []struct {
+		name      string
+		out       string
+		execErr   error
+		wantPeers int
+		wantErr   bool
+	}{
+		{"peers parsed", peersJSON, nil, 1, false},
+		{"empty json array", `[]`, nil, 0, false},
+		// A fabric without BFD, or a node where bfdd is not running, is an
+		// expected state for a default-on check — not an error.
+		{"bfdd not running", "% BFD is not running\n", nil, 0, false},
+		{"unknown command", "% Unknown command: show bfd peers json", nil, 0, false},
+		{"empty output", "", nil, 0, false},
+		{"exec failure", "vtysh: connect failed", errors.New("exit status 1"), 0, true},
+		{"malformed json array", `[{"peer":`, nil, 0, true},
+		// Reading unparseable output as "no peers" would report a fabric whose
+		// BFD is healthy as running none, flipping the gauge to +Inf.
+		{"contaminated json is an error, not an empty peer list", "vtysh: warning\n" + peersJSON, nil, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := newVtyshRecorder()
+			rec.on([]string{"vtysh", "-c", "show bfd peers json"}, tt.out, tt.execErr)
+			rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+
+			peers, err := rm.ListFRRBFDPeers()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ListFRRBFDPeers() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if len(peers) != tt.wantPeers {
+				t.Errorf("got %d peers, want %d", len(peers), tt.wantPeers)
+			}
+			if len(rec.calls) != 1 || strings.Join(rec.calls[0], " ") != peersCmd {
+				t.Errorf("calls = %v, want exactly %q", rec.calls, peersCmd)
+			}
+		})
+	}
+}
+
+// Peers outside the agent's VRF belong to another routing domain and must not
+// drive this agent's estimate.
+func TestWorstPeerDetectTime(t *testing.T) {
+	peers := []frrBFDPeer{
+		{Peer: "192.0.2.1", VRF: "vrf-provider", ReceiveInterval: 150, TransmitInterval: 150, DetectMultiplier: 3},
+		{Peer: "198.51.100.1", VRF: "default", ReceiveInterval: 1000, TransmitInterval: 1000, DetectMultiplier: 3},
+	}
+
+	got, name := worstPeerDetectTime(peers, "vrf-provider")
+	if got != 450*time.Millisecond || name != "192.0.2.1" {
+		t.Errorf("worstPeerDetectTime() = (%v, %q), want (450ms, %q)", got, name, "192.0.2.1")
+	}
+
+	if got, name := worstPeerDetectTime(peers, "vrf-absent"); got != 0 || name != "" {
+		t.Errorf("worstPeerDetectTime(absent vrf) = (%v, %q), want (0, \"\")", got, name)
+	}
+	if got, _ := worstPeerDetectTime(nil, "vrf-provider"); got != 0 {
+		t.Errorf("worstPeerDetectTime(nil) = %v, want 0", got)
+	}
+}
+
+// bfdd omits fields it has not negotiated, so an absent vrf means "unknown".
+// Comparing it against the configured VRF discards a healthy session and makes
+// the check report that nothing bounds the failover.
+func TestWorstPeerDetectTimeKeepsPeersWithoutAReportedVRF(t *testing.T) {
+	peers := []frrBFDPeer{
+		{Peer: "192.0.2.1", ReceiveInterval: 150, TransmitInterval: 150, DetectMultiplier: 3},
+	}
+
+	got, name := worstPeerDetectTime(peers, "vrf-provider")
+	if got != 450*time.Millisecond || name != "192.0.2.1" {
+		t.Errorf("worstPeerDetectTime() = (%v, %q), want (450ms, %q) — an unreported vrf is unknown, not foreign",
+			got, name, "192.0.2.1")
+	}
+}
+
+// bfdTestAgent builds an agent whose OVS and vtysh calls are recorded, with
+// one default-timer Geneve tunnel and one slow FRR BFD peer.
+func bfdTestAgent(t *testing.T, cfg Config) (*Agent, *ovsRecorder, *vtyshRecorder) {
+	t.Helper()
+	ovsRec := newOVSRecorder()
+	ovsRec.on(strings.Fields("ovs-vsctl --format=json --columns=name,bfd find Interface type=geneve"),
+		geneveFindDefaultTimers, nil)
+
+	vtyshRec := newVtyshRecorder()
+	vtyshRec.on([]string{"vtysh", "-c", "show bfd peers json"},
+		`[{"peer":"192.0.2.1","vrf":"vrf-provider","status":"up",`+
+			`"receive-interval":300,"transmit-interval":300,"remote-transmit-interval":1000,"detect-multiplier":3}]`, nil)
+
+	cfg.VRFName = "vrf-provider"
+	rm := &RouteManager{vrfName: "vrf-provider", execOVSHook: ovsRec.hook(), execVtyshHook: vtyshRec.hook()}
+	return &Agent{cfg: cfg, routing: rm}, ovsRec, vtyshRec
+}
+
+// mutatingCommands returns the recorded calls that would change OVS or FRR
+// state — the check must never issue any of them.
+func mutatingCommands(calls [][]string) []string {
+	var found []string
+	for _, c := range calls {
+		joined := strings.Join(c, " ")
+		if strings.Contains(joined, "set Interface") ||
+			strings.Contains(joined, "conf t") ||
+			strings.Contains(joined, "router bgp") {
+			found = append(found, joined)
+		}
+	}
+	return found
+}
+
+// With defaults the agent estimates and exports the detection time but leaves
+// OVS and FRR untouched.
+func TestReconcileBFDDefaultsIsReadOnly(t *testing.T) {
+	m := withTestMetrics(t)
+	a, ovsRec, vtyshRec := bfdTestAgent(t, Config{BFDCheckEnabled: true, BFDCheckMaxDetect: time.Second})
+
+	a.reconcileBFD()
+
+	if got := mutatingCommands(ovsRec.calls); len(got) > 0 {
+		t.Errorf("check modified OVS state: %v", got)
+	}
+	if got := mutatingCommands(vtyshRec.calls); len(got) > 0 {
+		t.Errorf("check modified FRR state: %v", got)
+	}
+
+	// Default OVS timers → 3 × 1000 ms; the FRR peer's remote transmit
+	// interval of 1000 ms → 3 × 1000 ms as well.
+	if v, ok := bfdDetectValue(t, m, "ovn"); !ok || v != 3 {
+		t.Errorf("bfd_detect_seconds{layer=ovn} = %v (present=%v), want 3", v, ok)
+	}
+	if v, ok := bfdDetectValue(t, m, "frr"); !ok || v != 3 {
+		t.Errorf("bfd_detect_seconds{layer=frr} = %v (present=%v), want 3", v, ok)
+	}
+}
+
+func TestReconcileBFDCheckDisabledIssuesNoCommands(t *testing.T) {
+	withTestMetrics(t)
+	a, ovsRec, vtyshRec := bfdTestAgent(t, Config{BFDCheckEnabled: false})
+
+	a.reconcileBFD()
+
+	if len(ovsRec.calls) != 0 {
+		t.Errorf("OVS calls = %v, want none when the check is disabled", ovsRec.calls)
+	}
+	if len(vtyshRec.calls) != 0 {
+		t.Errorf("vtysh calls = %v, want none when the check is disabled", vtyshRec.calls)
+	}
+}
+
+// Port-forward-only nodes run no OVS, so the OVN layer is skipped — but FRR
+// still announces the VIP /32s there, so its layer must still run.
+func TestReconcileBFDPortForwardOnlySkipsOVNLayer(t *testing.T) {
+	m := withTestMetrics(t)
+	a, ovsRec, vtyshRec := bfdTestAgent(t, Config{
+		BFDCheckEnabled: true, BFDCheckMaxDetect: time.Second, PortForwardOnly: true,
+	})
+
+	a.reconcileBFD()
+
+	if len(ovsRec.calls) != 0 {
+		t.Errorf("OVS calls = %v, want none in port-forward-only mode", ovsRec.calls)
+	}
+	if len(vtyshRec.calls) == 0 {
+		t.Error("the FRR layer must still run in port-forward-only mode")
+	}
+	if v, _ := bfdDetectValue(t, m, "ovn"); !math.IsNaN(v) {
+		t.Errorf("bfd_detect_seconds{layer=ovn} = %v, want NaN (never measured)", v)
+	}
+	if v, _ := bfdDetectValue(t, m, "frr"); v != 3 {
+		t.Errorf("bfd_detect_seconds{layer=frr} = %v, want 3", v)
+	}
+}
+
+// A failing layer is logged and skipped; it must not abort the other layer or
+// leave a stale estimate behind. Its gauge goes to NaN, not to 0: an
+// ovsdb-server the agent cannot reach says nothing about the detection time,
+// and 0 would read as the fastest possible one.
+func TestReconcileBFDToleratesLayerFailures(t *testing.T) {
+	m := withTestMetrics(t)
+	ovsRec := newOVSRecorder()
+	ovsRec.on(strings.Fields("ovs-vsctl --format=json --columns=name,bfd find Interface type=geneve"),
+		"ovs-vsctl: database connection failed", errors.New("exit status 1"))
+	vtyshRec := newVtyshRecorder()
+	vtyshRec.on([]string{"vtysh", "-c", "show bfd peers json"},
+		`[{"peer":"192.0.2.1","vrf":"vrf-provider","receive-interval":150,"transmit-interval":150,"detect-multiplier":3}]`, nil)
+
+	rm := &RouteManager{vrfName: "vrf-provider", execOVSHook: ovsRec.hook(), execVtyshHook: vtyshRec.hook()}
+	a := &Agent{cfg: Config{BFDCheckEnabled: true, BFDCheckMaxDetect: time.Second, VRFName: "vrf-provider"}, routing: rm}
+
+	a.reconcileBFD()
+
+	if v, _ := bfdDetectValue(t, m, "ovn"); !math.IsNaN(v) {
+		t.Errorf("bfd_detect_seconds{layer=ovn} = %v, want NaN after an enumeration failure", v)
+	}
+	if got := bfdCheckErrorCount(t, m, "ovn"); got != 1 {
+		t.Errorf("bfd_check_errors_total{layer=ovn} = %v, want 1", got)
+	}
+	if v, _ := bfdDetectValue(t, m, "frr"); v != 0.45 {
+		t.Errorf("bfd_detect_seconds{layer=frr} = %v, want 0.45 — the FRR layer must still run", v)
+	}
+	if got := bfdCheckErrorCount(t, m, "frr"); got != 0 {
+		t.Errorf("bfd_check_errors_total{layer=frr} = %v, want 0 — that layer was read fine", got)
+	}
+}
+
+// A node whose tunnels run no BFD session, and a VRF with no BFD peer, are the
+// worst states this check can find: nothing bounds the failover at all. They
+// must not share the gauge value of the best state.
+func TestReconcileBFDNoSessionReportsUnboundedDetection(t *testing.T) {
+	m := withTestMetrics(t)
+	ovsRec := newOVSRecorder()
+	ovsRec.on(strings.Fields("ovs-vsctl --format=json --columns=name,bfd find Interface type=geneve"),
+		`{"data":[["genev_sys_6081",["map",[]]]],"headings":["name","bfd"]}`, nil)
+	vtyshRec := newVtyshRecorder()
+	vtyshRec.on([]string{"vtysh", "-c", "show bfd peers json"}, "% BFD is not running\n", nil)
+
+	rm := &RouteManager{vrfName: "vrf-provider", execOVSHook: ovsRec.hook(), execVtyshHook: vtyshRec.hook()}
+	a := &Agent{cfg: Config{BFDCheckEnabled: true, BFDCheckMaxDetect: time.Second, VRFName: "vrf-provider"}, routing: rm}
+
+	a.reconcileBFD()
+
+	for _, layer := range []string{"ovn", "frr"} {
+		v, _ := bfdDetectValue(t, m, layer)
+		if !math.IsInf(v, 1) {
+			t.Errorf("bfd_detect_seconds{layer=%s} = %v, want +Inf — no BFD session bounds the failover", layer, v)
+		}
+		// Nothing failed to read, so this is not an error state.
+		if got := bfdCheckErrorCount(t, m, layer); got != 0 {
+			t.Errorf("bfd_check_errors_total{layer=%s} = %v, want 0", layer, got)
+		}
+	}
+}
+
+// A gauge that keeps its last good value once measurement stops lets an alert
+// on bfd_detect_seconds stay quiet, and a dashboard read healthy, while the
+// agent has measured nothing for hours.
+func TestReconcileBFDClearsTheEstimateWhenMeasurementStops(t *testing.T) {
+	m := withTestMetrics(t)
+	a, ovsRec, vtyshRec := bfdTestAgent(t, Config{BFDCheckEnabled: true, BFDCheckMaxDetect: time.Second})
+
+	a.reconcileBFD()
+	for _, layer := range []string{"ovn", "frr"} {
+		if v, ok := bfdDetectValue(t, m, layer); !ok || v != 3 {
+			t.Fatalf("bfd_detect_seconds{layer=%s} = %v (present=%v), want 3 before the failure", layer, v, ok)
+		}
+	}
+
+	// ovsdb-server became unreachable — the OVN layer is now unknown. bfdd is
+	// still answering, and it reports no session at all — the FRR layer is
+	// known, and unbounded.
+	ovsRec.on(strings.Fields("ovs-vsctl --format=json --columns=name,bfd find Interface type=geneve"),
+		"ovs-vsctl: database connection failed", errors.New("exit status 1"))
+	vtyshRec.on([]string{"vtysh", "-c", "show bfd peers json"}, `[]`, nil)
+
+	a.reconcileBFD()
+
+	if v, _ := bfdDetectValue(t, m, "ovn"); !math.IsNaN(v) {
+		t.Errorf("bfd_detect_seconds{layer=ovn} = %v, want NaN — a stale estimate must not survive an unreadable layer", v)
+	}
+	if v, _ := bfdDetectValue(t, m, "frr"); !math.IsInf(v, 1) {
+		t.Errorf("bfd_detect_seconds{layer=frr} = %v, want +Inf — a stale estimate must not survive a vanished session", v)
+	}
+}

--- a/config.go
+++ b/config.go
@@ -164,6 +164,20 @@ type Config struct {
 	PortForwardL3mdevAccept bool             // set udp/tcp_l3mdev_accept=1 for cross-VRF same-host backends (default: false)
 	PortForwardCTZone       int              // conntrack zone for DNAT flows; must not collide with OVN zones (default: 64000)
 	PortForwards            []PortForwardVIP // VIP forwarding rules from config
+
+	// BFD failover detection. The check is read-only visibility; the two
+	// manage flags are independent opt-ins that write OVS/FRR state.
+	BFDCheckEnabled   bool          // estimate and export the BFD detection floor every reconcile
+	BFDCheckMaxDetect time.Duration // warn when the estimate exceeds this
+
+	OVNBFDManage  bool // set bfd:min_rx/bfd:min_tx on local Geneve tunnel interfaces
+	OVNBFDMinRxMs int  // desired OVS bfd:min_rx in milliseconds
+	OVNBFDMinTxMs int  // desired OVS bfd:min_tx in milliseconds
+
+	FRRBFDManage     bool // enable BFD on the VRF's already-configured BGP neighbors
+	FRRBFDMinRxMs    int  // desired FRR BFD receive-interval in milliseconds
+	FRRBFDMinTxMs    int  // desired FRR BFD transmit-interval in milliseconds
+	FRRBFDMultiplier int  // desired FRR BFD detect-multiplier
 }
 
 // configFile is the YAML representation of the config file.
@@ -202,6 +216,18 @@ type configFile struct {
 	PortForwardL3mdevAccept *bool            `yaml:"port_forward_l3mdev_accept"`
 	PortForwardCTZone       *int             `yaml:"port_forward_ct_zone"`
 	PortForwards            []PortForwardVIP `yaml:"port_forwards"`
+
+	BFDCheckEnabled   *bool  `yaml:"bfd_check_enabled"`
+	BFDCheckMaxDetect string `yaml:"bfd_check_max_detect"`
+
+	OVNBFDManage  *bool `yaml:"ovn_bfd_manage"`
+	OVNBFDMinRxMs *int  `yaml:"ovn_bfd_min_rx_ms"`
+	OVNBFDMinTxMs *int  `yaml:"ovn_bfd_min_tx_ms"`
+
+	FRRBFDManage     *bool `yaml:"frr_bfd_manage"`
+	FRRBFDMinRxMs    *int  `yaml:"frr_bfd_min_rx_ms"`
+	FRRBFDMinTxMs    *int  `yaml:"frr_bfd_min_tx_ms"`
+	FRRBFDMultiplier *int  `yaml:"frr_bfd_multiplier"`
 }
 
 // loadConfig builds the configuration with the following priority
@@ -243,6 +269,16 @@ func loadConfig(args []string) (Config, error) {
 		fPortForwardTableID      = fs.Int("port-forward-table-id", 201, "Routing table ID for DNAT return traffic (1-252)")
 		fPortForwardL3mdevAccept = fs.Bool("port-forward-l3mdev-accept", false, "Set udp/tcp_l3mdev_accept=1 for cross-VRF same-host DNAT backends")
 		fPortForwardCTZone       = fs.Int("port-forward-ct-zone", 64000, "Conntrack zone for DNAT flows (must not collide with OVN zones, 1-65535)")
+
+		fBFDCheckEnabled   = fs.Bool("bfd-check-enabled", true, "Estimate the BFD failure-detection time every reconcile and export it as a metric")
+		fBFDCheckMaxDetect = fs.String("bfd-check-max-detect", "", "Warn when the estimated BFD detection time exceeds this duration (e.g. 1s)")
+		fOVNBFDManage      = fs.Bool("ovn-bfd-manage", false, "Manage bfd:min_rx/bfd:min_tx on local OVN Geneve tunnel interfaces")
+		fOVNBFDMinRxMs     = fs.Int("ovn-bfd-min-rx-ms", 150, "Desired OVS bfd:min_rx for Geneve tunnels in milliseconds (1-60000)")
+		fOVNBFDMinTxMs     = fs.Int("ovn-bfd-min-tx-ms", 150, "Desired OVS bfd:min_tx for Geneve tunnels in milliseconds (1-60000)")
+		fFRRBFDManage      = fs.Bool("frr-bfd-manage", false, "Enable BFD on the VRF's already-configured FRR BGP neighbors")
+		fFRRBFDMinRxMs     = fs.Int("frr-bfd-min-rx-ms", 150, "Desired FRR BFD receive-interval in milliseconds (10-60000)")
+		fFRRBFDMinTxMs     = fs.Int("frr-bfd-min-tx-ms", 150, "Desired FRR BFD transmit-interval in milliseconds (10-60000)")
+		fFRRBFDMultiplier  = fs.Int("frr-bfd-multiplier", 3, "Desired FRR BFD detect-multiplier (2-255)")
 	)
 
 	if err := fs.Parse(args); err != nil {
@@ -273,6 +309,13 @@ func loadConfig(args []string) (Config, error) {
 		PortForwardDev:          "loopback1",
 		PortForwardTableID:      201,
 		PortForwardCTZone:       64000,
+		BFDCheckEnabled:         true,
+		BFDCheckMaxDetect:       1 * time.Second,
+		OVNBFDMinRxMs:           150,
+		OVNBFDMinTxMs:           150,
+		FRRBFDMinRxMs:           150,
+		FRRBFDMinTxMs:           150,
+		FRRBFDMultiplier:        3,
 	}
 
 	// Layer 1: config file
@@ -356,6 +399,28 @@ func loadConfig(args []string) (Config, error) {
 			cfg.PortForwardL3mdevAccept = *fPortForwardL3mdevAccept
 		case "port-forward-ct-zone":
 			cfg.PortForwardCTZone = *fPortForwardCTZone
+		case "bfd-check-enabled":
+			cfg.BFDCheckEnabled = *fBFDCheckEnabled
+		case "bfd-check-max-detect":
+			if d, err := time.ParseDuration(*fBFDCheckMaxDetect); err == nil {
+				cfg.BFDCheckMaxDetect = d
+			} else {
+				slog.Warn("ignoring invalid bfd-check-max-detect flag value", "value", *fBFDCheckMaxDetect, "error", err)
+			}
+		case "ovn-bfd-manage":
+			cfg.OVNBFDManage = *fOVNBFDManage
+		case "ovn-bfd-min-rx-ms":
+			cfg.OVNBFDMinRxMs = *fOVNBFDMinRxMs
+		case "ovn-bfd-min-tx-ms":
+			cfg.OVNBFDMinTxMs = *fOVNBFDMinTxMs
+		case "frr-bfd-manage":
+			cfg.FRRBFDManage = *fFRRBFDManage
+		case "frr-bfd-min-rx-ms":
+			cfg.FRRBFDMinRxMs = *fFRRBFDMinRxMs
+		case "frr-bfd-min-tx-ms":
+			cfg.FRRBFDMinTxMs = *fFRRBFDMinTxMs
+		case "frr-bfd-multiplier":
+			cfg.FRRBFDMultiplier = *fFRRBFDMultiplier
 		}
 	})
 
@@ -570,6 +635,33 @@ func validateConfig(cfg *Config) error {
 		}
 	}
 
+	// BFD validation. Each block is gated on its own enable flag so that
+	// values left at an out-of-range setting for a disabled feature do not
+	// prevent the agent from starting.
+	if cfg.BFDCheckEnabled && cfg.BFDCheckMaxDetect <= 0 {
+		return fmt.Errorf("bfd-check-enabled requires a positive bfd-check-max-detect")
+	}
+	if cfg.OVNBFDManage {
+		if cfg.OVNBFDMinRxMs < 1 || cfg.OVNBFDMinRxMs > 60000 {
+			return fmt.Errorf("invalid ovn-bfd-min-rx-ms: %d (must be 1-60000)", cfg.OVNBFDMinRxMs)
+		}
+		if cfg.OVNBFDMinTxMs < 1 || cfg.OVNBFDMinTxMs > 60000 {
+			return fmt.Errorf("invalid ovn-bfd-min-tx-ms: %d (must be 1-60000)", cfg.OVNBFDMinTxMs)
+		}
+	}
+	if cfg.FRRBFDManage {
+		// FRR rejects intervals below 10 ms and multipliers outside 2-255.
+		if cfg.FRRBFDMinRxMs < 10 || cfg.FRRBFDMinRxMs > 60000 {
+			return fmt.Errorf("invalid frr-bfd-min-rx-ms: %d (must be 10-60000)", cfg.FRRBFDMinRxMs)
+		}
+		if cfg.FRRBFDMinTxMs < 10 || cfg.FRRBFDMinTxMs > 60000 {
+			return fmt.Errorf("invalid frr-bfd-min-tx-ms: %d (must be 10-60000)", cfg.FRRBFDMinTxMs)
+		}
+		if cfg.FRRBFDMultiplier < 2 || cfg.FRRBFDMultiplier > 255 {
+			return fmt.Errorf("invalid frr-bfd-multiplier: %d (must be 2-255)", cfg.FRRBFDMultiplier)
+		}
+	}
+
 	return nil
 }
 
@@ -716,6 +808,37 @@ func applyFileConfig(cfg *Config, fc *configFile) {
 	if len(fc.PortForwards) > 0 {
 		cfg.PortForwards = fc.PortForwards
 	}
+	if fc.BFDCheckEnabled != nil {
+		cfg.BFDCheckEnabled = *fc.BFDCheckEnabled
+	}
+	if fc.BFDCheckMaxDetect != "" {
+		if d, err := time.ParseDuration(fc.BFDCheckMaxDetect); err == nil {
+			cfg.BFDCheckMaxDetect = d
+		} else {
+			slog.Warn("ignoring invalid bfd_check_max_detect in config file", "value", fc.BFDCheckMaxDetect, "error", err)
+		}
+	}
+	if fc.OVNBFDManage != nil {
+		cfg.OVNBFDManage = *fc.OVNBFDManage
+	}
+	if fc.OVNBFDMinRxMs != nil {
+		cfg.OVNBFDMinRxMs = *fc.OVNBFDMinRxMs
+	}
+	if fc.OVNBFDMinTxMs != nil {
+		cfg.OVNBFDMinTxMs = *fc.OVNBFDMinTxMs
+	}
+	if fc.FRRBFDManage != nil {
+		cfg.FRRBFDManage = *fc.FRRBFDManage
+	}
+	if fc.FRRBFDMinRxMs != nil {
+		cfg.FRRBFDMinRxMs = *fc.FRRBFDMinRxMs
+	}
+	if fc.FRRBFDMinTxMs != nil {
+		cfg.FRRBFDMinTxMs = *fc.FRRBFDMinTxMs
+	}
+	if fc.FRRBFDMultiplier != nil {
+		cfg.FRRBFDMultiplier = *fc.FRRBFDMultiplier
+	}
 }
 
 func applyEnvConfig(cfg *Config) {
@@ -830,6 +953,52 @@ func applyEnvConfig(cfg *Config) {
 		var zone int
 		if _, err := fmt.Sscanf(v, "%d", &zone); err == nil {
 			cfg.PortForwardCTZone = zone
+		}
+	}
+	if v := os.Getenv("OVN_NETWORK_BFD_CHECK_ENABLED"); v == "0" || v == "false" {
+		cfg.BFDCheckEnabled = false
+	}
+	if v := os.Getenv("OVN_NETWORK_BFD_CHECK_MAX_DETECT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.BFDCheckMaxDetect = d
+		} else {
+			slog.Warn("ignoring invalid OVN_NETWORK_BFD_CHECK_MAX_DETECT env var", "value", v, "error", err)
+		}
+	}
+	if v := os.Getenv("OVN_NETWORK_OVN_BFD_MANAGE"); v == "1" || v == "true" {
+		cfg.OVNBFDManage = true
+	}
+	if v := os.Getenv("OVN_NETWORK_OVN_BFD_MIN_RX_MS"); v != "" {
+		var ms int
+		if _, err := fmt.Sscanf(v, "%d", &ms); err == nil {
+			cfg.OVNBFDMinRxMs = ms
+		}
+	}
+	if v := os.Getenv("OVN_NETWORK_OVN_BFD_MIN_TX_MS"); v != "" {
+		var ms int
+		if _, err := fmt.Sscanf(v, "%d", &ms); err == nil {
+			cfg.OVNBFDMinTxMs = ms
+		}
+	}
+	if v := os.Getenv("OVN_NETWORK_FRR_BFD_MANAGE"); v == "1" || v == "true" {
+		cfg.FRRBFDManage = true
+	}
+	if v := os.Getenv("OVN_NETWORK_FRR_BFD_MIN_RX_MS"); v != "" {
+		var ms int
+		if _, err := fmt.Sscanf(v, "%d", &ms); err == nil {
+			cfg.FRRBFDMinRxMs = ms
+		}
+	}
+	if v := os.Getenv("OVN_NETWORK_FRR_BFD_MIN_TX_MS"); v != "" {
+		var ms int
+		if _, err := fmt.Sscanf(v, "%d", &ms); err == nil {
+			cfg.FRRBFDMinTxMs = ms
+		}
+	}
+	if v := os.Getenv("OVN_NETWORK_FRR_BFD_MULTIPLIER"); v != "" {
+		var mult int
+		if _, err := fmt.Sscanf(v, "%d", &mult); err == nil {
+			cfg.FRRBFDMultiplier = mult
 		}
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -326,6 +326,28 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if cfg.VethLeakRulePriority != 2000 {
 		t.Errorf("VethLeakRulePriority = %d, want 2000", cfg.VethLeakRulePriority)
 	}
+	// BFD: the check is on by default, both manage flags are off.
+	if !cfg.BFDCheckEnabled {
+		t.Error("BFDCheckEnabled should be true by default")
+	}
+	if cfg.BFDCheckMaxDetect != time.Second {
+		t.Errorf("BFDCheckMaxDetect = %v, want %v", cfg.BFDCheckMaxDetect, time.Second)
+	}
+	if cfg.OVNBFDManage {
+		t.Error("OVNBFDManage should be false by default")
+	}
+	if cfg.FRRBFDManage {
+		t.Error("FRRBFDManage should be false by default")
+	}
+	if cfg.OVNBFDMinRxMs != 150 || cfg.OVNBFDMinTxMs != 150 {
+		t.Errorf("OVN BFD timers = %d/%d, want 150/150", cfg.OVNBFDMinRxMs, cfg.OVNBFDMinTxMs)
+	}
+	if cfg.FRRBFDMinRxMs != 150 || cfg.FRRBFDMinTxMs != 150 {
+		t.Errorf("FRR BFD timers = %d/%d, want 150/150", cfg.FRRBFDMinRxMs, cfg.FRRBFDMinTxMs)
+	}
+	if cfg.FRRBFDMultiplier != 3 {
+		t.Errorf("FRRBFDMultiplier = %d, want 3", cfg.FRRBFDMultiplier)
+	}
 }
 
 func TestLoadConfigVethLeakEnabledByDefault(t *testing.T) {
@@ -1848,4 +1870,229 @@ func TestLoadConfigRejectsIncompleteOVN(t *testing.T) {
 			t.Error("expected error when only ovn-nb-remote is set")
 		}
 	})
+}
+
+// =============================================================================
+// BFD failover detection options
+// =============================================================================
+
+func TestLoadConfigBFDCLIFlags(t *testing.T) {
+	cfg, err := loadConfig(fullModeArgs(
+		"--bfd-check-enabled=false",
+		"--bfd-check-max-detect", "500ms",
+		"--ovn-bfd-manage",
+		"--ovn-bfd-min-rx-ms", "100",
+		"--ovn-bfd-min-tx-ms", "120",
+		"--frr-bfd-manage",
+		"--frr-bfd-min-rx-ms", "200",
+		"--frr-bfd-min-tx-ms", "250",
+		"--frr-bfd-multiplier", "5",
+	))
+	if err != nil {
+		t.Fatalf("loadConfig() error: %v", err)
+	}
+	if cfg.BFDCheckEnabled {
+		t.Error("BFDCheckEnabled should be false")
+	}
+	if cfg.BFDCheckMaxDetect != 500*time.Millisecond {
+		t.Errorf("BFDCheckMaxDetect = %v, want 500ms", cfg.BFDCheckMaxDetect)
+	}
+	if !cfg.OVNBFDManage || !cfg.FRRBFDManage {
+		t.Error("both manage flags should be true")
+	}
+	if cfg.OVNBFDMinRxMs != 100 || cfg.OVNBFDMinTxMs != 120 {
+		t.Errorf("OVN BFD timers = %d/%d, want 100/120", cfg.OVNBFDMinRxMs, cfg.OVNBFDMinTxMs)
+	}
+	if cfg.FRRBFDMinRxMs != 200 || cfg.FRRBFDMinTxMs != 250 {
+		t.Errorf("FRR BFD timers = %d/%d, want 200/250", cfg.FRRBFDMinRxMs, cfg.FRRBFDMinTxMs)
+	}
+	if cfg.FRRBFDMultiplier != 5 {
+		t.Errorf("FRRBFDMultiplier = %d, want 5", cfg.FRRBFDMultiplier)
+	}
+}
+
+// The manage flags are independent: enabling one must not enable the other.
+func TestLoadConfigBFDManageFlagsIndependent(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantOVN bool
+		wantFRR bool
+	}{
+		{"both off by default", nil, false, false},
+		{"only OVN", []string{"--ovn-bfd-manage"}, true, false},
+		{"only FRR", []string{"--frr-bfd-manage"}, false, true},
+		{"both", []string{"--ovn-bfd-manage", "--frr-bfd-manage"}, true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := loadConfig(fullModeArgs(tt.args...))
+			if err != nil {
+				t.Fatalf("loadConfig() error: %v", err)
+			}
+			if cfg.OVNBFDManage != tt.wantOVN {
+				t.Errorf("OVNBFDManage = %v, want %v", cfg.OVNBFDManage, tt.wantOVN)
+			}
+			if cfg.FRRBFDManage != tt.wantFRR {
+				t.Errorf("FRRBFDManage = %v, want %v", cfg.FRRBFDManage, tt.wantFRR)
+			}
+		})
+	}
+}
+
+func TestApplyEnvConfigBFD(t *testing.T) {
+	cfg := Config{BFDCheckEnabled: true, BFDCheckMaxDetect: time.Second}
+	t.Setenv("OVN_NETWORK_BFD_CHECK_ENABLED", "false")
+	t.Setenv("OVN_NETWORK_BFD_CHECK_MAX_DETECT", "750ms")
+	t.Setenv("OVN_NETWORK_OVN_BFD_MANAGE", "true")
+	t.Setenv("OVN_NETWORK_OVN_BFD_MIN_RX_MS", "100")
+	t.Setenv("OVN_NETWORK_OVN_BFD_MIN_TX_MS", "110")
+	t.Setenv("OVN_NETWORK_FRR_BFD_MANAGE", "1")
+	t.Setenv("OVN_NETWORK_FRR_BFD_MIN_RX_MS", "200")
+	t.Setenv("OVN_NETWORK_FRR_BFD_MIN_TX_MS", "210")
+	t.Setenv("OVN_NETWORK_FRR_BFD_MULTIPLIER", "4")
+	applyEnvConfig(&cfg)
+
+	if cfg.BFDCheckEnabled {
+		t.Error("BFDCheckEnabled should be false")
+	}
+	if cfg.BFDCheckMaxDetect != 750*time.Millisecond {
+		t.Errorf("BFDCheckMaxDetect = %v, want 750ms", cfg.BFDCheckMaxDetect)
+	}
+	if !cfg.OVNBFDManage || !cfg.FRRBFDManage {
+		t.Error("both manage flags should be true")
+	}
+	if cfg.OVNBFDMinRxMs != 100 || cfg.OVNBFDMinTxMs != 110 {
+		t.Errorf("OVN BFD timers = %d/%d, want 100/110", cfg.OVNBFDMinRxMs, cfg.OVNBFDMinTxMs)
+	}
+	if cfg.FRRBFDMinRxMs != 200 || cfg.FRRBFDMinTxMs != 210 {
+		t.Errorf("FRR BFD timers = %d/%d, want 200/210", cfg.FRRBFDMinRxMs, cfg.FRRBFDMinTxMs)
+	}
+	if cfg.FRRBFDMultiplier != 4 {
+		t.Errorf("FRRBFDMultiplier = %d, want 4", cfg.FRRBFDMultiplier)
+	}
+}
+
+// Malformed env values must be ignored, leaving the prior value intact —
+// a typo must not silently reconfigure the BFD timers.
+func TestApplyEnvConfigBFDInvalidValues(t *testing.T) {
+	cfg := Config{BFDCheckEnabled: true, BFDCheckMaxDetect: time.Second, OVNBFDMinRxMs: 150, FRRBFDMultiplier: 3}
+	t.Setenv("OVN_NETWORK_BFD_CHECK_ENABLED", "yes-please") // not "0"/"false"
+	t.Setenv("OVN_NETWORK_BFD_CHECK_MAX_DETECT", "soon")
+	t.Setenv("OVN_NETWORK_OVN_BFD_MANAGE", "maybe") // not "1"/"true"
+	t.Setenv("OVN_NETWORK_OVN_BFD_MIN_RX_MS", "fast")
+	t.Setenv("OVN_NETWORK_FRR_BFD_MULTIPLIER", "many")
+	applyEnvConfig(&cfg)
+
+	if !cfg.BFDCheckEnabled {
+		t.Error("BFDCheckEnabled should stay true for an unrecognised value")
+	}
+	if cfg.BFDCheckMaxDetect != time.Second {
+		t.Errorf("BFDCheckMaxDetect = %v, want 1s (invalid value ignored)", cfg.BFDCheckMaxDetect)
+	}
+	if cfg.OVNBFDManage {
+		t.Error("OVNBFDManage should stay false for an unrecognised value")
+	}
+	if cfg.OVNBFDMinRxMs != 150 {
+		t.Errorf("OVNBFDMinRxMs = %d, want 150 (invalid value ignored)", cfg.OVNBFDMinRxMs)
+	}
+	if cfg.FRRBFDMultiplier != 3 {
+		t.Errorf("FRRBFDMultiplier = %d, want 3 (invalid value ignored)", cfg.FRRBFDMultiplier)
+	}
+}
+
+func TestApplyFileConfigBFD(t *testing.T) {
+	cfg := Config{BFDCheckEnabled: true, BFDCheckMaxDetect: time.Second, OVNBFDMinRxMs: 150, FRRBFDMultiplier: 3}
+	checkEnabled := false
+	ovnManage := true
+	frrManage := true
+	minRx := 100
+	mult := 5
+	fc := configFile{
+		BFDCheckEnabled:   &checkEnabled,
+		BFDCheckMaxDetect: "450ms",
+		OVNBFDManage:      &ovnManage,
+		OVNBFDMinRxMs:     &minRx,
+		FRRBFDManage:      &frrManage,
+		FRRBFDMultiplier:  &mult,
+	}
+	applyFileConfig(&cfg, &fc)
+
+	if cfg.BFDCheckEnabled {
+		t.Error("BFDCheckEnabled should be false")
+	}
+	if cfg.BFDCheckMaxDetect != 450*time.Millisecond {
+		t.Errorf("BFDCheckMaxDetect = %v, want 450ms", cfg.BFDCheckMaxDetect)
+	}
+	if !cfg.OVNBFDManage || !cfg.FRRBFDManage {
+		t.Error("both manage flags should be true")
+	}
+	if cfg.OVNBFDMinRxMs != 100 {
+		t.Errorf("OVNBFDMinRxMs = %d, want 100", cfg.OVNBFDMinRxMs)
+	}
+	if cfg.FRRBFDMultiplier != 5 {
+		t.Errorf("FRRBFDMultiplier = %d, want 5", cfg.FRRBFDMultiplier)
+	}
+	// Unset pointers must not clobber the existing values.
+	if cfg.OVNBFDMinTxMs != 0 {
+		t.Errorf("OVNBFDMinTxMs = %d, want 0 (untouched)", cfg.OVNBFDMinTxMs)
+	}
+}
+
+func TestApplyFileConfigBFDInvalidDuration(t *testing.T) {
+	cfg := Config{BFDCheckMaxDetect: time.Second}
+	applyFileConfig(&cfg, &configFile{BFDCheckMaxDetect: "not-a-duration"})
+	if cfg.BFDCheckMaxDetect != time.Second {
+		t.Errorf("BFDCheckMaxDetect = %v, want 1s (invalid value ignored)", cfg.BFDCheckMaxDetect)
+	}
+}
+
+// BFD validation is gated on each feature's enable flag: out-of-range values
+// for a disabled feature must not prevent the agent from starting.
+func TestValidateConfigBFD(t *testing.T) {
+	base := func() Config {
+		return Config{
+			VethNexthop:       "169.254.0.1",
+			VRFName:           "vrf-provider",
+			BFDCheckEnabled:   true,
+			BFDCheckMaxDetect: time.Second,
+			OVNBFDMinRxMs:     150,
+			OVNBFDMinTxMs:     150,
+			FRRBFDMinRxMs:     150,
+			FRRBFDMinTxMs:     150,
+			FRRBFDMultiplier:  3,
+		}
+	}
+	tests := []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr bool
+	}{
+		{"defaults are valid", func(*Config) {}, false},
+		{"check enabled with zero max detect", func(c *Config) { c.BFDCheckMaxDetect = 0 }, true},
+		{"check enabled with negative max detect", func(c *Config) { c.BFDCheckMaxDetect = -time.Second }, true},
+		{"check disabled tolerates zero max detect", func(c *Config) {
+			c.BFDCheckEnabled = false
+			c.BFDCheckMaxDetect = 0
+		}, false},
+		{"ovn manage with zero min_rx", func(c *Config) { c.OVNBFDManage = true; c.OVNBFDMinRxMs = 0 }, true},
+		{"ovn manage with oversized min_tx", func(c *Config) { c.OVNBFDManage = true; c.OVNBFDMinTxMs = 60001 }, true},
+		{"ovn manage disabled tolerates zero min_rx", func(c *Config) { c.OVNBFDMinRxMs = 0 }, false},
+		{"frr manage with too-small min_rx", func(c *Config) { c.FRRBFDManage = true; c.FRRBFDMinRxMs = 9 }, true},
+		{"frr manage with too-small min_tx", func(c *Config) { c.FRRBFDManage = true; c.FRRBFDMinTxMs = 0 }, true},
+		{"frr manage with multiplier 1", func(c *Config) { c.FRRBFDManage = true; c.FRRBFDMultiplier = 1 }, true},
+		{"frr manage with multiplier 256", func(c *Config) { c.FRRBFDManage = true; c.FRRBFDMultiplier = 256 }, true},
+		{"frr manage disabled tolerates multiplier 1", func(c *Config) { c.FRRBFDMultiplier = 1 }, false},
+		{"both manage enabled with valid values", func(c *Config) { c.OVNBFDManage = true; c.FRRBFDManage = true }, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := base()
+			tt.mutate(&cfg)
+			err := validateConfig(&cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
           { text: 'Gatewayless provider networks', link: '/explanation/gatewayless-networks' },
           { text: 'Port forwarding (DNAT)', link: '/explanation/port-forwarding' },
           { text: 'Gateway drain mode', link: '/explanation/gateway-drain' },
+          { text: 'BFD failover detection', link: '/explanation/bfd-failover-detection' },
         ],
       },
       {

--- a/docs/explanation/bfd-failover-detection.md
+++ b/docs/explanation/bfd-failover-detection.md
@@ -1,0 +1,182 @@
+# BFD failover detection
+
+## Background: where the failover time actually goes
+
+A *graceful* shutdown is handled by [gateway drain mode](./gateway-drain): the
+agent migrates the chassisredirect ports away before it stops announcing
+routes, so there is no blackhole window.
+
+An *ungraceful* failure — a node crash, a network partition, an
+`ovn-controller` crash — has no such handshake. Nobody tells OVN that the
+gateway chassis is gone; OVN has to *notice*. It notices via BFD, the
+sub-second liveness protocol running over the Geneve tunnels between chassis.
+Until BFD declares the tunnel down, OVN still believes the dead chassis owns
+the `chassisredirect` Port_Binding and will not move it anywhere.
+
+That detection time dominates the total failover time:
+
+| Phase | Typical duration |
+|-------|------------------|
+| BFD declares the dead chassis' tunnel down | ~3 s with untuned timers |
+| OVN moves the `chassisredirect` Port_Binding | tens of milliseconds |
+| The surviving agent reacts and programs routes | < 1 s |
+
+The agent's own reaction is already fast: an OVN event bypasses the reconcile
+debounce entirely (`immediateStateRefresh`). Shaving time off the agent buys
+nothing while the first row costs three seconds. **BFD detection is the
+floor**, and until you measure it you do not know where that floor is.
+
+## The two BFD layers
+
+Two independent BFD layers bound an ungraceful failover, and they fail in
+different ways:
+
+**OVN tunnel BFD** runs between chassis over the Geneve tunnels.
+`ovn-controller` enables it (`bfd:enable=true` on the tunnel interface) but
+sets no timers, so OVS uses its own defaults. It decides *when OVN moves the
+gateway*.
+
+**FRR BGP BFD** runs between this node and the external fabric. It decides
+*when the fabric stops sending traffic to a crashed node*. Without it, the
+fabric keeps the dead node's `/32` announcements until the BGP hold timer
+expires — typically far longer than OVN's failover. A node that crashes
+outright cannot withdraw its own routes, so this gap is real precisely in the
+case that matters most.
+
+Tuning one and not the other leaves the slower one as the floor.
+
+## Estimating the detection time
+
+BFD declares a peer dead after `detect multiplier` intervals of silence, where
+the interval is the slower of the two directions. The agent estimates each
+layer from the state it can read locally:
+
+- **OVN tunnels** (`ovs-vsctl find Interface type=geneve`, the `bfd` column):
+  `mult × max(min_rx, min_tx)`. The OVS defaults are `min_rx=1000 ms`,
+  `min_tx=100 ms`, `mult=3` — hence the ~3 s figure quoted above.
+- **FRR sessions** (`vtysh -c "show bfd peers json"`):
+  `detect-multiplier × max(receive-interval, remote-transmit-interval)`.
+
+The worst case per layer is exported as
+`ovn_network_agent_bfd_detect_seconds{layer="ovn"|"frr"}` and logged as a
+warning when it exceeds `bfd_check_max_detect` (default `1s`). This check is
+on by default and modifies nothing.
+
+The gauge distinguishes three states that a plain number cannot:
+
+| Value | Meaning |
+|-------|---------|
+| a duration | the estimated detection time on that layer |
+| `+Inf` | nothing bounds the detection: the layer runs no BFD session, or a BGP neighbor in the VRF runs none |
+| `NaN` | the layer could not be read — `ovs-vsctl` or `vtysh` failed |
+
+`+Inf` is not a corner case: it is the state of every node before
+`frr_bfd_manage` is enabled, and the alert rule `bfd_detect_seconds > 1` has to
+catch it. A *single* BGP neighbor without a session is enough to raise it: the
+fabric withdraws this node's `/32`s over every session it has, so the neighbor
+that has none bounds the failover, however fast the others are. `NaN` matches no
+comparison at all, which is the point — a layer the
+agent cannot see says nothing about the failover time. A cycle that hits it
+increments `ovn_network_agent_bfd_check_errors_total{layer}` and replaces the
+last good value rather than leaving it in place, so a stale reading never
+outlives the state it was taken from.
+
+Two caveats on the OVN estimate. It reads only the **local** side's
+configuration, and the negotiated interval is the maximum across *both*
+endpoints — so the real detection time is at least the estimate, and lowering
+timers on one node alone changes nothing. Timers have to be lowered
+fleet-wide. And a tunnel without `bfd:enable=true` runs no session at all, so
+it contributes nothing to the estimate.
+
+## Lowering the floor
+
+With `min_rx = min_tx = 150 ms` and the default multiplier of 3, the OVN floor
+drops from ~3 s to ~450 ms. `ovn_bfd_manage` sets those keys on the local
+Geneve tunnel interfaces; `frr_bfd_manage` does the equivalent for the VRF's
+BGP sessions. Both default to off, toggle independently, and are documented in
+the [configuration reference](../reference/configuration).
+
+Aggressive timers are not free. Each session sends a packet every `min_tx`
+milliseconds and every missed window is one step towards declaring the peer
+dead, so lowering the timers raises the packet rate and makes the session
+correspondingly less tolerant of scheduling jitter and transient loss. A
+control plane under memory pressure or a busy `ovn-controller` can miss three
+150 ms windows without anything actually being wrong; the result is a spurious
+failover, which is more disruptive than the 3 s it saved. 150 ms is a
+reasonable starting point on a healthy fabric — validate it under load before
+rolling it out, and back off if you see flapping.
+
+### `ovn_bfd_manage` and ovn-controller
+
+The agent sets only `bfd:min_rx` and `bfd:min_tx`. It never touches
+`bfd:enable`, which `ovn-controller` owns.
+
+Every drifted tunnel is written by a single `ovs-vsctl` transaction, not one
+per tunnel. A tunnel `ovn-controller` destroyed since the enumeration is skipped
+by `--if-exists` rather than failing the transaction.
+
+**Verify against your deployed OVN version that `ovn-controller` preserves
+operator-set timer keys on the tunnel interfaces.** Some versions rewrite the
+`bfd` column when they reprogram a tunnel. If yours does, the agent re-applies
+the timers on the next reconcile — self-healing, but with a window in which the
+timers are back to their defaults, and a log line on every reconcile cycle.
+
+You do not have to take the agent's word for it. The estimate is always read
+back from the `bfd` column, never taken from the values the agent just wrote,
+so an `ovn-controller` that reverts them keeps `bfd_detect_seconds{layer="ovn"}`
+pinned at the untuned floor. A metric that stays at `3` with `ovn_bfd_manage`
+enabled means the writes are not sticking.
+
+### `frr_bfd_manage` and the fabric
+
+The agent discovers the VRF's **already-configured** BGP neighbors and adds
+the `bfd` knob to them, attaching each to a `bfd profile` named
+`ovn-network-agent` that carries the configured timers. It never configures
+BGP peering itself: the AS number for `router bgp <as> vrf <vrf>` is read from
+the running configuration, and a VRF with no `router bgp` stanza is an error
+rather than an instance the agent creates.
+
+Because the timers live in the profile, `bgpd` keeps reporting its own session
+defaults (`3` / `300 ms` / `300 ms`) per neighbor — those are not the effective
+values, and the agent does not compare against them. What it compares against is
+the running configuration: a neighbor is left alone only when
+`neighbor <addr> bfd profile ovn-network-agent` is already in the VRF's
+`router bgp` stanza. A neighbor an operator gave a plain `neighbor <addr> bfd`
+runs at `bgpd`'s defaults, so the agent attaches it to the profile anyway.
+
+Each neighbor is attached at most once per agent start. Not every peering FRR
+reports can be rendered back as `neighbor <addr> bfd profile ovn-network-agent`
+— a peer-group member whose BFD FRR writes under the group is one — and
+attaching such a neighbor on every reconcile would reinstall its BGP session
+every 60 seconds. The agent logs the neighbors it has attached that never
+appeared in the running configuration and leaves them alone; the `frr` layer
+reads `+Inf` for as long as one of them has no BFD session.
+
+The profile itself is written on the first reconcile after the agent starts, so
+**a changed timer setting takes effect on agent restart**, not on the next
+reconcile. It is written again whenever the running configuration no longer
+carries it: FRR holds the profile only in its running state, and a
+`systemctl reload frr` reapplies an `frr.conf` that has the neighbors' `bfd
+profile` lines but not the profile stanza the agent never persisted.
+
+Two operational prerequisites:
+
+- `bfdd` must be running in FRR. Without it, `vtysh` reports no BFD peers and
+  the `frr` layer reads `+Inf` — nothing bounds the fabric's route withdrawal.
+- **The fabric side must enable BFD too.** BFD is a two-party protocol; a
+  session where only one end is configured never comes up, and the `/32`
+  withdrawal stays as slow as the BGP hold timer.
+
+## What this does not change
+
+BFD tuning lowers the *detection* floor. It does not change OVN's HA model
+(`Gateway_Chassis` vs `HA_Chassis_Group`), and it does not help a graceful
+shutdown — that path is already covered by
+[gateway drain mode](./gateway-drain), which avoids detection entirely by
+handing the gateway over before leaving.
+
+## Configuration
+
+For the option names, defaults, and env vars, see the
+[configuration reference](../reference/configuration). For the exported metric
+see the [metrics reference](../reference/metrics).

--- a/docs/explanation/gateway-drain.md
+++ b/docs/explanation/gateway-drain.md
@@ -9,7 +9,9 @@ two things happen nearly simultaneously:
    node, so the external fabric stops sending traffic here within seconds.
 2. **OVN BFD failover** — OVN detects that the gateway chassis is gone and
    migrates chassisredirect ports to standby chassis. This relies on BFD
-   timeouts (typically 3×1s = 3 seconds) or periodic probing.
+   timeouts (typically 3×1s = 3 seconds) or periodic probing. See
+   [BFD failover detection](./bfd-failover-detection) for measuring and
+   lowering this floor.
 
 The problem is the **gap between these two events**. During the window where
 BGP has already withdrawn routes but OVN has not yet completed failover,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -42,3 +42,12 @@ regenerate it with `go generate ./...`.
 | `--port-forward-table-id` | `201` | Routing table ID for DNAT return traffic (1-252) |
 | `--port-forward-l3mdev-accept` | `false` | Set udp/tcp_l3mdev_accept=1 for cross-VRF same-host DNAT backends |
 | `--port-forward-ct-zone` | `64000` | Conntrack zone for DNAT flows (must not collide with OVN zones, 1-65535) |
+| `--bfd-check-enabled` | `true` | Estimate the BFD failure-detection time every reconcile and export it as a metric |
+| `--bfd-check-max-detect` | `1s` | Warn when the estimated BFD detection time exceeds this duration (e.g. 1s) |
+| `--ovn-bfd-manage` | `false` | Manage bfd:min_rx/bfd:min_tx on local OVN Geneve tunnel interfaces |
+| `--ovn-bfd-min-rx-ms` | `150` | Desired OVS bfd:min_rx for Geneve tunnels in milliseconds (1-60000) |
+| `--ovn-bfd-min-tx-ms` | `150` | Desired OVS bfd:min_tx for Geneve tunnels in milliseconds (1-60000) |
+| `--frr-bfd-manage` | `false` | Enable BFD on the VRF's already-configured FRR BGP neighbors |
+| `--frr-bfd-min-rx-ms` | `150` | Desired FRR BFD receive-interval in milliseconds (10-60000) |
+| `--frr-bfd-min-tx-ms` | `150` | Desired FRR BFD transmit-interval in milliseconds (10-60000) |
+| `--frr-bfd-multiplier` | `3` | Desired FRR BFD detect-multiplier (2-255) |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -48,6 +48,15 @@ regenerate this page with `go generate ./...`.
 | `--port-forward-table-id` | `OVN_NETWORK_PORT_FORWARD_TABLE_ID` | `port_forward_table_id` | `201` | Routing table ID for DNAT return traffic (1-252) |
 | `--port-forward-l3mdev-accept` | `OVN_NETWORK_PORT_FORWARD_L3MDEV_ACCEPT` | `port_forward_l3mdev_accept` | `false` | Set udp/tcp_l3mdev_accept=1 for cross-VRF same-host DNAT backends |
 | `--port-forward-ct-zone` | `OVN_NETWORK_PORT_FORWARD_CT_ZONE` | `port_forward_ct_zone` | `64000` | Conntrack zone for DNAT flows (must not collide with OVN zones, 1-65535) |
+| `--bfd-check-enabled` | `OVN_NETWORK_BFD_CHECK_ENABLED` | `bfd_check_enabled` | `true` | Estimate the BFD failure-detection time every reconcile and export it as a metric |
+| `--bfd-check-max-detect` | `OVN_NETWORK_BFD_CHECK_MAX_DETECT` | `bfd_check_max_detect` | `1s` | Warn when the estimated BFD detection time exceeds this duration (e.g. 1s) |
+| `--ovn-bfd-manage` | `OVN_NETWORK_OVN_BFD_MANAGE` | `ovn_bfd_manage` | `false` | Manage bfd:min_rx/bfd:min_tx on local OVN Geneve tunnel interfaces |
+| `--ovn-bfd-min-rx-ms` | `OVN_NETWORK_OVN_BFD_MIN_RX_MS` | `ovn_bfd_min_rx_ms` | `150` | Desired OVS bfd:min_rx for Geneve tunnels in milliseconds (1-60000) |
+| `--ovn-bfd-min-tx-ms` | `OVN_NETWORK_OVN_BFD_MIN_TX_MS` | `ovn_bfd_min_tx_ms` | `150` | Desired OVS bfd:min_tx for Geneve tunnels in milliseconds (1-60000) |
+| `--frr-bfd-manage` | `OVN_NETWORK_FRR_BFD_MANAGE` | `frr_bfd_manage` | `false` | Enable BFD on the VRF's already-configured FRR BGP neighbors |
+| `--frr-bfd-min-rx-ms` | `OVN_NETWORK_FRR_BFD_MIN_RX_MS` | `frr_bfd_min_rx_ms` | `150` | Desired FRR BFD receive-interval in milliseconds (10-60000) |
+| `--frr-bfd-min-tx-ms` | `OVN_NETWORK_FRR_BFD_MIN_TX_MS` | `frr_bfd_min_tx_ms` | `150` | Desired FRR BFD transmit-interval in milliseconds (10-60000) |
+| `--frr-bfd-multiplier` | `OVN_NETWORK_FRR_BFD_MULTIPLIER` | `frr_bfd_multiplier` | `3` | Desired FRR BFD detect-multiplier (2-255) |
 
 Additional YAML-only keys:
 

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -40,6 +40,8 @@ regenerate it with `go generate ./...`.
 | `ovn_network_agent_drain_total` | counter (vec) | `outcome`={`completed`,`timeout`,`error`,`noop`} | Total drain operations, labelled by outcome (completed, timeout, error, noop). |
 | `ovn_network_agent_stale_chassis_cleanup_total` | counter (vec) | `outcome`={`success`,`error`} | Total stale chassis cleanup events, labelled by outcome (success, error). |
 | `ovn_network_agent_missing_chassis` | gauge | — | Number of chassis currently tracked as missing from the SB Chassis table. |
+| `ovn_network_agent_bfd_detect_seconds` | gauge (vec) | `layer`={`ovn`,`frr`} | Estimated BFD failure-detection time in seconds per layer (worst case across local OVN Geneve tunnels / FRR BFD peers in the VRF). This is the floor for ungraceful gateway failover. +Inf = nothing bounds the detection: the layer runs no BFD session, or a BGP neighbor in the VRF runs none. NaN = the layer could not be read; see bfd_check_errors_total. |
+| `ovn_network_agent_bfd_check_errors_total` | counter (vec) | `layer`={`ovn`,`frr`} | Total failures to read a layer's BFD state (ovs-vsctl or vtysh). While this rises, bfd_detect_seconds for that layer is NaN. |
 
 ## Suggested alerts
 

--- a/metrics.go
+++ b/metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"math"
 	"net"
 	"net/http"
 	"time"
@@ -47,6 +48,10 @@ type metricsRegistry struct {
 	// Stale chassis cleanup
 	staleChassisCleanupTotal *prometheus.CounterVec
 	missingChassis           prometheus.Gauge
+
+	// BFD detection
+	bfdDetectSeconds    *prometheus.GaugeVec
+	bfdCheckErrorsTotal *prometheus.CounterVec
 }
 
 // metrics is the process-wide registry. It is non-nil after initMetrics()
@@ -161,6 +166,18 @@ func newMetricsRegistry() *metricsRegistry {
 			Name:      "missing_chassis",
 			Help:      "Number of chassis currently tracked as missing from the SB Chassis table.",
 		}),
+
+		bfdDetectSeconds: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "bfd_detect_seconds",
+			Help:      "Estimated BFD failure-detection time in seconds per layer (worst case across local OVN Geneve tunnels / FRR BFD peers in the VRF). This is the floor for ungraceful gateway failover. +Inf = nothing bounds the detection: the layer runs no BFD session, or a BGP neighbor in the VRF runs none. NaN = the layer could not be read; see bfd_check_errors_total.",
+		}, []string{"layer"}),
+
+		bfdCheckErrorsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "bfd_check_errors_total",
+			Help:      "Total failures to read a layer's BFD state (ovs-vsctl or vtysh). While this rises, bfd_detect_seconds for that layer is NaN.",
+		}, []string{"layer"}),
 	}
 
 	reg.MustRegister(
@@ -179,6 +196,8 @@ func newMetricsRegistry() *metricsRegistry {
 		m.drainTotal,
 		m.staleChassisCleanupTotal,
 		m.missingChassis,
+		m.bfdDetectSeconds,
+		m.bfdCheckErrorsTotal,
 	)
 
 	// Initialise label series so they appear in /metrics with a zero value
@@ -197,6 +216,12 @@ func newMetricsRegistry() *metricsRegistry {
 	m.staleChassisCleanupTotal.WithLabelValues("error").Add(0)
 	m.ovnConnectionState.WithLabelValues("nb").Set(0)
 	m.ovnConnectionState.WithLabelValues("sb").Set(0)
+	m.bfdCheckErrorsTotal.WithLabelValues("ovn").Add(0)
+	m.bfdCheckErrorsTotal.WithLabelValues("frr").Add(0)
+	// Nothing has been measured yet. Zero would be indistinguishable from an
+	// instantaneous detection time — the healthiest reading the gauge can take.
+	m.bfdDetectSeconds.WithLabelValues("ovn").Set(math.NaN())
+	m.bfdDetectSeconds.WithLabelValues("frr").Set(math.NaN())
 
 	return m
 }
@@ -347,4 +372,18 @@ func setMissingChassis(n int) {
 		return
 	}
 	metrics.missingChassis.Set(float64(n))
+}
+
+func setBFDDetectSeconds(layer string, seconds float64) {
+	if metrics == nil {
+		return
+	}
+	metrics.bfdDetectSeconds.WithLabelValues(layer).Set(seconds)
+}
+
+func recordBFDCheckError(layer string) {
+	if metrics == nil {
+		return
+	}
+	metrics.bfdCheckErrorsTotal.WithLabelValues(layer).Inc()
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"strings"
@@ -39,6 +40,8 @@ func TestRecordingHelpersAreNilSafe(t *testing.T) {
 	recordDrain("completed", time.Second)
 	recordStaleChassisCleanup("success", 2)
 	setMissingChassis(1)
+	setBFDDetectSeconds("ovn", 3)
+	recordBFDCheckError("ovn")
 }
 
 func TestNewMetricsRegistryRegistersAllCollectors(t *testing.T) {
@@ -64,6 +67,8 @@ func TestNewMetricsRegistryRegistersAllCollectors(t *testing.T) {
 		"ovn_network_agent_drain_total",
 		"ovn_network_agent_stale_chassis_cleanup_total",
 		"ovn_network_agent_missing_chassis",
+		"ovn_network_agent_bfd_detect_seconds",
+		"ovn_network_agent_bfd_check_errors_total",
 	}
 	gotNames := make(map[string]bool, len(got))
 	for _, mf := range got {
@@ -410,5 +415,108 @@ func TestStartMetricsServerErrorsOnInvalidAddr(t *testing.T) {
 	defer cancel()
 	if err := startMetricsServer(ctx, "127.0.0.1:not-a-port", newMetricsRegistry()); err == nil {
 		t.Fatal("expected error for invalid addr, got nil")
+	}
+}
+
+// bfdDetectValue returns the gauge value for one layer of
+// ovn_network_agent_bfd_detect_seconds, and whether the series exists.
+func bfdDetectValue(t *testing.T, m *metricsRegistry, layer string) (float64, bool) {
+	t.Helper()
+	got, err := m.registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather() error: %v", err)
+	}
+	for _, mf := range got {
+		if mf.GetName() != "ovn_network_agent_bfd_detect_seconds" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			for _, lp := range metric.GetLabel() {
+				if lp.GetName() == "layer" && lp.GetValue() == layer {
+					return metric.GetGauge().GetValue(), true
+				}
+			}
+		}
+	}
+	return 0, false
+}
+
+// bfdCheckErrorCount returns the counter value for one layer of
+// ovn_network_agent_bfd_check_errors_total.
+func bfdCheckErrorCount(t *testing.T, m *metricsRegistry, layer string) float64 {
+	t.Helper()
+	got, err := m.registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather() error: %v", err)
+	}
+	for _, mf := range got {
+		if mf.GetName() != "ovn_network_agent_bfd_check_errors_total" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			for _, lp := range metric.GetLabel() {
+				if lp.GetName() == "layer" && lp.GetValue() == layer {
+					return metric.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	t.Fatalf("layer %q missing from bfd_check_errors_total", layer)
+	return 0
+}
+
+// A layer whose state cannot be read has an unknown detection time, not a
+// zero-second one. Counting the read failures is what lets an operator tell the
+// two apart, because NaN satisfies no comparison an alert can express.
+func TestRecordBFDCheckErrorCountsPerLayer(t *testing.T) {
+	m := withTestMetrics(t)
+
+	for _, layer := range []string{"ovn", "frr"} {
+		if v := bfdCheckErrorCount(t, m, layer); v != 0 {
+			t.Errorf("layer %q = %v on a fresh registry, want 0", layer, v)
+		}
+	}
+
+	recordBFDCheckError("ovn")
+	recordBFDCheckError("ovn")
+
+	if v := bfdCheckErrorCount(t, m, "ovn"); v != 2 {
+		t.Errorf("layer ovn = %v, want 2", v)
+	}
+	if v := bfdCheckErrorCount(t, m, "frr"); v != 0 {
+		t.Errorf("layer frr = %v after two ovn errors, want 0", v)
+	}
+}
+
+func TestSetBFDDetectSeconds(t *testing.T) {
+	m := withTestMetrics(t)
+
+	// Both layers are bootstrapped as NaN so they appear on the first scrape
+	// without claiming the instantaneous — i.e. perfect — detection time that a
+	// zero would assert before anything has been measured.
+	for _, layer := range []string{"ovn", "frr"} {
+		v, ok := bfdDetectValue(t, m, layer)
+		if !ok {
+			t.Fatalf("layer %q missing from a fresh registry", layer)
+		}
+		if !math.IsNaN(v) {
+			t.Errorf("layer %q = %v on a fresh registry, want NaN", layer, v)
+		}
+	}
+
+	setBFDDetectSeconds("ovn", 3)
+	setBFDDetectSeconds("frr", 0.45)
+
+	if v, _ := bfdDetectValue(t, m, "ovn"); v != 3 {
+		t.Errorf("layer ovn = %v, want 3", v)
+	}
+	if v, _ := bfdDetectValue(t, m, "frr"); v != 0.45 {
+		t.Errorf("layer frr = %v, want 0.45", v)
+	}
+
+	// Setting one layer must not disturb the other.
+	setBFDDetectSeconds("ovn", 0.45)
+	if v, _ := bfdDetectValue(t, m, "frr"); v != 0.45 {
+		t.Errorf("layer frr = %v after updating ovn, want 0.45", v)
 	}
 }

--- a/ovn-network-agent.default
+++ b/ovn-network-agent.default
@@ -128,3 +128,30 @@ OVN_NETWORK_OVN_NB_REMOTE=tcp:10.10.0.1:6641,tcp:10.10.0.2:6641,tcp:10.10.0.3:66
 # that affects ALL sockets — only enable when needed.
 # Accepts "1" / "true" to enable.
 #OVN_NETWORK_PORT_FORWARD_L3MDEV_ACCEPT=false
+
+# =============================================================================
+# BFD failover detection
+# =============================================================================
+# The check is read-only and on by default; the manage options are independent
+# opt-ins that write OVS/FRR state.
+
+# Estimate the BFD detection time every reconcile, export it as
+# ovn_network_agent_bfd_detect_seconds and warn above BFD_CHECK_MAX_DETECT.
+# Accepts "0" / "false" to disable.
+#OVN_NETWORK_BFD_CHECK_ENABLED=true
+
+# Warn when the estimated BFD detection time exceeds this duration.
+#OVN_NETWORK_BFD_CHECK_MAX_DETECT=1s
+
+# Manage bfd:min_rx / bfd:min_tx on local OVN Geneve tunnel interfaces.
+# Accepts "1" / "true" to enable.
+#OVN_NETWORK_OVN_BFD_MANAGE=false
+#OVN_NETWORK_OVN_BFD_MIN_RX_MS=150
+#OVN_NETWORK_OVN_BFD_MIN_TX_MS=150
+
+# Enable BFD on the VRF's already-configured FRR BGP neighbors.
+# Accepts "1" / "true" to enable. The fabric side must enable BFD too.
+#OVN_NETWORK_FRR_BFD_MANAGE=false
+#OVN_NETWORK_FRR_BFD_MIN_RX_MS=150
+#OVN_NETWORK_FRR_BFD_MIN_TX_MS=150
+#OVN_NETWORK_FRR_BFD_MULTIPLIER=3

--- a/ovn-network-agent.yaml.sample
+++ b/ovn-network-agent.yaml.sample
@@ -245,3 +245,36 @@ ovn_nb_remote: "tcp:10.10.0.1:6641,tcp:10.10.0.2:6641,tcp:10.10.0.3:6641"
 #       - proto: tcp
 #         port: 443
 #         dest_addr: "10.0.0.100"
+
+# =============================================================================
+# BFD failover detection
+# =============================================================================
+# Ungraceful failover (node crash, partition, ovn-controller crash) is
+# dominated by OVN's BFD-based detection of the dead gateway chassis. The
+# check below is read-only and on by default; the two manage options are
+# independent opt-ins that write OVS/FRR state. See
+# https://osism.github.io/ovn-network-agent/explanation/bfd-failover-detection
+
+# Estimate the BFD detection time every reconcile, export it as
+# ovn_network_agent_bfd_detect_seconds{layer="ovn"|"frr"} and warn when it
+# exceeds bfd_check_max_detect. Reads OVS and FRR state only.
+#bfd_check_enabled: true
+
+# Warn when the estimated detection time exceeds this duration.
+#bfd_check_max_detect: 1s
+
+# Manage bfd:min_rx / bfd:min_tx on the local OVN Geneve tunnel interfaces.
+# ovn-controller sets only bfd:enable=true. Verify against the deployed OVN
+# version that operator-set timer keys are preserved before relying on this.
+# With 150/150 ms and OVS' detect multiplier of 3 the floor drops to ~450 ms.
+#ovn_bfd_manage: false
+#ovn_bfd_min_rx_ms: 150
+#ovn_bfd_min_tx_ms: 150
+
+# Enable BFD on the VRF's already-configured BGP neighbors (the agent never
+# configures peering itself) using a "ovn-network-agent" bfd profile. Closes
+# the stale /32 gap on a full node crash. The fabric side must enable BFD too.
+#frr_bfd_manage: false
+#frr_bfd_min_rx_ms: 150
+#frr_bfd_min_tx_ms: 150
+#frr_bfd_multiplier: 3

--- a/ovs.go
+++ b/ovs.go
@@ -569,3 +569,46 @@ func (rm *RouteManager) findGeneveInterfaces() ([]byte, error) {
 	}
 	return out, nil
 }
+
+// setInterfaceBFDTimers sets the operator-managed BFD timer keys on the given
+// OVS interfaces. bfd:enable is deliberately left alone — ovn-controller owns
+// it.
+//
+// All interfaces are written by one ovs-vsctl invocation, joined by `--`.
+// ovsCommandTimeout bounds a single invocation, not a reconcile: a chassis whose
+// tunnels are all drifted would otherwise fork one bounded command per remote
+// chassis, and a wedged ovsdb-server could hold the agent's only loop goroutine
+// for hours — no route programming, no stale-chassis cleanup, and no SIGTERM
+// drain — behind what looks like a 30 s bound.
+//
+// --if-exists: ovn-controller creates and destroys Geneve tunnels as chassis
+// join and leave the cluster, so a tunnel enumerated moments ago may already be
+// gone by the time it is written. It makes that clause a no-op instead of
+// failing the transaction and leaving every other tunnel untuned.
+func (rm *RouteManager) setInterfaceBFDTimers(names []string, minRxMs, minTxMs int) error {
+	args := make([]string, 0, len(names)*7)
+	for _, name := range names {
+		// The name comes from the Interface table, unvalidated. `--` is
+		// ovs-vsctl's own clause separator and a leading `-` starts an option,
+		// so such a name re-partitions the command line: the transaction fails
+		// and one poisoned row leaves every tunnel in the batch untuned.
+		// ovn-controller's `ovn-<hash>` names pass, so the guard costs nothing.
+		if strings.HasPrefix(name, "-") || !isValidIdentifier(name) {
+			slog.Warn("skipping Geneve interface with an unexpected name", "interface", name)
+			continue
+		}
+		if len(args) > 0 {
+			args = append(args, "--")
+		}
+		args = append(args, "--if-exists", "set", "Interface", name,
+			fmt.Sprintf("bfd:min_rx=%d", minRxMs), fmt.Sprintf("bfd:min_tx=%d", minTxMs))
+	}
+	if len(args) == 0 {
+		return nil
+	}
+	out, err := rm.runOVS("ovs-vsctl", args...)
+	if err != nil {
+		return fmt.Errorf("set BFD timers on %d interfaces: %w (output: %s)", len(names), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/ovs.go
+++ b/ovs.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net"
 	"os/exec"
 	"sort"
 	"strings"
+	"time"
 )
 
 const (
@@ -57,21 +59,47 @@ func MACTweakFlow(cookie, ofport, mac string, ipv6 bool) string {
 		cookie, proto, ofport, mac)
 }
 
+// ovsCommandTimeout bounds a single OVS invocation. Reconciliation runs on the
+// agent's only loop goroutine, so an ovs-vsctl that never returns — a wedged
+// ovsdb-server, a hung wrapper container — would stop route programming and
+// keep the SIGTERM handler from ever draining the gateways off this node.
+const ovsCommandTimeout = 30 * time.Second
+
+// ovsInternalTimeout is passed to every ovs-vsctl and ovs-ofctl as --timeout so
+// the OVS command bounds itself.
+//
+// Killing the command's process group only reaches processes on this host. With
+// the documented `docker exec openvswitch_vswitchd` wrapper the real ovs-vsctl
+// runs in another container, where no signal from the agent reaches it: on a
+// wedged ovsdb-server it keeps retrying its connection forever while the agent
+// forks a fresh one every reconcile. It expires before ovsCommandTimeout so the
+// command reports its own timeout rather than being killed.
+const ovsInternalTimeout = ovsCommandTimeout - 5*time.Second
+
 // ovsCmd builds an exec.Cmd for an OVS command, prepending the configured
 // wrapper (e.g. "docker exec openvswitch_vswitchd") if set.
-func (rm *RouteManager) ovsCmd(binary string, args ...string) *exec.Cmd {
+func (rm *RouteManager) ovsCmd(ctx context.Context, binary string, args ...string) *exec.Cmd {
 	if len(rm.ovsWrapper) > 0 {
 		fullArgs := append(rm.ovsWrapper[1:], binary)
 		fullArgs = append(fullArgs, args...)
-		return exec.Command(rm.ovsWrapper[0], fullArgs...)
+		return exec.CommandContext(ctx, rm.ovsWrapper[0], fullArgs...)
 	}
-	return exec.Command(binary, args...)
+	return exec.CommandContext(ctx, binary, args...)
 }
 
-// runOVS builds and runs an OVS command. When execOVSHook is set (tests) the
-// command is dispatched through it instead of being executed.
+// runOVS builds and runs an OVS command under ovsCommandTimeout, doubly bounded:
+// the context kills the command's process group here, and --timeout stops the
+// ovs-vsctl or ovs-ofctl itself wherever an ovs_wrapper started it. When
+// execOVSHook is set (tests) the command is dispatched through it instead of
+// being executed.
 func (rm *RouteManager) runOVS(binary string, args ...string) ([]byte, error) {
-	cmd := rm.ovsCmd(binary, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), ovsCommandTimeout)
+	defer cancel()
+	// Both binaries take --timeout as a common option before the command verb.
+	args = append([]string{fmt.Sprintf("--timeout=%d", int(ovsInternalTimeout.Seconds()))}, args...)
+	cmd := rm.ovsCmd(ctx, binary, args...)
+	cmd.WaitDelay = commandWaitDelay
+	killProcessGroup(cmd)
 	if rm.execOVSHook != nil {
 		return rm.execOVSHook(cmd)
 	}
@@ -529,4 +557,15 @@ func (rm *RouteManager) addOVSFlow(flow string) error {
 		return fmt.Errorf("ovs-ofctl add-flow %s %q: %w (output: %s)", rm.bridgeDev, flow, err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// findGeneveInterfaces returns the raw `ovs-vsctl find` JSON describing the
+// local OVN Geneve tunnel interfaces and their BFD configuration. See bfd.go
+// for the parser and the detection-time estimate built on top of it.
+func (rm *RouteManager) findGeneveInterfaces() ([]byte, error) {
+	out, err := rm.runOVS("ovs-vsctl", "--format=json", "--columns=name,bfd", "find", "Interface", "type=geneve")
+	if err != nil {
+		return nil, fmt.Errorf("ovs-vsctl find geneve interfaces: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
 }

--- a/ovs_test.go
+++ b/ovs_test.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 )
 
 // ovsRecorder captures calls to RouteManager.runOVS for assertion. It returns
@@ -32,11 +33,25 @@ func (r *ovsRecorder) on(args []string, out string, err error) {
 	r.responses[strings.Join(args, " ")] = ovsResponse{out: []byte(out), err: err}
 }
 
+// stripOVSTimeout removes the self-bounding --timeout flag runOVS injects into
+// every OVS argv, so the fixtures and assertions below name the command the
+// agent means to run. TestRunOVSBoundsTheOVSCommandItself covers the flag.
+func stripOVSTimeout(args []string) []string {
+	stripped := make([]string, 0, len(args))
+	for _, a := range args {
+		if strings.HasPrefix(a, "--timeout=") {
+			continue
+		}
+		stripped = append(stripped, a)
+	}
+	return stripped
+}
+
 func (r *ovsRecorder) hook() ovsExecFunc {
 	return func(cmd *exec.Cmd) ([]byte, error) {
-		args := append([]string{}, cmd.Args...)
+		args := stripOVSTimeout(cmd.Args)
 		r.calls = append(r.calls, args)
-		if resp, ok := r.responses[strings.Join(cmd.Args, " ")]; ok {
+		if resp, ok := r.responses[strings.Join(args, " ")]; ok {
 			return resp.out, resp.err
 		}
 		return nil, nil
@@ -154,7 +169,7 @@ func TestOVSCmdWrapperPrepended(t *testing.T) {
 		ovsWrapper: []string{"docker", "exec", "openvswitch_vswitchd"},
 	}
 
-	cmd := rm.ovsCmd("ovs-ofctl", "add-flow", "br-ex", "flow")
+	cmd := rm.ovsCmd(t.Context(), "ovs-ofctl", "add-flow", "br-ex", "flow")
 	want := []string{"docker", "exec", "openvswitch_vswitchd", "ovs-ofctl", "add-flow", "br-ex", "flow"}
 	if !reflect.DeepEqual(cmd.Args, want) {
 		t.Errorf("ovsCmd args = %v, want %v", cmd.Args, want)
@@ -164,7 +179,7 @@ func TestOVSCmdWrapperPrepended(t *testing.T) {
 func TestOVSCmdNoWrapper(t *testing.T) {
 	rm := &RouteManager{bridgeDev: "br-ex"}
 
-	cmd := rm.ovsCmd("ovs-ofctl", "add-flow", "br-ex", "flow")
+	cmd := rm.ovsCmd(t.Context(), "ovs-ofctl", "add-flow", "br-ex", "flow")
 	want := []string{"ovs-ofctl", "add-flow", "br-ex", "flow"}
 	if !reflect.DeepEqual(cmd.Args, want) {
 		t.Errorf("ovsCmd args = %v, want %v", cmd.Args, want)
@@ -864,12 +879,73 @@ func TestGetOFPortRejectsInvalidValues(t *testing.T) {
 	}
 }
 
+// exec.CommandContext kills only the direct child on timeout. An ovs_wrapper
+// that leaves a hung grandchild holding the output pipe would keep Wait — and
+// with it the reconcile goroutine — blocked forever unless WaitDelay is set.
+func TestRunOVSBoundsWaitOnTheOutputPipe(t *testing.T) {
+	var waitDelay time.Duration
+	rm := &RouteManager{execOVSHook: func(cmd *exec.Cmd) ([]byte, error) {
+		waitDelay = cmd.WaitDelay
+		return nil, nil
+	}}
+
+	if _, err := rm.runOVS("ovs-vsctl", "show"); err != nil {
+		t.Fatalf("runOVS() error: %v", err)
+	}
+	if waitDelay != commandWaitDelay {
+		t.Errorf("WaitDelay = %v, want %v — the command timeout bounds nothing without it", waitDelay, commandWaitDelay)
+	}
+}
+
+// An ovs_wrapper such as `nsenter -t 1 -n` or `sudo` forks the ovs-vsctl that
+// blocks. Killing the direct child alone leaves it running, holding its OVSDB
+// connection, and the next reconcile forks another one.
+func TestRunOVSKillsTheWholeProcessGroup(t *testing.T) {
+	var captured *exec.Cmd
+	rm := &RouteManager{execOVSHook: func(cmd *exec.Cmd) ([]byte, error) {
+		captured = cmd
+		return nil, nil
+	}}
+
+	if _, err := rm.runOVS("ovs-vsctl", "show"); err != nil {
+		t.Fatalf("runOVS() error: %v", err)
+	}
+	if captured.SysProcAttr == nil || !captured.SysProcAttr.Setpgid {
+		t.Error("SysProcAttr.Setpgid is not set — the command shares the agent's process group, so it cannot be signalled as a group")
+	}
+	if captured.Cancel == nil {
+		t.Error("Cancel is not overridden — the default kills the direct child only, orphaning whatever it forked")
+	}
+}
+
+// No signal the agent sends reaches an ovs-vsctl an ovs_wrapper started in
+// another container, so the OVS command must bound itself.
+func TestRunOVSBoundsTheOVSCommandItself(t *testing.T) {
+	var args []string
+	rm := &RouteManager{execOVSHook: func(cmd *exec.Cmd) ([]byte, error) {
+		args = append([]string{}, cmd.Args...)
+		return nil, nil
+	}}
+
+	if _, err := rm.runOVS("ovs-ofctl", "del-flows", "br-ex"); err != nil {
+		t.Fatalf("runOVS() error: %v", err)
+	}
+	want := []string{"ovs-ofctl", "--timeout=25", "del-flows", "br-ex"}
+	if !reflect.DeepEqual(args, want) {
+		t.Errorf("args = %v, want %v", args, want)
+	}
+	if ovsInternalTimeout >= ovsCommandTimeout {
+		t.Errorf("ovsInternalTimeout = %v, want less than ovsCommandTimeout (%v) so the command reports its own timeout",
+			ovsInternalTimeout, ovsCommandTimeout)
+	}
+}
+
 func TestRunOVSWithoutHookCallsCombinedOutput(t *testing.T) {
 	// Sanity check that runOVS without a hook does run a real command.
 	// /usr/bin/true (or "true" on PATH) is a portable success exit; on macOS
 	// and Linux build agents this should always be present.
 	rm := &RouteManager{}
-	cmd := rm.ovsCmd("true")
+	cmd := rm.ovsCmd(t.Context(), "true")
 	if cmd.Args[0] != "true" {
 		t.Skipf("unexpected command shape: %v", cmd.Args)
 	}

--- a/routing.go
+++ b/routing.go
@@ -1,14 +1,20 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
+	"os"
 	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
+	"time"
 )
 
 // ovsExecFunc is the signature of an exec.Cmd runner. Tests inject a stub via
@@ -75,13 +81,74 @@ type RouteManager struct {
 	execVtyshHook ovsExecFunc
 }
 
-// runVtysh executes a vtysh command, dispatching through execVtyshHook when set.
+// vtyshCommandTimeout bounds a single vtysh invocation. vtysh blocks on FRR's
+// configuration lock, which a concurrent frr-reload or a bgpd that stopped
+// reading its vty socket can hold indefinitely. Reconciliation runs on the
+// agent's only loop goroutine, so an unbounded wait there stops route
+// programming and keeps the SIGTERM handler from ever draining the gateways.
+const vtyshCommandTimeout = 10 * time.Second
+
+// commandWaitDelay bounds how long Wait may keep blocking after a command's
+// context has expired and the command's process group has been killed.
+//
+// Wait first drains the output pipe, which reaches EOF only once every process
+// holding the write end has exited. killProcessGroup below reaps the whole tree
+// on this host, but a wrapper that runs the real command elsewhere — the
+// documented `docker exec openvswitch_vswitchd` starts it in another container —
+// leaves it holding the pipe. Without a WaitDelay the timeouts above would bound
+// nothing at all.
+const commandWaitDelay = 5 * time.Second
+
+// killProcessGroup makes a command's timeout reach the processes it forked.
+//
+// exec.CommandContext's default cancel is Process.Kill, which signals the direct
+// child only. Both runners fork through something that in turn forks the process
+// that blocks: vtysh spawns per-daemon children, and ovs_wrapper is free-form —
+// `nsenter -t 1 -n`, `ip netns exec`, `sudo` and `chroot` all leave the hung
+// grandchild running. That grandchild is precisely the command the timeout
+// exists to escape, and a reconcile that leaves one behind every cycle
+// accumulates them without bound. Giving the child its own process group and
+// signalling the group reaps the whole tree.
+func killProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			// The whole group is gone: the command finished as the deadline
+			// fired. os/exec answers that race by reporting the command's own
+			// result, which the default Process.Kill cancel would also do.
+			return os.ErrProcessDone
+		}
+		return err
+	}
+}
+
+// runVtysh executes a vtysh command under vtyshCommandTimeout, dispatching
+// through execVtyshHook when set.
+//
+// Only stdout is returned. vtysh writes its own diagnostics — a daemon it could
+// not reach, a vty socket that went away — to stderr, and every caller below
+// parses the result as structured data: running-config stanzas keyed on
+// indentation, and JSON. A merged stream would let one stderr line truncate a
+// stanza or make a JSON document unrecognisable, which the callers cannot tell
+// apart from FRR reporting nothing. On failure stderr goes into the error, where
+// it is a diagnostic rather than input.
 func (rm *RouteManager) runVtysh(args ...string) ([]byte, error) {
-	cmd := exec.Command("vtysh", args...)
+	ctx, cancel := context.WithTimeout(context.Background(), vtyshCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "vtysh", args...)
+	cmd.WaitDelay = commandWaitDelay
+	killProcessGroup(cmd)
 	if rm.execVtyshHook != nil {
 		return rm.execVtyshHook(cmd)
 	}
-	return cmd.CombinedOutput()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return out, fmt.Errorf("%w (stderr: %s)", err, strings.TrimSpace(stderr.String()))
+	}
+	return out, nil
 }
 
 func NewRouteManager(cfg Config) *RouteManager {

--- a/routing.go
+++ b/routing.go
@@ -47,6 +47,24 @@ type RouteManager struct {
 	// FRR prefix-list management
 	frrPrefixList string
 
+	// frrBFDProfileApplied records that the agent's bfd profile has been
+	// written to FRR in this process. The profile carries the BFD timers, and
+	// FRR's running configuration omits a profile value that matches bfdd's
+	// default, so the configured timers cannot be compared against it for drift.
+	// Writing the profile once per start is what applies a changed timer
+	// configuration. Whether FRR still *has* the profile is a separate question
+	// that EnsureFRRBFD does read back — see frrBFDProfileConfigured.
+	// Only the single reconcile goroutine touches this.
+	frrBFDProfileApplied bool
+
+	// frrBFDAttached holds the BGP neighbors this process has already attached
+	// to the agent's bfd profile with a vtysh command FRR accepted. A neighbor
+	// that is in here and still absent from the running configuration's profile
+	// lines can never be rendered — attaching it again every reconcile would
+	// reinstall its BGP session forever. Only the single reconcile goroutine
+	// touches this.
+	frrBFDAttached map[string]bool
+
 	// Port forwarding (DNAT) settings
 	portForwardEnabled      bool
 	portForwardDev          string

--- a/routing_test.go
+++ b/routing_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 // vtyshRecorder captures calls to RouteManager.runVtysh for assertion. It
@@ -33,6 +34,44 @@ func (r *vtyshRecorder) hook() ovsExecFunc {
 			return resp.out, resp.err
 		}
 		return nil, nil
+	}
+}
+
+// A vtysh blocked on FRR's configuration lock is killed when the context
+// expires, but Wait keeps blocking on the output pipe until every process
+// holding it exits. Without WaitDelay the timeout bounds nothing.
+func TestRunVtyshBoundsWaitOnTheOutputPipe(t *testing.T) {
+	var waitDelay time.Duration
+	rm := &RouteManager{execVtyshHook: func(cmd *exec.Cmd) ([]byte, error) {
+		waitDelay = cmd.WaitDelay
+		return nil, nil
+	}}
+
+	if _, err := rm.runVtysh("-c", "show running-config"); err != nil {
+		t.Fatalf("runVtysh() error: %v", err)
+	}
+	if waitDelay != commandWaitDelay {
+		t.Errorf("WaitDelay = %v, want %v — the command timeout bounds nothing without it", waitDelay, commandWaitDelay)
+	}
+}
+
+// vtysh forks a child per FRR daemon. Killing vtysh alone leaves them behind,
+// each still holding the vty socket the next reconcile needs.
+func TestRunVtyshKillsTheWholeProcessGroup(t *testing.T) {
+	var captured *exec.Cmd
+	rm := &RouteManager{execVtyshHook: func(cmd *exec.Cmd) ([]byte, error) {
+		captured = cmd
+		return nil, nil
+	}}
+
+	if _, err := rm.runVtysh("-c", "show running-config"); err != nil {
+		t.Fatalf("runVtysh() error: %v", err)
+	}
+	if captured.SysProcAttr == nil || !captured.SysProcAttr.Setpgid {
+		t.Error("SysProcAttr.Setpgid is not set — the command shares the agent's process group, so it cannot be signalled as a group")
+	}
+	if captured.Cancel == nil {
+		t.Error("Cancel is not overridden — the default kills the direct child only, orphaning whatever it forked")
 	}
 }
 


### PR DESCRIPTION
Ungraceful FIP failover is bounded by BFD-based detection of the dead gateway chassis (~3×1s), not by the agent's own reaction (<1s via `immediateStateRefresh`). Today those timers are invisible to the agent, so operators have no signal on the real failover floor and no lever to lower it.

This branch adds `bfd.go`: a read-only detection-time check that is **on by default**, plus two **independently toggleable, default-off** managers that lower the floor on each layer.

Closes #128

## Commits, in order

**`f88eee5` config: add BFD check and manage options**
Adds the nine-option surface through all four config layers (defaults → file → env → flags): `bfd_check_enabled` (default `true`), `bfd_check_max_detect` (`1s`), `ovn_bfd_manage` (`false`) with `ovn_bfd_min_rx_ms`/`ovn_bfd_min_tx_ms` (`150`), and `frr_bfd_manage` (`false`) with `frr_bfd_min_rx_ms`/`frr_bfd_min_tx_ms` (`150`) and `frr_bfd_multiplier` (`3`). Timer values are validated only when their manager is enabled, so an out-of-range value for a disabled feature never blocks startup. Regenerates `docs/reference/configuration.md` and `docs/reference/cli.md` via `docgen`, and updates the sample config and defaults file.

**`70bc003` metrics: add bfd_detect_seconds gauge**
Exports `ovn_network_agent_bfd_detect_seconds{layer="ovn"|"frr"}` — the estimated failure-detection floor, worst case within each layer.

**`09115d4` bfd: add per-reconcile BFD detection-time check**
The default-on, read-only check. The OVN layer enumerates local Geneve tunnels (`ovs-vsctl --format=json --columns=name,bfd find Interface type=geneve`) and estimates detection time as `mult × max(min_rx, min_tx)`; the FRR layer reads `vtysh -c "show bfd peers json"`. Each layer's worst case is exported, and anything above `bfd_check_max_detect` is warned on. It runs at the *end* of `reconcile` so it never delays route programming on the failover hot path, and a failing layer is logged rather than aborting the cycle. A fabric without BFD, or a node without `bfdd`, makes vtysh print a notice instead of JSON — for a default-on check that is an expected state, so it yields no peers rather than an error. The OVN layer is skipped entirely in `port_forward_only` mode, where there is no OVS.

**`20abe15` bfd: add opt-in OVN tunnel BFD timer management**
With `ovn_bfd_manage=true`, sets `bfd:min_rx`/`bfd:min_tx` on the local Geneve tunnel interfaces. At the default 150/150 ms and OVS' detect multiplier of 3, the dead-gateway detection floor drops from ~3 s to ~450 ms. Only drifted tunnels are written and all of them go out in one `ovs-vsctl` invocation (`--if-exists`, clauses joined by `--`), so an already-converged reconcile issues no OVS command. `bfd:enable` is never touched — `ovn-controller` owns it; if a given OVN version reverts the operator-set timer keys, the next reconcile re-applies them.

**`1a80664` bfd: add opt-in FRR BGP-session BFD management**
With `frr_bfd_manage=true`, discovers the VRF's **already-configured** BGP neighbors (`show bgp vrf <vrf> neighbors json`) and attaches each to an `ovn-network-agent` bfd profile carrying the configured timers. Peering itself is never configured — only the `bfd` knob is added to neighbors an operator declared. This closes the "stale `/32` from the dead node" gap: without BFD the fabric keeps a crashed node's routes until the BGP hold timer expires. Neighbors that already match are left alone; the work that is needed goes out as one batched vtysh call.

**`04decb2` docs: describe the BFD failover-detection floor**
New `docs/explanation/bfd-failover-detection.md`: why ungraceful failover is bounded by BFD rather than the agent, how each layer's detection time is estimated, what the recommended 150/150 ms timers buy, and the cost of tuning too aggressively. Documents both caveats the options carry. Cross-links from `gateway-drain.md`, which previously asserted the 3×1s baseline as a dead end.

## Divergences from the issue, and why

- **Metric name is `ovn_network_agent_bfd_detect_seconds`,** not the issue's `ovn_network_bfd_detect_seconds`. It follows `metricsNamespace` like every other metric in the registry.
- **An extra metric, `bfd_check_errors_total{layer}`,** and NaN/`+Inf` sentinels on the gauge instead of the issue's "bootstrap to 0". `0` is the *healthiest* value the gauge can take, so bootstrapping to it would silence every threshold alert on exactly the reading that means "I could not measure". `NaN` = layer unreadable (and the error counter rises); `+Inf` = nothing bounds detection, i.e. the layer runs no BFD session at all.
- **`runOVS` and `runVtysh` were hardened with command timeouts** (`09115d4`, touching pre-existing `ovs.go`/`routing.go`). This was not in the issue's scope, but the check forks `ovs-vsctl`/`vtysh` on the agent's only loop goroutine on *every* reconcile, and neither runner was previously bounded. A wedged `ovsdb-server` or an FRR config lock held by a concurrent `frr-reload` would stop route programming and keep the SIGTERM handler from ever draining the gateways off the node. Each command now gets a context timeout, `--timeout` where the binary supports it, a `WaitDelay`, and a process-group kill (`exec.CommandContext`'s default `Process.Kill` reaches only the direct child, which is not the hung process behind an `ovs_wrapper` such as `docker exec`). **This affects all existing OVS and vtysh call sites, not just BFD** — worth a careful look.
- **The tunnel list is not cached.** The issue hinted at caching it and re-enumerating only on event-triggered reconciles. It re-enumerates every reconcile: one `ovs-vsctl find` after route programming has already completed, off the hot path. Worth revisiting if it shows up in profiles.
- **"Already profiled" is decided from `show running-config`,** not from the neighbors JSON. A neighbor can have BFD but no profile — an operator's plain `neighbor <addr> bfd`, or a vtysh killed between the two commands that attach one — and would then run at bgpd's session defaults forever. `neighbor <addr> bfd profile <name>` is the line the agent writes and FRR renders back verbatim, whereas the key an attached profile is reported under has changed across FRR releases.
- **The FRR manager declines to act when the VRF has no `router bgp` stanza** (or one whose AS is in asdot notation, which does not parse). `router bgp <as> vrf <vrf>` is create-or-enter, and the agent's contract is to add the `bfd` knob to peering an operator declared — never to instantiate a BGP instance.

## Reviewer notes

- Two caveats are documented rather than solved, both flagged in the issue: whether `ovn-controller` preserves operator-set `bfd:` timer keys **must be verified against the deployed OVN version** before relying on `ovn_bfd_manage`; and `frr_bfd_manage` does nothing unless the **fabric side enables BFD too**.
- `RouteManager` gains two pieces of process-local state, `frrBFDProfileApplied` and `frrBFDAttached`. The latter exists because a neighbor that FRR accepted but never renders back into the running config would otherwise be re-attached every reconcile, resetting its BGP session forever.
- The commit message on `70bc003` says both label series are "bootstrapped to 0"; the code it introduces bootstraps the gauge to `NaN` (the counter to 0). The message is stale, the code is what the rest of the branch relies on.
- `go build ./...` and `go test ./... -count=1` pass. `bfd_test.go` (1404 lines) covers the parsers, the estimators, idempotence of both managers, and the neighbor/interface identifier guards, with `ovs-vsctl`/`vtysh` stubbed through the existing `execOVSHook`/`execVtyshHook` pattern.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) ffc4daf with Claude:claude-opus-4-8_
