### PR TITLE
Replace fixed drain delays with an active takeover handshake

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -433,10 +433,23 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 	// Ensure routes for all desired IPs (FIPs, SNATs, and port forward VIPs).
 	// When no local routers are present but port forwards are configured,
 	// this still installs VIP routes on br-ex and in FRR.
+	announced := false
 	if len(desiredIPs) > 0 || state.HasLocalRouters {
-		a.ensureRoutes(desiredIPs, ipDev, skipKernelRoute)
+		announced = a.ensureRoutes(desiredIPs, ipDev, skipKernelRoute)
 	} else {
 		a.removeAllRoutes("no locally active routers and no port forward VIPs")
+	}
+
+	// On a node that owns local routers, stamp the takeover readiness marker on
+	// each managed default route once the announce succeeded. A draining peer
+	// polls NB for this marker before it releases its own FIP routes, so it
+	// must only be written when this node can actually forward (ensureRoutes
+	// returns true only after RefreshBGP succeeded). HasLocalRouters is false in
+	// port-forward-only mode (a.ovn is nil), so this is skipped there.
+	if announced && state.HasLocalRouters {
+		if err := a.ovn.MarkTakeoverReady(ctx, state.LocalRouters); err != nil {
+			slog.Error("failed to write takeover readiness marker", "error", err)
+		}
 	}
 
 	// Surface desired routes that are configured in FRR but not actually
