### PR TITLE
config: fail fast on invalid values, warn on unknown keys, keep every config surface in sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,9 @@ install: build
 # Regenerate docs/reference/{configuration,cli,metrics}.md from the
 # canonical Go declarations in config.go and metrics.go. See
 # tools/docgen for the implementation. Run after touching either
-# file or the agent's flag/env/YAML surface.
+# file or the agent's flag/env/YAML surface. The generator also fails
+# if ovn-network-agent.default or ovn-network-agent.yaml.sample misses
+# an option the agent consumes.
 docs-gen:
 	go run ./tools/docgen
 

--- a/config.go
+++ b/config.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
+	"log/slog"
 	"net"
 	"os"
 	"strconv"
@@ -642,7 +645,27 @@ func readConfigFile(path string) (configFile, error) {
 	if err := yaml.Unmarshal(data, &fc); err != nil {
 		return configFile{}, err
 	}
+	warnUnknownConfigKeys(path, data)
 	return fc, nil
+}
+
+// warnUnknownConfigKeys re-decodes the config file with strict field
+// checking and logs a prominent warning naming any key that does not
+// map to a known configFile field. The lenient yaml.Unmarshal above has
+// already applied the recognised keys; a typo like "drain_on_shutdow"
+// would otherwise be dropped and the default applied silently — exactly
+// where a wrong effective value (drain/cleanup) turns a routine reboot
+// into an outage. Unknown keys are still accepted (never fail the load)
+// so newer config keys stay forward-compatible with an older agent.
+func warnUnknownConfigKeys(path string, data []byte) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	var probe configFile
+	// io.EOF is returned for an empty or comment-only file, which is not
+	// an unknown-key condition.
+	if err := dec.Decode(&probe); err != nil && !errors.Is(err, io.EOF) {
+		slog.Warn("config file contains unknown keys (ignored — check for typos)", "path", path, "error", err)
+	}
 }
 
 func applyFileConfig(cfg *Config, fc *configFile) error {

--- a/config.go
+++ b/config.go
@@ -797,16 +797,26 @@ func applyEnvConfig(cfg *Config) error {
 	if v := os.Getenv("OVN_NETWORK_LOG_LEVEL"); v != "" {
 		cfg.LogLevel = v
 	}
-	if v := os.Getenv("OVN_NETWORK_DRY_RUN"); v == "1" || v == "true" {
-		cfg.DryRun = true
+	if v := os.Getenv("OVN_NETWORK_DRY_RUN"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("invalid OVN_NETWORK_DRY_RUN %q: %w", v, err)
+		}
+		cfg.DryRun = b
 	}
-	if v := os.Getenv("OVN_NETWORK_CLEANUP_ON_SHUTDOWN"); v == "0" || v == "false" {
-		cfg.CleanupOnShutdown = false
+	if v := os.Getenv("OVN_NETWORK_CLEANUP_ON_SHUTDOWN"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("invalid OVN_NETWORK_CLEANUP_ON_SHUTDOWN %q: %w", v, err)
+		}
+		cfg.CleanupOnShutdown = b
 	}
-	if v := os.Getenv("OVN_NETWORK_DRAIN_ON_SHUTDOWN"); v == "0" || v == "false" {
-		cfg.DrainOnShutdown = false
-	} else if v == "1" || v == "true" {
-		cfg.DrainOnShutdown = true
+	if v := os.Getenv("OVN_NETWORK_DRAIN_ON_SHUTDOWN"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("invalid OVN_NETWORK_DRAIN_ON_SHUTDOWN %q: %w", v, err)
+		}
+		cfg.DrainOnShutdown = b
 	}
 	if v := os.Getenv("OVN_NETWORK_DRAIN_TIMEOUT"); v != "" {
 		d, err := time.ParseDuration(v)
@@ -835,8 +845,12 @@ func applyEnvConfig(cfg *Config) error {
 	if v := os.Getenv("OVN_NETWORK_METRICS_LISTEN"); v != "" {
 		cfg.MetricsListen = v
 	}
-	if v := os.Getenv("OVN_NETWORK_VETH_LEAK_ENABLED"); v == "0" || v == "false" {
-		cfg.VethLeakEnabled = false
+	if v := os.Getenv("OVN_NETWORK_VETH_LEAK_ENABLED"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("invalid OVN_NETWORK_VETH_LEAK_ENABLED %q: %w", v, err)
+		}
+		cfg.VethLeakEnabled = b
 	}
 	if v := os.Getenv("OVN_NETWORK_VETH_PROVIDER_IP"); v != "" {
 		cfg.VethProviderIP = v
@@ -865,8 +879,12 @@ func applyEnvConfig(cfg *Config) error {
 		}
 		cfg.PortForwardTableID = id
 	}
-	if v := os.Getenv("OVN_NETWORK_PORT_FORWARD_L3MDEV_ACCEPT"); v == "1" || v == "true" {
-		cfg.PortForwardL3mdevAccept = true
+	if v := os.Getenv("OVN_NETWORK_PORT_FORWARD_L3MDEV_ACCEPT"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("invalid OVN_NETWORK_PORT_FORWARD_L3MDEV_ACCEPT %q: %w", v, err)
+		}
+		cfg.PortForwardL3mdevAccept = b
 	}
 	if v := os.Getenv("OVN_NETWORK_PORT_FORWARD_CT_ZONE"); v != "" {
 		zone, err := strconv.Atoi(v)

--- a/config.go
+++ b/config.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log/slog"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -283,14 +283,22 @@ func loadConfig(args []string) (Config, error) {
 		if err != nil {
 			return Config{}, fmt.Errorf("load config %s: %w", *configPath, err)
 		}
-		applyFileConfig(&cfg, &fc)
+		if err := applyFileConfig(&cfg, &fc); err != nil {
+			return Config{}, fmt.Errorf("load config %s: %w", *configPath, err)
+		}
 	}
 
 	// Layer 2: environment variables
-	applyEnvConfig(&cfg)
+	if err := applyEnvConfig(&cfg); err != nil {
+		return Config{}, err
+	}
 
 	// Layer 3: CLI flags (only explicitly set ones)
+	var flagErr error
 	fs.Visit(func(f *flag.Flag) {
+		if flagErr != nil {
+			return
+		}
 		switch f.Name {
 		case "ovn-sb-remote":
 			cfg.OVNSBRemote = *fOVNSB
@@ -313,9 +321,12 @@ func loadConfig(args []string) (Config, error) {
 		case "ovs-wrapper":
 			cfg.OVSWrapper = *fOVSWrapper
 		case "reconcile-interval":
-			if d, err := time.ParseDuration(*fInterval); err == nil {
-				cfg.ReconcileInterval = d
+			d, err := time.ParseDuration(*fInterval)
+			if err != nil {
+				flagErr = fmt.Errorf("invalid -reconcile-interval %q: %w", *fInterval, err)
+				return
 			}
+			cfg.ReconcileInterval = d
 		case "log-level":
 			cfg.LogLevel = *fLogLevel
 		case "dry-run":
@@ -325,21 +336,28 @@ func loadConfig(args []string) (Config, error) {
 		case "drain-on-shutdown":
 			cfg.DrainOnShutdown = *fDrainOnShutdown
 		case "drain-timeout":
-			if d, err := time.ParseDuration(*fDrainTimeout); err == nil {
-				cfg.DrainTimeout = d
+			d, err := time.ParseDuration(*fDrainTimeout)
+			if err != nil {
+				flagErr = fmt.Errorf("invalid -drain-timeout %q: %w", *fDrainTimeout, err)
+				return
 			}
+			cfg.DrainTimeout = d
 		case "drain-settle-delay":
-			if d, err := time.ParseDuration(*fDrainSettleDelay); err == nil {
-				cfg.DrainSettleDelay = d
+			d, err := time.ParseDuration(*fDrainSettleDelay)
+			if err != nil {
+				flagErr = fmt.Errorf("invalid -drain-settle-delay %q: %w", *fDrainSettleDelay, err)
+				return
 			}
+			cfg.DrainSettleDelay = d
 		case "frr-prefix-list":
 			cfg.FRRPrefixList = *fFRRPrefixList
 		case "stale-chassis-grace-period":
-			if d, err := time.ParseDuration(*fStaleGrace); err == nil {
-				cfg.StaleChassisGracePeriod = d
-			} else {
-				slog.Warn("ignoring invalid stale-chassis-grace-period flag value", "value", *fStaleGrace, "error", err)
+			d, err := time.ParseDuration(*fStaleGrace)
+			if err != nil {
+				flagErr = fmt.Errorf("invalid -stale-chassis-grace-period %q: %w", *fStaleGrace, err)
+				return
 			}
+			cfg.StaleChassisGracePeriod = d
 		case "metrics-listen":
 			cfg.MetricsListen = *fMetricsListen
 		case "veth-leak-enabled":
@@ -360,6 +378,9 @@ func loadConfig(args []string) (Config, error) {
 			cfg.PortForwardCTZone = *fPortForwardCTZone
 		}
 	})
+	if flagErr != nil {
+		return Config{}, flagErr
+	}
 
 	// Validate configuration
 	if err := validateConfig(&cfg); err != nil {
@@ -624,7 +645,7 @@ func readConfigFile(path string) (configFile, error) {
 	return fc, nil
 }
 
-func applyFileConfig(cfg *Config, fc *configFile) {
+func applyFileConfig(cfg *Config, fc *configFile) error {
 	if fc.OVNSBRemote != "" {
 		cfg.OVNSBRemote = fc.OVNSBRemote
 	}
@@ -656,9 +677,11 @@ func applyFileConfig(cfg *Config, fc *configFile) {
 		cfg.RouteTableID = *fc.RouteTableID
 	}
 	if fc.ReconcileInterval != "" {
-		if d, err := time.ParseDuration(fc.ReconcileInterval); err == nil {
-			cfg.ReconcileInterval = d
+		d, err := time.ParseDuration(fc.ReconcileInterval)
+		if err != nil {
+			return fmt.Errorf("invalid reconcile_interval %q: %w", fc.ReconcileInterval, err)
 		}
+		cfg.ReconcileInterval = d
 	}
 	if fc.LogLevel != "" {
 		cfg.LogLevel = fc.LogLevel
@@ -673,28 +696,28 @@ func applyFileConfig(cfg *Config, fc *configFile) {
 		cfg.DrainOnShutdown = *fc.DrainOnShutdown
 	}
 	if fc.DrainTimeout != "" {
-		if d, err := time.ParseDuration(fc.DrainTimeout); err == nil {
-			cfg.DrainTimeout = d
-		} else {
-			slog.Warn("ignoring invalid drain_timeout in config file", "value", fc.DrainTimeout, "error", err)
+		d, err := time.ParseDuration(fc.DrainTimeout)
+		if err != nil {
+			return fmt.Errorf("invalid drain_timeout %q: %w", fc.DrainTimeout, err)
 		}
+		cfg.DrainTimeout = d
 	}
 	if fc.DrainSettleDelay != "" {
-		if d, err := time.ParseDuration(fc.DrainSettleDelay); err == nil {
-			cfg.DrainSettleDelay = d
-		} else {
-			slog.Warn("ignoring invalid drain_settle_delay in config file", "value", fc.DrainSettleDelay, "error", err)
+		d, err := time.ParseDuration(fc.DrainSettleDelay)
+		if err != nil {
+			return fmt.Errorf("invalid drain_settle_delay %q: %w", fc.DrainSettleDelay, err)
 		}
+		cfg.DrainSettleDelay = d
 	}
 	if fc.FRRPrefixList != "" {
 		cfg.FRRPrefixList = fc.FRRPrefixList
 	}
 	if fc.StaleChassisGracePeriod != "" {
-		if d, err := time.ParseDuration(fc.StaleChassisGracePeriod); err == nil {
-			cfg.StaleChassisGracePeriod = d
-		} else {
-			slog.Warn("ignoring invalid stale_chassis_grace_period in config file", "value", fc.StaleChassisGracePeriod, "error", err)
+		d, err := time.ParseDuration(fc.StaleChassisGracePeriod)
+		if err != nil {
+			return fmt.Errorf("invalid stale_chassis_grace_period %q: %w", fc.StaleChassisGracePeriod, err)
 		}
+		cfg.StaleChassisGracePeriod = d
 	}
 	if fc.MetricsListen != "" {
 		cfg.MetricsListen = fc.MetricsListen
@@ -726,9 +749,10 @@ func applyFileConfig(cfg *Config, fc *configFile) {
 	if len(fc.PortForwards) > 0 {
 		cfg.PortForwards = fc.PortForwards
 	}
+	return nil
 }
 
-func applyEnvConfig(cfg *Config) {
+func applyEnvConfig(cfg *Config) error {
 	if v := os.Getenv("OVN_NETWORK_OVN_SB_REMOTE"); v != "" {
 		cfg.OVNSBRemote = v
 	}
@@ -757,15 +781,18 @@ func applyEnvConfig(cfg *Config) {
 		cfg.OVSWrapper = v
 	}
 	if v := os.Getenv("OVN_NETWORK_ROUTE_TABLE_ID"); v != "" {
-		var id int
-		if _, err := fmt.Sscanf(v, "%d", &id); err == nil {
-			cfg.RouteTableID = id
+		id, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("invalid OVN_NETWORK_ROUTE_TABLE_ID %q: %w", v, err)
 		}
+		cfg.RouteTableID = id
 	}
 	if v := os.Getenv("OVN_NETWORK_RECONCILE_INTERVAL"); v != "" {
-		if d, err := time.ParseDuration(v); err == nil {
-			cfg.ReconcileInterval = d
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("invalid OVN_NETWORK_RECONCILE_INTERVAL %q: %w", v, err)
 		}
+		cfg.ReconcileInterval = d
 	}
 	if v := os.Getenv("OVN_NETWORK_LOG_LEVEL"); v != "" {
 		cfg.LogLevel = v
@@ -782,28 +809,28 @@ func applyEnvConfig(cfg *Config) {
 		cfg.DrainOnShutdown = true
 	}
 	if v := os.Getenv("OVN_NETWORK_DRAIN_TIMEOUT"); v != "" {
-		if d, err := time.ParseDuration(v); err == nil {
-			cfg.DrainTimeout = d
-		} else {
-			slog.Warn("ignoring invalid OVN_NETWORK_DRAIN_TIMEOUT env var", "value", v, "error", err)
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("invalid OVN_NETWORK_DRAIN_TIMEOUT %q: %w", v, err)
 		}
+		cfg.DrainTimeout = d
 	}
 	if v := os.Getenv("OVN_NETWORK_DRAIN_SETTLE_DELAY"); v != "" {
-		if d, err := time.ParseDuration(v); err == nil {
-			cfg.DrainSettleDelay = d
-		} else {
-			slog.Warn("ignoring invalid OVN_NETWORK_DRAIN_SETTLE_DELAY env var", "value", v, "error", err)
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("invalid OVN_NETWORK_DRAIN_SETTLE_DELAY %q: %w", v, err)
 		}
+		cfg.DrainSettleDelay = d
 	}
 	if v := os.Getenv("OVN_NETWORK_FRR_PREFIX_LIST"); v != "" {
 		cfg.FRRPrefixList = v
 	}
 	if v := os.Getenv("OVN_NETWORK_STALE_CHASSIS_GRACE_PERIOD"); v != "" {
-		if d, err := time.ParseDuration(v); err == nil {
-			cfg.StaleChassisGracePeriod = d
-		} else {
-			slog.Warn("ignoring invalid OVN_NETWORK_STALE_CHASSIS_GRACE_PERIOD env var", "value", v, "error", err)
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("invalid OVN_NETWORK_STALE_CHASSIS_GRACE_PERIOD %q: %w", v, err)
 		}
+		cfg.StaleChassisGracePeriod = d
 	}
 	if v := os.Getenv("OVN_NETWORK_METRICS_LISTEN"); v != "" {
 		cfg.MetricsListen = v
@@ -815,33 +842,38 @@ func applyEnvConfig(cfg *Config) {
 		cfg.VethProviderIP = v
 	}
 	if v := os.Getenv("OVN_NETWORK_VETH_LEAK_TABLE_ID"); v != "" {
-		var id int
-		if _, err := fmt.Sscanf(v, "%d", &id); err == nil {
-			cfg.VethLeakTableID = id
+		id, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("invalid OVN_NETWORK_VETH_LEAK_TABLE_ID %q: %w", v, err)
 		}
+		cfg.VethLeakTableID = id
 	}
 	if v := os.Getenv("OVN_NETWORK_VETH_LEAK_RULE_PRIORITY"); v != "" {
-		var prio int
-		if _, err := fmt.Sscanf(v, "%d", &prio); err == nil {
-			cfg.VethLeakRulePriority = prio
+		prio, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("invalid OVN_NETWORK_VETH_LEAK_RULE_PRIORITY %q: %w", v, err)
 		}
+		cfg.VethLeakRulePriority = prio
 	}
 	if v := os.Getenv("OVN_NETWORK_PORT_FORWARD_DEV"); v != "" {
 		cfg.PortForwardDev = v
 	}
 	if v := os.Getenv("OVN_NETWORK_PORT_FORWARD_TABLE_ID"); v != "" {
-		var id int
-		if _, err := fmt.Sscanf(v, "%d", &id); err == nil {
-			cfg.PortForwardTableID = id
+		id, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("invalid OVN_NETWORK_PORT_FORWARD_TABLE_ID %q: %w", v, err)
 		}
+		cfg.PortForwardTableID = id
 	}
 	if v := os.Getenv("OVN_NETWORK_PORT_FORWARD_L3MDEV_ACCEPT"); v == "1" || v == "true" {
 		cfg.PortForwardL3mdevAccept = true
 	}
 	if v := os.Getenv("OVN_NETWORK_PORT_FORWARD_CT_ZONE"); v != "" {
-		var zone int
-		if _, err := fmt.Sscanf(v, "%d", &zone); err == nil {
-			cfg.PortForwardCTZone = zone
+		zone, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("invalid OVN_NETWORK_PORT_FORWARD_CT_ZONE %q: %w", v, err)
 		}
+		cfg.PortForwardCTZone = zone
 	}
+	return nil
 }

--- a/config.go
+++ b/config.go
@@ -127,6 +127,12 @@ type Config struct {
 	ReconcileInterval time.Duration
 	LogLevel          string
 	DryRun            bool
+
+	// CheckConfig is CLI-only (--check-config): parse and validate the
+	// configuration, then exit without running the agent. It has no
+	// environment-variable or YAML binding.
+	CheckConfig bool
+
 	CleanupOnShutdown bool
 	DrainOnShutdown   bool
 	DrainTimeout      time.Duration
@@ -217,6 +223,7 @@ func loadConfig(args []string) (Config, error) {
 	var (
 		configPath         = fs.String("config", os.Getenv("OVN_NETWORK_CONFIG"), "Path to YAML config file")
 		showVersion        = fs.Bool("version", false, "Print version and exit")
+		fCheckConfig       = fs.Bool("check-config", false, "Validate configuration and exit (exit code 0 = valid, 1 = invalid)")
 		fOVNSB             = fs.String("ovn-sb-remote", "", "OVN Southbound DB remote, comma-separated for cluster")
 		fOVNNB             = fs.String("ovn-nb-remote", "", "OVN Northbound DB remote, comma-separated for cluster")
 		fBridge            = fs.String("bridge-dev", "", "Provider bridge device for kernel routes")
@@ -384,6 +391,10 @@ func loadConfig(args []string) (Config, error) {
 	if flagErr != nil {
 		return Config{}, flagErr
 	}
+
+	// --check-config is a CLI-only action flag (parse + validate + exit);
+	// it has no env/YAML binding, so it is read straight from the flag.
+	cfg.CheckConfig = *fCheckConfig
 
 	// Validate configuration
 	if err := validateConfig(&cfg); err != nil {

--- a/config.go
+++ b/config.go
@@ -448,6 +448,14 @@ func validateConfig(cfg *Config) error {
 		return fmt.Errorf("invalid frr-prefix-list: %q (only alphanumeric, hyphen, underscore, dot allowed)", cfg.FRRPrefixList)
 	}
 
+	// ReconcileInterval feeds time.NewTicker, which panics on a
+	// non-positive duration — reject it here so a bad value fails the
+	// config load instead of crashing the agent after it has already
+	// mutated system state.
+	if cfg.ReconcileInterval <= 0 {
+		return fmt.Errorf("invalid reconcile-interval: %v (must be positive)", cfg.ReconcileInterval)
+	}
+
 	if cfg.DrainTimeout < 0 {
 		return fmt.Errorf("invalid drain-timeout: must be non-negative")
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -95,6 +95,72 @@ func TestReadConfigFileInvalidYAML(t *testing.T) {
 	}
 }
 
+func TestLoadConfigWarnsOnUnknownFileKey(t *testing.T) {
+	t.Run("typo warns but is accepted", func(t *testing.T) {
+		buf := captureSlog(t)
+		// "drain_on_shutdow" is a typo of "drain_on_shutdown"; the
+		// unknown key must be flagged, and the default (true) applied.
+		content := `
+ovn_sb_remote: "tcp:10.0.0.1:6642"
+ovn_nb_remote: "tcp:10.0.0.1:6641"
+veth_leak_enabled: false
+drain_on_shutdow: false
+`
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("write test config: %v", err)
+		}
+
+		cfg, err := loadConfig([]string{"--config", path})
+		if err != nil {
+			t.Fatalf("loadConfig() error: %v", err)
+		}
+		if !cfg.DrainOnShutdown {
+			t.Error("DrainOnShutdown should keep its default (true) when the key is a typo")
+		}
+		if !strings.Contains(buf.String(), "drain_on_shutdow") {
+			t.Errorf("expected a warning naming drain_on_shutdow, got: %q", buf.String())
+		}
+	})
+
+	t.Run("valid file produces no unknown-key warning", func(t *testing.T) {
+		buf := captureSlog(t)
+		content := `
+ovn_sb_remote: "tcp:10.0.0.1:6642"
+ovn_nb_remote: "tcp:10.0.0.1:6641"
+veth_leak_enabled: false
+drain_on_shutdown: false
+`
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("write test config: %v", err)
+		}
+		if _, err := loadConfig([]string{"--config", path}); err != nil {
+			t.Fatalf("loadConfig() error: %v", err)
+		}
+		if strings.Contains(buf.String(), "unknown keys") {
+			t.Errorf("unexpected unknown-key warning for a valid file: %q", buf.String())
+		}
+	})
+
+	t.Run("comment-only file produces no unknown-key warning", func(t *testing.T) {
+		buf := captureSlog(t)
+		// Only comments and blank lines: the strict probe decode returns
+		// io.EOF, which must not be mistaken for an unknown key.
+		content := "# just a comment\n\n"
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("write test config: %v", err)
+		}
+		if _, err := readConfigFile(path); err != nil {
+			t.Fatalf("readConfigFile() error: %v", err)
+		}
+		if strings.Contains(buf.String(), "unknown keys") {
+			t.Errorf("unexpected unknown-key warning for a comment-only file: %q", buf.String())
+		}
+	})
+}
+
 func TestReadConfigFileNetworkCIDRList(t *testing.T) {
 	content := `
 ovn_sb_remote: "tcp:10.0.0.1:6642"

--- a/config_test.go
+++ b/config_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -171,7 +172,9 @@ func TestStringOrSliceUnmarshalRejectsMappingInput(t *testing.T) {
 func TestApplyEnvConfigMultipleCIDRs(t *testing.T) {
 	cfg := Config{}
 	t.Setenv("OVN_NETWORK_NETWORK_CIDR", "10.0.0.0/24,172.16.0.0/12")
-	applyEnvConfig(&cfg)
+	if err := applyEnvConfig(&cfg); err != nil {
+		t.Fatalf("applyEnvConfig: %v", err)
+	}
 
 	if len(cfg.NetworkCIDRs) != 2 {
 		t.Fatalf("NetworkCIDRs length = %d, want 2", len(cfg.NetworkCIDRs))
@@ -197,7 +200,9 @@ func TestApplyFileConfig(t *testing.T) {
 		ReconcileInterval: "30s",
 	}
 
-	applyFileConfig(&cfg, &fc)
+	if err := applyFileConfig(&cfg, &fc); err != nil {
+		t.Fatalf("applyFileConfig: %v", err)
+	}
 
 	if cfg.OVNSBRemote != "tcp:10.0.0.1:6642" {
 		t.Errorf("OVNSBRemote = %q, want %q", cfg.OVNSBRemote, "tcp:10.0.0.1:6642")
@@ -231,7 +236,9 @@ func TestApplyFileConfigEmptyFieldsNoOverride(t *testing.T) {
 
 	fc := configFile{} // All empty.
 
-	applyFileConfig(&cfg, &fc)
+	if err := applyFileConfig(&cfg, &fc); err != nil {
+		t.Fatalf("applyFileConfig: %v", err)
+	}
 
 	if cfg.BridgeDev != "br-ex" {
 		t.Errorf("BridgeDev = %q, want %q (should not be overridden)", cfg.BridgeDev, "br-ex")
@@ -253,7 +260,9 @@ func TestApplyEnvConfig(t *testing.T) {
 	t.Setenv("OVN_NETWORK_NETWORK_CIDR", "10.0.0.0/24")
 	t.Setenv("OVN_NETWORK_GATEWAY_PORT", "cr-lrp-test")
 
-	applyEnvConfig(&cfg)
+	if err := applyEnvConfig(&cfg); err != nil {
+		t.Fatalf("applyEnvConfig: %v", err)
+	}
 
 	if cfg.OVNSBRemote != "tcp:10.0.0.99:6642" {
 		t.Errorf("OVNSBRemote = %q, want %q", cfg.OVNSBRemote, "tcp:10.0.0.99:6642")
@@ -277,16 +286,101 @@ func TestApplyEnvConfig(t *testing.T) {
 }
 
 func TestApplyEnvConfigInvalidDuration(t *testing.T) {
-	cfg := Config{
-		ReconcileInterval: 60 * time.Second,
+	cases := []struct {
+		env string
+	}{
+		{"OVN_NETWORK_RECONCILE_INTERVAL"},
+		{"OVN_NETWORK_DRAIN_TIMEOUT"},
+		{"OVN_NETWORK_DRAIN_SETTLE_DELAY"},
+		{"OVN_NETWORK_STALE_CHASSIS_GRACE_PERIOD"},
 	}
+	for _, tc := range cases {
+		t.Run(tc.env, func(t *testing.T) {
+			cfg := Config{}
+			t.Setenv(tc.env, "notaduration")
 
-	t.Setenv("OVN_NETWORK_RECONCILE_INTERVAL", "notaduration")
+			err := applyEnvConfig(&cfg)
+			if err == nil {
+				t.Fatalf("expected error for %s=notaduration", tc.env)
+			}
+			if !strings.Contains(err.Error(), tc.env) {
+				t.Errorf("error %q does not name %s", err, tc.env)
+			}
+		})
+	}
+}
 
-	applyEnvConfig(&cfg)
+func TestApplyEnvConfigInvalidInt(t *testing.T) {
+	cases := []struct {
+		env string
+	}{
+		{"OVN_NETWORK_ROUTE_TABLE_ID"},
+		{"OVN_NETWORK_VETH_LEAK_TABLE_ID"},
+		{"OVN_NETWORK_VETH_LEAK_RULE_PRIORITY"},
+		{"OVN_NETWORK_PORT_FORWARD_TABLE_ID"},
+		{"OVN_NETWORK_PORT_FORWARD_CT_ZONE"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.env, func(t *testing.T) {
+			cfg := Config{}
+			t.Setenv(tc.env, "notanumber")
 
-	if cfg.ReconcileInterval != 60*time.Second {
-		t.Errorf("ReconcileInterval = %v, want %v (should not be overridden by invalid value)", cfg.ReconcileInterval, 60*time.Second)
+			err := applyEnvConfig(&cfg)
+			if err == nil {
+				t.Fatalf("expected error for %s=notanumber", tc.env)
+			}
+			if !strings.Contains(err.Error(), tc.env) {
+				t.Errorf("error %q does not name %s", err, tc.env)
+			}
+		})
+	}
+}
+
+func TestApplyFileConfigInvalidDurations(t *testing.T) {
+	cases := []struct {
+		name string
+		fc   configFile
+		key  string
+	}{
+		{"reconcile_interval", configFile{ReconcileInterval: "notaduration"}, "reconcile_interval"},
+		{"drain_timeout", configFile{DrainTimeout: "notaduration"}, "drain_timeout"},
+		{"drain_settle_delay", configFile{DrainSettleDelay: "notaduration"}, "drain_settle_delay"},
+		{"stale_chassis_grace_period", configFile{StaleChassisGracePeriod: "notaduration"}, "stale_chassis_grace_period"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{}
+			err := applyFileConfig(&cfg, &tc.fc)
+			if err == nil {
+				t.Fatalf("expected error for invalid %s", tc.key)
+			}
+			if !strings.Contains(err.Error(), tc.key) {
+				t.Errorf("error %q does not name %s", err, tc.key)
+			}
+		})
+	}
+}
+
+func TestLoadConfigInvalidDurationFlags(t *testing.T) {
+	cases := []struct {
+		flag string
+	}{
+		{"--reconcile-interval"},
+		{"--drain-timeout"},
+		{"--drain-settle-delay"},
+		{"--stale-chassis-grace-period"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.flag, func(t *testing.T) {
+			_, err := loadConfig(fullModeArgs(tc.flag, "notaduration"))
+			if err == nil {
+				t.Fatalf("expected error for %s notaduration", tc.flag)
+			}
+			name := strings.TrimLeft(tc.flag, "-")
+			if !strings.Contains(err.Error(), name) {
+				t.Errorf("error %q does not name %s", err, name)
+			}
+		})
 	}
 }
 
@@ -397,7 +491,9 @@ func TestLoadConfigDryRunDefault(t *testing.T) {
 func TestApplyEnvConfigDryRun(t *testing.T) {
 	cfg := Config{}
 	t.Setenv("OVN_NETWORK_DRY_RUN", "true")
-	applyEnvConfig(&cfg)
+	if err := applyEnvConfig(&cfg); err != nil {
+		t.Fatalf("applyEnvConfig: %v", err)
+	}
 	if !cfg.DryRun {
 		t.Error("DryRun should be true when OVN_NETWORK_DRY_RUN=true")
 	}
@@ -407,7 +503,9 @@ func TestApplyFileConfigDryRun(t *testing.T) {
 	cfg := Config{}
 	dryRun := true
 	fc := configFile{DryRun: &dryRun}
-	applyFileConfig(&cfg, &fc)
+	if err := applyFileConfig(&cfg, &fc); err != nil {
+		t.Fatalf("applyFileConfig: %v", err)
+	}
 	if !cfg.DryRun {
 		t.Error("DryRun should be true when set in config file")
 	}
@@ -436,7 +534,9 @@ func TestLoadConfigCleanupOnShutdownDisabledViaCLI(t *testing.T) {
 func TestApplyEnvConfigCleanupOnShutdownFalse(t *testing.T) {
 	cfg := Config{CleanupOnShutdown: true}
 	t.Setenv("OVN_NETWORK_CLEANUP_ON_SHUTDOWN", "false")
-	applyEnvConfig(&cfg)
+	if err := applyEnvConfig(&cfg); err != nil {
+		t.Fatalf("applyEnvConfig: %v", err)
+	}
 	if cfg.CleanupOnShutdown {
 		t.Error("CleanupOnShutdown should be false when OVN_NETWORK_CLEANUP_ON_SHUTDOWN=false")
 	}
@@ -445,7 +545,9 @@ func TestApplyEnvConfigCleanupOnShutdownFalse(t *testing.T) {
 func TestApplyEnvConfigDrainOnShutdownFalse(t *testing.T) {
 	cfg := Config{DrainOnShutdown: true}
 	t.Setenv("OVN_NETWORK_DRAIN_ON_SHUTDOWN", "false")
-	applyEnvConfig(&cfg)
+	if err := applyEnvConfig(&cfg); err != nil {
+		t.Fatalf("applyEnvConfig: %v", err)
+	}
 	if cfg.DrainOnShutdown {
 		t.Error("DrainOnShutdown should be false when OVN_NETWORK_DRAIN_ON_SHUTDOWN=false")
 	}
@@ -454,7 +556,9 @@ func TestApplyEnvConfigDrainOnShutdownFalse(t *testing.T) {
 func TestApplyEnvConfigDrainOnShutdownTrue(t *testing.T) {
 	cfg := Config{DrainOnShutdown: false}
 	t.Setenv("OVN_NETWORK_DRAIN_ON_SHUTDOWN", "true")
-	applyEnvConfig(&cfg)
+	if err := applyEnvConfig(&cfg); err != nil {
+		t.Fatalf("applyEnvConfig: %v", err)
+	}
 	if !cfg.DrainOnShutdown {
 		t.Error("DrainOnShutdown should be true when OVN_NETWORK_DRAIN_ON_SHUTDOWN=true")
 	}
@@ -463,7 +567,9 @@ func TestApplyEnvConfigDrainOnShutdownTrue(t *testing.T) {
 func TestApplyEnvConfigDrainOnShutdownOne(t *testing.T) {
 	cfg := Config{DrainOnShutdown: false}
 	t.Setenv("OVN_NETWORK_DRAIN_ON_SHUTDOWN", "1")
-	applyEnvConfig(&cfg)
+	if err := applyEnvConfig(&cfg); err != nil {
+		t.Fatalf("applyEnvConfig: %v", err)
+	}
 	if !cfg.DrainOnShutdown {
 		t.Error("DrainOnShutdown should be true when OVN_NETWORK_DRAIN_ON_SHUTDOWN=1")
 	}
@@ -472,7 +578,9 @@ func TestApplyEnvConfigDrainOnShutdownOne(t *testing.T) {
 func TestApplyEnvConfigCleanupOnShutdownZero(t *testing.T) {
 	cfg := Config{CleanupOnShutdown: true}
 	t.Setenv("OVN_NETWORK_CLEANUP_ON_SHUTDOWN", "0")
-	applyEnvConfig(&cfg)
+	if err := applyEnvConfig(&cfg); err != nil {
+		t.Fatalf("applyEnvConfig: %v", err)
+	}
 	if cfg.CleanupOnShutdown {
 		t.Error("CleanupOnShutdown should be false when OVN_NETWORK_CLEANUP_ON_SHUTDOWN=0")
 	}
@@ -482,7 +590,9 @@ func TestApplyFileConfigCleanupOnShutdown(t *testing.T) {
 	cfg := Config{CleanupOnShutdown: true}
 	cleanup := false
 	fc := configFile{CleanupOnShutdown: &cleanup}
-	applyFileConfig(&cfg, &fc)
+	if err := applyFileConfig(&cfg, &fc); err != nil {
+		t.Fatalf("applyFileConfig: %v", err)
+	}
 	if cfg.CleanupOnShutdown {
 		t.Error("CleanupOnShutdown should be false when set to false in config file")
 	}
@@ -491,7 +601,9 @@ func TestApplyFileConfigCleanupOnShutdown(t *testing.T) {
 func TestApplyFileConfigCleanupOnShutdownNil(t *testing.T) {
 	cfg := Config{CleanupOnShutdown: true}
 	fc := configFile{} // CleanupOnShutdown is nil
-	applyFileConfig(&cfg, &fc)
+	if err := applyFileConfig(&cfg, &fc); err != nil {
+		t.Fatalf("applyFileConfig: %v", err)
+	}
 	if !cfg.CleanupOnShutdown {
 		t.Error("CleanupOnShutdown should remain true when not set in config file")
 	}
@@ -714,7 +826,9 @@ func TestLoadConfigRouteTableIDInvalid(t *testing.T) {
 func TestApplyEnvConfigRouteTableID(t *testing.T) {
 	cfg := Config{}
 	t.Setenv("OVN_NETWORK_ROUTE_TABLE_ID", "42")
-	applyEnvConfig(&cfg)
+	if err := applyEnvConfig(&cfg); err != nil {
+		t.Fatalf("applyEnvConfig: %v", err)
+	}
 
 	if cfg.RouteTableID != 42 {
 		t.Errorf("RouteTableID = %d, want 42", cfg.RouteTableID)
@@ -846,7 +960,9 @@ func TestApplyEnvConfigVethLeak(t *testing.T) {
 	t.Setenv("OVN_NETWORK_VETH_PROVIDER_IP", "169.254.0.5")
 	t.Setenv("OVN_NETWORK_VETH_LEAK_TABLE_ID", "201")
 	t.Setenv("OVN_NETWORK_VETH_LEAK_RULE_PRIORITY", "3000")
-	applyEnvConfig(&cfg)
+	if err := applyEnvConfig(&cfg); err != nil {
+		t.Fatalf("applyEnvConfig: %v", err)
+	}
 
 	if cfg.VethLeakEnabled {
 		t.Error("VethLeakEnabled should be false")
@@ -873,7 +989,9 @@ func TestApplyFileConfigVethLeak(t *testing.T) {
 		VethLeakTableID:      &tableID,
 		VethLeakRulePriority: &prio,
 	}
-	applyFileConfig(&cfg, &fc)
+	if err := applyFileConfig(&cfg, &fc); err != nil {
+		t.Fatalf("applyFileConfig: %v", err)
+	}
 
 	if cfg.VethLeakEnabled {
 		t.Error("VethLeakEnabled should be false")
@@ -972,7 +1090,9 @@ func TestLoadConfigStaleChassisGracePeriodDisabled(t *testing.T) {
 func TestApplyEnvConfigStaleChassisGracePeriod(t *testing.T) {
 	cfg := Config{StaleChassisGracePeriod: 5 * time.Minute}
 	t.Setenv("OVN_NETWORK_STALE_CHASSIS_GRACE_PERIOD", "3m")
-	applyEnvConfig(&cfg)
+	if err := applyEnvConfig(&cfg); err != nil {
+		t.Fatalf("applyEnvConfig: %v", err)
+	}
 	if cfg.StaleChassisGracePeriod != 3*time.Minute {
 		t.Errorf("StaleChassisGracePeriod = %v, want %v", cfg.StaleChassisGracePeriod, 3*time.Minute)
 	}
@@ -981,7 +1101,9 @@ func TestApplyEnvConfigStaleChassisGracePeriod(t *testing.T) {
 func TestApplyFileConfigStaleChassisGracePeriod(t *testing.T) {
 	cfg := Config{StaleChassisGracePeriod: 5 * time.Minute}
 	fc := configFile{StaleChassisGracePeriod: "2m"}
-	applyFileConfig(&cfg, &fc)
+	if err := applyFileConfig(&cfg, &fc); err != nil {
+		t.Fatalf("applyFileConfig: %v", err)
+	}
 	if cfg.StaleChassisGracePeriod != 2*time.Minute {
 		t.Errorf("StaleChassisGracePeriod = %v, want %v", cfg.StaleChassisGracePeriod, 2*time.Minute)
 	}
@@ -990,7 +1112,9 @@ func TestApplyFileConfigStaleChassisGracePeriod(t *testing.T) {
 func TestApplyFileConfigStaleChassisGracePeriodEmpty(t *testing.T) {
 	cfg := Config{StaleChassisGracePeriod: 5 * time.Minute}
 	fc := configFile{}
-	applyFileConfig(&cfg, &fc)
+	if err := applyFileConfig(&cfg, &fc); err != nil {
+		t.Fatalf("applyFileConfig: %v", err)
+	}
 	if cfg.StaleChassisGracePeriod != 5*time.Minute {
 		t.Errorf("StaleChassisGracePeriod = %v, want %v (should keep default)", cfg.StaleChassisGracePeriod, 5*time.Minute)
 	}
@@ -1063,7 +1187,9 @@ func TestLoadConfigDrainSettleDelayDisabled(t *testing.T) {
 func TestApplyEnvConfigDrainSettleDelay(t *testing.T) {
 	cfg := Config{DrainSettleDelay: 3 * time.Second}
 	t.Setenv("OVN_NETWORK_DRAIN_SETTLE_DELAY", "5s")
-	applyEnvConfig(&cfg)
+	if err := applyEnvConfig(&cfg); err != nil {
+		t.Fatalf("applyEnvConfig: %v", err)
+	}
 	if cfg.DrainSettleDelay != 5*time.Second {
 		t.Errorf("DrainSettleDelay = %v, want %v", cfg.DrainSettleDelay, 5*time.Second)
 	}
@@ -1072,7 +1198,9 @@ func TestApplyEnvConfigDrainSettleDelay(t *testing.T) {
 func TestApplyFileConfigDrainSettleDelay(t *testing.T) {
 	cfg := Config{DrainSettleDelay: 3 * time.Second}
 	fc := configFile{DrainSettleDelay: "10s"}
-	applyFileConfig(&cfg, &fc)
+	if err := applyFileConfig(&cfg, &fc); err != nil {
+		t.Fatalf("applyFileConfig: %v", err)
+	}
 	if cfg.DrainSettleDelay != 10*time.Second {
 		t.Errorf("DrainSettleDelay = %v, want %v", cfg.DrainSettleDelay, 10*time.Second)
 	}
@@ -1081,7 +1209,9 @@ func TestApplyFileConfigDrainSettleDelay(t *testing.T) {
 func TestApplyFileConfigDrainSettleDelayEmpty(t *testing.T) {
 	cfg := Config{DrainSettleDelay: 3 * time.Second}
 	fc := configFile{}
-	applyFileConfig(&cfg, &fc)
+	if err := applyFileConfig(&cfg, &fc); err != nil {
+		t.Fatalf("applyFileConfig: %v", err)
+	}
 	if cfg.DrainSettleDelay != 3*time.Second {
 		t.Errorf("DrainSettleDelay = %v, want %v (should keep default)", cfg.DrainSettleDelay, 3*time.Second)
 	}
@@ -1124,7 +1254,9 @@ func TestValidateConfigDrainSettleDelayNegative(t *testing.T) {
 func TestApplyEnvConfigFRRPrefixList(t *testing.T) {
 	cfg := Config{}
 	t.Setenv("OVN_NETWORK_FRR_PREFIX_LIST", "MY-LIST")
-	applyEnvConfig(&cfg)
+	if err := applyEnvConfig(&cfg); err != nil {
+		t.Fatalf("applyEnvConfig: %v", err)
+	}
 	if cfg.FRRPrefixList != "MY-LIST" {
 		t.Errorf("FRRPrefixList = %q, want %q", cfg.FRRPrefixList, "MY-LIST")
 	}
@@ -1133,7 +1265,9 @@ func TestApplyEnvConfigFRRPrefixList(t *testing.T) {
 func TestApplyFileConfigFRRPrefixList(t *testing.T) {
 	cfg := Config{}
 	fc := configFile{FRRPrefixList: "FILE-LIST"}
-	applyFileConfig(&cfg, &fc)
+	if err := applyFileConfig(&cfg, &fc); err != nil {
+		t.Fatalf("applyFileConfig: %v", err)
+	}
 	if cfg.FRRPrefixList != "FILE-LIST" {
 		t.Errorf("FRRPrefixList = %q, want %q", cfg.FRRPrefixList, "FILE-LIST")
 	}
@@ -1390,7 +1524,9 @@ func TestApplyEnvConfigPortForward(t *testing.T) {
 	t.Setenv("OVN_NETWORK_PORT_FORWARD_DEV", "loopback1")
 	t.Setenv("OVN_NETWORK_PORT_FORWARD_TABLE_ID", "202")
 
-	applyEnvConfig(&cfg)
+	if err := applyEnvConfig(&cfg); err != nil {
+		t.Fatalf("applyEnvConfig: %v", err)
+	}
 
 	if cfg.PortForwardDev != "loopback1" {
 		t.Errorf("PortForwardDev = %q, want %q", cfg.PortForwardDev, "loopback1")
@@ -1433,7 +1569,9 @@ func TestApplyFileConfigPortForward(t *testing.T) {
 		},
 	}
 
-	applyFileConfig(&cfg, &fc)
+	if err := applyFileConfig(&cfg, &fc); err != nil {
+		t.Fatalf("applyFileConfig: %v", err)
+	}
 
 	if cfg.PortForwardDev != "loopback1" {
 		t.Errorf("PortForwardDev = %q, want %q", cfg.PortForwardDev, "loopback1")
@@ -1453,7 +1591,9 @@ func TestApplyFileConfigPortForwardEmpty(t *testing.T) {
 	}
 	fc := configFile{} // no port forward fields set
 
-	applyFileConfig(&cfg, &fc)
+	if err := applyFileConfig(&cfg, &fc); err != nil {
+		t.Fatalf("applyFileConfig: %v", err)
+	}
 
 	if cfg.PortForwardDev != "loopback1" {
 		t.Errorf("PortForwardDev should remain %q, got %q", "loopback1", cfg.PortForwardDev)
@@ -1715,7 +1855,9 @@ func TestLoadConfigMetricsListenViaCLI(t *testing.T) {
 func TestApplyEnvConfigMetricsListen(t *testing.T) {
 	cfg := Config{}
 	t.Setenv("OVN_NETWORK_METRICS_LISTEN", "0.0.0.0:9273")
-	applyEnvConfig(&cfg)
+	if err := applyEnvConfig(&cfg); err != nil {
+		t.Fatalf("applyEnvConfig: %v", err)
+	}
 	if cfg.MetricsListen != "0.0.0.0:9273" {
 		t.Errorf("MetricsListen = %q, want %q", cfg.MetricsListen, "0.0.0.0:9273")
 	}
@@ -1725,7 +1867,9 @@ func TestApplyFileConfigMetricsListen(t *testing.T) {
 	cfg := Config{}
 	listen := "127.0.0.1:9273"
 	fc := configFile{MetricsListen: listen}
-	applyFileConfig(&cfg, &fc)
+	if err := applyFileConfig(&cfg, &fc); err != nil {
+		t.Fatalf("applyFileConfig: %v", err)
+	}
 	if cfg.MetricsListen != listen {
 		t.Errorf("MetricsListen = %q, want %q", cfg.MetricsListen, listen)
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -554,6 +554,28 @@ func TestLoadConfigDryRunDefault(t *testing.T) {
 	}
 }
 
+func TestLoadConfigCheckConfigFlag(t *testing.T) {
+	t.Run("set", func(t *testing.T) {
+		cfg, err := loadConfig(fullModeArgs("--check-config"))
+		if err != nil {
+			t.Fatalf("loadConfig() error: %v", err)
+		}
+		if !cfg.CheckConfig {
+			t.Error("CheckConfig should be true when --check-config is set")
+		}
+	})
+
+	t.Run("default", func(t *testing.T) {
+		cfg, err := loadConfig(fullModeArgs())
+		if err != nil {
+			t.Fatalf("loadConfig() error: %v", err)
+		}
+		if cfg.CheckConfig {
+			t.Error("CheckConfig should be false by default")
+		}
+	})
+}
+
 func TestApplyEnvConfigDryRun(t *testing.T) {
 	cfg := Config{}
 	t.Setenv("OVN_NETWORK_DRY_RUN", "true")

--- a/config_test.go
+++ b/config_test.go
@@ -582,62 +582,72 @@ func TestValidateConfig(t *testing.T) {
 	}{
 		{
 			"valid defaults",
-			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider"},
+			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", ReconcileInterval: 60 * time.Second},
 			false,
 		},
 		{
 			"valid with single CIDR",
-			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", NetworkCIDRs: []string{"10.0.0.0/24"}},
+			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", ReconcileInterval: 60 * time.Second, NetworkCIDRs: []string{"10.0.0.0/24"}},
 			false,
 		},
 		{
 			"valid with multiple CIDRs",
-			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", NetworkCIDRs: []string{"10.0.0.0/24", "172.16.0.0/12"}},
+			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", ReconcileInterval: 60 * time.Second, NetworkCIDRs: []string{"10.0.0.0/24", "172.16.0.0/12"}},
 			false,
 		},
 		{
 			"invalid nexthop",
-			Config{VethNexthop: "bad", VRFName: "vrf-provider"},
+			Config{VethNexthop: "bad", VRFName: "vrf-provider", ReconcileInterval: 60 * time.Second},
 			true,
 		},
 		{
 			"invalid VRF name",
-			Config{VethNexthop: "169.254.0.1", VRFName: "bad name"},
+			Config{VethNexthop: "169.254.0.1", VRFName: "bad name", ReconcileInterval: 60 * time.Second},
 			true,
 		},
 		{
 			"invalid CIDR",
-			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", NetworkCIDRs: []string{"bad"}},
+			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", ReconcileInterval: 60 * time.Second, NetworkCIDRs: []string{"bad"}},
 			true,
 		},
 		{
 			"one valid one invalid CIDR",
-			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", NetworkCIDRs: []string{"10.0.0.0/24", "bad"}},
+			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", ReconcileInterval: 60 * time.Second, NetworkCIDRs: []string{"10.0.0.0/24", "bad"}},
 			true,
 		},
 		{
 			"valid route table ID",
-			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", RouteTableID: 100},
+			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", ReconcileInterval: 60 * time.Second, RouteTableID: 100},
 			false,
 		},
 		{
 			"route table ID zero (main table)",
-			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", RouteTableID: 0},
+			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", ReconcileInterval: 60 * time.Second, RouteTableID: 0},
 			false,
 		},
 		{
 			"route table ID max",
-			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", RouteTableID: 252},
+			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", ReconcileInterval: 60 * time.Second, RouteTableID: 252},
 			false,
 		},
 		{
 			"route table ID too high",
-			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", RouteTableID: 253},
+			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", ReconcileInterval: 60 * time.Second, RouteTableID: 253},
 			true,
 		},
 		{
 			"route table ID negative",
-			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", RouteTableID: -1},
+			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", ReconcileInterval: 60 * time.Second, RouteTableID: -1},
+			true,
+		},
+		{
+			"reconcile interval zero",
+			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", ReconcileInterval: 0},
+			true,
+		},
+		{
+			"reconcile interval negative",
+			Config{VethNexthop: "169.254.0.1", VRFName: "vrf-provider", ReconcileInterval: -1 * time.Second},
 			true,
 		},
 	}
@@ -650,6 +660,38 @@ func TestValidateConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLoadConfigRejectsNonPositiveReconcileInterval(t *testing.T) {
+	t.Run("flag zero", func(t *testing.T) {
+		_, err := loadConfig(fullModeArgs("--reconcile-interval", "0s"))
+		if err == nil {
+			t.Fatal("expected error for --reconcile-interval 0s")
+		}
+	})
+
+	t.Run("flag negative", func(t *testing.T) {
+		_, err := loadConfig(fullModeArgs("--reconcile-interval", "-5s"))
+		if err == nil {
+			t.Fatal("expected error for --reconcile-interval -5s")
+		}
+	})
+
+	t.Run("file zero", func(t *testing.T) {
+		content := `
+ovn_sb_remote: "tcp:10.0.0.1:6642"
+ovn_nb_remote: "tcp:10.0.0.1:6641"
+veth_leak_enabled: false
+reconcile_interval: "0s"
+`
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("write test config: %v", err)
+		}
+		if _, err := loadConfig([]string{"--config", path}); err == nil {
+			t.Fatal("expected error for reconcile_interval 0s in config file")
+		}
+	})
 }
 
 func TestLoadConfigRouteTableIDCLI(t *testing.T) {
@@ -979,6 +1021,7 @@ func TestValidateConfigStaleChassisGracePeriodNegative(t *testing.T) {
 	cfg := Config{
 		VethNexthop:             "169.254.0.1",
 		VRFName:                 "vrf-provider",
+		ReconcileInterval:       60 * time.Second,
 		StaleChassisGracePeriod: -1 * time.Minute,
 	}
 	err := validateConfig(&cfg)
@@ -1067,9 +1110,10 @@ drain_settle_delay: "4s"
 
 func TestValidateConfigDrainSettleDelayNegative(t *testing.T) {
 	cfg := Config{
-		VethNexthop:      "169.254.0.1",
-		VRFName:          "vrf-provider",
-		DrainSettleDelay: -1 * time.Second,
+		VethNexthop:       "169.254.0.1",
+		VRFName:           "vrf-provider",
+		ReconcileInterval: 60 * time.Second,
+		DrainSettleDelay:  -1 * time.Second,
 	}
 	err := validateConfig(&cfg)
 	if err == nil {
@@ -1154,6 +1198,7 @@ func TestPortForwardValidation(t *testing.T) {
 	base := func() Config {
 		return Config{
 			VethNexthop:        "169.254.0.1",
+			ReconcileInterval:  60 * time.Second,
 			VethLeakEnabled:    true,
 			VethLeakTableID:    200,
 			PortForwardDev:     "loopback1",
@@ -1486,6 +1531,7 @@ func TestPortForwardMultiBackendValidation(t *testing.T) {
 	base := func() Config {
 		return Config{
 			VethNexthop:        "169.254.0.1",
+			ReconcileInterval:  60 * time.Second,
 			VethLeakEnabled:    true,
 			VethLeakTableID:    200,
 			PortForwardDev:     "loopback1",
@@ -1609,9 +1655,10 @@ port_forwards:
 // VethProviderIP) trips this test instead of silently changing the contract.
 func TestVethProviderIPAutoComputeWrapsAt255_255_255_255(t *testing.T) {
 	cfg := Config{
-		VethNexthop:     "255.255.255.255",
-		VethLeakEnabled: true,
-		VethLeakTableID: 200,
+		VethNexthop:       "255.255.255.255",
+		ReconcileInterval: 60 * time.Second,
+		VethLeakEnabled:   true,
+		VethLeakTableID:   200,
 		// VethProviderIP intentionally unset — triggers auto-compute.
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -586,6 +586,78 @@ func TestApplyEnvConfigCleanupOnShutdownZero(t *testing.T) {
 	}
 }
 
+// TestApplyEnvConfigBooleansBothDirections locks in the unified boolean
+// env semantics: every boolean env var is honoured in both directions,
+// including the directions that were previously dead (e.g.
+// CLEANUP_ON_SHUTDOWN was false-only, DRY_RUN was true-only). Each case
+// starts from the opposite of the value being set so the change is
+// observable.
+func TestApplyEnvConfigBooleansBothDirections(t *testing.T) {
+	cases := []struct {
+		env   string
+		value string
+		start Config
+		want  bool
+		get   func(Config) bool
+	}{
+		// DRY_RUN was true-only: prove the disable direction now applies.
+		{"OVN_NETWORK_DRY_RUN", "false", Config{DryRun: true}, false, func(c Config) bool { return c.DryRun }},
+		{"OVN_NETWORK_DRY_RUN", "0", Config{DryRun: true}, false, func(c Config) bool { return c.DryRun }},
+		{"OVN_NETWORK_DRY_RUN", "true", Config{DryRun: false}, true, func(c Config) bool { return c.DryRun }},
+		// CLEANUP_ON_SHUTDOWN was false-only: prove the re-enable direction
+		// now overrides a file-level false, per the documented priority.
+		{"OVN_NETWORK_CLEANUP_ON_SHUTDOWN", "true", Config{CleanupOnShutdown: false}, true, func(c Config) bool { return c.CleanupOnShutdown }},
+		{"OVN_NETWORK_CLEANUP_ON_SHUTDOWN", "false", Config{CleanupOnShutdown: true}, false, func(c Config) bool { return c.CleanupOnShutdown }},
+		// DRAIN_ON_SHUTDOWN was already bidirectional; keep it covered.
+		{"OVN_NETWORK_DRAIN_ON_SHUTDOWN", "false", Config{DrainOnShutdown: true}, false, func(c Config) bool { return c.DrainOnShutdown }},
+		{"OVN_NETWORK_DRAIN_ON_SHUTDOWN", "true", Config{DrainOnShutdown: false}, true, func(c Config) bool { return c.DrainOnShutdown }},
+		// VETH_LEAK_ENABLED was false-only: prove the re-enable direction.
+		{"OVN_NETWORK_VETH_LEAK_ENABLED", "true", Config{VethLeakEnabled: false}, true, func(c Config) bool { return c.VethLeakEnabled }},
+		{"OVN_NETWORK_VETH_LEAK_ENABLED", "false", Config{VethLeakEnabled: true}, false, func(c Config) bool { return c.VethLeakEnabled }},
+		// PORT_FORWARD_L3MDEV_ACCEPT was true-only: prove the disable direction.
+		{"OVN_NETWORK_PORT_FORWARD_L3MDEV_ACCEPT", "false", Config{PortForwardL3mdevAccept: true}, false, func(c Config) bool { return c.PortForwardL3mdevAccept }},
+		{"OVN_NETWORK_PORT_FORWARD_L3MDEV_ACCEPT", "true", Config{PortForwardL3mdevAccept: false}, true, func(c Config) bool { return c.PortForwardL3mdevAccept }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.env+"="+tc.value, func(t *testing.T) {
+			cfg := tc.start
+			t.Setenv(tc.env, tc.value)
+			if err := applyEnvConfig(&cfg); err != nil {
+				t.Fatalf("applyEnvConfig: %v", err)
+			}
+			if got := tc.get(cfg); got != tc.want {
+				t.Errorf("%s=%s: field = %v, want %v", tc.env, tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestApplyEnvConfigInvalidBool(t *testing.T) {
+	cases := []struct {
+		env string
+	}{
+		{"OVN_NETWORK_DRY_RUN"},
+		{"OVN_NETWORK_CLEANUP_ON_SHUTDOWN"},
+		{"OVN_NETWORK_DRAIN_ON_SHUTDOWN"},
+		{"OVN_NETWORK_VETH_LEAK_ENABLED"},
+		{"OVN_NETWORK_PORT_FORWARD_L3MDEV_ACCEPT"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.env, func(t *testing.T) {
+			cfg := Config{}
+			t.Setenv(tc.env, "yes")
+
+			err := applyEnvConfig(&cfg)
+			if err == nil {
+				t.Fatalf("expected error for %s=yes", tc.env)
+			}
+			if !strings.Contains(err.Error(), tc.env) {
+				t.Errorf("error %q does not name %s", err, tc.env)
+			}
+		})
+	}
+}
+
 func TestApplyFileConfigCleanupOnShutdown(t *testing.T) {
 	cfg := Config{CleanupOnShutdown: true}
 	cleanup := false

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -113,6 +113,38 @@ Switching modes at runtime is not supported — it requires a restart.
   DNAT).
 - **Permissions**: root or `CAP_NET_ADMIN` for netlink route manipulation.
 
+## Validate a configuration
+
+Use `--check-config` to parse and validate the full configuration and exit,
+without connecting to OVN or touching system state. This is the pre-restart
+gate for upgrade automation: run it before restarting a live gateway node so
+a bad config is caught before it can disrupt the agent.
+
+```bash
+ovn-network-agent --check-config --config /etc/ovn-network-agent/config.yaml
+```
+
+The exit code is the contract:
+
+- `0` — the configuration is valid; the command prints `configuration OK`.
+- `1` — the configuration is invalid; the command logs a `configuration
+  error` naming the offending setting.
+
+`--check-config` applies the same layering (CLI flags, environment variables,
+config file) and the same validation the agent runs at startup, so it
+exercises the exact configuration the agent would load.
+
+The agent fails fast on bad input rather than starting with a surprising
+effective value:
+
+- An unparsable or out-of-range value — an unparsable duration or integer, or
+  a non-positive `reconcile_interval` — is a startup error naming the setting,
+  on the flag, environment-variable, and config-file paths alike.
+- An unknown config-file key (for example a typo like `drain_on_shutdow`) is
+  logged as a warning naming the key and then ignored — the key is accepted so
+  a newer config stays forward-compatible with an older agent, but the typo is
+  no longer silent.
+
 ## Where to go next
 
 - [Configuration reference](../reference/configuration) — every setting in one

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -14,6 +14,7 @@ regenerate it with `go generate ./...`.
 |------|---------|-------------|
 | `--config` |  | Path to YAML config file |
 | `--version` | `false` | Print version and exit |
+| `--check-config` | `false` | Validate configuration and exit (exit code 0 = valid, 1 = invalid) |
 | `--ovn-sb-remote` |  | OVN Southbound DB remote, comma-separated for cluster |
 | `--ovn-nb-remote` |  | OVN Northbound DB remote, comma-separated for cluster |
 | `--bridge-dev` | `br-ex` | Provider bridge device for kernel routes |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -20,6 +20,7 @@ regenerate this page with `go generate ./...`.
 |------|---------|------------|---------|-------------|
 | `--config` | `OVN_NETWORK_CONFIG` | — |  | Path to YAML config file |
 | `--version` | — | — | `false` | Print version and exit |
+| `--check-config` | — | — | `false` | Validate configuration and exit (exit code 0 = valid, 1 = invalid) |
 | `--ovn-sb-remote` | `OVN_NETWORK_OVN_SB_REMOTE` | `ovn_sb_remote` |  | OVN Southbound DB remote, comma-separated for cluster |
 | `--ovn-nb-remote` | `OVN_NETWORK_OVN_NB_REMOTE` | `ovn_nb_remote` |  | OVN Northbound DB remote, comma-separated for cluster |
 | `--bridge-dev` | `OVN_NETWORK_BRIDGE_DEV` | `bridge_dev` | `br-ex` | Provider bridge device for kernel routes |

--- a/main.go
+++ b/main.go
@@ -28,6 +28,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	// --check-config: the configuration parsed and validated above; report
+	// success and exit without running the agent. Invalid configs already
+	// exited 1 via the error path above.
+	if cfg.CheckConfig {
+		fmt.Println("configuration OK")
+		return
+	}
+
 	setupLogging(cfg.LogLevel)
 
 	// The OVN-vs-port-forward-only decision is made in config validation

--- a/ovn-network-agent.default
+++ b/ovn-network-agent.default
@@ -56,7 +56,7 @@ OVN_NETWORK_OVN_NB_REMOTE=tcp:10.10.0.1:6641,tcp:10.10.0.2:6641,tcp:10.10.0.3:66
 #OVN_NETWORK_LOG_LEVEL=info
 
 # Dry-run mode: connect and reconcile but only log what would be done.
-# Accepts "1" / "true" to enable.
+# Accepts "1"/"true" to enable, "0"/"false" to disable.
 #OVN_NETWORK_DRY_RUN=false
 
 # Remove all managed routes on shutdown (default: true)
@@ -126,5 +126,5 @@ OVN_NETWORK_OVN_NB_REMOTE=tcp:10.10.0.1:6641,tcp:10.10.0.2:6641,tcp:10.10.0.3:66
 # Enable udp/tcp_l3mdev_accept sysctl. Required when a DNAT backend runs on
 # the same host but in a different VRF than the VIP. This is a global sysctl
 # that affects ALL sockets — only enable when needed.
-# Accepts "1" / "true" to enable.
+# Accepts "1"/"true" to enable, "0"/"false" to disable.
 #OVN_NETWORK_PORT_FORWARD_L3MDEV_ACCEPT=false

--- a/ovn-network-agent.default
+++ b/ovn-network-agent.default
@@ -5,7 +5,8 @@
 #
 # This file lists every env var consumed by the agent (see applyEnvConfig in
 # config.go). All values shown after "=" are the built-in defaults; uncomment
-# only the lines you need to override.
+# only the lines you need to override. CI (tools/docgen) fails the build if
+# this file misses an env var the agent consumes, so the list stays complete.
 
 # Path to a YAML config file. Equivalent to passing --config on the CLI.
 # Settings in this file are overridden by env vars below (and CLI flags).
@@ -75,6 +76,10 @@ OVN_NETWORK_OVN_NB_REMOTE=tcp:10.10.0.1:6641,tcp:10.10.0.2:6641,tcp:10.10.0.3:66
 # Maximum time to wait for gateway drain (Go duration format).
 # After this timeout, shutdown proceeds even if some gateways have not migrated.
 #OVN_NETWORK_DRAIN_TIMEOUT=60s
+
+# Safety margin held after the takeover chassis signals readiness, before
+# cleanup withdraws the FIP routes (Go duration format). Set to "0" to disable.
+#OVN_NETWORK_DRAIN_SETTLE_DELAY=500ms
 
 # FRR prefix-list to manage dynamically. The agent adds/removes
 # "permit <network> ge 32 le 32" entries for each discovered provider network.

--- a/ovn-network-agent.yaml.sample
+++ b/ovn-network-agent.yaml.sample
@@ -120,10 +120,8 @@ ovn_nb_remote: "tcp:10.10.0.1:6641,tcp:10.10.0.2:6641,tcp:10.10.0.3:6641"
 # When set to a host:port, the agent serves Prometheus-formatted metrics on
 # /metrics (and a basic /healthz). Bind to 127.0.0.1 for node-local scraping
 # only; use 0.0.0.0 to expose to remote scrapers.
-# Exposed metrics include: reconcile_total, reconcile_duration_seconds,
-# desired_ips, route_readds_total, consecutive_readds, ovn_connection_state,
-# drain_duration_seconds, drain_total, stale_chassis_cleanup_total,
-# missing_chassis (all prefixed with ovn_network_agent_).
+# The full metric list is generated into the metrics reference:
+# https://osism.github.io/ovn-network-agent/reference/metrics
 # metrics_listen: "127.0.0.1:9273"
 
 # Veth VRF route leaking (replaces contrib/veth-vrf-leak.sh)

--- a/tools/docgen/main.go
+++ b/tools/docgen/main.go
@@ -56,4 +56,11 @@ func main() {
 		}
 		fmt.Printf("wrote %s\n", path)
 	}
+
+	// The shipped operator-facing config surfaces (ovn-network-agent.default,
+	// ovn-network-agent.yaml.sample) must cover every option, the same way
+	// docs/reference/ must — fail the generator if either has drifted.
+	if err := checkSamples(*root, info); err != nil {
+		log.Fatalf("sample config check: %v", err)
+	}
 }

--- a/tools/docgen/parse_test.go
+++ b/tools/docgen/parse_test.go
@@ -25,6 +25,7 @@ const configFixture = `package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"time"
 )
@@ -64,16 +65,23 @@ func loadConfig(args []string) (Config, error) {
 		BridgeDev:         "br-ex",
 		ReconcileInterval: 60 * time.Second,
 	}
+	var flagErr error
 	fs.Visit(func(f *flag.Flag) {
+		if flagErr != nil {
+			return
+		}
 		switch f.Name {
 		case "bridge-dev":
 			cfg.BridgeDev = *fBridge
 		case "route-table-id":
 			cfg.RouteTableID = *fTableID
 		case "reconcile-interval":
-			if d, err := time.ParseDuration(*fInterval); err == nil {
-				cfg.ReconcileInterval = d
+			d, err := time.ParseDuration(*fInterval)
+			if err != nil {
+				flagErr = fmt.Errorf("invalid -reconcile-interval %q: %w", *fInterval, err)
+				return
 			}
+			cfg.ReconcileInterval = d
 		case "dry-run":
 			cfg.DryRun = *fDryRun
 		case "ovn-sb-remote":
@@ -83,7 +91,7 @@ func loadConfig(args []string) (Config, error) {
 	return cfg, nil
 }
 
-func applyFileConfig(cfg *Config, fc *configFile) {
+func applyFileConfig(cfg *Config, fc *configFile) error {
 	if fc.BridgeDev != "" {
 		cfg.BridgeDev = fc.BridgeDev
 	}
@@ -91,9 +99,11 @@ func applyFileConfig(cfg *Config, fc *configFile) {
 		cfg.RouteTableID = *fc.RouteTableID
 	}
 	if fc.ReconcileInterval != "" {
-		if d, err := time.ParseDuration(fc.ReconcileInterval); err == nil {
-			cfg.ReconcileInterval = d
+		d, err := time.ParseDuration(fc.ReconcileInterval)
+		if err != nil {
+			return fmt.Errorf("invalid reconcile_interval %q: %w", fc.ReconcileInterval, err)
 		}
+		cfg.ReconcileInterval = d
 	}
 	if fc.DryRun != nil {
 		cfg.DryRun = *fc.DryRun
@@ -101,9 +111,10 @@ func applyFileConfig(cfg *Config, fc *configFile) {
 	if fc.OVNSBRemote != "" {
 		cfg.OVNSBRemote = fc.OVNSBRemote
 	}
+	return nil
 }
 
-func applyEnvConfig(cfg *Config) {
+func applyEnvConfig(cfg *Config) error {
 	if v := os.Getenv("OVN_NETWORK_BRIDGE_DEV"); v != "" {
 		cfg.BridgeDev = v
 	}
@@ -111,10 +122,13 @@ func applyEnvConfig(cfg *Config) {
 		cfg.OVNSBRemote = v
 	}
 	if v := os.Getenv("OVN_NETWORK_RECONCILE_INTERVAL"); v != "" {
-		if d, err := time.ParseDuration(v); err == nil {
-			cfg.ReconcileInterval = d
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("invalid OVN_NETWORK_RECONCILE_INTERVAL %q: %w", v, err)
 		}
+		cfg.ReconcileInterval = d
 	}
+	return nil
 }
 `
 

--- a/tools/docgen/samples.go
+++ b/tools/docgen/samples.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// checkSamples verifies that the two operator-facing config surfaces
+// that ship in the .deb — ovn-network-agent.default (env vars) and
+// ovn-network-agent.yaml.sample (YAML keys) — cover every option the
+// agent actually consumes. It gives those files the same anti-drift
+// guarantee docs/reference/ already has via the docs-gen CI job: the
+// generator (go run ./tools/docgen) fails when either file misses an
+// option, so a new flag/env/YAML key cannot land without the sample
+// being updated too.
+func checkSamples(root string, info *sourceInfo) error {
+	defaultPath := filepath.Join(root, "ovn-network-agent.default")
+	samplePath := filepath.Join(root, "ovn-network-agent.yaml.sample")
+
+	defaultData, err := os.ReadFile(defaultPath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", defaultPath, err)
+	}
+	sampleData, err := os.ReadFile(samplePath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", samplePath, err)
+	}
+
+	var problems []string
+	if missing := missingEnvVars(string(defaultData), requiredEnvVars(info)); len(missing) > 0 {
+		problems = append(problems, fmt.Sprintf("%s is missing env vars: %s", defaultPath, strings.Join(missing, ", ")))
+	}
+	if missing := missingYAMLKeys(string(sampleData), requiredYAMLKeys(info)); len(missing) > 0 {
+		problems = append(problems, fmt.Sprintf("%s is missing YAML keys: %s", samplePath, strings.Join(missing, ", ")))
+	}
+	if len(problems) > 0 {
+		return errors.New(strings.Join(problems, "\n"))
+	}
+	return nil
+}
+
+// requiredEnvVars is the sorted set of environment variables the agent
+// reads: every var bound in applyEnvConfig plus any implicit env var
+// used as a flag default (e.g. --config defaults to
+// os.Getenv("OVN_NETWORK_CONFIG")).
+func requiredEnvVars(info *sourceInfo) []string {
+	set := map[string]bool{}
+	for _, v := range info.EnvByField {
+		set[v] = true
+	}
+	for _, fl := range info.Flags {
+		if fl.ImplicitEnv != "" {
+			set[fl.ImplicitEnv] = true
+		}
+	}
+	return sortedKeys(set)
+}
+
+// requiredYAMLKeys is the sorted set of YAML keys the agent accepts,
+// gathered by walking configFile and following every struct-typed field
+// so nested structures (currently PortForwardVIP → PortForwardRule) stay
+// covered as they are added. A hardcoded list of struct names would
+// silently under-cover a newly-added nested struct — the exact drift
+// this tool exists to prevent.
+func requiredYAMLKeys(info *sourceInfo) []string {
+	set := map[string]bool{}
+	seen := map[string]bool{}
+	var visit func(name string)
+	visit = func(name string) {
+		if seen[name] {
+			return
+		}
+		seen[name] = true
+		st := info.Structs[name]
+		if st == nil {
+			return
+		}
+		for _, f := range st.Fields {
+			if f.YAMLTag != "" {
+				set[f.YAMLTag] = true
+			}
+			visit(baseTypeName(f.Type))
+		}
+	}
+	visit("configFile")
+	return sortedKeys(set)
+}
+
+// baseTypeName strips pointer, slice, array, and map wrappers from a
+// field's source type text to reach the underlying named type (e.g.
+// "[]PortForwardVIP" and "*PortForwardRule" both resolve to their bare
+// struct name). Scalars like "string" are returned unchanged; callers
+// look the result up in info.Structs, where non-struct names simply miss.
+func baseTypeName(typ string) string {
+	typ = strings.TrimPrefix(typ, "*")
+	if i := strings.LastIndex(typ, "]"); i >= 0 {
+		typ = typ[i+1:]
+	}
+	return strings.TrimPrefix(typ, "*")
+}
+
+// missingEnvVars returns the vars that do not appear in content as an
+// assignment line. A line counts whether or not it is commented out
+// (the sample ships every override commented), so `#VAR=default` and
+// `VAR=value` both satisfy VAR. The trailing `=` prevents a prefix like
+// OVN_NETWORK_DRAIN_TIMEOUT from satisfying OVN_NETWORK_DRAIN_SETTLE_DELAY.
+func missingEnvVars(content string, vars []string) []string {
+	var missing []string
+	for _, v := range vars {
+		re := regexp.MustCompile(`(?m)^\s*#?\s*` + regexp.QuoteMeta(v) + `=`)
+		if !re.MatchString(content) {
+			missing = append(missing, v)
+		}
+	}
+	return missing
+}
+
+// missingYAMLKeys returns the keys that do not appear in content as a
+// mapping key. A key counts whether it is commented, indented, or
+// list-item-prefixed (`#   - vip:`). The `\s*:` anchor keeps dest_addr
+// from being satisfied by a dest_addrs: line.
+func missingYAMLKeys(content string, keys []string) []string {
+	var missing []string
+	for _, k := range keys {
+		re := regexp.MustCompile(`(?m)^\s*#?\s*(?:- )?` + regexp.QuoteMeta(k) + `\s*:`)
+		if !re.MatchString(content) {
+			missing = append(missing, k)
+		}
+	}
+	return missing
+}
+
+func sortedKeys(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/tools/docgen/samples_test.go
+++ b/tools/docgen/samples_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMissingEnvVars(t *testing.T) {
+	// BRIDGE_DEV is present but commented; OVN_SB_REMOTE is present and
+	// uncommented; METRICS_LISTEN is absent entirely.
+	content := "#OVN_NETWORK_BRIDGE_DEV=br-ex\nOVN_NETWORK_OVN_SB_REMOTE=tcp:10.0.0.1:6642\n"
+	vars := []string{
+		"OVN_NETWORK_BRIDGE_DEV",
+		"OVN_NETWORK_OVN_SB_REMOTE",
+		"OVN_NETWORK_METRICS_LISTEN",
+	}
+	got := missingEnvVars(content, vars)
+	if len(got) != 1 || got[0] != "OVN_NETWORK_METRICS_LISTEN" {
+		t.Errorf("missingEnvVars = %v, want [OVN_NETWORK_METRICS_LISTEN]", got)
+	}
+}
+
+func TestMissingEnvVarsPrefixIsNotAMatch(t *testing.T) {
+	// A shorter var name must not be satisfied by a longer one that shares
+	// its prefix — the trailing "=" anchor guards against that.
+	content := "#OVN_NETWORK_DRAIN_TIMEOUT=60s\n"
+	got := missingEnvVars(content, []string{"OVN_NETWORK_DRAIN"})
+	if len(got) != 1 || got[0] != "OVN_NETWORK_DRAIN" {
+		t.Errorf("missingEnvVars = %v, want [OVN_NETWORK_DRAIN] (prefix must not match)", got)
+	}
+}
+
+func TestMissingYAMLKeys(t *testing.T) {
+	// bridge_dev commented, network_cidr uncommented, vip/manage_vip as
+	// commented list items, dest_addrs as a deeply-indented commented key.
+	// dest_addr is absent and must NOT be satisfied by dest_addrs.
+	content := `
+# bridge_dev: "br-ex"
+network_cidr:
+  - "10.0.0.0/24"
+#   - vip: "198.51.100.10"
+#     manage_vip: true
+#         dest_addrs:
+`
+	keys := []string{"bridge_dev", "network_cidr", "vip", "manage_vip", "dest_addrs", "dest_addr"}
+	got := missingYAMLKeys(content, keys)
+	if len(got) != 1 || got[0] != "dest_addr" {
+		t.Errorf("missingYAMLKeys = %v, want [dest_addr] (dest_addrs must not satisfy dest_addr)", got)
+	}
+}
+
+func TestRequiredEnvVarsIncludesImplicitEnv(t *testing.T) {
+	info := &sourceInfo{
+		EnvByField: map[string]string{
+			"BridgeDev":   "OVN_NETWORK_BRIDGE_DEV",
+			"OVNSBRemote": "OVN_NETWORK_OVN_SB_REMOTE",
+		},
+		Flags: []flagInfo{
+			{Name: "config", ImplicitEnv: "OVN_NETWORK_CONFIG"},
+		},
+	}
+	got := requiredEnvVars(info)
+	want := []string{
+		"OVN_NETWORK_BRIDGE_DEV",
+		"OVN_NETWORK_CONFIG",
+		"OVN_NETWORK_OVN_SB_REMOTE",
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("requiredEnvVars = %v, want %v", got, want)
+	}
+}
+
+func TestRequiredYAMLKeysFollowsNestedStructFields(t *testing.T) {
+	// configFile reaches PortForwardVIP through a struct-typed field,
+	// which reaches PortForwardRule, which reaches a further nested
+	// struct. requiredYAMLKeys must discover every key by following those
+	// fields rather than a hardcoded list of struct names — otherwise a
+	// newly-added nested struct (here PortForwardHealthCheck, reachable
+	// only via PortForwardRule) is silently dropped from the required set.
+	info := &sourceInfo{
+		Structs: map[string]*structInfo{
+			"configFile": {Name: "configFile", Fields: []structField{
+				{Name: "BridgeDev", Type: "string", YAMLTag: "bridge_dev"},
+				{Name: "PortForwards", Type: "[]PortForwardVIP", YAMLTag: "port_forwards"},
+			}},
+			"PortForwardVIP": {Name: "PortForwardVIP", Fields: []structField{
+				{Name: "VIP", Type: "string", YAMLTag: "vip"},
+				{Name: "ManageVIP", Type: "bool", YAMLTag: "manage_vip"},
+				{Name: "Rules", Type: "[]PortForwardRule", YAMLTag: "rules"},
+			}},
+			"PortForwardRule": {Name: "PortForwardRule", Fields: []structField{
+				{Name: "Proto", Type: "string", YAMLTag: "proto"},
+				{Name: "DestAddr", Type: "string", YAMLTag: "dest_addr"},
+				{Name: "HealthCheck", Type: "*PortForwardHealthCheck", YAMLTag: "health_check"},
+			}},
+			"PortForwardHealthCheck": {Name: "PortForwardHealthCheck", Fields: []structField{
+				{Name: "Path", Type: "string", YAMLTag: "path"},
+			}},
+		},
+	}
+	got := requiredYAMLKeys(info)
+	for _, want := range []string{"bridge_dev", "port_forwards", "vip", "manage_vip", "rules", "proto", "dest_addr", "health_check", "path"} {
+		if !containsString(got, want) {
+			t.Errorf("requiredYAMLKeys = %v, missing %q", got, want)
+		}
+	}
+}
+
+func TestCheckSamples(t *testing.T) {
+	info := &sourceInfo{
+		EnvByField: map[string]string{"BridgeDev": "OVN_NETWORK_BRIDGE_DEV"},
+		Flags:      []flagInfo{{Name: "config", ImplicitEnv: "OVN_NETWORK_CONFIG"}},
+		Structs: map[string]*structInfo{
+			"configFile": {Name: "configFile", Fields: []structField{
+				{Name: "BridgeDev", YAMLTag: "bridge_dev"},
+			}},
+		},
+	}
+
+	writeSamples := func(t *testing.T, def, sample string) string {
+		t.Helper()
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "ovn-network-agent.default"), []byte(def), 0o644); err != nil {
+			t.Fatalf("write default: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "ovn-network-agent.yaml.sample"), []byte(sample), 0o644); err != nil {
+			t.Fatalf("write sample: %v", err)
+		}
+		return root
+	}
+
+	t.Run("complete files pass", func(t *testing.T) {
+		root := writeSamples(t,
+			"#OVN_NETWORK_CONFIG=/etc/x\n#OVN_NETWORK_BRIDGE_DEV=br-ex\n",
+			"# bridge_dev: \"br-ex\"\n",
+		)
+		if err := checkSamples(root, info); err != nil {
+			t.Errorf("checkSamples() = %v, want nil", err)
+		}
+	})
+
+	t.Run("missing env var fails naming file and var", func(t *testing.T) {
+		root := writeSamples(t,
+			"#OVN_NETWORK_CONFIG=/etc/x\n", // BRIDGE_DEV omitted
+			"# bridge_dev: \"br-ex\"\n",
+		)
+		err := checkSamples(root, info)
+		if err == nil {
+			t.Fatal("checkSamples() = nil, want error for missing env var")
+		}
+		if !strings.Contains(err.Error(), "ovn-network-agent.default") || !strings.Contains(err.Error(), "OVN_NETWORK_BRIDGE_DEV") {
+			t.Errorf("error %q does not name the file and the missing var", err)
+		}
+	})
+
+	t.Run("missing YAML key fails naming file and key", func(t *testing.T) {
+		root := writeSamples(t,
+			"#OVN_NETWORK_CONFIG=/etc/x\n#OVN_NETWORK_BRIDGE_DEV=br-ex\n",
+			"# nothing useful here\n", // bridge_dev omitted
+		)
+		err := checkSamples(root, info)
+		if err == nil {
+			t.Fatal("checkSamples() = nil, want error for missing YAML key")
+		}
+		if !strings.Contains(err.Error(), "ovn-network-agent.yaml.sample") || !strings.Contains(err.Error(), "bridge_dev") {
+			t.Errorf("error %q does not name the file and the missing key", err)
+		}
+	})
+}


### PR DESCRIPTION
Closes #159

## Summary

The config loader was lenient to the point of hiding operator mistakes — an unparsable or out-of-range value could silently fall back to a default, a typo'd YAML key was dropped, and a boolean env var could only be honored in one direction. Two config surfaces that ship in the `.deb` (`ovn-network-agent.default`, `ovn-network-agent.yaml.sample`) had also drifted because only `docs/reference/` was covered by the docgen sync gate.

This branch makes invalid config a **hard, named startup error** (fail fast before any system state is mutated), **warns on unknown YAML keys** while staying forward-compatible, and **locks every shipped config surface** under the same docgen/CI drift check that `docs/reference/` already had. It also adds a `--check-config` action flag for pre-restart validation.

## Change set (in commit order)

1. **`a45a21d` config: reject non-positive reconcile-interval** — A `reconcile_interval` of `0s` or negative passed `validateConfig` and reached `time.NewTicker` (agent.go), which panics on a non-positive duration — *after* the agent had already mutated system state (bridge IP, veth pair, nftables, OVN connection). `validateConfig` now rejects it up front. The other durations were audited and are already bounded (drain-timeout / drain-settle-delay reject negatives; stale-chassis-grace-period `0` is a valid "disabled").

2. **`c91e77f` config: fail fast on unparsable duration and integer values** — Previously an unparsable value was silently ignored on some paths, warned-but-ignored on others, and integer env vars accepted trailing junk via `fmt.Sscanf` — so behaviour differed between the flag, env, and file paths. Now `applyFileConfig` / `applyEnvConfig` return an error, the `fs.Visit` closure captures the first flag parse error, `loadConfig` propagates it (file errors stay wrapped as `load config <path>`), and integer env vars parse with `strconv.Atoi`. The parse shapes preserve the `(fc-field, cfg-field)` and getenv-init pairings that `tools/docgen` relies on.

3. **`a1ad478` config: honor both directions for every boolean env var** — `OVN_NETWORK_DRY_RUN` and `OVN_NETWORK_PORT_FORWARD_L3MDEV_ACCEPT` were honored true-only, while `OVN_NETWORK_CLEANUP_ON_SHUTDOWN` and `OVN_NETWORK_VETH_LEAK_ENABLED` were honored false-only — so an env var could never override a config-file value in the "dead" direction, violating the documented `CLI > env > file > defaults` priority. All five booleans now parse with `strconv.ParseBool` (both directions, error on garbage). Behaviour note: on a node that relied on the previously dead direction, the env var now takes effect — this is the intended, documented priority.

4. **`cd79ef4` config: warn on unknown config file keys** — `yaml.Unmarshal` without `KnownFields` silently dropped any key it did not recognise, so a typo like `drain_on_shutdow: false` was discarded and the default applied — precisely for the drain/cleanup options where a wrong effective value turns a routine reboot into an outage. After the lenient decode, the bytes are re-decoded with a strict `yaml.Decoder` (`KnownFields(true)`) into a throwaway struct, and each unknown key is logged with a prominent warning (name + line). Unknown keys are still accepted, so a newer config stays forward-compatible with an older agent; an empty/comment-only file (`io.EOF`) is not treated as an unknown key.

5. **`0cfd934` config: add --check-config for pre-restart validation** — A CLI-only `--check-config` action flag runs the full parse + validate path and exits: exit 0 / `configuration OK` when valid, exit 1 / `configuration error` naming the offending setting when not. It has no env/YAML binding. Documents the flag and the fail-fast / warn-on-unknown-keys contract in the configuration guide, and regenerates the CLI and configuration reference tables.

6. **`a5995c6` config: sync shipped env file and sample with the code** — `ovn-network-agent.default` claimed to list every env var but omitted `OVN_NETWORK_DRAIN_SETTLE_DELAY` (now added). `ovn-network-agent.yaml.sample` hand-enumerated 10 of 15 metrics; the stale list is replaced with a link to the generated metrics reference so it can no longer fall behind `metrics.go`.

7. **`b06c112` docgen: fail when shipped samples miss a config option** — Extends `tools/docgen` with `checkSamples`: it derives the required env vars (`applyEnvConfig` bindings plus implicit `os.Getenv` flag defaults) and YAML keys (`configFile` plus the nested port-forward structs) from the same AST the reference docs come from, then fails the generator naming any option a shipped file misses. Matchers accept commented / indented / list-item entries and anchor tightly (e.g. `dest_addr` is not satisfied by `dest_addrs`, nor one env var by a longer one sharing its prefix). Because the `docs-gen` CI job already runs `go run ./tools/docgen`, no workflow change is needed.

## Notes for the reviewer

- **Fail-fast over warn-only.** Issue #159 phrased the invalid-value task as "every unparsable value warns (or fails)". This branch chose **fails** — a named hard startup error — consistent with the issue's own "fail fast" title and acceptance criterion that a bad value "always produces a visible warning naming the key" before the agent touches system state.
- **Boolean asymmetries found differed from the issue example.** The issue illustrated the asymmetry with `CLEANUP_ON_SHUTDOWN` vs `DRAIN_ON_SHUTDOWN`; the actual one-directional vars in the code were `DRY_RUN` / `PORT_FORWARD_L3MDEV_ACCEPT` (true-only) and `CLEANUP_ON_SHUTDOWN` / `VETH_LEAK_ENABLED` (false-only). All five booleans are now symmetric, satisfying the intent.

Every acceptance-criterion item and task checkbox in #159 is covered by the commits above.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 01245b5 with Claude:claude-opus-4-8_
