### PR TITLE
Agent: isolate per-item reconcile failures and guard the IPv4-only data plane

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -681,14 +681,17 @@ func (a *Agent) ensureRoutes(desiredIPs []string, ipDev map[string]string, skipK
 		}
 	}
 
-	// Collect stale routes for batch removal. Entries for still-desired IPs
-	// on the wrong device were already moved by the route replace above and
-	// must not withdraw the FRR announcement.
+	// Collect stale routes for batch removal. currentKernel/currentFRR are
+	// already scoped to agent-owned routes (protocol-tagged kernel routes,
+	// veth-nexthop FRR statics), so every listed route that is no longer
+	// desired is the agent's own leftover and safe to withdraw. Entries for
+	// still-desired IPs on the wrong device were already moved by the route
+	// replace above and must not withdraw the FRR announcement.
 	var delFRR []string
 	var removedKernel []kernelRouteEntry
 	removedSet := make(map[string]bool)
 	for _, e := range currentKernel {
-		if desiredSet[e.IP] || !a.isManaged(e.IP) {
+		if desiredSet[e.IP] {
 			continue
 		}
 		slog.Info("removing stale route", "ip", e.IP, "dev", e.Dev)
@@ -702,7 +705,7 @@ func (a *Agent) ensureRoutes(desiredIPs []string, ipDev map[string]string, skipK
 
 	// Collect orphaned FRR routes that have no corresponding kernel route.
 	for _, ip := range currentFRR {
-		if !desiredSet[ip] && a.isManaged(ip) && !removedSet[ip] {
+		if !desiredSet[ip] && !removedSet[ip] {
 			slog.Info("removing orphaned FRR route", "ip", ip)
 			delFRR = append(delFRR, ip)
 		}
@@ -747,20 +750,19 @@ func (a *Agent) ensureRoutes(desiredIPs []string, ipDev map[string]string, skipK
 	return announced
 }
 
-// removeAllRoutes removes all managed FIP routes.
+// removeAllRoutes removes every agent-owned FIP route. Ownership is scoped by
+// the route listings themselves — ListFRRRoutes returns only statics via the
+// agent's veth nexthop and ListKernelRoutes only protocol-tagged routes — so
+// operator-created routes are never touched.
 // The reason parameter is used in log messages to indicate why routes are being removed.
 func (a *Agent) removeAllRoutes(reason string) {
-	// Collect all managed FRR routes for batch removal (FRR first to stop attracting traffic).
+	// Collect all agent-owned FRR routes for batch removal (FRR first to stop attracting traffic).
 	var delFRR []string
 	currentFRR, err := a.routing.ListFRRRoutes()
 	if err != nil {
 		slog.Error("failed to list FRR routes", "error", err)
 	} else {
-		for _, ip := range currentFRR {
-			if a.isManaged(ip) {
-				delFRR = append(delFRR, ip)
-			}
-		}
+		delFRR = append(delFRR, currentFRR...)
 	}
 
 	if len(delFRR) > 0 {
@@ -778,11 +780,9 @@ func (a *Agent) removeAllRoutes(reason string) {
 			slog.Error("failed to list kernel routes", "error", err)
 		} else {
 			for _, e := range currentKernel {
-				if a.isManaged(e.IP) {
-					slog.Info("removing kernel route", "ip", e.IP, "dev", e.Dev, "reason", reason)
-					if err := a.routing.DelKernelRoute(e.IP, e.Dev); err != nil {
-						slog.Error("failed to remove kernel route", "ip", e.IP, "dev", e.Dev, "error", err)
-					}
+				slog.Info("removing kernel route", "ip", e.IP, "dev", e.Dev, "reason", reason)
+				if err := a.routing.DelKernelRoute(e.IP, e.Dev); err != nil {
+					slog.Error("failed to remove kernel route", "ip", e.IP, "dev", e.Dev, "error", err)
 				}
 			}
 		}
@@ -848,7 +848,8 @@ const consecutiveReAddThreshold = 3
 // (on the right interface) and an FRR static route after route mutations.
 // Any route that disappeared (e.g. due to a vtysh race or unexpected FRR
 // behaviour) is re-added immediately so that existing connections are not
-// disrupted.
+// disrupted. Every desired IP is agent-produced by construction, so all are
+// verified — ownership is no longer inferred from CIDR membership.
 //
 // Returns the number of routes that had to be re-added (0 means all routes
 // were present). The agent tracks consecutive non-zero results and escalates
@@ -886,9 +887,6 @@ func (a *Agent) verifyRoutes(desiredIPs []string, ipDev map[string]string, skipK
 	var reAddFRR []string
 	reAddKernel := 0
 	for _, ip := range desiredIPs {
-		if !a.isManaged(ip) {
-			continue
-		}
 		if !frrSet[ip] {
 			slog.Warn("FRR route missing after route change, re-adding", "ip", ip)
 			reAddFRR = append(reAddFRR, ip)
@@ -946,16 +944,6 @@ func (a *Agent) checkFRRRouteActivity(desiredIPs []string) {
 		slog.Error("FRR static routes are configured but inactive — these FIPs are not advertised via BGP",
 			"count", len(inactive), "ips", inactive, "vrf", a.cfg.VRFName)
 	}
-}
-
-// isManaged returns true if the IP is within any of the effective network CIDRs.
-// If no CIDRs are configured or discovered, all /32 routes on the bridge are considered managed.
-func (a *Agent) isManaged(ip string) bool {
-	if len(a.effectiveFilters) == 0 {
-		return true
-	}
-	parsedIP := net.ParseIP(ip)
-	return parsedIP != nil && containedInAny(parsedIP, a.effectiveFilters)
 }
 
 // uniqueIPs deduplicates and sorts a list of IP strings.

--- a/agent.go
+++ b/agent.go
@@ -297,13 +297,29 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 		return desiredSegments[i].LocalnetPort < desiredSegments[j].LocalnetPort
 	})
 
-	// hairpinIPs is the flat list of IPs for kernel routes and FRR.
-	// Map keys are already unique; just sort for deterministic ordering.
+	// hairpinIPs is the flat list of IPs for kernel routes and FRR — the
+	// single choke point where the IPv4-only route/announce plane forks off
+	// the deliberately dual-stack hairpinTargets map. Non-IPv4 addresses (IPv6
+	// FIPs, SNAT IPs, and LRP gateway IPs) are excluded here: everything
+	// downstream (AddKernelRoute, AddFRRRoutes, BGP, the takeover marker) is
+	// IPv4-only, so a v6 address would fail the FRR batch and block the marker.
+	// The OVS hairpin plane keeps the v6 targets (#54); full IPv6 route support
+	// is tracked in #85/#70. Map keys are already unique; just sort.
 	hairpinIPs := make([]string, 0, len(hairpinTargets))
+	var excludedNonV4 []string
 	for ip := range hairpinTargets {
+		if parsed := net.ParseIP(ip); parsed == nil || parsed.To4() == nil {
+			excludedNonV4 = append(excludedNonV4, ip)
+			continue
+		}
 		hairpinIPs = append(hairpinIPs, ip)
 	}
 	sort.Strings(hairpinIPs)
+	if len(excludedNonV4) > 0 {
+		sort.Strings(excludedNonV4)
+		slog.Debug("excluding non-IPv4 addresses from the route/announce plane, IPv6 support tracked in #85/#70",
+			"ips", excludedNonV4)
+	}
 
 	// desiredIPs extends hairpinIPs with port-forward VIPs — these need
 	// kernel routes on br-ex and FRR static routes for BGP announcement,
@@ -537,10 +553,22 @@ func (a *Agent) cleanupStaleChassis(ctx context.Context, allChassis map[string]b
 	setMissingChassis(len(a.missingChassis))
 }
 
-// computeEffectiveNetworks returns the network filters to use: manual config if set,
-// otherwise auto-discovered networks from OVN Logical_Router_Port.
+// computeEffectiveNetworks returns the network filters to use: manual config if
+// set, otherwise auto-discovered networks from OVN Logical_Router_Port. Only
+// IPv4 networks are returned — a.effectiveFilters feeds IPv4-only planes
+// (ReconcileVethLeakNetworks, ReconcileFRRPrefixList, and the "table ip"
+// provider-network rules in ReconcilePortForward), so a v6 network discovered
+// from a dual-stack LRP would otherwise abort those loops mid-way or fail the
+// whole nft ruleset load. Full IPv6 support is tracked in #85/#70.
 func (a *Agent) computeEffectiveNetworks(discovered []*net.IPNet) []*net.IPNet {
-	return effectiveNetworkFilters(a.cfg.NetworkFilters, discovered)
+	eff := effectiveNetworkFilters(a.cfg.NetworkFilters, discovered)
+	v4 := make([]*net.IPNet, 0, len(eff))
+	for _, n := range eff {
+		if n.IP.To4() != nil {
+			v4 = append(v4, n)
+		}
+	}
+	return v4
 }
 
 // segmentRouteUnresolved reports whether an IP on the given localnet segment

--- a/agent_test.go
+++ b/agent_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os/exec"
 	"reflect"
 	"strings"
 	"sync/atomic"
@@ -101,6 +102,15 @@ func TestComputeEffectiveNetworks(t *testing.T) {
 		eff := a.computeEffectiveNetworks(nil)
 		if len(eff) != 0 {
 			t.Errorf("expected empty, got %v", eff)
+		}
+	})
+
+	t.Run("drops IPv6 networks from a dual-stack discovered set", func(t *testing.T) {
+		_, v6, _ := net.ParseCIDR("2001:db8::/64")
+		a := &Agent{cfg: Config{}}
+		eff := a.computeEffectiveNetworks([]*net.IPNet{discovered, v6})
+		if len(eff) != 1 || eff[0].String() != "198.51.100.0/24" {
+			t.Errorf("expected only the v4 network, got %v", eff)
 		}
 	})
 }
@@ -478,6 +488,80 @@ func TestReconcileWritesMarkerAfterSuccessfulAnnounce(t *testing.T) {
 	}
 	a.reconcile(context.Background(), "test")
 
+	if !hasMarkerUpdate(nb.writeTransacts(), "host-a") {
+		t.Fatalf("reconcile did not stamp the takeover marker for host-a; writes: %v", nb.writeTransacts())
+	}
+}
+
+// TestReconcileMixedFamilyAnnouncesV4AndWritesMarker drives a non-dry-run
+// reconcile for a router whose NAT set carries both a v4 and a v6 FIP (issue
+// #158 test a). The v4 FIP must be announced via vtysh and the v6 string must
+// never reach a vtysh command, so the FRR batch never fails on an IPv6 route —
+// which lets the announce succeed and the takeover marker be stamped. Without
+// the family guard the v6 FIP would reach AddFRRRoutes as an "ip route
+// 2001:db8::50/32" batch, error the whole batch, and withhold the marker.
+//
+// The v4 FIP's kernel route is pre-seeded via listKernelRoutesHook so
+// AddKernelRoute (Linux-only) is never invoked; the OVS hook errors so segment
+// discovery bails cleanly (hairpin reconcile becomes a no-op) — neither path
+// affects the announce outcome under test.
+func TestReconcileMixedFamilyAnnouncesV4AndWritesMarker(t *testing.T) {
+	const (
+		v4FIP  = "198.51.100.50"
+		v6FIP  = "2001:db8::50"
+		bridge = "ovnagent-nonexistent-br"
+		lrpMAC = "fa:16:3e:aa:aa:aa"
+	)
+	rec := newVtyshRecorder()
+	rm := &RouteManager{
+		bridgeDev:     bridge,
+		vrfName:       "vrf-provider",
+		vethNexthop:   "169.254.0.1",
+		execVtyshHook: rec.hook(),
+		execOVSHook: func(*exec.Cmd) ([]byte, error) {
+			return nil, errors.New("test: no ovs available")
+		},
+		// The v4 FIP's /32 already exists on the bridge, so ensureRoutes sees
+		// no missing kernel route and never calls the Linux-only AddKernelRoute.
+		listKernelRoutesHook: func() ([]kernelRouteEntry, error) {
+			return []kernelRouteEntry{{IP: v4FIP, Dev: bridge}}, nil
+		},
+	}
+
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+	c.state.LocalRouters = []LocalRouterInfo{{RouterName: "r1", RouterUUID: "lr1", LRPName: "lrp-r1", LRPMAC: lrpMAC}}
+	c.state.HasLocalRouters = true
+	c.state.NATIPToRouterMAC = map[string]string{v4FIP: lrpMAC, v6FIP: lrpMAC}
+	nb.setRows("Logical_Router", &NBLogicalRouter{UUID: "lr1", Name: "r1", StaticRoutes: []string{"sr1"}})
+	nb.setRows("Logical_Router_Static_Route", &NBLogicalRouterStaticRoute{
+		UUID:     "sr1",
+		IPPrefix: "0.0.0.0/0",
+		ExternalIDs: map[string]string{
+			"ovn-network-agent":         "managed",
+			"ovn-network-agent-chassis": "host-b",
+			takeoverReadyMarkerKey:      "host-b",
+		},
+	})
+
+	a := &Agent{
+		cfg:            Config{},
+		ovn:            c,
+		routing:        rm,
+		reconcileCh:    make(chan struct{}, 1),
+		missingChassis: make(map[string]time.Time),
+	}
+	a.reconcile(context.Background(), "test")
+
+	var joined string
+	for _, call := range rec.calls {
+		joined += " " + strings.Join(call, " ")
+	}
+	if !strings.Contains(joined, "ip route "+v4FIP+"/32 169.254.0.1") {
+		t.Errorf("v4 FIP was not announced via vtysh; calls: %v", rec.calls)
+	}
+	if strings.Contains(joined, v6FIP) {
+		t.Errorf("v6 FIP must never reach a vtysh command; calls: %v", rec.calls)
+	}
 	if !hasMarkerUpdate(nb.writeTransacts(), "host-a") {
 		t.Fatalf("reconcile did not stamp the takeover marker for host-a; writes: %v", nb.writeTransacts())
 	}

--- a/agent_test.go
+++ b/agent_test.go
@@ -39,44 +39,6 @@ func TestUniqueIPs(t *testing.T) {
 	}
 }
 
-func TestIsManaged(t *testing.T) {
-	tests := []struct {
-		name  string
-		cidrs []string
-		ip    string
-		want  bool
-	}{
-		{"no filter matches all", nil, "192.168.1.1", true},
-		{"matching CIDR /24", []string{"10.0.0.0/24"}, "10.0.0.5", true},
-		{"non-matching CIDR", []string{"10.0.0.0/24"}, "192.168.1.1", false},
-		{"broader CIDR /16 matches", []string{"10.0.0.0/16"}, "10.0.1.5", true},
-		{"narrower CIDR /24 excludes", []string{"10.0.0.0/24"}, "10.0.1.5", false},
-		{"boundary IP included", []string{"10.0.0.0/24"}, "10.0.0.255", true},
-		{"invalid IP returns false", []string{"10.0.0.0/24"}, "not-an-ip", false},
-		{"multiple CIDRs first matches", []string{"10.0.0.0/24", "172.16.0.0/12"}, "10.0.0.5", true},
-		{"multiple CIDRs second matches", []string{"10.0.0.0/24", "172.16.0.0/12"}, "172.20.0.1", true},
-		{"multiple CIDRs none matches", []string{"10.0.0.0/24", "172.16.0.0/12"}, "192.168.1.1", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var filters []*net.IPNet
-			for _, cidrStr := range tt.cidrs {
-				_, cidr, err := net.ParseCIDR(cidrStr)
-				if err != nil {
-					t.Fatalf("ParseCIDR(%q) error: %v", cidrStr, err)
-				}
-				filters = append(filters, cidr)
-			}
-			a := &Agent{effectiveFilters: filters}
-			got := a.isManaged(tt.ip)
-			if got != tt.want {
-				t.Errorf("isManaged(%q) with cidrs %v = %v, want %v", tt.ip, tt.cidrs, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestComputeEffectiveNetworks(t *testing.T) {
 	_, manual, _ := net.ParseCIDR("10.0.0.0/24")
 	_, discovered, _ := net.ParseCIDR("198.51.100.0/24")
@@ -113,24 +75,6 @@ func TestComputeEffectiveNetworks(t *testing.T) {
 			t.Errorf("expected only the v4 network, got %v", eff)
 		}
 	})
-}
-
-func TestIsManagedWithEffectiveFilters(t *testing.T) {
-	_, cidr, _ := net.ParseCIDR("198.51.100.0/24")
-	a := &Agent{effectiveFilters: []*net.IPNet{cidr}}
-
-	if !a.isManaged("198.51.100.10") {
-		t.Error("198.51.100.10 should be managed within 198.51.100.0/24")
-	}
-	if a.isManaged("10.0.0.1") {
-		t.Error("10.0.0.1 should not be managed outside 198.51.100.0/24")
-	}
-
-	// With nil effectiveFilters, all IPs are managed.
-	a.effectiveFilters = nil
-	if !a.isManaged("10.0.0.1") {
-		t.Error("all IPs should be managed when effectiveFilters is nil")
-	}
 }
 
 func TestTriggerReconcile(t *testing.T) {
@@ -175,7 +119,11 @@ func TestVerifyRoutesDryRun(t *testing.T) {
 	}
 }
 
-func TestVerifyRoutesSkipsUnmanagedIPs(t *testing.T) {
+// TestVerifyRoutesVerifiesDesiredRegardlessOfFilters proves route ownership no
+// longer comes from CIDR membership: a desired IP outside effectiveFilters
+// (e.g. a port-forward VIP under a narrow manual network_cidr) is still
+// verified and re-added, matching ensureRoutes which always installed it.
+func TestVerifyRoutesVerifiesDesiredRegardlessOfFilters(t *testing.T) {
 	rm := &RouteManager{
 		bridgeDev:   "br-ex",
 		vrfName:     "vrf-provider",
@@ -188,10 +136,11 @@ func TestVerifyRoutesSkipsUnmanagedIPs(t *testing.T) {
 		effectiveFilters: []*net.IPNet{cidr},
 	}
 
-	// IPs outside the managed CIDR should be skipped — zero re-adds.
+	// Two IPs outside the manual filter. In dry-run every list call returns
+	// empty, so each desired IP is seen as missing → 2 FRR + 2 kernel re-adds.
 	n := a.verifyRoutes([]string{"192.168.1.1", "172.16.0.1"}, nil, nil)
-	if n != 0 {
-		t.Errorf("expected 0 re-adds for unmanaged IPs, got %d", n)
+	if n != 4 {
+		t.Errorf("expected 4 re-adds for desired IPs outside the filter, got %d", n)
 	}
 }
 
@@ -236,8 +185,8 @@ func TestVerifyRoutesConsecutiveReAddCounter(t *testing.T) {
 		}
 	}
 
-	// A cycle with no managed IPs (nothing to re-add) resets the counter.
-	a.verifyRoutes([]string{"192.168.1.1"}, nil, nil) // unmanaged → 0 re-adds
+	// A cycle with an empty desired set (nothing to re-add) resets the counter.
+	a.verifyRoutes(nil, nil, nil)
 	if a.consecutiveReAdds != 0 {
 		t.Errorf("expected consecutiveReAdds=0 after clean cycle, got %d", a.consecutiveReAdds)
 	}

--- a/docs/explanation/gatewayless-networks.md
+++ b/docs/explanation/gatewayless-networks.md
@@ -195,7 +195,12 @@ after an upgrade — that is the intended fix.
   `/32` routes, but this path is not asserted by tests.
 - The **IPv6 kernel path** is out of scope (status quo): bridge IP, proxy
   ARP, `/32` routes, and the virtual gateway are IPv4-only; the per-port
-  IPv6 MAC-tweak flow variant is kept.
+  IPv6 MAC-tweak flow variant is kept. Non-IPv4 NAT and LRP addresses are
+  filtered out of the kernel/FRR desired set at ingest, so a dual-stack
+  router announces its v4 FIPs normally while its v6 OVS flow variants
+  remain. Full IPv6 support is tracked in
+  [#85](https://github.com/osism/ovn-network-agent/issues/85) /
+  [#70](https://github.com/osism/ovn-network-agent/issues/70).
 
 The `localnet_segments` gauge reports how many segments are currently
 bound — see the [metrics reference](../reference/metrics).

--- a/docs/explanation/how-it-works.md
+++ b/docs/explanation/how-it-works.md
@@ -44,7 +44,21 @@ provider bridge).
    - Ensures `/32` **kernel routes** (with IP rules when using a dedicated
      routing table) and **FRR static routes** in the VRF for each FIP, SNAT
      IP, router LRP gateway IP, and (independent of router locality)
-     configured port-forward VIP.
+     configured port-forward VIP. Only **IPv4** addresses enter this
+     route/announce plane; non-IPv4 NAT and LRP addresses are excluded until
+     full IPv6 support ([#85](https://github.com/osism/ovn-network-agent/issues/85),
+     [#70](https://github.com/osism/ovn-network-agent/issues/70)) lands. A
+     single malformed OVN row (an invalid `external_ip`) degrades only its own
+     FIP — it never fails the whole batch.
+   - **Route ownership** is explicit: every agent-created kernel route is
+     tagged with the agent's route protocol (`proto 44`) and every FRR static
+     route uses the agent's veth next-hop. Reconciliation — including standby
+     cleanup — touches only those agent-owned routes, so operator-created
+     kernel routes on the bridge and operator static routes in the VRF are
+     never removed. On upgrade from a version that predates the protocol tag,
+     still-desired routes are re-tagged automatically on the next reconcile;
+     any stale pre-upgrade leftovers are indistinguishable from operator
+     routes and must be cleaned up once by hand.
    - If configured, reconciles the **FRR prefix-list** with
      `permit <network> ge 32 le 32` entries for each discovered provider
      network.

--- a/ovn.go
+++ b/ovn.go
@@ -651,11 +651,17 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 			continue
 		}
 		ip := nat.ExternalIP
-		if len(effectiveFilters) > 0 {
-			parsedIP := net.ParseIP(ip)
-			if parsedIP == nil || !containedInAny(parsedIP, effectiveFilters) {
-				continue
-			}
+		// Validate every external IP unconditionally: a malformed row must
+		// die here at ingest, regardless of whether a filter is in effect, so
+		// it can never reach an nft/FRR/kernel command payload downstream.
+		parsedIP := net.ParseIP(ip)
+		if parsedIP == nil {
+			slog.Warn("skipping NAT entry with invalid external IP",
+				"external_ip", ip, "nat", nat.UUID, "type", nat.Type)
+			continue
+		}
+		if len(effectiveFilters) > 0 && !containedInAny(parsedIP, effectiveFilters) {
+			continue
 		}
 		natIPToRouterMAC[ip] = routerMAC
 		if seg, ok := natUUIDToSegment[nat.UUID]; ok {
@@ -665,7 +671,16 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 		case "dnat_and_snat":
 			fips = append(fips, ip)
 		case "snat":
-			snatIPs = append(snatIPs, ip)
+			// SNATIPs feeds the IPv4-only nft masquerade set (buildNftRuleset's
+			// "table ip"), so keep IPv6 out until full v6 support (#85/#70)
+			// lands. The dual-stack natIPToRouterMAC above still carries the
+			// address for the family-aware OVS hairpin plane (#54).
+			if parsedIP.To4() != nil {
+				snatIPs = append(snatIPs, ip)
+			} else {
+				slog.Debug("excluding non-IPv4 SNAT external IP from the nft masquerade set, IPv6 support tracked in #85/#70",
+					"external_ip", ip)
+			}
 		}
 	}
 
@@ -692,13 +707,21 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 		routerMAC := lrpNameToMAC[peer]
 		for _, natAddr := range pb.NatAddresses {
 			for _, ip := range parseNatAddressIPs(natAddr) {
-				if len(effectiveFilters) > 0 {
-					parsedIP := net.ParseIP(ip)
-					if parsedIP == nil || !containedInAny(parsedIP, effectiveFilters) {
-						continue
-					}
+				// parseNatAddressIPs only yields net.ParseIP-valid addresses;
+				// re-parse here so the filter and family gate apply to every
+				// candidate regardless of whether a filter is in effect.
+				parsedIP := net.ParseIP(ip)
+				if len(effectiveFilters) > 0 && !containedInAny(parsedIP, effectiveFilters) {
+					continue
 				}
-				snatIPs = append(snatIPs, ip)
+				// Keep IPv6 out of the IPv4-only nft masquerade set (#85/#70)
+				// while still tracking it for the OVS hairpin plane (#54).
+				if parsedIP.To4() != nil {
+					snatIPs = append(snatIPs, ip)
+				} else {
+					slog.Debug("excluding non-IPv4 SB SNAT address from the nft masquerade set, IPv6 support tracked in #85/#70",
+						"external_ip", ip)
+				}
 				if routerMAC != "" {
 					natIPToRouterMAC[ip] = routerMAC
 				}

--- a/ovn_test.go
+++ b/ovn_test.go
@@ -914,6 +914,142 @@ func TestRefreshStatePopulatesLocalRoutersAndNATs(t *testing.T) {
 	}
 }
 
+// emptyFilterLocalRouterFakes wires an OVNClient whose sole locally-active
+// router has an LRP with no parseable networks, so refreshState discovers no
+// network filters and computes an empty effectiveFilters set. This is the
+// standby/edge condition weakness #3 of issue #158 describes, where NAT
+// external IPs previously reached the command payloads unvalidated.
+func emptyFilterLocalRouterFakes(t *testing.T, nats ...*NBNAT) *OVNClient {
+	t.Helper()
+	c, nb, sb := newOVNClientWithFakes(t, "host-a")
+
+	sb.setRows("Chassis", &SBChassis{UUID: "ch-a", Name: "ch-a", Hostname: "host-a"})
+	chA := "ch-a"
+	sb.setRows("Port_Binding",
+		&SBPortBinding{UUID: "pb-1", LogicalPort: "cr-lrp-local", Type: "chassisredirect", Chassis: &chA},
+	)
+	nb.setRows("Logical_Router_Port",
+		// Empty Networks → no discovered CIDRs → empty effectiveFilters.
+		&NBLogicalRouterPort{UUID: "lrp-uuid-local", Name: "lrp-local", MAC: "fa:16:3e:aa:aa:aa"},
+	)
+	natUUIDs := make([]string, 0, len(nats))
+	rows := make([]any, 0, len(nats))
+	for _, n := range nats {
+		natUUIDs = append(natUUIDs, n.UUID)
+		rows = append(rows, n)
+	}
+	nb.setRows("NAT", rows...)
+	nb.setRows("Logical_Router",
+		&NBLogicalRouter{UUID: "lr-local", Name: "router-local", Ports: []string{"lrp-uuid-local"}, Nat: natUUIDs},
+	)
+
+	c.state.LocalChassisName = "host-a"
+	c.refreshState(context.Background())
+	return c
+}
+
+// TestRefreshStateDropsMalformedNATExternalIP proves a NAT row with an
+// unparseable external_ip is dropped at ingest even when no filter is in
+// effect: the raw string must not survive into SNATIPs, FIPs, or
+// NATIPToRouterMAC (weakness #3, AC "nft/vtysh payloads only ever contain
+// values that passed net.ParseIP").
+func TestRefreshStateDropsMalformedNATExternalIP(t *testing.T) {
+	c := emptyFilterLocalRouterFakes(t,
+		&NBNAT{UUID: "nat-fip", Type: "dnat_and_snat", ExternalIP: "198.51.100.50"},
+		&NBNAT{UUID: "nat-snat", Type: "snat", ExternalIP: "198.51.100.51"},
+		&NBNAT{UUID: "nat-bad", Type: "snat", ExternalIP: "not-an-ip"},
+	)
+	snap := c.GetState()
+
+	// Precondition for the weakness: no filters were derived.
+	if len(snap.DiscoveredNetworks) != 0 {
+		t.Fatalf("expected empty DiscoveredNetworks, got %v", snap.DiscoveredNetworks)
+	}
+	if got := snap.FIPs; !reflect.DeepEqual(got, []string{"198.51.100.50"}) {
+		t.Errorf("FIPs = %v, want [198.51.100.50]", got)
+	}
+	if got := snap.SNATIPs; !reflect.DeepEqual(got, []string{"198.51.100.51"}) {
+		t.Errorf("SNATIPs = %v, want [198.51.100.51] (malformed row must be dropped)", got)
+	}
+	if _, ok := snap.NATIPToRouterMAC["not-an-ip"]; ok {
+		t.Errorf("NATIPToRouterMAC must not contain the malformed external IP: %v", snap.NATIPToRouterMAC)
+	}
+}
+
+// TestRefreshStateKeepsV6ForHairpinButNotSNATIPs proves the family gate on the
+// nft-bound SNATIPs list is independent of filter presence: with empty filters,
+// a v6 SNAT and a v6 FIP are still tracked in NATIPToRouterMAC (the dual-stack
+// OVS hairpin plane, #54) but never land in SNATIPs (the IPv4-only nft
+// masquerade set). Covers steps 5 and 5b's family gate.
+func TestRefreshStateKeepsV6ForHairpinButNotSNATIPs(t *testing.T) {
+	c := emptyFilterLocalRouterFakes(t,
+		&NBNAT{UUID: "nat-v4snat", Type: "snat", ExternalIP: "198.51.100.51"},
+		&NBNAT{UUID: "nat-v6snat", Type: "snat", ExternalIP: "2001:db8::51"},
+		&NBNAT{UUID: "nat-v6fip", Type: "dnat_and_snat", ExternalIP: "2001:db8::50"},
+	)
+	snap := c.GetState()
+
+	if got := snap.SNATIPs; !reflect.DeepEqual(got, []string{"198.51.100.51"}) {
+		t.Errorf("SNATIPs = %v, want [198.51.100.51] (v6 must be excluded)", got)
+	}
+	// The v6 addresses remain available for the family-aware OVS hairpin plane.
+	for _, ip := range []string{"2001:db8::51", "2001:db8::50"} {
+		if snap.NATIPToRouterMAC[ip] != "fa:16:3e:aa:aa:aa" {
+			t.Errorf("NATIPToRouterMAC[%s] = %q, want the LRP MAC (v6 kept for hairpin)",
+				ip, snap.NATIPToRouterMAC[ip])
+		}
+	}
+	if got := snap.FIPs; !reflect.DeepEqual(got, []string{"2001:db8::50"}) {
+		t.Errorf("FIPs = %v, want [2001:db8::50] (FIP list stays dual-stack)", got)
+	}
+}
+
+// TestRefreshStateKeepsV6SBNatAddressForHairpinButNotSNATIPs drives the same
+// family gate through the SB gateway NatAddresses path (step 5b): a v6 SNAT
+// address discovered from a Port_Binding's NatAddresses stays in
+// NATIPToRouterMAC for the dual-stack OVS hairpin plane (#54) but never lands
+// in the IPv4-only nft masquerade set (SNATIPs, #85/#70). The LRP carries no
+// networks, so effectiveFilters is empty and the To4() gate is the only thing
+// separating the two addresses.
+func TestRefreshStateKeepsV6SBNatAddressForHairpinButNotSNATIPs(t *testing.T) {
+	c, nb, sb := newOVNClientWithFakes(t, "host-a")
+
+	sb.setRows("Chassis", &SBChassis{UUID: "ch-a", Name: "ch-a", Hostname: "host-a"})
+	chA := "ch-a"
+	sb.setRows("Port_Binding",
+		&SBPortBinding{UUID: "pb-cr", LogicalPort: "cr-lrp-local", Type: "chassisredirect", Chassis: &chA},
+		&SBPortBinding{
+			UUID: "pb-patch", LogicalPort: "ext", Type: "patch",
+			Options:     map[string]string{"peer": "lrp-local"},
+			ExternalIDs: map[string]string{"neutron:device_owner": "network:router_gateway"},
+			NatAddresses: []string{
+				"fa:16:3e:11:22:33 198.51.100.60 is_chassis_resident(\"cr-lrp-local\")",
+				"fa:16:3e:11:22:33 2001:db8::60 is_chassis_resident(\"cr-lrp-local\")",
+			},
+		},
+	)
+	nb.setRows("Logical_Router_Port",
+		// Empty Networks → no discovered CIDRs → empty effectiveFilters.
+		&NBLogicalRouterPort{UUID: "lrp-uuid-local", Name: "lrp-local", MAC: "fa:16:3e:aa:aa:aa"},
+	)
+	nb.setRows("Logical_Router",
+		&NBLogicalRouter{UUID: "lr-local", Name: "router-local", Ports: []string{"lrp-uuid-local"}},
+	)
+
+	c.state.LocalChassisName = "host-a"
+	c.refreshState(context.Background())
+	snap := c.GetState()
+
+	if got := snap.SNATIPs; !reflect.DeepEqual(got, []string{"198.51.100.60"}) {
+		t.Errorf("SNATIPs = %v, want [198.51.100.60] (v6 SB SNAT must be excluded)", got)
+	}
+	// The v6 address stays available for the family-aware OVS hairpin plane.
+	if snap.NATIPToRouterMAC["2001:db8::60"] != "fa:16:3e:aa:aa:aa" {
+		t.Errorf("NATIPToRouterMAC[2001:db8::60] = %q, want the LRP MAC (v6 kept for hairpin)",
+			snap.NATIPToRouterMAC["2001:db8::60"])
+	}
+}
+
 // TestRefreshStateResolvesLocalnetSegments verifies the SB-driven segment
 // resolution: each locally-active router is associated with the localnet
 // segment (localnet port + physnet + optional VLAN tag) of its external

--- a/ovs.go
+++ b/ovs.go
@@ -425,6 +425,12 @@ func HairpinFlow(cookie, ofport, ip, bridgeMAC, routerMAC string, ipv6 bool) str
 //
 // Pass nil or an empty map to remove all hairpin flows (e.g. when no
 // locally-active routers remain).
+//
+// The up-front del-flows sweep is a hard precondition: if it fails the method
+// returns without touching the plane. Per-flow failures thereafter (an invalid
+// IP or a failed add-flow) are logged and skipped so one bad row never leaves
+// the hairpin plane empty for every other FIP — the delete-then-abort behaviour
+// this replaces.
 func (rm *RouteManager) ReconcileOVSHairpinFlows(targets map[string]HairpinTarget) error {
 	if rm.dryRun {
 		slog.Info("[dry-run] would reconcile OVS hairpin flows", "count", len(targets))
@@ -446,7 +452,8 @@ func (rm *RouteManager) ReconcileOVSHairpinFlows(targets map[string]HairpinTarge
 	for ip, target := range targets {
 		parsed := net.ParseIP(ip)
 		if parsed == nil {
-			return fmt.Errorf("invalid IP %q", ip)
+			slog.Warn("skipping hairpin flow for invalid IP", "ip", ip)
+			continue
 		}
 		b := rm.segmentBindingFor(target.Segment)
 		if b == nil {
@@ -457,7 +464,9 @@ func (rm *RouteManager) ReconcileOVSHairpinFlows(targets map[string]HairpinTarge
 		isIPv6 := parsed.To4() == nil
 		flow := HairpinFlow(ovsCookieHairpin, b.ofport, ip, b.kernelMAC, target.RouterMAC, isIPv6)
 		if err := rm.addOVSFlow(flow); err != nil {
-			return fmt.Errorf("add hairpin flow for %s: %w", ip, err)
+			slog.Warn("failed to add hairpin flow, skipping",
+				"ip", ip, "segment", target.Segment, "error", err)
+			continue
 		}
 	}
 

--- a/ovs_test.go
+++ b/ovs_test.go
@@ -699,7 +699,11 @@ func TestReconcileOVSHairpinFlowsNoBindingsIsNoOp(t *testing.T) {
 	}
 }
 
-func TestReconcileOVSHairpinFlowsRejectsInvalidIP(t *testing.T) {
+// TestReconcileOVSHairpinFlowsSkipsInvalidIP proves an invalid IP is skipped
+// with no error and does not prevent the healthy flow from installing (issue
+// #158 test b, hairpin half). The old behaviour deleted every flow up front
+// then aborted on the first invalid IP, leaving the plane permanently empty.
+func TestReconcileOVSHairpinFlowsSkipsInvalidIP(t *testing.T) {
 	rec := newOVSRecorder()
 	rm := &RouteManager{
 		bridgeDev:   "br-ex",
@@ -707,12 +711,47 @@ func TestReconcileOVSHairpinFlowsRejectsInvalidIP(t *testing.T) {
 		execOVSHook: rec.hook(),
 	}
 
-	err := rm.ReconcileOVSHairpinFlows(map[string]HairpinTarget{"not-an-ip": {RouterMAC: "aa:aa:aa:aa:aa:aa"}})
-	if err == nil {
-		t.Fatal("expected error for invalid IP, got nil")
+	targets := map[string]HairpinTarget{
+		"not-an-ip":     {RouterMAC: "aa:aa:aa:aa:aa:aa"},
+		"5.182.234.199": {RouterMAC: "fa:16:3e:6f:a1:64"},
 	}
-	if !strings.Contains(err.Error(), "invalid IP") {
-		t.Errorf("expected 'invalid IP' in error, got: %v", err)
+	if err := rm.ReconcileOVSHairpinFlows(targets); err != nil {
+		t.Fatalf("ReconcileOVSHairpinFlows() must skip the invalid IP, got: %v", err)
+	}
+
+	wantHealthy := "cookie=0x998,priority=910,ip,in_port=42,ip_dst=5.182.234.199/32,actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:6f:a1:64,output:in_port"
+	if !containsFlow(rec.findAddFlows(), wantHealthy) {
+		t.Errorf("healthy flow not installed despite the invalid sibling; got %v", rec.findAddFlows())
+	}
+}
+
+// TestReconcileOVSHairpinFlowsAddFailureDoesNotStarveOthers proves a failed
+// add-flow for one FIP does not abort the loop: the other FIP's flow still
+// installs and the call returns nil (issue #158 test b). Mirrors
+// TestEnsureSegmentsAddFailureDoesNotStarveOthers.
+func TestReconcileOVSHairpinFlowsAddFailureDoesNotStarveOthers(t *testing.T) {
+	rec := newOVSRecorder()
+	// The flow for the first FIP fails to install.
+	const failingFlow = "cookie=0x998,priority=910,ip,in_port=42,ip_dst=5.182.234.199/32,actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:6f:a1:64,output:in_port"
+	rec.on([]string{"ovs-ofctl", "add-flow", "br-ex", failingFlow}, "add-flow failed", errors.New("bad flow"))
+
+	rm := &RouteManager{
+		bridgeDev:   "br-ex",
+		segments:    fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"),
+		execOVSHook: rec.hook(),
+	}
+
+	targets := map[string]HairpinTarget{
+		"5.182.234.199": {RouterMAC: "fa:16:3e:6f:a1:64"},
+		"203.0.113.50":  {RouterMAC: "fa:16:3e:00:01:02"},
+	}
+	if err := rm.ReconcileOVSHairpinFlows(targets); err != nil {
+		t.Fatalf("ReconcileOVSHairpinFlows() must tolerate a per-flow add failure, got: %v", err)
+	}
+
+	wantSurviving := "cookie=0x998,priority=910,ip,in_port=42,ip_dst=203.0.113.50/32,actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:00:01:02,output:in_port"
+	if !containsFlow(rec.findAddFlows(), wantSurviving) {
+		t.Errorf("healthy flow not installed after the sibling's add-flow failure; got %v", rec.findAddFlows())
 	}
 }
 

--- a/routing.go
+++ b/routing.go
@@ -267,7 +267,10 @@ func (rm *RouteManager) HasFRRRoute(ip string) bool {
 	return strings.Contains(string(output), "static")
 }
 
-// ListFRRRoutes returns all static /32 routes in the VRF.
+// ListFRRRoutes returns the agent's own static /32 routes in the VRF: those
+// installed via the agent's veth nexthop. This nexthop scoping is the FRR
+// analog of the kernel protocol tag — without it, reconciliation would treat
+// operator-created statics as agent-owned and withdraw them on standby nodes.
 func (rm *RouteManager) ListFRRRoutes() ([]string, error) {
 	if rm.dryRun {
 		return nil, nil
@@ -280,21 +283,38 @@ func (rm *RouteManager) ListFRRRoutes() ([]string, error) {
 	var ips []string
 	for _, line := range strings.Split(string(output), "\n") {
 		line = strings.TrimSpace(line)
-		// Lines like: S>* 198.51.100.10/32 [1/0] via 169.254.0.1, ...
-		if strings.HasPrefix(line, "S") && strings.Contains(line, "/32") {
-			parts := strings.Fields(line)
-			for _, p := range parts {
-				if strings.Contains(p, "/32") {
-					ip, _, _ := net.ParseCIDR(p)
-					if ip != nil {
-						ips = append(ips, ip.String())
-					}
-					break
+		// Lines like: S>* 198.51.100.10/32 [1/0] via 169.254.0.1, veth-default, ...
+		if !strings.HasPrefix(line, "S") || !strings.Contains(line, "/32") {
+			continue
+		}
+		// Only report statics installed via the agent's own nexthop.
+		if frrRouteNexthop(line) != rm.vethNexthop {
+			continue
+		}
+		for _, p := range strings.Fields(line) {
+			if strings.Contains(p, "/32") {
+				ip, _, _ := net.ParseCIDR(p)
+				if ip != nil {
+					ips = append(ips, ip.String())
 				}
+				break
 			}
 		}
 	}
 	return ips, nil
+}
+
+// frrRouteNexthop returns the nexthop address in an FRR "show ip route" line —
+// the token following "via", with any trailing comma stripped. Returns "" when
+// the line has no via clause.
+func frrRouteNexthop(line string) string {
+	fields := strings.Fields(line)
+	for i, f := range fields {
+		if f == "via" && i+1 < len(fields) {
+			return strings.TrimRight(fields[i+1], ",")
+		}
+	}
+	return ""
 }
 
 // frrRouteEntry is the subset of an FRR `show ip route ... json` route object

--- a/routing.go
+++ b/routing.go
@@ -128,10 +128,18 @@ func (rm *RouteManager) listKernelRoutes() ([]kernelRouteEntry, error) {
 	return rm.ListKernelRoutes()
 }
 
-// validateIP checks that the given string is a valid IPv4 address.
+// validateIP checks that the given string is a valid IPv4 address. IPv6 is
+// rejected: the FRR and kernel route paths that call this are IPv4-only (vtysh
+// "ip route .../32", net.CIDRMask(32, 32)), so a v6 address would produce an
+// invalid command or a malformed route. Full IPv6 support is tracked in
+// #85/#70.
 func validateIP(ip string) error {
-	if net.ParseIP(ip) == nil {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
 		return fmt.Errorf("invalid IP address: %q", ip)
+	}
+	if parsed.To4() == nil {
+		return fmt.Errorf("not an IPv4 address: %q", ip)
 	}
 	return nil
 }

--- a/routing.go
+++ b/routing.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -158,28 +159,44 @@ func (rm *RouteManager) AddFRRRoute(ip string) error {
 // thousands of FIPs at startup.
 const frrBatchSize = 500
 
-// AddFRRRoutes adds static /32 routes for all given IPs via vtysh.
-// IPs are validated before any commands are executed.  The list is chunked
-// into batches of frrBatchSize to stay within OS argument-list limits.
+// AddFRRRoutes adds static /32 routes for all given IPs via vtysh. Invalid
+// entries are skipped with a warning instead of rejecting the whole batch, so
+// one malformed OVN row degrades only its own FIP. The valid IPs are chunked
+// into batches of frrBatchSize to stay within OS argument-list limits; a failed
+// chunk is logged and the remaining chunks still run. The returned error is the
+// join of every failed chunk (nil when every valid route applied), so a real
+// vtysh command failure still makes ensureRoutes withhold the takeover marker,
+// while un-installable entries are dropped without blocking the rest.
 func (rm *RouteManager) AddFRRRoutes(ips []string) error {
 	if len(ips) == 0 {
 		return nil
 	}
+	valid := make([]string, 0, len(ips))
+	var skipped []string
 	for _, ip := range ips {
 		if err := validateIP(ip); err != nil {
-			return err
+			skipped = append(skipped, ip)
+			continue
 		}
+		valid = append(valid, ip)
 	}
-	if rm.dryRun {
-		slog.Info("[dry-run] would add FRR routes", "count", len(ips), "vrf", rm.vrfName, "nexthop", rm.vethNexthop)
+	if len(skipped) > 0 {
+		slog.Warn("skipping invalid IPs in FRR route batch", "count", len(skipped), "ips", skipped)
+	}
+	if len(valid) == 0 {
 		return nil
 	}
-	for start := 0; start < len(ips); start += frrBatchSize {
+	if rm.dryRun {
+		slog.Info("[dry-run] would add FRR routes", "count", len(valid), "vrf", rm.vrfName, "nexthop", rm.vethNexthop)
+		return nil
+	}
+	var errs []error
+	for start := 0; start < len(valid); start += frrBatchSize {
 		end := start + frrBatchSize
-		if end > len(ips) {
-			end = len(ips)
+		if end > len(valid) {
+			end = len(valid)
 		}
-		chunk := ips[start:end]
+		chunk := valid[start:end]
 		args := []string{"-c", "conf t", "-c", fmt.Sprintf("vrf %s", rm.vrfName)}
 		for _, ip := range chunk {
 			args = append(args, "-c", fmt.Sprintf("ip route %s/32 %s", ip, rm.vethNexthop))
@@ -187,11 +204,14 @@ func (rm *RouteManager) AddFRRRoutes(ips []string) error {
 		args = append(args, "-c", "exit-vrf", "-c", "end")
 		output, err := rm.runVtysh(args...)
 		if err != nil {
-			return fmt.Errorf("vtysh batch add %d routes: %w (output: %s)", len(chunk), err, strings.TrimSpace(string(output)))
+			slog.Error("failed to add FRR route chunk, continuing with the next",
+				"count", len(chunk), "vrf", rm.vrfName, "error", err, "output", strings.TrimSpace(string(output)))
+			errs = append(errs, fmt.Errorf("vtysh batch add %d routes: %w (output: %s)", len(chunk), err, strings.TrimSpace(string(output))))
+			continue
 		}
 		slog.Info("FRR routes ensured", "count", len(chunk), "vrf", rm.vrfName, "nexthop", rm.vethNexthop)
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // DelFRRRoute is a convenience wrapper for DelFRRRoutes with a single IP.

--- a/routing_linux.go
+++ b/routing_linux.go
@@ -12,9 +12,12 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-// rtProtoOVNNetworkAgent is a custom route protocol number used to tag kernel
-// routes created by ReconcileVethLeakNetworks. This distinguishes them from
-// routes installed by FRR/zebra (which use RTPROT_ZEBRA or RTPROT_STATIC).
+// rtProtoOVNNetworkAgent is a custom route protocol number used to tag every
+// kernel route the agent creates — the per-network veth-leak routes and the
+// per-FIP /32 routes on the provider bridge. It distinguishes agent routes from
+// routes installed by FRR/zebra (RTPROT_ZEBRA/RTPROT_STATIC) and from
+// operator-created routes, so ListKernelRoutes returns only agent-owned routes
+// and reconciliation never reaps a route the agent did not install.
 const rtProtoOVNNetworkAgent = 44
 
 // CheckBridgeDevice verifies that the bridge device exists and that the agent
@@ -342,6 +345,9 @@ func (rm *RouteManager) AddKernelRoute(ip, dev string) error {
 		LinkIndex: link.Attrs().Index,
 		Dst:       dst,
 		Scope:     netlink.SCOPE_LINK,
+		// Tag the route as agent-owned so ListKernelRoutes reconciles only
+		// routes the agent installed and never reaps operator-created ones.
+		Protocol: rtProtoOVNNetworkAgent,
 	}
 	if rm.routeTableID > 0 {
 		route.Table = rm.routeTableID
@@ -391,6 +397,10 @@ func (rm *RouteManager) DelKernelRoute(ip, dev string) error {
 		LinkIndex: link.Attrs().Index,
 		Dst:       dst,
 		Scope:     netlink.SCOPE_LINK,
+		// Match only the agent's own tagged route: a protocol mismatch surfaces
+		// as "no such process" (treated as already-absent below), so a delete
+		// can never remove an operator-created route for the same IP.
+		Protocol: rtProtoOVNNetworkAgent,
 	}
 	if rm.routeTableID > 0 {
 		route.Table = rm.routeTableID
@@ -408,19 +418,20 @@ func (rm *RouteManager) DelKernelRoute(ip, dev string) error {
 	return nil
 }
 
-// ListKernelRoutes returns all agent-relevant /32 routes as (IP, device)
-// pairs. When a dedicated routing table is configured, the whole table is
-// listed — routes on any interface — so per-segment leftovers survive an
-// agent restart; otherwise routes on the bridge device and its VLAN
-// subinterfaces are listed.
+// ListKernelRoutes returns the agent's own /32 routes as (IP, device) pairs.
+// Only routes tagged with rtProtoOVNNetworkAgent are returned, so operator- and
+// FRR-created routes are invisible to reconciliation and never reaped. When a
+// dedicated routing table is configured, the whole table is listed — routes on
+// any interface — so per-segment leftovers survive an agent restart; otherwise
+// routes on the bridge device and its VLAN subinterfaces are listed.
 func (rm *RouteManager) ListKernelRoutes() ([]kernelRouteEntry, error) {
 	if rm.dryRun {
 		return nil, nil
 	}
 
 	if rm.routeTableID > 0 {
-		filter := &netlink.Route{Table: rm.routeTableID}
-		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, filter, netlink.RT_FILTER_TABLE)
+		filter := &netlink.Route{Table: rm.routeTableID, Protocol: rtProtoOVNNetworkAgent}
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, filter, netlink.RT_FILTER_TABLE|netlink.RT_FILTER_PROTOCOL)
 		if err != nil {
 			return nil, fmt.Errorf("list routes in table %d: %w", rm.routeTableID, err)
 		}
@@ -461,6 +472,10 @@ func (rm *RouteManager) ListKernelRoutes() ([]kernelRouteEntry, error) {
 		}
 		for _, r := range routes {
 			if r.Dst == nil {
+				continue
+			}
+			// Only reconcile the agent's own routes; skip operator/FRR routes.
+			if r.Protocol != rtProtoOVNNetworkAgent {
 				continue
 			}
 			if ones, _ := r.Dst.Mask.Size(); ones == 32 {

--- a/routing_test.go
+++ b/routing_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"os/exec"
 	"reflect"
@@ -213,18 +214,78 @@ func TestFRRRoutesBatchValidation(t *testing.T) {
 		dryRun:      true,
 	}
 
-	invalid := []string{"10.0.0.1", "not-an-ip", "10.0.0.2"}
-	if err := rm.AddFRRRoutes(invalid); err == nil {
-		t.Error("AddFRRRoutes() with invalid IP should return error")
+	// AddFRRRoutes now skips invalid entries instead of rejecting the whole
+	// batch, so a mixed list applies the valid IPs and returns nil. DelFRRRoutes
+	// keeps fail-fast validation (its inputs are self-sourced from FRR output).
+	mixed := []string{"10.0.0.1", "not-an-ip", "10.0.0.2"}
+	if err := rm.AddFRRRoutes(mixed); err != nil {
+		t.Errorf("AddFRRRoutes() with a mixed list should skip the invalid entry, got: %v", err)
 	}
-	if err := rm.DelFRRRoutes(invalid); err == nil {
+	if err := rm.DelFRRRoutes(mixed); err == nil {
 		t.Error("DelFRRRoutes() with invalid IP should return error")
 	}
 
-	// CIDR notation is not a valid bare IP.
-	cidr := []string{"10.0.0.1/32"}
-	if err := rm.AddFRRRoutes(cidr); err == nil {
-		t.Error("AddFRRRoutes() with CIDR notation should return error")
+	// A list of only-invalid entries is a no-op, not an error.
+	if err := rm.AddFRRRoutes([]string{"10.0.0.1/32"}); err != nil {
+		t.Errorf("AddFRRRoutes() with only invalid entries should be a no-op, got: %v", err)
+	}
+}
+
+// TestAddFRRRoutesSkipsInvalidAndContinues proves a single malformed IP is
+// dropped from the vtysh batch while the healthy IPs still install in one call
+// (issue #158 test b, FRR half).
+func TestAddFRRRoutesSkipsInvalidAndContinues(t *testing.T) {
+	rec := newVtyshRecorder()
+	rm := &RouteManager{
+		vrfName:       "vrf-provider",
+		vethNexthop:   "169.254.0.1",
+		execVtyshHook: rec.hook(),
+	}
+	if err := rm.AddFRRRoutes([]string{"10.0.0.1", "not-an-ip", "10.0.0.2"}); err != nil {
+		t.Fatalf("AddFRRRoutes: unexpected error %v", err)
+	}
+	if len(rec.calls) != 1 {
+		t.Fatalf("expected exactly one vtysh batch, got %d: %v", len(rec.calls), rec.calls)
+	}
+	joined := strings.Join(rec.calls[0], " ")
+	if !strings.Contains(joined, "ip route 10.0.0.1/32 169.254.0.1") ||
+		!strings.Contains(joined, "ip route 10.0.0.2/32 169.254.0.1") {
+		t.Errorf("healthy IPs missing from batch: %v", rec.calls[0])
+	}
+	if strings.Contains(joined, "not-an-ip") {
+		t.Errorf("invalid IP must not reach the vtysh batch: %v", rec.calls[0])
+	}
+}
+
+// TestAddFRRRoutesContinuesPastFailedChunk proves a vtysh failure on the first
+// chunk does not abort the remaining chunks: both are issued, and the returned
+// error reflects the failed one (issue #158 test b — a failed chunk no longer
+// aborts the rest).
+func TestAddFRRRoutesContinuesPastFailedChunk(t *testing.T) {
+	// frrBatchSize+1 IPs span exactly two chunks.
+	ips := make([]string, 0, frrBatchSize+1)
+	for i := 0; i < frrBatchSize+1; i++ {
+		ips = append(ips, fmt.Sprintf("10.%d.%d.%d", i/65536, (i/256)%256, i%256))
+	}
+
+	var calls int
+	rm := &RouteManager{
+		vrfName:     "vrf-provider",
+		vethNexthop: "169.254.0.1",
+		execVtyshHook: func(*exec.Cmd) ([]byte, error) {
+			calls++
+			if calls == 1 {
+				return []byte("boom"), errors.New("vtysh failed")
+			}
+			return nil, nil
+		},
+	}
+	err := rm.AddFRRRoutes(ips)
+	if err == nil {
+		t.Fatal("expected an aggregated error from the failed chunk, got nil")
+	}
+	if calls != 2 {
+		t.Errorf("expected both chunks to be issued despite the first failing, got %d calls", calls)
 	}
 }
 

--- a/routing_test.go
+++ b/routing_test.go
@@ -506,7 +506,8 @@ func TestValidateIP(t *testing.T) {
 		{"10.0.0.1", false},
 		{"192.168.1.1", false},
 		{"255.255.255.255", false},
-		{"::1", false},
+		{"::1", true},         // IPv6 is rejected: the route paths are v4-only.
+		{"2001:db8::1", true}, // IPv6 is rejected.
 		{"", true},
 		{"not-an-ip", true},
 		{"10.0.0.1/32", true},

--- a/routing_test.go
+++ b/routing_test.go
@@ -636,10 +636,13 @@ func TestListFRRRoutes_ParsesStaticRoutes(t *testing.T) {
 S>* 198.51.100.11/32 [1/0] via 169.254.0.1, veth-default, weight 1, 00:00:01
 C>* 10.0.0.0/24 is directly connected, br-ex, 00:00:01
 S>* 203.0.113.10/32 [1/0] via 169.254.0.1, veth-default, weight 1, 00:00:01
+S>* 192.0.2.99/32 [1/0] via 192.0.2.1, eth0, weight 1, 00:00:01
 `,
 		nil,
 	)
-	rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+	// The agent owns only statics via its own veth nexthop; an operator static
+	// via a different nexthop (192.0.2.1) must be excluded from the result.
+	rm := &RouteManager{vrfName: "vrf-provider", vethNexthop: "169.254.0.1", execVtyshHook: rec.hook()}
 
 	got, err := rm.ListFRRRoutes()
 	if err != nil {
@@ -647,7 +650,7 @@ S>* 203.0.113.10/32 [1/0] via 169.254.0.1, veth-default, weight 1, 00:00:01
 	}
 	want := []string{"198.51.100.10", "198.51.100.11", "203.0.113.10"}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("ListFRRRoutes() = %v, want %v", got, want)
+		t.Errorf("ListFRRRoutes() = %v, want %v (operator static via a foreign nexthop must be excluded)", got, want)
 	}
 }
 

--- a/test/integration/scenario_dual_stack_routing_test.go
+++ b/test/integration/scenario_dual_stack_routing_test.go
@@ -1,0 +1,81 @@
+//go:build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/osism/ovn-network-agent/test/integration/testenv"
+)
+
+// Dual-stack v4-guard scenario for issue #158 (tests a and b end to end).
+//
+// A dual-stack router carries both a v4 and a v6 network on its LRP, one v4
+// FIP, one v6 FIP, and one NAT row with a malformed external_ip. The agent
+// must:
+//   - install the v4 FIP's kernel + FRR routes and stamp the takeover-readiness
+//     marker (the v4 announce plane is unaffected by the v6 addresses)
+//   - keep the v6 FIP's OVS hairpin flow (the hairpin plane stays dual-stack,
+//     pinning #54's behaviour)
+//   - never fail the FRR batch: the malformed row is dropped at ingest and the
+//     v6 addresses are filtered out of the route/announce plane, so no
+//     "failed to batch-add FRR routes" ever appears.
+//
+// Before #158, the v6 LRP gateway IP and v6 FIP reached AddFRRRoutes as invalid
+// "ip route <v6>/32" commands, errored the whole batch, held announced=false,
+// and blocked the marker — degrading every drain/takeover to the full timeout.
+func TestScenario_DualStackV4Guard(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:   "dsguard",
+		LRPMAC: "fa:16:3e:77:00:01",
+		LRPNetworks: []string{
+			"198.51.100.11/24",
+			"2001:db8:cafe::11/64",
+		},
+	})
+
+	cfg := testenv.Defaults()
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	const (
+		v4FIP = "198.51.100.55"
+		v6FIP = "2001:db8:cafe::55"
+	)
+	testenv.AddFIP(t, ctx, nb, router, v4FIP, "10.0.0.55")
+	testenv.AddFIP(t, ctx, nb, router, v6FIP, "fd00::55")
+	// A malformed NAT row that must degrade exactly nothing.
+	testenv.AddFIP(t, ctx, nb, router, "not-an-ip", "10.0.0.66")
+
+	// The v4 FIP still announces via kernel + FRR despite the dual-stack router
+	// and the malformed sibling row.
+	testenv.AssertKernelRoute(t, v4FIP, 15*time.Second)
+	testenv.AssertFRRRoute(t, v4FIP, 15*time.Second)
+
+	// The v6 FIP keeps its OVS hairpin flow (dual-stack hairpin plane, #54).
+	testenv.AssertOVSFlowMatches(t, "0x998",
+		func(line string) bool {
+			return strings.Contains(line, "ipv6_dst="+v6FIP) &&
+				strings.Contains(line, "mod_dl_dst:"+router.LRPMAC)
+		}, 15*time.Second, "v6 hairpin flow for FIP "+v6FIP)
+
+	// The takeover-readiness marker is stamped on the managed default route:
+	// proof the v4 announce succeeded (announced=true) even though the router
+	// is dual-stack and one NAT row was malformed.
+	local := testenv.LocalHostname(t)
+	testenv.Eventually(t, func() bool {
+		r, ok := testenv.FindStaticRoute(t, ctx, nb, router.RouterUUID, "0.0.0.0/0")
+		return ok && r.ExternalIDs["ovn-network-agent-advertised"] == local
+	}, 20*time.Second, 250*time.Millisecond,
+		"agent must stamp the takeover-readiness marker for its v4 FIPs")
+
+	// The malformed row and the v6 addresses never fail the FRR batch.
+	if logs := a.LogTail(100000); strings.Contains(logs, "failed to batch-add FRR routes") {
+		t.Errorf("FRR batch must not fail on the dual-stack/malformed input; last logs:\n%s", a.LogTail(60))
+	}
+}

--- a/test/integration/scenario_network_cidrs_test.go
+++ b/test/integration/scenario_network_cidrs_test.go
@@ -131,23 +131,23 @@ func TestScenario_NetworkCIDRsRestartPrunesOutOfScopeFIP(t *testing.T) {
 	testenv.AssertNoFRRRoute(t, fipDropped, 15*time.Second)
 }
 
-// TestScenario_NetworkCIDRsEmptyFiltersClaimAllBridge32s (#57 scenario 3):
+// TestScenario_NetworkCIDRsEmptyFiltersClaimAllBridge32s (#57 scenario 3,
+// updated for #158):
 //
-// With no manual filter AND no locally-active routers (so no auto-discovery),
-// effectiveFilters is empty. The agent must treat every /32 on the bridge
-// as managed — that is the implicit "no filters means manage everything"
-// contract isManaged returning true on empty filters relies on. Without
-// explicit coverage, a refactor that flips that default to "manage nothing"
-// would silently leak orphan routes on chassis idle between gateway moves.
+// With no manual filter AND no locally-active routers, the agent still reaps
+// its own leftover /32 routes on br-ex. Ownership is now scoped by the route
+// protocol tag (rtproto 44) instead of the old "empty filters means manage
+// everything" default: ListKernelRoutes returns only proto-44 routes, so a
+// stray the agent itself planted (or left behind from a previous run) is
+// observed and removed, while operator routes are ignored (covered by
+// TestScenario_OperatorRouteSurvivesStandbyReconcile).
 //
 // We pin the contract down by planting a stray /32 on br-ex with the agent's
-// own protocol number (rtproto 44, the value used for veth-leak per-network
-// routes — the issue calls it out specifically) and verifying the agent
-// reaps it. Path-wise: with no local routers and no port-forward VIPs,
-// reconcile takes the removeAllRoutes branch (agent.go's "no locally active
-// routers and no port forward VIPs"). removeAllRoutes calls isManaged on
-// every kernel /32 on the bridge — empty filters means it returns true,
-// so the stray gets removed.
+// own protocol number (rtproto 44) and verifying the agent reaps it.
+// Path-wise: with no local routers and no port-forward VIPs, reconcile takes
+// the removeAllRoutes branch (agent.go's "no locally active routers and no
+// port forward VIPs"). removeAllRoutes lists the agent-owned kernel /32s —
+// the proto-44 stray is one — and removes them.
 func TestScenario_NetworkCIDRsEmptyFiltersClaimAllBridge32s(t *testing.T) {
 	_, cancel, _, _ := startScenario(t)
 	defer cancel()
@@ -174,13 +174,62 @@ func TestScenario_NetworkCIDRsEmptyFiltersClaimAllBridge32s(t *testing.T) {
 }
 
 // addStrayBridgeRoute plants a /32 on the bridge with the agent's own protocol
-// number (rtproto 44). The agent's ListKernelRoutes ignores protocol — it
-// returns every /32 on the bridge — so the planted route is observable to the
-// agent's reconcile loop the same way a leftover from a previous run would be.
+// number (rtproto 44). ListKernelRoutes returns only proto-44 routes, so the
+// planted route is observed as agent-owned by the reconcile loop — exactly as
+// a leftover from a previous run would be — and is reaped.
 func addStrayBridgeRoute(t *testing.T, ip string) {
 	t.Helper()
 	args := []string{"route", "add", ip + "/32", "dev", testenv.DefaultBridgeDev, "proto", "44"}
 	if out, err := exec.Command("ip", args...).CombinedOutput(); err != nil {
 		t.Fatalf("ip %s: %v (%s)", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
 	}
+}
+
+// addOperatorBridgeRoute plants a /32 on the bridge WITHOUT the agent's
+// protocol number, standing in for an operator-created debugging route. Because
+// ListKernelRoutes filters on rtproto 44, this route is invisible to the agent
+// and must survive reconciliation.
+func addOperatorBridgeRoute(t *testing.T, ip string) {
+	t.Helper()
+	args := []string{"route", "add", ip + "/32", "dev", testenv.DefaultBridgeDev}
+	if out, err := exec.Command("ip", args...).CombinedOutput(); err != nil {
+		t.Fatalf("ip %s: %v (%s)", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+}
+
+// delBridgeRoute removes a /32 planted on the bridge, best-effort.
+func delBridgeRoute(t *testing.T, ip string) {
+	t.Helper()
+	_ = exec.Command("ip", "route", "del", ip+"/32", "dev", testenv.DefaultBridgeDev).Run()
+}
+
+// TestScenario_OperatorRouteSurvivesStandbyReconcile (#158 test c):
+//
+// An operator adds a /32 debugging route on br-ex by hand (kernel default
+// protocol, not rtproto 44). On a standby node — no local routers, no manual
+// filter — the agent runs the removeAllRoutes branch every reconcile. Before
+// #158 the empty-filters "manage everything" default deleted this route; now
+// that ListKernelRoutes is scoped to proto-44 routes, the operator route is
+// invisible to the agent and must persist across several fast reconcile ticks.
+func TestScenario_OperatorRouteSurvivesStandbyReconcile(t *testing.T) {
+	_, cancel, _, _ := startScenario(t)
+	defer cancel()
+
+	const operatorIP = "198.51.100.77"
+	addOperatorBridgeRoute(t, operatorIP)
+	t.Cleanup(func() { delBridgeRoute(t, operatorIP) })
+
+	// Sanity: the route exists before the agent starts.
+	testenv.AssertKernelRoute(t, operatorIP, 1*time.Second)
+
+	cfg := testenv.FastDefaults()
+	// No MakeLocalRouter and no NetworkCIDRs: the standby/idle condition where
+	// reconcile takes the removeAllRoutes branch every tick.
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// FastDefaults ticks at 2s; let ~4 ticks pass, then confirm the operator
+	// route is still present — the agent never owned it, so it is never reaped.
+	time.Sleep(8 * time.Second)
+	testenv.AssertKernelRoute(t, operatorIP, 1*time.Second)
 }


### PR DESCRIPTION
Closes #158

## Summary

The desired-IP reconcile pipeline ingested OVN data without an address-family guard and applied it with batch-abort semantics. Four weaknesses compounded into real failover failures: IPv6 addresses poisoned the IPv4-only route path, one malformed row aborted whole batches (and left the hairpin plane permanently empty), NAT `external_ip` reached command payloads unvalidated when no filters were in effect, and empty effective filters made *every* route "managed" so standby gateways deleted operator-created routes.

This branch guards the IPv4-only data plane at ingest, isolates per-item failures across the FRR/OVS reconcile paths, and replaces CIDR-membership ownership with explicit ownership markers (protocol-tagged kernel routes, veth-nexthop FRR statics).

## Change set (in commit order)

- **`57331a2` ovn: validate NAT external IPs unconditionally in refreshState** — `refreshState` only ran `net.ParseIP` on a NAT `external_ip` when a network filter was in effect, so with empty filters a malformed row landed in `SNATIPs`/`NATIPToRouterMAC` and reached the nft/FRR/kernel payloads. Now every external IP is validated at ingest and malformed rows are dropped; only the IPv4-only `SNATIPs` append is gated on `To4()`, so IPv6 SNAT addresses stay available for the dual-stack OVS hairpin plane but never enter the nft masquerade set. The same structure is applied to the SB gateway `NatAddresses` path (step 5b).

- **`2a7360d` agent: route and announce only IPv4 from the desired set** — Filters the desired route/announce fork (`hairpinIPs`) to IPv4 so IPv6 FIPs, SNAT IPs, and LRP gateway IPs no longer reach the IPv4-only kernel/FRR/BGP path where a v6 address fails the vtysh batch and blocks the takeover-readiness marker. The OVS hairpin plane keeps the v6 targets (#54). Also filters `computeEffectiveNetworks` to IPv4 networks, since `effectiveFilters` feeds IPv4-only planes.

- **`997c7c5` routing: enforce IPv4 in validateIP** — `validateIP` documented "valid IPv4" but accepted any `net.ParseIP` success. Now rejects `To4() == nil` as defense in depth behind the ingest guard.

- **`3ffbe26` routing: skip invalid IPs and failed chunks in AddFRRRoutes** — `AddFRRRoutes` rejected the whole batch on the first invalid IP and returned on the first failed vtysh chunk. Now partitions invalid entries out with a warning, runs every chunk, and joins their errors: an un-installable entry is dropped without blocking the batch, a failed chunk no longer aborts the rest, and a real command failure is still surfaced so `ensureRoutes` withholds the takeover marker.

- **`a5042f6` ovs: continue past per-flow failures in hairpin reconcile** — `ReconcileOVSHairpinFlows` deleted every cookie-0x998 flow up front, then returned on the first invalid IP or failed add-flow, leaving the hairpin plane permanently empty. Applies the `EnsureSegments` skip-and-log pattern: the up-front del-flows stays a hard precondition, but per-flow failures are logged and skipped.

- **`dd2d22d` routing: own kernel routes via protocol tag, FRR routes via nexthop** — Replaces CIDR-membership ownership (`isManaged`) with explicit markers: every agent-created kernel route is tagged with `Protocol: rtProtoOVNNetworkAgent`, `ListKernelRoutes`/`DelKernelRoute` operate only on tagged routes, and `ListFRRRoutes` is scoped to statics installed via the agent's veth nexthop. Operator-created routes and statics are now invisible to reconciliation on active and standby nodes alike.

- **`98301b2` agent: retire the empty-filters managed-route fallback** — `isManaged` returned true for every IP when `effectiveFilters` was empty, so a standby gateway treated every /32 on br-ex and every static in the VRF as its own and deleted them. With ownership now coming from the route listings themselves, the `isManaged` gates are dropped from `ensureRoutes`, `removeAllRoutes`, and `verifyRoutes`, and `isManaged` is deleted. `verifyRoutes` now re-adds desired IPs outside a narrow manual filter, consistent with `ensureRoutes`.

- **`3eb089f` test/integration: cover dual-stack announce and route ownership** — Adds `TestScenario_DualStackV4Guard` (issue tests a and b: a dual-stack router with a v4 FIP, a v6 FIP, and a malformed NAT row still announces the v4 FIP's routes and stamps the takeover marker, keeps the v6 hairpin flow, and never fails the FRR batch) and `TestScenario_OperatorRouteSurvivesStandbyReconcile` (issue test c: an operator /32 without the agent's protocol tag survives standby reconcile cycles). Updates the empty-filters scenario's contract comments for the protocol-tag ownership model.

- **`e94aea6` docs: describe route ownership tags and the IPv4-only guard** — Documents the kernel route protocol tag (proto 44) and FRR veth-nexthop ownership, that reconciliation touches only agent-owned routes, and that non-IPv4 addresses are excluded from the kernel/FRR/announce plane until #85/#70 land. Adds a one-time upgrade note for pre-tag leftovers.

## Notes for the reviewer

- The change set maps 1:1 to the issue's task list; all four weaknesses and all three required tests (a/b/c) are covered.
- The IPv4-only guard is intentionally scoped: the OVS hairpin plane still carries IPv6 targets (#54), and full IPv6 support remains tracked in #85/#70. This branch only guards the v4 plane until those land.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 01245b5 with Claude:claude-opus-4-8_
