### PR TITLE
Make E2E lab bring-up failures diagnosable and retry transient daemon starts

### DIFF
--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -117,6 +117,19 @@ containers, which is what containerlab requires.
 waits for OVN NB to become reachable from the host, then provisions
 the lab in three layers, described below.
 
+Bring-up gates on three readiness waits: OVN NB reachability, SB
+chassis registration for every gateway, and the upstream `bgpd`. The
+`bgpd` start — the one daemon bootstrap starts itself — is retried up
+to `BGPD_START_ATTEMPTS` (default `3`) times, each attempt waiting
+`BGPD_WAIT_SECS` (default `30` s) for the daemon to register, so a
+one-off startup hiccup heals itself instead of failing the job. When
+any gate times out, the awaited daemon's own output and surrounding
+state are dumped into the job log (and, for a CI run, the collected
+artifacts — see [Triaging a failed run](#triaging-a-failed-run)) so
+the failure can be root-caused after the fact. The mid-run lab recycle
+in `drain-hitless` re-runs the same gates, so it inherits the same
+diagnostics and retries.
+
 ### NB DB
 
 - tenant logical switch `ls0` (`192.168.10.0/24`),
@@ -905,8 +918,15 @@ writes:
   ovn/sb-<table>.txt               — full SB row dumps (Chassis, Port_Binding, …)
   frr/<gateway>-running-config.txt — `vtysh -c "show running-config"`
   frr/<gateway>-bgp-summary.txt    — `vtysh -c "show bgp summary"`
+  frr/upstream-running-config.txt  — upstream `vtysh -c "show running-config"`
+  frr/upstream-show-daemons.txt    — upstream `vtysh -c "show daemons"`
+  frr/upstream-bgp-summary.txt     — upstream `vtysh -c "show bgp summary"`
+  frr/upstream-daemons-file.txt    — upstream `/etc/frr/daemons`
+  frr/upstream-processes.txt       — upstream process list (`ps`)
+  frr/upstream-frr-log.txt         — upstream `/var/log/frr/*` tail
   kernel/<gateway>-ip-route.txt    — `ip route show table all`
   agent/<gateway>.log              — copy of the gateway container's stdout
+  ovn-controller/<gateway>.log     — gateway `ovn-controller` log (chassis-registration daemon)
   hairpin/hairpin-flows-before.txt — `cookie=0x998` flows on master:br-ex before adding FIP_B (hairpin only)
   hairpin/hairpin-flows-after.txt  — `cookie=0x998` flows on master:br-ex after adding FIP_B (hairpin only)
   pf-external/pf-backend.log       — per-connection source-IP log from the workload-side HTTP responder (pf-external only)

--- a/test/e2e/bootstrap.sh
+++ b/test/e2e/bootstrap.sh
@@ -63,6 +63,12 @@
 # Usage:
 #   ./test/e2e/bootstrap.sh                    # against the default `ovn-e2e` lab
 #   LAB_NAME=other ./test/e2e/bootstrap.sh     # override the containerlab lab name
+#
+# When a readiness gate times out, the awaited daemon's own output and
+# surrounding state are dumped to stderr (the job log) so the failure
+# can be root-caused from the collected artifacts. The upstream bgpd
+# start honours:
+#   BGPD_WAIT_SECS=30      # readiness wait per start attempt, seconds
 
 set -euo pipefail
 
@@ -110,6 +116,11 @@ UNDERLAY_LINKS=(
 BGP_ASN_GATEWAYS="${BGP_ASN_GATEWAYS:-65000}"
 BGP_ASN_UPSTREAM="${BGP_ASN_UPSTREAM:-65001}"
 BGP_ROUTER_ID_UPSTREAM="${BGP_ROUTER_ID_UPSTREAM:-100.64.0.1}"
+
+# Upstream bgpd start budget. The daemon is started in-place (see
+# configure_upstream_frr) and polled for readiness; BGPD_WAIT_SECS is
+# the readiness wait per start attempt.
+BGPD_WAIT_SECS="${BGPD_WAIT_SECS:-30}"
 
 CLIENT_NAME="${CLIENT_NAME:-client-1}"
 CLIENT_NODE="clab-${LAB_NAME}-${CLIENT_NAME}"
@@ -161,6 +172,11 @@ wait_for_nb() {
         sleep 1
     done
     echo "OVN NB at ${OVN_CENTRAL} did not become reachable within 60s" >&2
+    # One final probe with stderr passed through so the actual
+    # connection error reaches the job log, plus the central container's
+    # stdout (northd/ovsdb daemon output — see central-entrypoint.sh).
+    nbctl --timeout=2 show 1>&2 || true
+    docker logs --tail 50 "${OVN_CENTRAL}" >&2 || true
     exit 1
 }
 
@@ -194,6 +210,18 @@ wait_for_chassis() {
     done
     echo "SB chassis registration timed out; missing:${missing:-<unknown>}" >&2
     docker exec "${OVN_CENTRAL}" ovn-sbctl list Chassis >&2 || true
+    # For each still-missing gateway, dump the daemon whose registration
+    # we were waiting on (ovn-controller logs to a file, not stdout) plus
+    # the container's entrypoint output, which catches a container that
+    # died before ovn-controller even started.
+    # shellcheck disable=SC2086  # ${missing} is a space-separated name list
+    for name in ${missing}; do
+        log "--- ${name}: ovn-controller.log ---"
+        docker exec "clab-${LAB_NAME}-${name}" \
+            tail -n 50 /var/log/ovn/ovn-controller.log >&2 || true
+        log "--- ${name}: docker logs ---"
+        docker logs --tail 30 "clab-${LAB_NAME}-${name}" >&2 || true
+    done
     exit 1
 }
 
@@ -334,6 +362,27 @@ configure_upstream() {
     "
 }
 
+# Dump the upstream container's FRR daemon state to stderr (the job
+# log) so a bgpd bring-up failure can be root-caused after the fact. The
+# upstream image is unpinned (frrouting/frr:latest), so every command is
+# individually best-effort and drawn from an independent source: a
+# future image change degrades one section, not the whole report.
+dump_upstream_frr_state() {
+    log "dumping ${UPSTREAM_NODE} FRR state for triage"
+    log "--- /etc/frr/daemons ---"
+    docker exec "${UPSTREAM_NODE}" cat /etc/frr/daemons >&2 || true
+    log "--- vtysh show daemons ---"
+    docker exec "${UPSTREAM_NODE}" vtysh -c "show daemons" >&2 || true
+    log "--- vtysh show version ---"
+    docker exec "${UPSTREAM_NODE}" vtysh -c "show version" >&2 || true
+    log "--- process list ---"
+    docker exec "${UPSTREAM_NODE}" ps >&2 || true
+    log "--- tail /var/log/frr/* ---"
+    docker exec "${UPSTREAM_NODE}" sh -c 'tail -n 100 /var/log/frr/* 2>/dev/null' >&2 || true
+    log "--- docker logs (watchfrr / PID 1) ---"
+    docker logs --tail 100 "${UPSTREAM_NODE}" >&2 || true
+}
+
 configure_upstream_frr() {
     log "configuring ${UPSTREAM_NODE} FRR (BGP to each gateway)"
     # bgpd ships disabled (bgpd=no) in the frrouting/frr image. Restart
@@ -343,22 +392,41 @@ configure_upstream_frr() {
     # before this script gets to the vtysh call. Start bgpd in-place
     # instead, and keep the daemons file in sync so a future restart
     # would honour it.
-    docker exec "${UPSTREAM_NODE}" sh -ec '
-        if grep -q "^bgpd=no" /etc/frr/daemons 2>/dev/null; then
-            sed -i "s/^bgpd=no/bgpd=yes/" /etc/frr/daemons
-        fi
-        if ! pgrep -x bgpd >/dev/null; then
-            /usr/lib/frr/bgpd -d -A 127.0.0.1 -u frr -g frr || true
-        fi
-        for _ in $(seq 1 30); do
-            if vtysh -c "show daemons" 2>/dev/null | grep -qw bgpd; then
-                exit 0
-            fi
-            sleep 1
-        done
-        echo "bgpd did not come up on $(hostname)" >&2
+    #
+    # BGPD_WAIT_SECS is passed in via `docker exec --env` (the
+    # ensure_workload_netns pattern) so the script body stays
+    # single-quoted; the start output is captured and surfaced to the
+    # job log instead of discarded, so a failed start names its cause.
+    if ! docker exec -i --env "BGPD_WAIT_SECS=${BGPD_WAIT_SECS}" \
+            "${UPSTREAM_NODE}" sh -eu <<'EOSH'; then
+if grep -q "^bgpd=no" /etc/frr/daemons 2>/dev/null; then
+    sed -i "s/^bgpd=no/bgpd=yes/" /etc/frr/daemons
+fi
+start_out=""
+if ! pgrep -x bgpd >/dev/null; then
+    if start_out=$(/usr/lib/frr/bgpd -d -A 127.0.0.1 -u frr -g frr 2>&1); then
+        :
+    else
+        rc=$?
+        printf 'bgpd start exited %s: %s\n' "${rc}" "${start_out}" >&2
+    fi
+fi
+for _ in $(seq 1 "${BGPD_WAIT_SECS}"); do
+    if vtysh -c "show daemons" 2>/dev/null | grep -qw bgpd; then
+        exit 0
+    fi
+    sleep 1
+done
+echo "bgpd did not come up on $(hostname) within ${BGPD_WAIT_SECS}s" >&2
+if [ -n "${start_out}" ]; then
+    printf 'last bgpd start output: %s\n' "${start_out}" >&2
+fi
+exit 1
+EOSH
+        dump_upstream_frr_state
+        echo "bgpd did not come up on ${UPSTREAM_NODE}" >&2
         exit 1
-    '
+    fi
     # Push BGP config in one vtysh transaction. Build the script with
     # literal newlines — earlier this used $(printf '…\n…') chained with
     # ${var}$(...) concatenation, but command substitution strips

--- a/test/e2e/bootstrap.sh
+++ b/test/e2e/bootstrap.sh
@@ -69,6 +69,7 @@
 # can be root-caused from the collected artifacts. The upstream bgpd
 # start honours:
 #   BGPD_WAIT_SECS=30      # readiness wait per start attempt, seconds
+#   BGPD_START_ATTEMPTS=3  # bounded retries before bring-up is failed
 
 set -euo pipefail
 
@@ -119,8 +120,11 @@ BGP_ROUTER_ID_UPSTREAM="${BGP_ROUTER_ID_UPSTREAM:-100.64.0.1}"
 
 # Upstream bgpd start budget. The daemon is started in-place (see
 # configure_upstream_frr) and polled for readiness; BGPD_WAIT_SECS is
-# the readiness wait per start attempt.
+# the readiness wait per start attempt, and the start is retried up to
+# BGPD_START_ATTEMPTS times so a one-off startup hiccup does not cost a
+# full job re-run.
 BGPD_WAIT_SECS="${BGPD_WAIT_SECS:-30}"
+BGPD_START_ATTEMPTS="${BGPD_START_ATTEMPTS:-3}"
 
 CLIENT_NAME="${CLIENT_NAME:-client-1}"
 CLIENT_NODE="clab-${LAB_NAME}-${CLIENT_NAME}"
@@ -383,22 +387,25 @@ dump_upstream_frr_state() {
     docker logs --tail 100 "${UPSTREAM_NODE}" >&2 || true
 }
 
-configure_upstream_frr() {
-    log "configuring ${UPSTREAM_NODE} FRR (BGP to each gateway)"
-    # bgpd ships disabled (bgpd=no) in the frrouting/frr image. Restart
-    # is NOT an option here: the container's PID 1 is the watchfrr that
-    # supervises the FRR daemons, and `/usr/lib/frr/frrinit.sh restart`
-    # tears down that whole process tree → the container exits with 137
-    # before this script gets to the vtysh call. Start bgpd in-place
-    # instead, and keep the daemons file in sync so a future restart
-    # would honour it.
-    #
-    # BGPD_WAIT_SECS is passed in via `docker exec --env` (the
-    # ensure_workload_netns pattern) so the script body stays
-    # single-quoted; the start output is captured and surfaced to the
-    # job log instead of discarded, so a failed start names its cause.
-    if ! docker exec -i --env "BGPD_WAIT_SECS=${BGPD_WAIT_SECS}" \
-            "${UPSTREAM_NODE}" sh -eu <<'EOSH'; then
+# Start bgpd on the upstream container and wait for it to register,
+# once. Returns non-zero (without exiting the script) when bgpd does not
+# come up within ${BGPD_WAIT_SECS}, so the caller can retry.
+#
+# bgpd ships disabled (bgpd=no) in the frrouting/frr image. Restart is
+# NOT an option here: the container's PID 1 is the watchfrr that
+# supervises the FRR daemons, and `/usr/lib/frr/frrinit.sh restart`
+# tears down that whole process tree → the container exits with 137
+# before this script gets to the vtysh call. Start bgpd in-place
+# instead, and keep the daemons file in sync so a future restart would
+# honour it.
+#
+# BGPD_WAIT_SECS is passed in via `docker exec --env` (the
+# ensure_workload_netns pattern) so the script body stays single-quoted;
+# the start output is captured and surfaced to the job log instead of
+# discarded, so a failed start names its cause.
+start_upstream_bgpd() {
+    docker exec -i --env "BGPD_WAIT_SECS=${BGPD_WAIT_SECS}" \
+        "${UPSTREAM_NODE}" sh -eu <<'EOSH'
 if grep -q "^bgpd=no" /etc/frr/daemons 2>/dev/null; then
     sed -i "s/^bgpd=no/bgpd=yes/" /etc/frr/daemons
 fi
@@ -423,10 +430,29 @@ if [ -n "${start_out}" ]; then
 fi
 exit 1
 EOSH
-        dump_upstream_frr_state
-        echo "bgpd did not come up on ${UPSTREAM_NODE}" >&2
-        exit 1
-    fi
+}
+
+configure_upstream_frr() {
+    log "configuring ${UPSTREAM_NODE} FRR (BGP to each gateway)"
+    # Retry the bgpd start within a bounded budget so a transient startup
+    # hiccup heals itself instead of failing the whole job. A wedged
+    # half-start is killed between attempts so it cannot poison the next
+    # one; after the final attempt the daemon state is dumped and the
+    # bring-up aborts.
+    local attempt
+    for attempt in $(seq 1 "${BGPD_START_ATTEMPTS}"); do
+        if start_upstream_bgpd; then
+            log "bgpd up on ${UPSTREAM_NODE} (attempt ${attempt}/${BGPD_START_ATTEMPTS})"
+            break
+        fi
+        log "bgpd start attempt ${attempt}/${BGPD_START_ATTEMPTS} failed on ${UPSTREAM_NODE}"
+        docker exec "${UPSTREAM_NODE}" pkill -x bgpd || true
+        if [ "${attempt}" -eq "${BGPD_START_ATTEMPTS}" ]; then
+            dump_upstream_frr_state
+            echo "bgpd did not come up on ${UPSTREAM_NODE} after ${BGPD_START_ATTEMPTS} attempts" >&2
+            exit 1
+        fi
+    done
     # Push BGP config in one vtysh transaction. Build the script with
     # literal newlines — earlier this used $(printf '…\n…') chained with
     # ${var}$(...) concatenation, but command substitution strips

--- a/test/e2e/scenarios/collect-artifacts.sh
+++ b/test/e2e/scenarios/collect-artifacts.sh
@@ -10,6 +10,8 @@
 #   <out>/ovn/{nb,sb}-<table>.txt           — `ovn-nbctl list`/`ovn-sbctl list` dumps
 #   <out>/frr/<gateway>-running-config.txt  — FRR `show running-config`
 #   <out>/frr/<gateway>-bgp-summary.txt     — `show bgp summary`
+#   <out>/frr/upstream-*.txt                — upstream FRR daemon + BGP state
+#   <out>/ovn-controller/<gateway>.log      — gateway ovn-controller log (chassis-registration daemon)
 #   <out>/agent/<gateway>.log               — `docker logs` of the gateway (agent runs in foreground)
 #
 # Best-effort: every command is allowed to fail individually so a single
@@ -122,6 +124,20 @@ collect_frr() {
     done
     capture "${OUT_DIR}/frr/upstream-running-config.txt" \
         exec_in "${UPSTREAM}" vtysh -c "show running-config"
+    # The upstream bgpd start is the one daemon bring-up performs itself
+    # (see bootstrap.sh:configure_upstream_frr); capture the same state
+    # its failure path dumps into the job log so a bring-up flake can be
+    # root-caused from the artifact bundle alone.
+    capture "${OUT_DIR}/frr/upstream-show-daemons.txt" \
+        exec_in "${UPSTREAM}" vtysh -c "show daemons"
+    capture "${OUT_DIR}/frr/upstream-bgp-summary.txt" \
+        exec_in "${UPSTREAM}" vtysh -c "show bgp summary"
+    capture "${OUT_DIR}/frr/upstream-daemons-file.txt" \
+        exec_in "${UPSTREAM}" cat /etc/frr/daemons
+    capture "${OUT_DIR}/frr/upstream-processes.txt" \
+        exec_in "${UPSTREAM}" ps
+    capture "${OUT_DIR}/frr/upstream-frr-log.txt" \
+        exec_in "${UPSTREAM}" sh -c 'tail -n 200 /var/log/frr/* 2>/dev/null'
 }
 
 collect_kernel() {
@@ -146,6 +162,18 @@ collect_agent_logs() {
     done
 }
 
+# The SB chassis-registration gate waits for each gateway's
+# ovn-controller to register. ovn-controller logs to a file rather than
+# the container's stdout (which the entrypoint reserves for the agent),
+# so `docker logs` does not carry it — pull the log file explicitly.
+collect_ovn_controller_logs() {
+    log "ovn-controller logs from each gateway"
+    for gw in "${GATEWAYS[@]}"; do
+        capture "${OUT_DIR}/ovn-controller/${gw}.log" \
+            exec_in "${gw}" cat /var/log/ovn/ovn-controller.log
+    done
+}
+
 main() {
     log "writing artifacts to ${OUT_DIR}"
     collect_inspect
@@ -155,6 +183,7 @@ main() {
     collect_frr
     collect_kernel
     collect_agent_logs
+    collect_ovn_controller_logs
     log "done"
 }
 


### PR DESCRIPTION
Closes #169

## What this does

The E2E lab bring-up gates on several third-party daemon readiness waits — OVN NB reachability, SB chassis registration on every gateway, and the upstream `bgpd` — and re-runs the same gates when a scenario recycles the lab mid-run. Until now those waits were silent on failure: the daemon start discarded its own error output, and a timed-out poll killed the job with a one-line message (`bgpd did not come up on upstream`) while the collected artifacts recorded nothing about *why* the daemon never appeared. Every such flake turned a PR red for reasons unrelated to the change under test, and left nothing behind to root-cause it.

This branch makes those failures diagnosable and less frequent: readiness gates now dump the awaited daemon's own output and surrounding state (to the job log and the artifact bundle), and the one daemon start bring-up performs itself — the upstream `bgpd` — is retried within a small bounded budget so a one-off hiccup heals itself instead of costing a full job re-run. The unpinned `frrouting/frr:latest` upstream image is intentionally kept as-is; pinning/swapping it is out of scope per the issue.

## Change set, in commit order

**`7d8ef38` — test/e2e: dump daemon state when a bring-up gate times out** (`test/e2e/bootstrap.sh`)
Adds a diagnostic dump to each readiness gate's timeout path:
- `wait_for_nb` now does one final `nbctl show` with stderr passed through (so the actual connection error reaches the log) plus `docker logs` of the central container (northd/ovsdb output).
- `wait_for_chassis` iterates the still-missing gateways and, for each, tails `/var/log/ovn/ovn-controller.log` (the daemon whose registration it was waiting on — it logs to a file, not stdout) plus the container's `docker logs` (catches a container that died before `ovn-controller` even started).

**`3b1738a` — test/e2e: retry the upstream bgpd start within a bounded budget** (`test/e2e/bootstrap.sh`)
Refactors the inline `bgpd` bring-up in `configure_upstream_frr` into a single-attempt helper `start_upstream_bgpd` and wraps it in a bounded retry loop:
- New env knobs `BGPD_WAIT_SECS` (default `30`) and `BGPD_START_ATTEMPTS` (default `3`).
- `start_upstream_bgpd` starts `bgpd` in-place (restart is deliberately avoided — PID 1 is `watchfrr`, so `frrinit.sh restart` would tear the container down with exit 137), captures the start command's output, and surfaces it to the job log on failure instead of discarding it. `BGPD_WAIT_SECS` is threaded in via `docker exec --env` so the heredoc body stays single-quoted.
- `configure_upstream_frr` retries up to `BGPD_START_ATTEMPTS` times, `pkill`-ing any wedged half-start between attempts so it can't poison the next one, and on the final failed attempt dumps full FRR state (new `dump_upstream_frr_state`: `/etc/frr/daemons`, `show daemons`, `show version`, `ps`, `/var/log/frr/*`, `docker logs`) before aborting.

**`14da8a9` — test/e2e: collect upstream FRR and ovn-controller state** (`test/e2e/scenarios/collect-artifacts.sh`)
Extends the artifact collector so a bring-up flake can be root-caused from the bundle alone, mirroring what the failure paths dump to the job log:
- `collect_frr` now also captures `show daemons`, `show bgp summary`, `/etc/frr/daemons`, `ps`, and a `/var/log/frr/*` tail for the upstream router.
- New `collect_ovn_controller_logs` pulls each gateway's `/var/log/ovn/ovn-controller.log` (the chassis-registration daemon, which `docker logs` does not carry) and is wired into `main`.

**`817ff87` — docs/e2e: document bring-up retries and the new triage artifacts** (`docs/contributing/e2e-tests.md`)
Documents the three readiness gates and the `bgpd` retry budget (`BGPD_START_ATTEMPTS` / `BGPD_WAIT_SECS`), notes that `drain-hitless`'s mid-run recycle inherits the same diagnostics and retries, and adds the new upstream `frr/upstream-*` and `ovn-controller/<gateway>.log` entries to the collected-artifacts reference.

## Notes for the reviewer

- Test-harness only — no product/runtime code changes.
- Behaviour tracks the issue faithfully; no scope divergence. The issue explicitly leaves the unpinned upstream image alone, which this branch honours (each dump/collect command is individually best-effort so a future image change degrades one section, not the whole report).

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 01245b5 with Claude:claude-opus-4-8_