@@ -558,7 +571,14 @@ func (a *Agent) desiredRouteDev(ip string, ipDev map[string]string) string {
 // segment interface is replaced. IPs in skipKernelRoute keep their existing
 // kernel route untouched — their VLAN segment did not resolve this cycle, so
 // moving the /32 to the bridge fallback would mis-deliver the traffic.
-func (a *Agent) ensureRoutes(desiredIPs []string, ipDev map[string]string, skipKernelRoute map[string]bool) {
+// ensureRoutes returns whether this node successfully announced the desired
+// routes: true unless a kernel-route add, an FRR add, or the BGP soft-refresh
+// failed. The drain takeover handshake uses it so a node that attracted BGP
+// traffic it cannot yet deliver never signals readiness to a draining peer. A
+// steady-state cycle with nothing to change returns true, so a marker missed
+// in one cycle self-heals on the next.
+func (a *Agent) ensureRoutes(desiredIPs []string, ipDev map[string]string, skipKernelRoute map[string]bool) bool {
+	announced := true
 	desiredSet := make(map[string]bool, len(desiredIPs))
 	for _, ip := range desiredIPs {
 		desiredSet[ip] = true
@@ -617,6 +637,7 @@ func (a *Agent) ensureRoutes(desiredIPs []string, ipDev map[string]string, skipK
 		if needsKernel {
 			if err := a.routing.AddKernelRoute(ip, dev); err != nil {
 				slog.Error("failed to add kernel route", "ip", ip, "dev", dev, "error", err)
+				announced = false
 			}
 		}
 		if needsFRR {
@@ -628,6 +649,7 @@ func (a *Agent) ensureRoutes(desiredIPs []string, ipDev map[string]string, skipK
 	if len(addFRR) > 0 {
 		if err := a.routing.AddFRRRoutes(addFRR); err != nil {
 			slog.Error("failed to batch-add FRR routes", "count", len(addFRR), "ips", addFRR, "error", err)
+			announced = false
 		}
 	}
 
@@ -683,6 +705,7 @@ func (a *Agent) ensureRoutes(desiredIPs []string, ipDev map[string]string, skipK
 	if len(addFRR) > 0 || len(delFRR) > 0 {
 		if err := a.routing.RefreshBGP(); err != nil {
 			slog.Warn("BGP soft-refresh failed, peers may wait for MRAI timer", "error", err)
+			announced = false
 		}
 	}
 
@@ -692,6 +715,8 @@ func (a *Agent) ensureRoutes(desiredIPs []string, ipDev map[string]string, skipK
 	if len(addFRR) > 0 || len(delFRR) > 0 {
 		a.verifyRoutes(desiredIPs, ipDev, skipKernelRoute)
 	}
+
+	return announced
 }
 
 // removeAllRoutes removes all managed FIP routes.

--- a/agent_test.go
+++ b/agent_test.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 )
 
 func TestUniqueIPs(t *testing.T) {
@@ -439,6 +441,103 @@ func TestReconcileNoLocalRoutersInvokesRemoveAllRoutes(t *testing.T) {
 	}
 }
 
+// TestReconcileWritesMarkerAfterSuccessfulAnnounce drives a dry-run reconcile
+// with one local router active on this chassis and its managed default route
+// carrying a peer's readiness marker. The announce succeeds (dry-run FRR/BGP
+// never fail), so reconcile must stamp the local chassis into the marker so a
+// draining peer learns this node has taken over. The nonexistent bridge makes
+// GetBridgeMAC fail, so EnsureGatewayRouting writes nothing and the marker
+// update is the only NB write.
+func TestReconcileWritesMarkerAfterSuccessfulAnnounce(t *testing.T) {
+	rm := &RouteManager{
+		bridgeDev:   "ovnagent-nonexistent-br",
+		vrfName:     "vrf-provider",
+		vethNexthop: "169.254.0.1",
+		dryRun:      true,
+	}
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+	c.state.LocalRouters = []LocalRouterInfo{{RouterName: "r1", RouterUUID: "lr1", LRPName: "lrp-r1"}}
+	c.state.HasLocalRouters = true
+	nb.setRows("Logical_Router", &NBLogicalRouter{UUID: "lr1", Name: "r1", StaticRoutes: []string{"sr1"}})
+	nb.setRows("Logical_Router_Static_Route", &NBLogicalRouterStaticRoute{
+		UUID:     "sr1",
+		IPPrefix: "0.0.0.0/0",
+		ExternalIDs: map[string]string{
+			"ovn-network-agent":         "managed",
+			"ovn-network-agent-chassis": "host-b",
+			takeoverReadyMarkerKey:      "host-b",
+		},
+	})
+
+	a := &Agent{
+		cfg:            Config{},
+		ovn:            c,
+		routing:        rm,
+		reconcileCh:    make(chan struct{}, 1),
+		missingChassis: make(map[string]time.Time),
+	}
+	a.reconcile(context.Background(), "test")
+
+	if !hasMarkerUpdate(nb.writeTransacts(), "host-a") {
+		t.Fatalf("reconcile did not stamp the takeover marker for host-a; writes: %v", nb.writeTransacts())
+	}
+}
+
+// TestReconcileSkipsMarkerWithoutLocalRouters proves the HasLocalRouters gate:
+// with no locally-active routers the node is not a takeover candidate, so even
+// though NB holds a managed default route, reconcile must not stamp a marker.
+func TestReconcileSkipsMarkerWithoutLocalRouters(t *testing.T) {
+	rm := &RouteManager{
+		bridgeDev:   "ovnagent-nonexistent-br",
+		vrfName:     "vrf-provider",
+		vethNexthop: "169.254.0.1",
+		dryRun:      true,
+	}
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+	// HasLocalRouters defaults to false.
+	nb.setRows("Logical_Router", &NBLogicalRouter{UUID: "lr1", Name: "r1", StaticRoutes: []string{"sr1"}})
+	nb.setRows("Logical_Router_Static_Route", &NBLogicalRouterStaticRoute{
+		UUID:     "sr1",
+		IPPrefix: "0.0.0.0/0",
+		ExternalIDs: map[string]string{
+			"ovn-network-agent":         "managed",
+			"ovn-network-agent-chassis": "host-b",
+			takeoverReadyMarkerKey:      "host-b",
+		},
+	})
+
+	a := &Agent{
+		cfg:            Config{},
+		ovn:            c,
+		routing:        rm,
+		reconcileCh:    make(chan struct{}, 1),
+		missingChassis: make(map[string]time.Time),
+	}
+	a.reconcile(context.Background(), "test")
+
+	if hasMarkerUpdate(nb.writeTransacts(), "host-a") {
+		t.Fatalf("reconcile wrote a takeover marker with no local routers; writes: %v", nb.writeTransacts())
+	}
+}
+
+// hasMarkerUpdate reports whether any recorded write updates a
+// Logical_Router_Static_Route external_ids with a takeover readiness marker
+// naming chassis.
+func hasMarkerUpdate(writes [][]ovsdb.Operation, chassis string) bool {
+	for _, batch := range writes {
+		for _, op := range batch {
+			if op.Op != ovsdb.OperationUpdate || op.Table != "Logical_Router_Static_Route" {
+				continue
+			}
+			ext, ok := op.Row["external_ids"].(map[string]string)
+			if ok && ext[takeoverReadyMarkerKey] == chassis {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // TestRemoveAllRoutesDryRun exercises removeAllRoutes end-to-end. In dry-run
 // mode List* helpers return (nil, nil) so the function walks every branch
 // (FRR list, kernel list, BGP refresh skipped because no routes to remove).
@@ -505,6 +604,64 @@ S>* 198.51.100.99/32 [1/0] via 169.254.0.1, veth-default, weight 1, 00:00:01
 	if !sawRefresh {
 		t.Errorf("expected BGP refresh after deletes, got calls: %v", rec.calls)
 	}
+}
+
+// TestEnsureRoutesReturnsAnnounceOutcome pins the announce outcome the drain
+// takeover handshake keys on: ensureRoutes returns true when the FIP routes
+// were announced (or nothing needed changing) and false when the FRR add or
+// the BGP soft-refresh failed. PortForwardOnly skips kernel routes so only the
+// FRR/BGP paths — the ones the outcome depends on — are exercised, keeping the
+// test off the real bridge.
+func TestEnsureRoutesReturnsAnnounceOutcome(t *testing.T) {
+	_, cidr, _ := net.ParseCIDR("198.51.100.0/24")
+	newAgent := func(rec *vtyshRecorder) *Agent {
+		rm := &RouteManager{
+			bridgeDev:     "ovnagent-nonexistent-br",
+			vrfName:       "vrf-provider",
+			vethNexthop:   "169.254.0.1",
+			execVtyshHook: rec.hook(),
+		}
+		return &Agent{cfg: Config{PortForwardOnly: true}, routing: rm, effectiveFilters: []*net.IPNet{cidr}}
+	}
+
+	t.Run("clean add announces", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		// FRR reports no routes, so the desired IP is added and BGP refreshed;
+		// the recorder returns success for both.
+		if !newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, nil, nil) {
+			t.Errorf("clean add cycle: announced = false, want true (calls: %v)", rec.calls)
+		}
+	})
+
+	t.Run("no-change cycle announces", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		// FRR already advertises the only desired IP: nothing is added or
+		// removed, so no BGP refresh runs and the cycle still announces.
+		rec.on([]string{"vtysh", "-c", "show ip route vrf vrf-provider static"},
+			"S>* 198.51.100.10/32 [1/0] via 169.254.0.1, veth-default, weight 1, 00:00:01\n", nil)
+		if !newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, nil, nil) {
+			t.Errorf("no-change cycle: announced = false, want true (calls: %v)", rec.calls)
+		}
+	})
+
+	t.Run("FRR add failure does not announce", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		rec.on([]string{"vtysh", "-c", "conf t", "-c", "vrf vrf-provider",
+			"-c", "ip route 198.51.100.10/32 169.254.0.1", "-c", "exit-vrf", "-c", "end"},
+			"", errors.New("vtysh add failed"))
+		if newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, nil, nil) {
+			t.Errorf("FRR add failure: announced = true, want false")
+		}
+	})
+
+	t.Run("BGP refresh failure does not announce", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		rec.on([]string{"vtysh", "-c", "clear ip bgp vrf vrf-provider * soft out"},
+			"", errors.New("bgp refresh failed"))
+		if newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, nil, nil) {
+			t.Errorf("BGP refresh failure: announced = true, want false")
+		}
+	})
 }
 
 // TestRemoveAllRoutesWithStubbedFRRList exercises the FRR-driven removal

--- a/config.go
+++ b/config.go
@@ -128,11 +128,13 @@ type Config struct {
 	DrainOnShutdown   bool
 	DrainTimeout      time.Duration
 
-	// DrainSettleDelay is how long to keep advertising FIP routes after
-	// the drain confirms all chassisredirect ports have migrated away,
-	// before cleanup withdraws them. The hold gives the takeover chassis
-	// time to finish OVN programming and BGP advertisement so external
-	// traffic is not blackholed. 0 = no hold.
+	// DrainSettleDelay is the safety margin held after the takeover chassis
+	// signals readiness (via the NB readiness marker) — or, when no marker can
+	// be expected, after the drain confirms the chassisredirect ports have
+	// migrated away — before cleanup withdraws the FIP routes. The marker wait
+	// itself is event-driven and bounded by drain_timeout, so this is only the
+	// final margin, not the whole hold. 0 disables the readiness wait and the
+	// margin entirely (cleanup runs as soon as the ports migrate).
 	DrainSettleDelay time.Duration
 
 	FRRPrefixList string // FRR prefix-list name to manage dynamically (e.g. ANNOUNCED-NETWORKS)
@@ -228,7 +230,7 @@ func loadConfig(args []string) (Config, error) {
 		fCleanupOnShutdown = fs.Bool("cleanup-on-shutdown", true, "Remove all managed routes on shutdown (SIGINT/SIGTERM)")
 		fDrainOnShutdown   = fs.Bool("drain-on-shutdown", true, "Drain HA gateways before shutdown by lowering Gateway_Chassis priority")
 		fDrainTimeout      = fs.String("drain-timeout", "", "Max time to wait for gateway drain (e.g. 60s)")
-		fDrainSettleDelay  = fs.String("drain-settle-delay", "", "Hold time after gateway drain before cleanup so the takeover chassis can finish coming up (e.g. 3s)")
+		fDrainSettleDelay  = fs.String("drain-settle-delay", "", "Safety margin held after the takeover chassis signals readiness, before cleanup (e.g. 500ms; 0 disables the hold)")
 
 		fFRRPrefixList        = fs.String("frr-prefix-list", "", "FRR prefix-list name to manage dynamically (default: ANNOUNCED-NETWORKS)")
 		fStaleGrace           = fs.String("stale-chassis-grace-period", "", "Grace period before cleaning up entries from missing chassis (e.g. 5m, 0 to disable)")
@@ -264,7 +266,7 @@ func loadConfig(args []string) (Config, error) {
 		CleanupOnShutdown:       true,
 		DrainOnShutdown:         true,
 		DrainTimeout:            60 * time.Second,
-		DrainSettleDelay:        3 * time.Second,
+		DrainSettleDelay:        500 * time.Millisecond,
 		FRRPrefixList:           "ANNOUNCED-NETWORKS",
 		StaleChassisGracePeriod: 5 * time.Minute,
 		VethLeakEnabled:         true,

--- a/config_test.go
+++ b/config_test.go
@@ -992,8 +992,8 @@ func TestLoadConfigDrainSettleDelayDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
-	if cfg.DrainSettleDelay != 3*time.Second {
-		t.Errorf("DrainSettleDelay = %v, want %v", cfg.DrainSettleDelay, 3*time.Second)
+	if cfg.DrainSettleDelay != 500*time.Millisecond {
+		t.Errorf("DrainSettleDelay = %v, want %v", cfg.DrainSettleDelay, 500*time.Millisecond)
 	}
 }
 

--- a/docs/explanation/gateway-drain.md
+++ b/docs/explanation/gateway-drain.md
@@ -28,9 +28,15 @@ agent:
    database for all locally-active router ports. Since standby chassis have
    priority >= 1, `ovn-northd` immediately begins migrating chassisredirect
    ports to standby chassis.
-2. **Polls the SB `Port_Binding` table** until all chassisredirect ports
-   have moved away from this chassis (or the drain timeout expires).
-3. **Proceeds with normal cleanup** — by this point OVN has already
+2. **Waits for the chassisredirect ports to move away** from this chassis.
+   The SB monitor is still connected during the drain, so the wait is
+   event-driven: each chassisredirect `Port_Binding` change wakes it
+   immediately, with a short safety re-poll and an overall bound of the
+   drain timeout.
+3. **Runs the takeover handshake** — it waits for the takeover chassis to
+   signal that it can forward (see [The takeover
+   handshake](#the-takeover-handshake)) before proceeding.
+4. **Proceeds with normal cleanup** — by this point OVN has already
    migrated traffic to another chassis, so the BGP withdrawal and route
    cleanup cause zero disruption.
 
@@ -70,13 +76,14 @@ already moved. The result is a hitless shutdown.
                           │
                           ▼
   ┌───────────────────────────────────────────────────────┐
-  │  2. SETTLE (hold for drain_settle_delay)              │
+  │  2. HANDSHAKE (await takeover, then hold margin)      │
   │                                                       │
-  │  Keep advertising FIP /32 routes and OVS flows so     │
-  │  this node still forwards external traffic            │
-  │  (hairpinned to the new gateway chassis) while the    │
-  │  takeover chassis finishes OVN programming, reconcile │
-  │  and BGP advertisement. Skipped if nothing migrated.  │
+  │  Wait until the takeover chassis stamps its           │
+  │  readiness marker on the managed default route,       │
+  │  then hold the drain_settle_delay safety margin.      │
+  │  Keeps advertising FIP /32 routes and OVS flows       │
+  │  meanwhile; bounded by drain_timeout, skipped         │
+  │  when nothing migrated.                               │
   └───────────────────────┬───────────────────────────────┘
                           │
                           ▼
@@ -127,9 +134,9 @@ already moved. The result is a hitless shutdown.
                  Normal reconciliation loop
 ```
 
-## The takeover race and the settle delay
+## The takeover handshake
 
-Draining the priority and polling until the chassisredirect port has
+Draining the priority and waiting until the chassisredirect port has
 migrated away makes the **OVN-internal** failover hitless. But "the port
 moved" is not the same as "the takeover chassis can forward external
 traffic". The leaving node advertises each FIP as a BGP `/32`; so does the
@@ -146,27 +153,44 @@ If step 1 wins, external traffic has no working path until step 2
 finishes — observed as roughly 5 s of packet loss on a continuous ping
 through a FIP.
 
-Two mechanisms close this race:
+Rather than paper over this race with a fixed sleep, the agents close it
+with an explicit two-sided handshake plus a BGP nudge:
 
-- **Post-drain settle delay** (`drain_settle_delay`, default 3 s). After
-  the poll loop confirms the ports have migrated, the leaving node holds
-  before cleanup. During the hold it still advertises its FIP routes and
-  keeps its OVS flows, so it continues forwarding external traffic —
-  hairpinned to the new gateway chassis over the tunnel — while the
-  takeover node comes up. The hold is bounded by `drain_timeout`, so total
-  graceful shutdown never exceeds that budget, and it is skipped when there
-  was nothing to drain.
+- **Readiness marker (the handshake).** At the end of a successful
+  failover reconcile — after it has installed its FIP routes **and** the
+  BGP soft-refresh below has succeeded — the takeover node stamps
+  `external_ids["ovn-network-agent-advertised"]="<chassis>"`
+  onto the router's managed default route in NB (a natural extension of
+  the chassis tag the agent already maintains there). The write is
+  idempotent and only happens once the node can actually forward, so it is
+  a truthful "ready" signal, not a timer.
+- **Awaiting the marker on the leaving node.** Instead of sleeping a fixed
+  settle delay, the leaving node polls NB at ~250 ms (through the
+  cache-consistency guard, so a stale cache cannot stall or short-circuit
+  it) until every managed default route it used to own carries a marker
+  naming a *different* chassis. Only then does it hold a small
+  `drain_settle_delay` safety margin and proceed to cleanup. While it
+  waits and holds, it keeps advertising its FIP routes and OVS flows, so it
+  continues forwarding external traffic — hairpinned to the new gateway
+  chassis over the tunnel — until the takeover node is provably up. The
+  whole handshake is bounded by `drain_timeout`: a takeover that never
+  signals (for example a peer running an older agent that does not write
+  the marker) falls back cleanly at the deadline and cleanup still runs.
+  Setting `drain_settle_delay` to `0` disables the wait and the margin
+  entirely, and a drain with no agent-managed default route degrades to
+  holding only the margin.
 - **BGP soft-refresh on the takeover node.** When the takeover node adds
   FIP `/32`s to FRR, the agent immediately issues `clear ip bgp … soft out`
   instead of waiting for FRR's normal redistribution timing. The soft
   refresh only re-evaluates outbound policy and re-sends routes — it never
   withdraws anything — so it shortens the takeover node's "ready" time
   (and also speeds up ungraceful failovers) at the cost of a small extra
-  UPDATE burst.
+  UPDATE burst. Because the readiness marker is written only after this
+  refresh succeeds, observing the marker means BGP has already been nudged.
 
 A portion of the remaining gap is OVN-intrinsic (`ovn-northd` /
 `ovn-controller` reprogramming) and cannot be closed from the agent; the
-settle delay only has to cover the takeover node's reconcile and BGP
+handshake only has to cover the takeover node's reconcile and BGP
 advertisement.
 
 ## Priority semantics

--- a/docs/guides/gateway-drain.md
+++ b/docs/guides/gateway-drain.md
@@ -8,21 +8,23 @@ and the shutdown sequence diagrams, see
 ## Default behavior
 
 Drain mode is **enabled by default** with a 60-second timeout and a
-3-second post-drain settle delay:
+500-millisecond post-readiness safety margin:
 
 ```yaml
 # Enable/disable drain (default: true)
 drain_on_shutdown: true
 
-# Maximum time to wait for migration (default: 60s)
-# After this timeout, the agent proceeds with shutdown even if some
-# gateways have not yet migrated.
+# Maximum time to wait for migration and the takeover handshake (default: 60s)
+# After this timeout, the agent proceeds with shutdown even if migration
+# or the readiness handshake has not completed.
 drain_timeout: "60s"
 
-# Hold time after migration completes, before cleanup (default: 3s)
-# Keeps this node advertising its FIP routes while the takeover chassis
-# finishes coming up. Set to 0 to disable. See "Settle delay" below.
-drain_settle_delay: "3s"
+# Safety margin held after the takeover chassis signals readiness (default: 500ms)
+# The node first waits for the takeover chassis to signal it can forward
+# (bounded by drain_timeout), then holds this additional margin before
+# cleanup. Set to 0 to disable the wait and the margin. See "Settle
+# delay" below.
+drain_settle_delay: "500ms"
 ```
 
 ## Override via CLI flags
@@ -30,7 +32,7 @@ drain_settle_delay: "3s"
 ```bash
 ovn-network-agent --drain-on-shutdown=false                 # disable drain
 ovn-network-agent --drain-timeout 120s                      # increase timeout
-ovn-network-agent --drain-settle-delay 5s                   # longer settle hold
+ovn-network-agent --drain-settle-delay 1s                   # longer safety margin
 ```
 
 ## Override via environment variables
@@ -39,7 +41,7 @@ ovn-network-agent --drain-settle-delay 5s                   # longer settle hold
 OVN_NETWORK_DRAIN_ON_SHUTDOWN=false                         # disable drain
 OVN_NETWORK_DRAIN_ON_SHUTDOWN=true                          # enable drain (over a config file that disables it)
 OVN_NETWORK_DRAIN_TIMEOUT=120s                              # increase timeout
-OVN_NETWORK_DRAIN_SETTLE_DELAY=5s                           # longer settle hold
+OVN_NETWORK_DRAIN_SETTLE_DELAY=1s                           # longer safety margin
 ```
 
 ## Settle delay
@@ -52,17 +54,31 @@ happen. If the leaving node withdrew its FIP routes the instant the port
 moved, external traffic would be blackholed for that gap (observed as
 ~5 s of packet loss).
 
-`drain_settle_delay` closes that race: after the drain confirms the ports
-have migrated, the agent keeps advertising its FIP `/32` routes and keeps
-its OVS flows for this long, continuing to forward external traffic
-(hairpinned to the new gateway chassis over the tunnel) until the takeover
-chassis has come up. Only then does cleanup withdraw the routes.
+The agents close that race with an active handshake instead of a fixed
+sleep: once the ports have migrated, the leaving node waits for the
+takeover chassis to stamp a readiness marker on the managed default route
+(written only after the takeover node has actually announced its FIP
+routes), and only then holds `drain_settle_delay` as a final safety
+margin before cleanup. Throughout the wait and the margin it keeps
+advertising its FIP `/32` routes and OVS flows, forwarding external
+traffic (hairpinned to the new gateway chassis over the tunnel) until the
+takeover chassis is provably up. For the full mechanism see
+[The takeover handshake](../explanation/gateway-drain#the-takeover-handshake).
 
-The trade-off is shutdown time: a graceful drain takes up to
-`drain_settle_delay` longer. The hold is bounded by `drain_timeout`, so
-total graceful shutdown never exceeds that budget. Set `drain_settle_delay`
-to `0` to disable the hold and have cleanup run as soon as the ports
+`drain_settle_delay` is therefore just the margin held *after* the
+readiness signal, not the whole hold — which is why its default dropped
+from `3s` to `500ms`. The entire handshake (readiness wait plus margin)
+is bounded by `drain_timeout`, so total graceful shutdown never exceeds
+that budget. Set `drain_settle_delay` to `0` to disable the readiness
+wait and the margin entirely and have cleanup run as soon as the ports
 migrate.
+
+**Rolling upgrades.** A peer running a pre-handshake agent never writes
+the readiness marker, so while you upgrade the agent fleet a drain waits
+for the full `drain_timeout` before falling back (safe — it never
+releases early, just slower). If you need faster drains during the
+upgrade window, temporarily lower `drain_timeout` or set
+`drain_settle_delay: 0`.
 
 ## When to disable drain
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -30,7 +30,7 @@ regenerate it with `go generate ./...`.
 | `--cleanup-on-shutdown` | `true` | Remove all managed routes on shutdown (SIGINT/SIGTERM) |
 | `--drain-on-shutdown` | `true` | Drain HA gateways before shutdown by lowering Gateway_Chassis priority |
 | `--drain-timeout` | `60s` | Max time to wait for gateway drain (e.g. 60s) |
-| `--drain-settle-delay` | `3s` | Hold time after gateway drain before cleanup so the takeover chassis can finish coming up (e.g. 3s) |
+| `--drain-settle-delay` | `500ms` | Safety margin held after the takeover chassis signals readiness, before cleanup (e.g. 500ms; 0 disables the hold) |
 | `--frr-prefix-list` | `ANNOUNCED-NETWORKS` | FRR prefix-list name to manage dynamically (default: ANNOUNCED-NETWORKS) |
 | `--stale-chassis-grace-period` | `5m` | Grace period before cleaning up entries from missing chassis (e.g. 5m, 0 to disable) |
 | `--veth-leak-enabled` | `true` | Enable veth VRF route leaking |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -36,7 +36,7 @@ regenerate this page with `go generate ./...`.
 | `--cleanup-on-shutdown` | `OVN_NETWORK_CLEANUP_ON_SHUTDOWN` | `cleanup_on_shutdown` | `true` | Remove all managed routes on shutdown (SIGINT/SIGTERM) |
 | `--drain-on-shutdown` | `OVN_NETWORK_DRAIN_ON_SHUTDOWN` | `drain_on_shutdown` | `true` | Drain HA gateways before shutdown by lowering Gateway_Chassis priority |
 | `--drain-timeout` | `OVN_NETWORK_DRAIN_TIMEOUT` | `drain_timeout` | `60s` | Max time to wait for gateway drain (e.g. 60s) |
-| `--drain-settle-delay` | `OVN_NETWORK_DRAIN_SETTLE_DELAY` | `drain_settle_delay` | `3s` | Hold time after gateway drain before cleanup so the takeover chassis can finish coming up (e.g. 3s) |
+| `--drain-settle-delay` | `OVN_NETWORK_DRAIN_SETTLE_DELAY` | `drain_settle_delay` | `500ms` | Safety margin held after the takeover chassis signals readiness, before cleanup (e.g. 500ms; 0 disables the hold) |
 | `--frr-prefix-list` | `OVN_NETWORK_FRR_PREFIX_LIST` | `frr_prefix_list` | `ANNOUNCED-NETWORKS` | FRR prefix-list name to manage dynamically (default: ANNOUNCED-NETWORKS) |
 | `--stale-chassis-grace-period` | `OVN_NETWORK_STALE_CHASSIS_GRACE_PERIOD` | `stale_chassis_grace_period` | `5m` | Grace period before cleaning up entries from missing chassis (e.g. 5m, 0 to disable) |
 | `--veth-leak-enabled` | `OVN_NETWORK_VETH_LEAK_ENABLED` | `veth_leak_enabled` | `true` | Enable veth VRF route leaking |

--- a/ovn-network-agent.yaml.sample
+++ b/ovn-network-agent.yaml.sample
@@ -94,13 +94,14 @@ ovn_nb_remote: "tcp:10.10.0.1:6641,tcp:10.10.0.2:6641,tcp:10.10.0.3:6641"
 # gateways have not yet migrated.
 # drain_timeout: "60s"
 
-# Hold time after the drain before cleanup (default: 3s)
-# Once the chassisredirect ports have migrated away, the agent keeps
-# advertising its FIP routes for this long so the takeover chassis can
-# finish OVN programming and BGP advertisement before the routes are
-# withdrawn. This extends total shutdown by up to drain_settle_delay,
-# bounded by drain_timeout. Set to 0 to disable the hold.
-# drain_settle_delay: "3s"
+# Safety margin held after the takeover chassis signals readiness (default: 500ms)
+# Once the chassisredirect ports have migrated away, the agent waits for the
+# takeover chassis to stamp its readiness marker on the managed default route
+# (bounded by drain_timeout), then keeps advertising its FIP routes for this
+# additional margin before cleanup withdraws them. Set to 0 to disable the
+# readiness wait and the margin entirely (cleanup runs as soon as the ports
+# migrate).
+# drain_settle_delay: "500ms"
 
 # FRR prefix-list to manage dynamically (default: ANNOUNCED-NETWORKS)
 # When set, the agent adds/removes "permit <network> ge 32 le 32" entries

--- a/ovn.go
+++ b/ovn.go
@@ -231,6 +231,14 @@ type OVNClient struct {
 	debounceCh  chan struct{}
 	immediateCh chan struct{}
 
+	// drainWatchCh receives signals from the SB event handler on
+	// chassisredirect Port_Binding changes. Unlike debounceCh/immediateCh it
+	// does not feed the refresh loop; DrainGateways consumes it so the drain
+	// wait re-checks countLocalCRPorts the moment a port migrates, instead of
+	// waiting for the fixed safety re-poll. Buffered with capacity 1 so a
+	// storm of events coalesces into at most one queued wake-up.
+	drainWatchCh chan struct{}
+
 	// loopDone is closed when refreshLoop exits. Set by Connect() before
 	// starting the loop; nil before Connect() succeeds.
 	loopDone chan struct{}
@@ -238,11 +246,12 @@ type OVNClient struct {
 
 func NewOVNClient(cfg Config, onChange func()) *OVNClient {
 	return &OVNClient{
-		cfg:         cfg,
-		state:       &OVNState{},
-		onChange:    onChange,
-		debounceCh:  make(chan struct{}, 1),
-		immediateCh: make(chan struct{}, 1),
+		cfg:          cfg,
+		state:        &OVNState{},
+		onChange:     onChange,
+		debounceCh:   make(chan struct{}, 1),
+		immediateCh:  make(chan struct{}, 1),
+		drainWatchCh: make(chan struct{}, 1),
 	}
 }
 
@@ -827,6 +836,23 @@ func (o *OVNClient) immediateStateRefresh() {
 	}
 }
 
+// signalDrainWatch wakes a DrainGateways poll waiting for chassisredirect
+// ports to migrate away. It is fired from the SB event handler on every
+// chassisredirect Port_Binding change so the drain re-checks countLocalCRPorts
+// the moment OVN rebinds a port, instead of waiting for the fixed safety
+// re-poll. Concurrent calls coalesce: at most one wake-up is queued. Outside a
+// drain nothing reads the channel, so the queued signal is simply harmless.
+func (o *OVNClient) signalDrainWatch() {
+	if !o.ready.Load() {
+		return // not fully connected yet
+	}
+	select {
+	case o.drainWatchCh <- struct{}{}:
+	default:
+		// already queued
+	}
+}
+
 // =============================================================================
 // SB event handler (implements cache.EventHandler)
 // =============================================================================
@@ -838,6 +864,7 @@ type sbEventHandler struct {
 func (h *sbEventHandler) OnAdd(table string, m model.Model) {
 	if h.isChassisRedirect(table, m) {
 		slog.Debug("chassisredirect port added, immediate refresh")
+		h.ovn.signalDrainWatch()
 		h.ovn.immediateStateRefresh()
 		return
 	}
@@ -847,6 +874,7 @@ func (h *sbEventHandler) OnAdd(table string, m model.Model) {
 func (h *sbEventHandler) OnUpdate(table string, old, new model.Model) {
 	if h.isChassisRedirect(table, new) {
 		slog.Debug("chassisredirect port updated, immediate refresh")
+		h.ovn.signalDrainWatch()
 		h.ovn.immediateStateRefresh()
 		return
 	}
@@ -856,6 +884,7 @@ func (h *sbEventHandler) OnUpdate(table string, old, new model.Model) {
 func (h *sbEventHandler) OnDelete(table string, m model.Model) {
 	if h.isChassisRedirect(table, m) {
 		slog.Debug("chassisredirect port deleted, immediate refresh")
+		h.ovn.signalDrainWatch()
 		h.ovn.immediateStateRefresh()
 		return
 	}

--- a/ovn_gateway.go
+++ b/ovn_gateway.go
@@ -108,6 +108,14 @@ const minActivePriority = 2
 // even the fallback path drains faster.
 const drainRecheckInterval = 1 * time.Second
 
+// takeoverReadyMarkerKey is the external_ids key the takeover node stamps on a
+// router's managed default route once it has successfully announced the FIP
+// routes (FRR routes installed and RefreshBGP succeeded). Its value is the
+// takeover chassis name. A leaving node's drain waits for this marker to name
+// the takeover chassis before it releases its own routes, so external traffic
+// is never withdrawn before the takeover node can forward it.
+const takeoverReadyMarkerKey = "ovn-network-agent-advertised"
+
 // EnsureActivePriorityLead ensures that for each locally-active router the
 // local Gateway_Chassis entry has a strictly higher priority than all peers
 // in the same HA group, and at least minActivePriority. The minimum
@@ -359,6 +367,86 @@ func (o *OVNClient) ensureDefaultRoute(ctx context.Context, lr LocalRouterInfo, 
 	}
 
 	slog.Info("default route created", "router", lr.RouterName, "vgw", vgwIP, "output_port", lr.LRPName)
+	return nil
+}
+
+// MarkTakeoverReady stamps external_ids[takeoverReadyMarkerKey] with the local
+// chassis name on each local router's managed default route, signalling a
+// draining peer that this chassis has taken over and can forward external
+// traffic. It is the writer half of the drain takeover handshake and a natural
+// extension of the chassis tag ensureDefaultRoute already maintains.
+//
+// The caller MUST only invoke it after the FRR routes are in place and
+// RefreshBGP has succeeded — writing the marker earlier would release the
+// leaving node before this chassis can actually forward. The write is
+// idempotent: a marker that already names this chassis is left untouched, so a
+// steady-state reconcile issues no transaction.
+//
+// The NB reads go through the cache-consistency guard so a stale monitor cache
+// cannot hide the managed route and silently skip the write.
+func (o *OVNClient) MarkTakeoverReady(ctx context.Context, localRouters []LocalRouterInfo) error {
+	if len(localRouters) == 0 {
+		return nil
+	}
+
+	routes, err := cachedList(ctx, o.nbClient, "Logical_Router_Static_Route",
+		lrsrCheckColumns, keyOfNBLogicalRouterStaticRoute, decodeNBLogicalRouterStaticRoute)
+	if err != nil {
+		return fmt.Errorf("list static routes: %w", err)
+	}
+	routers, err := cachedList(ctx, o.nbClient, "Logical_Router",
+		lrCheckColumns, keyOfNBLogicalRouter, decodeNBLogicalRouter)
+	if err != nil {
+		return fmt.Errorf("list routers: %w", err)
+	}
+
+	localRouterUUIDs := make(map[string]bool, len(localRouters))
+	for _, lr := range localRouters {
+		localRouterUUIDs[lr.RouterUUID] = true
+	}
+
+	// Only mark routes owned by a router active on this chassis.
+	routeOwnedLocally := make(map[string]bool)
+	for _, router := range routers {
+		if !localRouterUUIDs[router.UUID] {
+			continue
+		}
+		for _, ruuid := range router.StaticRoutes {
+			routeOwnedLocally[ruuid] = true
+		}
+	}
+
+	localChassis := o.state.LocalChassisName
+	marker := localChassis
+
+	var allOps []ovsdb.Operation
+	for i := range routes {
+		route := routes[i]
+		if !routeOwnedLocally[route.UUID] || route.IPPrefix != "0.0.0.0/0" {
+			continue
+		}
+		if route.ExternalIDs == nil || route.ExternalIDs["ovn-network-agent"] != "managed" {
+			continue
+		}
+		if route.ExternalIDs[takeoverReadyMarkerKey] == localChassis {
+			continue // already advertised by this chassis — idempotent no-op
+		}
+		route.ExternalIDs[takeoverReadyMarkerKey] = marker
+		ops, err := o.nbClient.Where(&route).Update(&route, &route.ExternalIDs)
+		if err != nil {
+			slog.Error("failed to build takeover marker update", "route", route.UUID, "error", err)
+			continue
+		}
+		allOps = append(allOps, ops...)
+	}
+
+	if len(allOps) == 0 {
+		return nil
+	}
+	if err := o.transactOps(ctx, allOps); err != nil {
+		return fmt.Errorf("write takeover readiness marker: %w", err)
+	}
+	slog.Info("drain: takeover readiness marker written", "chassis", localChassis, "marker", marker)
 	return nil
 }
 

--- a/ovn_gateway.go
+++ b/ovn_gateway.go
@@ -101,6 +101,13 @@ func (o *OVNClient) EnsureGatewayRouting(ctx context.Context, localRouters []Loc
 // tiebreak flapping) when a peer restarts.
 const minActivePriority = 2
 
+// drainRecheckInterval is the safety re-poll cadence of the drain migration
+// wait. The wait is primarily event-driven — a chassisredirect Port_Binding
+// change wakes it through drainWatchCh — so this ticker only bounds the worst
+// case if an event is ever missed. It is shorter than the old fixed 2s poll so
+// even the fallback path drains faster.
+const drainRecheckInterval = 1 * time.Second
+
 // EnsureActivePriorityLead ensures that for each locally-active router the
 // local Gateway_Chassis entry has a strictly higher priority than all peers
 // in the same HA group, and at least minActivePriority. The minimum
@@ -665,9 +672,11 @@ func (o *OVNClient) CleanupStaleChassisManagedEntries(ctx context.Context, stale
 
 // DrainGateways sets the Gateway_Chassis priority to 0 for this chassis on
 // all locally-active router ports, causing OVN to migrate chassisredirect
-// ports to standby chassis (which have priority >= 1). It then polls the
-// SB Port_Binding table until all gateways have moved away or the context
-// deadline is exceeded.
+// ports to standby chassis (which have priority >= 1). It then waits until
+// all gateways have moved away or the context deadline is exceeded. The wait
+// is event-driven: chassisredirect Port_Binding changes delivered by the SB
+// monitor wake it through drainWatchCh, with a short ticker as a safety
+// re-poll (see drainRecheckInterval).
 //
 // Once the ports have migrated, it holds for cfg.DrainSettleDelay before
 // returning (see settleAfterDrain) so the caller does not withdraw this
@@ -757,8 +766,12 @@ func (o *OVNClient) DrainGateways(ctx context.Context, localChassisName string) 
 		}
 	}
 
-	// Step 3: Poll SB until no chassisredirect ports remain on this chassis.
-	ticker := time.NewTicker(2 * time.Second)
+	// Step 3: Wait until no chassisredirect ports remain on this chassis. The
+	// wait is event-driven: the SB monitor is still connected during drain, so
+	// each chassisredirect Port_Binding change signals drainWatchCh and the
+	// wait re-checks countLocalCRPorts immediately. The ticker is only a safety
+	// re-poll in case an event is ever missed.
+	ticker := time.NewTicker(drainRecheckInterval)
 	defer ticker.Stop()
 
 	for {
@@ -777,6 +790,9 @@ func (o *OVNClient) DrainGateways(ctx context.Context, localChassisName string) 
 		case <-ctx.Done():
 			slog.Warn("drain: timeout exceeded, proceeding with shutdown", "remaining_gateways", remaining)
 			return nil
+		case <-o.drainWatchCh:
+			// A chassisredirect Port_Binding changed — re-check without waiting
+			// for the safety re-poll tick.
 		case <-ticker.C:
 		}
 	}

--- a/ovn_gateway.go
+++ b/ovn_gateway.go
@@ -116,6 +116,12 @@ const drainRecheckInterval = 1 * time.Second
 // is never withdrawn before the takeover node can forward it.
 const takeoverReadyMarkerKey = "ovn-network-agent-advertised"
 
+// takeoverMarkerPollInterval is the cadence at which awaitTakeoverReady
+// re-reads NB for the takeover node's readiness marker. It is short so a fast
+// takeover releases the leaving node quickly; the poll is bounded by the drain
+// context (drain_timeout).
+const takeoverMarkerPollInterval = 250 * time.Millisecond
+
 // EnsureActivePriorityLead ensures that for each locally-active router the
 // local Gateway_Chassis entry has a strictly higher priority than all peers
 // in the same HA group, and at least minActivePriority. The minimum
@@ -389,31 +395,9 @@ func (o *OVNClient) MarkTakeoverReady(ctx context.Context, localRouters []LocalR
 		return nil
 	}
 
-	routes, err := cachedList(ctx, o.nbClient, "Logical_Router_Static_Route",
-		lrsrCheckColumns, keyOfNBLogicalRouterStaticRoute, decodeNBLogicalRouterStaticRoute)
+	routes, err := o.localManagedDefaultRoutes(ctx, localRouters)
 	if err != nil {
-		return fmt.Errorf("list static routes: %w", err)
-	}
-	routers, err := cachedList(ctx, o.nbClient, "Logical_Router",
-		lrCheckColumns, keyOfNBLogicalRouter, decodeNBLogicalRouter)
-	if err != nil {
-		return fmt.Errorf("list routers: %w", err)
-	}
-
-	localRouterUUIDs := make(map[string]bool, len(localRouters))
-	for _, lr := range localRouters {
-		localRouterUUIDs[lr.RouterUUID] = true
-	}
-
-	// Only mark routes owned by a router active on this chassis.
-	routeOwnedLocally := make(map[string]bool)
-	for _, router := range routers {
-		if !localRouterUUIDs[router.UUID] {
-			continue
-		}
-		for _, ruuid := range router.StaticRoutes {
-			routeOwnedLocally[ruuid] = true
-		}
+		return err
 	}
 
 	localChassis := o.state.LocalChassisName
@@ -422,12 +406,6 @@ func (o *OVNClient) MarkTakeoverReady(ctx context.Context, localRouters []LocalR
 	var allOps []ovsdb.Operation
 	for i := range routes {
 		route := routes[i]
-		if !routeOwnedLocally[route.UUID] || route.IPPrefix != "0.0.0.0/0" {
-			continue
-		}
-		if route.ExternalIDs == nil || route.ExternalIDs["ovn-network-agent"] != "managed" {
-			continue
-		}
 		if route.ExternalIDs[takeoverReadyMarkerKey] == localChassis {
 			continue // already advertised by this chassis — idempotent no-op
 		}
@@ -766,9 +744,14 @@ func (o *OVNClient) CleanupStaleChassisManagedEntries(ctx context.Context, stale
 // monitor wake it through drainWatchCh, with a short ticker as a safety
 // re-poll (see drainRecheckInterval).
 //
-// Once the ports have migrated, it holds for cfg.DrainSettleDelay before
-// returning (see settleAfterDrain) so the caller does not withdraw this
-// chassis' BGP routes before the takeover chassis is ready to forward.
+// Once the ports have migrated, it runs the takeover handshake (see
+// awaitTakeoverReady): it waits until the takeover chassis stamps its
+// readiness marker onto the managed default routes this chassis used to own,
+// then holds only a small cfg.DrainSettleDelay safety margin before returning.
+// This keeps the caller from withdrawing this chassis' BGP routes before the
+// takeover chassis is ready to forward, while releasing as soon as it is —
+// instead of always paying a fixed settle delay. The whole handshake stays
+// bounded by ctx (drain_timeout).
 //
 // On the next startup, RestoreDrainedGateways sets drained entries back to
 // priority 1 (standby level) so the chassis rejoins the HA group.
@@ -869,7 +852,7 @@ func (o *OVNClient) DrainGateways(ctx context.Context, localChassisName string) 
 		}
 		if remaining == 0 {
 			slog.Info("drain: complete, all gateways migrated away")
-			o.settleAfterDrain(ctx)
+			o.awaitTakeoverReady(ctx, localChassisName)
 			return nil
 		}
 		slog.Info("drain: waiting for gateway migration", "remaining_gateways", remaining)
@@ -886,22 +869,79 @@ func (o *OVNClient) DrainGateways(ctx context.Context, localChassisName string) 
 	}
 }
 
-// settleAfterDrain pauses for cfg.DrainSettleDelay after the drain has
-// confirmed that all chassisredirect ports migrated away. During the hold
-// this chassis still advertises its FIP /32 routes and keeps its OVS flows,
-// so it continues forwarding external traffic — hairpinning to the new
-// gateway chassis over the tunnel — while the takeover chassis finishes its
-// OVN flow programming, reconcile and BGP advertisement. Without the hold,
-// cleanup() would withdraw the routes the instant the ports moved, before
-// the takeover chassis is ready, blackholing external traffic for the gap.
+// awaitTakeoverReady is the reader half of the drain takeover handshake. After
+// the chassisredirect ports have migrated away, it waits until the takeover
+// chassis stamps its readiness marker (see takeoverReadyMarkerKey) onto every
+// managed default route this chassis used to own, then holds a small
+// cfg.DrainSettleDelay safety margin and returns. This releases the leaving
+// node as soon as the takeover node has actually announced the FIP routes,
+// instead of after a fixed sleep.
 //
-// The wait is bounded by ctx (the drain context), so the settle never
-// pushes total shutdown past drain_timeout. A delay of 0 disables the hold.
-func (o *OVNClient) settleAfterDrain(ctx context.Context) {
+// A DrainSettleDelay of 0 disables the handshake entirely — both the marker
+// wait and the margin — preserving the documented "0 = no hold" escape hatch.
+// Routers whose default route is not agent-managed are excluded from the wait
+// set: no marker can ever appear for them, so if none of the local routers has
+// a managed default route the behaviour degrades to the plain margin hold. The
+// whole wait is bounded by ctx (drain_timeout): a takeover that never signals
+// falls back cleanly at the deadline and proceeds with cleanup.
+func (o *OVNClient) awaitTakeoverReady(ctx context.Context, localChassisName string) {
 	if o.cfg.DrainSettleDelay <= 0 {
+		return // handshake disabled
+	}
+
+	// Resolve the wait set once from the frozen pre-drain router snapshot: the
+	// managed default routes this chassis owned. The read goes through the
+	// cache-consistency guard so a stale NB cache cannot stall the handshake.
+	waitRoutes, err := o.localManagedDefaultRoutes(ctx, o.GetState().LocalRouters)
+	if err != nil {
+		slog.Warn("drain: could not resolve managed default routes, holding the safety margin only", "error", err)
+		o.holdSettleMargin(ctx)
 		return
 	}
-	slog.Info("drain: holding before cleanup so the takeover chassis can settle",
+	if len(waitRoutes) == 0 {
+		// No agent-managed default route to watch — nothing can signal
+		// readiness, so fall back to the plain margin hold.
+		o.holdSettleMargin(ctx)
+		return
+	}
+	waitUUIDs := make(map[string]bool, len(waitRoutes))
+	for _, r := range waitRoutes {
+		waitUUIDs[r.UUID] = true
+	}
+
+	ticker := time.NewTicker(takeoverMarkerPollInterval)
+	defer ticker.Stop()
+
+	for {
+		ready, err := o.takeoverMarkersReady(ctx, waitUUIDs, localChassisName)
+		switch {
+		case err != nil:
+			slog.Warn("drain: readiness marker poll failed, retrying", "error", err)
+		case ready:
+			slog.Info("drain: takeover readiness marker observed, holding safety margin",
+				"settle_delay", o.cfg.DrainSettleDelay)
+			o.holdSettleMargin(ctx)
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			slog.Warn("drain: takeover readiness marker not observed before timeout, proceeding with cleanup")
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// holdSettleMargin waits cfg.DrainSettleDelay after the readiness signal (or,
+// when no marker can be expected, after migration completed). During the hold
+// this chassis still advertises its FIP /32 routes and keeps its OVS flows, so
+// it keeps forwarding external traffic — hairpinning to the new gateway chassis
+// over the tunnel — for a last safety margin before cleanup withdraws the
+// routes. The wait is bounded by ctx (the drain context), so the margin never
+// pushes total shutdown past drain_timeout.
+func (o *OVNClient) holdSettleMargin(ctx context.Context) {
+	slog.Info("drain: holding the safety margin before cleanup",
 		"settle_delay", o.cfg.DrainSettleDelay)
 	timer := time.NewTimer(o.cfg.DrainSettleDelay)
 	defer timer.Stop()
@@ -909,6 +949,81 @@ func (o *OVNClient) settleAfterDrain(ctx context.Context) {
 	case <-ctx.Done():
 	case <-timer.C:
 	}
+}
+
+// localManagedDefaultRoutes returns the agent-managed default routes
+// (0.0.0.0/0 with ExternalIDs["ovn-network-agent"]=="managed") owned by the
+// given locally-active routers, read through the cache-consistency guard so a
+// stale NB cache cannot hide a route. It backs both halves of the drain
+// takeover handshake: the writer stamps the marker onto these routes, the
+// reader resolves its wait set from them.
+func (o *OVNClient) localManagedDefaultRoutes(ctx context.Context, localRouters []LocalRouterInfo) ([]NBLogicalRouterStaticRoute, error) {
+	if len(localRouters) == 0 {
+		return nil, nil
+	}
+	localRouterUUIDs := make(map[string]bool, len(localRouters))
+	for _, lr := range localRouters {
+		localRouterUUIDs[lr.RouterUUID] = true
+	}
+
+	routers, err := cachedList(ctx, o.nbClient, "Logical_Router",
+		lrCheckColumns, keyOfNBLogicalRouter, decodeNBLogicalRouter)
+	if err != nil {
+		return nil, fmt.Errorf("list routers: %w", err)
+	}
+	routeOwnedLocally := make(map[string]bool)
+	for _, router := range routers {
+		if !localRouterUUIDs[router.UUID] {
+			continue
+		}
+		for _, ruuid := range router.StaticRoutes {
+			routeOwnedLocally[ruuid] = true
+		}
+	}
+
+	routes, err := cachedList(ctx, o.nbClient, "Logical_Router_Static_Route",
+		lrsrCheckColumns, keyOfNBLogicalRouterStaticRoute, decodeNBLogicalRouterStaticRoute)
+	if err != nil {
+		return nil, fmt.Errorf("list static routes: %w", err)
+	}
+	var out []NBLogicalRouterStaticRoute
+	for i := range routes {
+		route := routes[i]
+		if !routeOwnedLocally[route.UUID] || route.IPPrefix != "0.0.0.0/0" {
+			continue
+		}
+		if route.ExternalIDs != nil && route.ExternalIDs["ovn-network-agent"] == "managed" {
+			out = append(out, route)
+		}
+	}
+	return out, nil
+}
+
+// takeoverMarkersReady reports whether every route in waitUUIDs carries a
+// readiness marker naming a chassis other than localChassisName. A route whose
+// row has vanished counts as satisfied (nothing left to hold for); an empty or
+// self-named marker does not. Read through the cache-consistency guard so a
+// stale cached marker value cannot make the handshake return early or stall.
+func (o *OVNClient) takeoverMarkersReady(ctx context.Context, waitUUIDs map[string]bool, localChassisName string) (bool, error) {
+	routes, err := cachedList(ctx, o.nbClient, "Logical_Router_Static_Route",
+		lrsrCheckColumns, keyOfNBLogicalRouterStaticRoute, decodeNBLogicalRouterStaticRoute)
+	if err != nil {
+		return false, fmt.Errorf("list static routes: %w", err)
+	}
+	markerByUUID := make(map[string]string, len(routes))
+	for _, route := range routes {
+		markerByUUID[route.UUID] = route.ExternalIDs[takeoverReadyMarkerKey]
+	}
+	for uuid := range waitUUIDs {
+		marker, present := markerByUUID[uuid]
+		if !present {
+			continue // route vanished — treat as migrated
+		}
+		if marker == "" || marker == localChassisName {
+			return false, nil // not yet advertised by a takeover chassis
+		}
+	}
+	return true, nil
 }
 
 // RestoreDrainedGateways sets Gateway_Chassis entries that were drained

--- a/ovn_gateway_writes_test.go
+++ b/ovn_gateway_writes_test.go
@@ -1281,6 +1281,45 @@ func TestDrainGateways_FallbackReturnsErrorOnTransactFailure(t *testing.T) {
 	}
 }
 
+// TestDrainGateways_EventSignalWakesMigrationWait verifies that a
+// chassisredirect Port_Binding change ends the drain migration wait through
+// drainWatchCh, without waiting for the safety re-poll tick. The settle delay
+// is 0 so only the wait itself is measured; the CR port is unbound and the
+// wake fired ~50ms in, far under the 1s drainRecheckInterval — so a prompt
+// return proves the event, not the ticker, ended the wait.
+func TestDrainGateways_EventSignalWakesMigrationWait(t *testing.T) {
+	c, nb, sb := newOVNClientWithFakes(t, "host-a")
+	c.cfg.DrainSettleDelay = 0
+	c.ready.Store(true)
+
+	nb.setRows("Gateway_Chassis",
+		&NBGatewayChassis{UUID: "g1", Name: "lrp-a_host-a", ChassisName: "host-a", Priority: 5},
+	)
+	// SB initially shows a chassisredirect port bound to host-a → first poll
+	// returns 1, so the drain enters the wait.
+	sb.setRows("Chassis", &SBChassis{UUID: "ch-a", Name: "ch-a", Hostname: "host-a"})
+	sb.setRows("Port_Binding",
+		&SBPortBinding{UUID: "pb1", Type: "chassisredirect", Chassis: strPtr("ch-a")},
+	)
+
+	// After the drain has entered the wait, unbind the port and wake it via a
+	// chassisredirect signal. 50ms is well under drainRecheckInterval (1s), so
+	// a prompt return can only come from the event, not the safety re-poll.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		sb.setRows("Port_Binding")
+		c.signalDrainWatch()
+	}()
+
+	start := time.Now()
+	if err := c.DrainGateways(context.Background(), "host-a"); err != nil {
+		t.Fatalf("DrainGateways: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed >= 500*time.Millisecond {
+		t.Errorf("drain returned after %v; expected the event to wake it well under the %v re-poll", elapsed, drainRecheckInterval)
+	}
+}
+
 // TestDrainGateways_SettleDelayHoldsBeforeReturn verifies that once the SB
 // shows all chassisredirect ports migrated away, DrainGateways holds for
 // cfg.DrainSettleDelay before returning so the caller does not withdraw BGP

--- a/ovn_gateway_writes_test.go
+++ b/ovn_gateway_writes_test.go
@@ -1406,10 +1406,130 @@ func TestDrainGateways_EventSignalWakesMigrationWait(t *testing.T) {
 	}
 }
 
-// TestDrainGateways_SettleDelayHoldsBeforeReturn verifies that once the SB
-// shows all chassisredirect ports migrated away, DrainGateways holds for
-// cfg.DrainSettleDelay before returning so the caller does not withdraw BGP
-// routes before the takeover chassis is ready.
+// TestAwaitTakeoverReady_ReturnsOnMarker verifies the reader half of the
+// handshake: with a managed default route whose marker still names the local
+// chassis, awaitTakeoverReady waits until the takeover chassis stamps its own
+// name, then returns after only the small safety margin — well before a long
+// drain deadline.
+func TestAwaitTakeoverReady_ReturnsOnMarker(t *testing.T) {
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+	c.cfg.DrainSettleDelay = 50 * time.Millisecond
+	c.state.LocalRouters = []LocalRouterInfo{{RouterUUID: "lr1"}}
+	nb.setRows("Logical_Router", &NBLogicalRouter{UUID: "lr1", StaticRoutes: []string{"sr1"}})
+	nb.setRows("Logical_Router_Static_Route", &NBLogicalRouterStaticRoute{
+		UUID:        "sr1",
+		IPPrefix:    "0.0.0.0/0",
+		ExternalIDs: map[string]string{"ovn-network-agent": "managed", takeoverReadyMarkerKey: "host-a"},
+	})
+
+	// Shortly after the wait starts, the takeover chassis stamps its name.
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		nb.setRows("Logical_Router_Static_Route", &NBLogicalRouterStaticRoute{
+			UUID:        "sr1",
+			IPPrefix:    "0.0.0.0/0",
+			ExternalIDs: map[string]string{"ovn-network-agent": "managed", takeoverReadyMarkerKey: "host-b"},
+		})
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	start := time.Now()
+	c.awaitTakeoverReady(ctx, "host-a")
+	elapsed := time.Since(start)
+	if elapsed < c.cfg.DrainSettleDelay {
+		t.Errorf("returned after %v, want at least the %v safety margin", elapsed, c.cfg.DrainSettleDelay)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("blocked %v; expected a prompt return on the marker, not the ctx deadline", elapsed)
+	}
+}
+
+// TestAwaitTakeoverReady_TimeoutFallbackWhenMarkerNeverAppears verifies the
+// clean fallback: when the marker never names a takeover chassis, the wait
+// ends at the drain deadline and logs the fallback so cleanup still runs.
+func TestAwaitTakeoverReady_TimeoutFallbackWhenMarkerNeverAppears(t *testing.T) {
+	buf := captureSlog(t)
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+	c.cfg.DrainSettleDelay = 50 * time.Millisecond
+	c.state.LocalRouters = []LocalRouterInfo{{RouterUUID: "lr1"}}
+	nb.setRows("Logical_Router", &NBLogicalRouter{UUID: "lr1", StaticRoutes: []string{"sr1"}})
+	nb.setRows("Logical_Router_Static_Route", &NBLogicalRouterStaticRoute{
+		UUID:        "sr1",
+		IPPrefix:    "0.0.0.0/0",
+		ExternalIDs: map[string]string{"ovn-network-agent": "managed", takeoverReadyMarkerKey: "host-a"},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	c.awaitTakeoverReady(ctx, "host-a")
+	elapsed := time.Since(start)
+	if elapsed < 250*time.Millisecond {
+		t.Errorf("returned after %v, expected it to wait for the ~300ms deadline", elapsed)
+	}
+	if !strings.Contains(buf.String(), "takeover readiness marker not observed before timeout") {
+		t.Errorf("expected timeout-fallback log line, got:\n%s", buf.String())
+	}
+}
+
+// TestAwaitTakeoverReady_DisabledWhenSettleZero pins the "0 = no hold" escape
+// hatch: a zero settle delay disables the whole handshake, so the wait returns
+// immediately and reads nothing from NB.
+func TestAwaitTakeoverReady_DisabledWhenSettleZero(t *testing.T) {
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+	c.cfg.DrainSettleDelay = 0
+	c.state.LocalRouters = []LocalRouterInfo{{RouterUUID: "lr1"}}
+	nb.setRows("Logical_Router", &NBLogicalRouter{UUID: "lr1", StaticRoutes: []string{"sr1"}})
+	nb.setRows("Logical_Router_Static_Route", &NBLogicalRouterStaticRoute{
+		UUID:        "sr1",
+		IPPrefix:    "0.0.0.0/0",
+		ExternalIDs: map[string]string{"ovn-network-agent": "managed", takeoverReadyMarkerKey: "host-a"},
+	})
+
+	start := time.Now()
+	c.awaitTakeoverReady(context.Background(), "host-a")
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Errorf("settle delay 0 must disable the handshake, but it blocked %v", elapsed)
+	}
+	if got := len(nb.recordedTransacts()); got != 0 {
+		t.Errorf("handshake disabled but read/wrote %d transactions, want 0", got)
+	}
+}
+
+// TestAwaitTakeoverReady_NoManagedRouteHoldsMarginOnly covers the degraded
+// path: when a local router has no agent-managed default route, no marker can
+// ever appear, so the wait falls back to holding only the safety margin
+// instead of polling to the deadline.
+func TestAwaitTakeoverReady_NoManagedRouteHoldsMarginOnly(t *testing.T) {
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+	c.cfg.DrainSettleDelay = 60 * time.Millisecond
+	c.state.LocalRouters = []LocalRouterInfo{{RouterUUID: "lr1"}}
+	nb.setRows("Logical_Router", &NBLogicalRouter{UUID: "lr1", StaticRoutes: []string{"sr1"}})
+	// Default route present but NOT agent-managed → excluded from the wait set.
+	nb.setRows("Logical_Router_Static_Route", &NBLogicalRouterStaticRoute{
+		UUID: "sr1", IPPrefix: "0.0.0.0/0", ExternalIDs: map[string]string{},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	start := time.Now()
+	c.awaitTakeoverReady(ctx, "host-a")
+	elapsed := time.Since(start)
+	if elapsed < c.cfg.DrainSettleDelay {
+		t.Errorf("returned after %v, want at least the %v margin", elapsed, c.cfg.DrainSettleDelay)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("no managed route must hold only the margin, not poll to the deadline; blocked %v", elapsed)
+	}
+}
+
+// TestDrainGateways_SettleDelayHoldsBeforeReturn verifies the empty-wait-set
+// path of the takeover handshake: once the SB shows all chassisredirect ports
+// migrated away and there is no managed default route to watch (the test state
+// has no local routers), DrainGateways holds for cfg.DrainSettleDelay before
+// returning so the caller does not withdraw BGP routes before the takeover
+// chassis is ready.
 func TestDrainGateways_SettleDelayHoldsBeforeReturn(t *testing.T) {
 	c, nb, sb := newOVNClientWithFakes(t, "host-a")
 	c.cfg.DrainSettleDelay = 80 * time.Millisecond
@@ -1433,10 +1553,11 @@ func TestDrainGateways_SettleDelayHoldsBeforeReturn(t *testing.T) {
 	}
 }
 
-// TestDrainGateways_SettleDelaySkippedWhenNothingToDrain ensures the settle
-// hold only applies after an actual migration: when there is nothing to
-// drain (non-HA / single-chassis / already drained) the function still
-// returns immediately even with a long settle delay configured.
+// TestDrainGateways_SettleDelaySkippedWhenNothingToDrain ensures the handshake
+// (and its margin) only run after an actual migration: when there is nothing
+// to drain (non-HA / single-chassis / already drained) DrainGateways takes the
+// no-op fast path and returns immediately even with a long settle delay
+// configured.
 func TestDrainGateways_SettleDelaySkippedWhenNothingToDrain(t *testing.T) {
 	c, nb, _ := newOVNClientWithFakes(t, "host-a")
 	c.cfg.DrainSettleDelay = 30 * time.Second

--- a/ovn_gateway_writes_test.go
+++ b/ovn_gateway_writes_test.go
@@ -1281,6 +1281,92 @@ func TestDrainGateways_FallbackReturnsErrorOnTransactFailure(t *testing.T) {
 	}
 }
 
+// TestMarkTakeoverReady_WritesAndIsIdempotent covers the marker writer: a
+// managed default route carrying a peer's marker is restamped for the local
+// chassis in exactly one update that preserves the other external_ids, the
+// re-run is a no-op once the marker already names this chassis, and a router
+// with no managed default route is left untouched.
+func TestMarkTakeoverReady_WritesAndIsIdempotent(t *testing.T) {
+	t.Run("writes and preserves other keys, then idempotent", func(t *testing.T) {
+		c, nb, _ := newOVNClientWithFakes(t, "host-a")
+		nb.setRows("Logical_Router", &NBLogicalRouter{UUID: "lr1", Name: "r1", StaticRoutes: []string{"sr1"}})
+		nb.setRows("Logical_Router_Static_Route", &NBLogicalRouterStaticRoute{
+			UUID:     "sr1",
+			IPPrefix: "0.0.0.0/0",
+			ExternalIDs: map[string]string{
+				"ovn-network-agent":         "managed",
+				"ovn-network-agent-chassis": "host-b",
+				takeoverReadyMarkerKey:      "host-b",
+			},
+		})
+		localRouters := []LocalRouterInfo{{RouterName: "r1", RouterUUID: "lr1"}}
+
+		if err := c.MarkTakeoverReady(context.Background(), localRouters); err != nil {
+			t.Fatalf("MarkTakeoverReady: %v", err)
+		}
+
+		writes := nb.writeTransacts()
+		if len(writes) != 1 {
+			t.Fatalf("expected exactly one write transaction, got %d", len(writes))
+		}
+		var updates []ovsdb.Operation
+		for _, op := range writes[0] {
+			if op.Op == ovsdb.OperationUpdate && op.Table == "Logical_Router_Static_Route" {
+				updates = append(updates, op)
+			}
+		}
+		if len(updates) != 1 {
+			t.Fatalf("expected one static-route update, got %d", len(updates))
+		}
+		ext, ok := updates[0].Row["external_ids"].(map[string]string)
+		if !ok {
+			t.Fatalf("update external_ids has type %T, want map[string]string", updates[0].Row["external_ids"])
+		}
+		if got := ext[takeoverReadyMarkerKey]; got != "host-a" {
+			t.Errorf("advertised marker = %q, want host-a", got)
+		}
+		if ext["ovn-network-agent"] != "managed" || ext["ovn-network-agent-chassis"] != "host-b" {
+			t.Errorf("marker write dropped existing external_ids: %v", ext)
+		}
+
+		// Re-run: the marker already names host-a, so no new write is issued.
+		if err := c.MarkTakeoverReady(context.Background(), localRouters); err != nil {
+			t.Fatalf("MarkTakeoverReady (rerun): %v", err)
+		}
+		if got := len(nb.writeTransacts()); got != 1 {
+			t.Errorf("rerun issued a redundant write: total write transactions = %d, want 1", got)
+		}
+	})
+
+	t.Run("no managed default route means no write", func(t *testing.T) {
+		c, nb, _ := newOVNClientWithFakes(t, "host-a")
+		nb.setRows("Logical_Router", &NBLogicalRouter{UUID: "lr1", Name: "r1", StaticRoutes: []string{"sr1"}})
+		// A default route that is NOT agent-managed (e.g. Neutron-configured).
+		nb.setRows("Logical_Router_Static_Route", &NBLogicalRouterStaticRoute{
+			UUID:        "sr1",
+			IPPrefix:    "0.0.0.0/0",
+			ExternalIDs: map[string]string{},
+		})
+
+		if err := c.MarkTakeoverReady(context.Background(), []LocalRouterInfo{{RouterUUID: "lr1"}}); err != nil {
+			t.Fatalf("MarkTakeoverReady: %v", err)
+		}
+		if got := len(nb.writeTransacts()); got != 0 {
+			t.Errorf("marker written for a non-managed default route: %d write transactions, want 0", got)
+		}
+	})
+
+	t.Run("empty local routers is a no-op", func(t *testing.T) {
+		c, nb, _ := newOVNClientWithFakes(t, "host-a")
+		if err := c.MarkTakeoverReady(context.Background(), nil); err != nil {
+			t.Fatalf("MarkTakeoverReady(nil): %v", err)
+		}
+		if got := len(nb.recordedTransacts()); got != 0 {
+			t.Errorf("empty local routers issued %d transactions, want 0", got)
+		}
+	})
+}
+
 // TestDrainGateways_EventSignalWakesMigrationWait verifies that a
 // chassisredirect Port_Binding change ends the drain migration wait through
 // drainWatchCh, without waiting for the safety re-poll tick. The settle delay

--- a/ovn_test.go
+++ b/ovn_test.go
@@ -547,6 +547,40 @@ func TestIsChassisRedirect(t *testing.T) {
 	}
 }
 
+// TestSBEventHandlerChassisRedirectSignalsDrainWatch verifies that the SB
+// event handler wakes a drain wait on chassisredirect Port_Binding changes:
+// OnAdd/OnUpdate/OnDelete each enqueue a coalesced drainWatchCh signal when
+// the client is ready, a non-chassisredirect model does not, and nothing is
+// enqueued before the client is ready.
+func TestSBEventHandlerChassisRedirectSignalsDrainWatch(t *testing.T) {
+	c, _, _ := newOVNClientWithFakes(t, "host-a")
+	h := &sbEventHandler{ovn: c}
+	cr := &SBPortBinding{Type: "chassisredirect", LogicalPort: "cr-lrp-abc"}
+
+	// Not ready: no signal is queued even for a chassisredirect change.
+	c.ready.Store(false)
+	h.OnUpdate("Port_Binding", cr, cr)
+	if got := len(c.drainWatchCh); got != 0 {
+		t.Fatalf("drainWatchCh len before ready = %d, want 0", got)
+	}
+
+	// Ready: each event handler enqueues at most one coalesced signal.
+	c.ready.Store(true)
+	h.OnAdd("Port_Binding", cr)
+	h.OnUpdate("Port_Binding", cr, cr)
+	h.OnDelete("Port_Binding", cr)
+	if got := len(c.drainWatchCh); got != 1 {
+		t.Fatalf("drainWatchCh len after chassisredirect events = %d, want 1 (coalesced)", got)
+	}
+
+	// Consume the signal; a non-chassisredirect change must not re-arm it.
+	<-c.drainWatchCh
+	h.OnUpdate("Port_Binding", &SBPortBinding{Type: "patch"}, &SBPortBinding{Type: "patch"})
+	if got := len(c.drainWatchCh); got != 0 {
+		t.Fatalf("drainWatchCh len after non-chassisredirect change = %d, want 0", got)
+	}
+}
+
 // TestDrainSignalsEmptiesBothChannels verifies that drainSignals consumes a
 // pending signal on each channel without blocking when they are empty.
 func TestDrainSignalsEmptiesBothChannels(t *testing.T) {

--- a/test/integration/scenario_drain_edges_test.go
+++ b/test/integration/scenario_drain_edges_test.go
@@ -162,6 +162,19 @@ func TestScenario_DrainKeepsRoutesWhenCleanupDisabled(t *testing.T) {
 	testenv.AssertNftChainExists(t, testenv.DefaultNftTable, "prerouting_dnat", 15*time.Second)
 	testenv.AssertVIPOnLoopback(t, pfVIP, 15*time.Second)
 
+	// Capture the agent's managed default route so the drain helper can stamp a
+	// peer readiness marker on it once the CR port has migrated (the #129
+	// takeover handshake), releasing the leaving node's settle on the marker
+	// instead of at drain_timeout — which is what keeps this test fast.
+	managedRoute := testenv.EventuallyValue(t, func() (testenv.NBLogicalRouterStaticRoute, bool) {
+		return testenv.FindStaticRoute(t, ctx, nb, router.RouterUUID, "0.0.0.0/0")
+	}, 15*time.Second, 100*time.Millisecond, "agent must create its managed default route before drain")
+	markerExtIDs := map[string]string{}
+	for k, v := range managedRoute.ExternalIDs {
+		markerExtIDs[k] = v
+	}
+	markerExtIDs["ovn-network-agent-advertised"] = "drainkeep-peer"
+
 	// Pre-stage a peer chassis so ovn-controller does not complain when
 	// the rebind goroutine moves the Port_Binding mid-drain.
 	peerUUID := testenv.MakeChassis(t, ctx, sb, "drainkeep-peer")
@@ -205,6 +218,25 @@ func TestScenario_DrainKeepsRoutesWhenCleanupDisabled(t *testing.T) {
 					if _, opErr := sb.Transact(ctx, ops...); opErr != nil {
 						select {
 						case errCh <- opErr:
+						default:
+						}
+						return
+					}
+					// The takeover node has "arrived": stamp the readiness
+					// marker on the managed default route so the leaving node's
+					// handshake releases on the marker, not at drain_timeout.
+					mark := &testenv.NBLogicalRouterStaticRoute{UUID: managedRoute.UUID, ExternalIDs: markerExtIDs}
+					mops, mErr := nb.Where(mark).Update(mark, &mark.ExternalIDs)
+					if mErr != nil {
+						select {
+						case errCh <- mErr:
+						default:
+						}
+						return
+					}
+					if _, mErr := nb.Transact(ctx, mops...); mErr != nil {
+						select {
+						case errCh <- mErr:
 						default:
 						}
 					}
@@ -255,6 +287,107 @@ func TestScenario_DrainKeepsRoutesWhenCleanupDisabled(t *testing.T) {
 	if !strings.Contains(logs, "shutting down, keeping routes in place") {
 		t.Errorf("expected keep-routes log line not found; last logs:\n%s", a.LogTail(40))
 	}
+}
+
+// TestScenario_DrainSettleTimeoutFallback (#129):
+//
+// With the takeover handshake active but no peer ever writing the readiness
+// marker, the leaving node's settle must fall back cleanly at drain_timeout:
+// the ports migrate (the rebind goroutine unblocks the migration wait), the
+// marker never names a takeover chassis, so awaitTakeoverReady logs the
+// timeout fallback, proceeds to cleanup, and the LRP /32 kernel route is gone
+// afterwards. This is the safe path for a takeover that never signals (e.g. a
+// mixed-version fleet where the peer runs a pre-handshake agent).
+func TestScenario_DrainSettleTimeoutFallback(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "drainfallback",
+		LRPNetworks: []string{"198.51.100.11/24"},
+		GatewayChassis: []testenv.GatewayChassisEntry{
+			{ChassisName: testenv.LocalHostname(t), Priority: 5},
+		},
+	})
+
+	cfg := testenv.Defaults()
+	on := true
+	cfg.DrainOnShutdown = &on
+	// Short drain_timeout so the marker-wait fallback fires quickly; no peer
+	// ever stamps the readiness marker in this scenario.
+	cfg.DrainTimeout = "3s"
+	cfg.ReconcileInterval = "2s"
+	a := readyAgent(t, cfg)
+
+	testenv.AssertKernelRoute(t, "198.51.100.11", 15*time.Second)
+
+	// Pre-stage a peer chassis and rebind the CR port once priority hits 0 so
+	// the migration wait completes; deliberately do NOT write the readiness
+	// marker, forcing the handshake to fall back at drain_timeout.
+	peerUUID := testenv.MakeChassis(t, ctx, sb, "drainfallback-peer")
+	gcName := "lrp-" + router.Name + "_" + testenv.LocalHostname(t)
+
+	errCh := make(chan error, 1)
+	pctx, pcancel := context.WithCancel(ctx)
+	defer pcancel()
+	go func() {
+		tick := time.NewTicker(50 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-pctx.Done():
+				return
+			case <-tick.C:
+				var entries []testenv.NBGatewayChassis
+				if err := nb.List(ctx, &entries); err != nil {
+					select {
+					case errCh <- err:
+					default:
+					}
+					return
+				}
+				for _, gc := range entries {
+					if gc.Name != gcName || gc.Priority != 0 {
+						continue
+					}
+					rebind := &testenv.SBPortBinding{UUID: router.CRPortUUID, Chassis: &peerUUID}
+					ops, opErr := sb.Where(rebind).Update(rebind, &rebind.Chassis)
+					if opErr != nil {
+						select {
+						case errCh <- opErr:
+						default:
+						}
+						return
+					}
+					if _, opErr := sb.Transact(ctx, ops...); opErr != nil {
+						select {
+						case errCh <- opErr:
+						default:
+						}
+					}
+					return
+				}
+			}
+		}
+	}()
+
+	if err := a.Stop(15 * time.Second); err != nil {
+		t.Fatalf("agent stop: %v", err)
+	}
+	pcancel()
+	select {
+	case err := <-errCh:
+		t.Fatalf("drain helper goroutine error: %v", err)
+	default:
+	}
+
+	logs := a.LogTail(100000)
+	if !strings.Contains(logs, "takeover readiness marker not observed before timeout") {
+		t.Errorf("expected the marker-timeout fallback log line; last logs:\n%s", a.LogTail(40))
+	}
+
+	// Cleanup still ran despite the fallback: the LRP /32 kernel route is gone.
+	testenv.AssertNoKernelRoute(t, "198.51.100.11", 5*time.Second)
 }
 
 // TestScenario_DrainStuckNBWrite (#59 scenario 4, optional):

--- a/test/integration/scenario_failover_test.go
+++ b/test/integration/scenario_failover_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -262,19 +263,36 @@ func TestScenario_DrainOnShutdown(t *testing.T) {
 	cfg := testenv.Defaults()
 	on := true
 	cfg.DrainOnShutdown = &on
+	// A generous drain_timeout so a Stop that finishes well under it proves the
+	// handshake — the readiness marker, not the deadline — ended the drain.
+	cfg.DrainTimeout = "30s"
 	cfg.ReconcileInterval = "2s"
 	a := readyAgent(t, cfg)
 
 	// Wait for at least the LRP-network /32 route to land before draining.
 	testenv.AssertKernelRoute(t, "198.51.100.11", 15*time.Second)
 
+	// Wait for the agent to create its managed default route, then capture its
+	// external_ids so the drain helper can stamp a peer's readiness marker on
+	// it mid-drain (simulating the takeover node completing its announce).
+	managedRoute := testenv.EventuallyValue(t, func() (testenv.NBLogicalRouterStaticRoute, bool) {
+		return testenv.FindStaticRoute(t, ctx, nb, router.RouterUUID, "0.0.0.0/0")
+	}, 15*time.Second, 100*time.Millisecond, "agent must create its managed default route before drain")
+	markerExtIDs := map[string]string{}
+	for k, v := range managedRoute.ExternalIDs {
+		markerExtIDs[k] = v
+	}
+	markerExtIDs["ovn-network-agent-advertised"] = "drain-peer"
+
 	// Pre-stage a peer chassis so ovn-controller does not complain when we
 	// rebind the Port_Binding mid-drain.
 	peerUUID := testenv.MakeChassis(t, ctx, sb, "drain-peer")
 	gcName := "lrp-" + router.Name + "_" + testenv.LocalHostname(t)
 
-	// Goroutine: poll NB for priority==0, record its timestamp, then
-	// rebind the CR port_binding to the peer so countLocalCRPorts returns 0.
+	// Goroutine: poll NB for priority==0, record its timestamp, rebind the CR
+	// port_binding to the peer so countLocalCRPorts returns 0, then stamp the
+	// takeover readiness marker on the managed default route so the leaving
+	// node's handshake releases on the marker instead of the drain timeout.
 	// We do not call t.Fatalf from this goroutine — testing.T methods are
 	// only safe on the test's own goroutine. Errors are surfaced via errCh.
 	var (
@@ -321,6 +339,22 @@ func TestScenario_DrainOnShutdown(t *testing.T) {
 						case errCh <- opErr:
 						default:
 						}
+						return
+					}
+					mark := &testenv.NBLogicalRouterStaticRoute{UUID: managedRoute.UUID, ExternalIDs: markerExtIDs}
+					mops, mErr := nb.Where(mark).Update(mark, &mark.ExternalIDs)
+					if mErr != nil {
+						select {
+						case errCh <- mErr:
+						default:
+						}
+						return
+					}
+					if _, mErr := nb.Transact(ctx, mops...); mErr != nil {
+						select {
+						case errCh <- mErr:
+						default:
+						}
 					}
 					return
 				}
@@ -328,14 +362,25 @@ func TestScenario_DrainOnShutdown(t *testing.T) {
 		}
 	}()
 
+	stopStart := time.Now()
 	if err := a.Stop(45 * time.Second); err != nil {
 		t.Fatalf("agent stop: %v", err)
 	}
+	stopElapsed := time.Since(stopStart)
 	pcancel()
 	select {
 	case err := <-errCh:
 		t.Fatalf("drain helper goroutine error: %v", err)
 	default:
+	}
+
+	// The settle ended on the marker, not on a timer: Stop finished well under
+	// the 30s drain_timeout, and the handshake logged the marker observation.
+	if stopElapsed > 15*time.Second {
+		t.Errorf("Stop took %s; expected a marker-driven drain well under the 30s drain_timeout", stopElapsed)
+	}
+	if logs := a.LogTail(100000); !strings.Contains(logs, "drain: takeover readiness marker observed") {
+		t.Errorf("expected the readiness-marker log line (marker-driven settle); last logs:\n%s", a.LogTail(40))
 	}
 
 	// Capture the moment the kernel route finally disappeared.

--- a/test/integration/scenario_metrics_test.go
+++ b/test/integration/scenario_metrics_test.go
@@ -104,6 +104,19 @@ func TestScenario_MetricsDrainOutcomeCompleted(t *testing.T) {
 		func(v float64, present bool) bool { return present && v == 0 },
 		5*time.Second)
 
+	// Capture the agent's managed default route so the rebind goroutine can
+	// stamp the peer readiness marker on it once the CR port has migrated (the
+	// #129 takeover handshake). Without it the leaving node blocks in
+	// awaitTakeoverReady until drain_timeout and Stop kills the agent.
+	managedRoute := testenv.EventuallyValue(t, func() (testenv.NBLogicalRouterStaticRoute, bool) {
+		return testenv.FindStaticRoute(t, ctx, nb, router.RouterUUID, "0.0.0.0/0")
+	}, 15*time.Second, 100*time.Millisecond, "agent must create its managed default route before drain")
+	markerExtIDs := map[string]string{}
+	for k, v := range managedRoute.ExternalIDs {
+		markerExtIDs[k] = v
+	}
+	markerExtIDs["ovn-network-agent-advertised"] = "metdrain-peer"
+
 	// Rebind goroutine: same shape as TestScenario_DrainOnShutdown — once
 	// the local Gateway_Chassis priority is lowered to 0, simulate
 	// ovn-northd by rebinding the CR Port_Binding to a peer so the drain
@@ -146,6 +159,25 @@ func TestScenario_MetricsDrainOutcomeCompleted(t *testing.T) {
 					if _, opErr := sb.Transact(ctx, ops...); opErr != nil {
 						select {
 						case errCh <- opErr:
+						default:
+						}
+						return
+					}
+					// The takeover node has "arrived": stamp the readiness marker on
+					// the managed default route so the leaving node's handshake releases
+					// on the marker instead of blocking until drain_timeout.
+					mark := &testenv.NBLogicalRouterStaticRoute{UUID: managedRoute.UUID, ExternalIDs: markerExtIDs}
+					mops, mErr := nb.Where(mark).Update(mark, &mark.ExternalIDs)
+					if mErr != nil {
+						select {
+						case errCh <- mErr:
+						default:
+						}
+						return
+					}
+					if _, mErr := nb.Transact(ctx, mops...); mErr != nil {
+						select {
+						case errCh <- mErr:
 						default:
 						}
 					}

--- a/test/integration/testenv/agent.go
+++ b/test/integration/testenv/agent.go
@@ -48,6 +48,7 @@ type AgentConfig struct {
 	ReconcileInterval       string `yaml:"reconcile_interval,omitempty"`
 	StaleChassisGracePeriod string `yaml:"stale_chassis_grace_period,omitempty"`
 	DrainTimeout            string `yaml:"drain_timeout,omitempty"`
+	DrainSettleDelay        string `yaml:"drain_settle_delay,omitempty"`
 
 	// MetricsListen is the address the agent's Prometheus /metrics endpoint
 	// binds to. Empty disables the endpoint (the agent's default). Scenario
@@ -385,6 +386,7 @@ func writeTempConfig(t *testing.T, cfg AgentConfig) string {
 	put("reconcile_interval", cfg.ReconcileInterval)
 	put("stale_chassis_grace_period", cfg.StaleChassisGracePeriod)
 	put("drain_timeout", cfg.DrainTimeout)
+	put("drain_settle_delay", cfg.DrainSettleDelay)
 	put("metrics_listen", cfg.MetricsListen)
 	putBool("dry_run", cfg.DryRun)
 	putBool("cleanup_on_shutdown", cfg.CleanupOnShutdown)


### PR DESCRIPTION
Closes #129.

## Summary

Replaces the fixed post-drain settle delay with an active, two-sided **takeover handshake** so a gateway drain hands off exactly when the takeover node is actually ready, instead of padding for the worst case.

Previously `DrainGateways` migrated the chassisredirect ports and then held a fixed `drain_settle_delay` (default 3s) to give the takeover node time to come up — worst-case-padded on both ends: a fast takeover still paid the full delay, and a slow one could be cut off.

## What changed

- **Writer half (agent).** After a successful FIP-route announce, the takeover node stamps `external_ids["ovn-network-agent-advertised"]=<chassis>` on each managed default route. `ensureRoutes` now reports whether the announce actually succeeded (kernel route + FRR + BGP soft-refresh), so a node that attracted BGP traffic it cannot yet deliver never signals readiness. The write extends the existing chassis tag, is idempotent, and reads NB through the cache-consistency guard.
- **Reader half (ovn).** `settleAfterDrain` is replaced by `awaitTakeoverReady`: once the CR ports have migrated, the leaving node polls NB at 250ms until every managed default route it used to own carries a readiness marker naming a *different* chassis, then holds only a small `drain_settle_delay` safety margin. The whole handshake is bounded by `drain_timeout` — a takeover that never signals falls back cleanly at the deadline and still runs cleanup.
- **Event-driven migration wait.** The migration wait now wakes from chassisredirect `Port_Binding` events (cap-1 `drainWatchCh`) instead of a fixed 2s poll, with a 1s ticker kept only as a safety re-poll.
- **Config.** `drain_settle_delay` is redefined as the post-readiness margin (default dropped 3s → 500ms); `0` still disables the wait entirely. Reference docs regenerated.
- **Docs.** The gateway-drain explanation and how-to are rewritten for the handshake, including a rolling-upgrade note: a peer running an older agent never writes the marker, so a drain waits the full `drain_timeout` before falling back.

## Testing

- `TestScenario_DrainOnShutdown` extended so the settle provably ends on the readiness marker (Stop finishes well under a generous 30s `drain_timeout`).
- New `TestScenario_DrainSettleTimeoutFallback` covers the no-marker fallback path and confirms cleanup still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
