### PR TITLE
ci: enforce the green-main contract and close scanner/build gaps

### DIFF
--- a/.github/actions/e2e-lab-setup/action.yml
+++ b/.github/actions/e2e-lab-setup/action.yml
@@ -1,0 +1,36 @@
+name: E2E lab setup
+description: >-
+  Install the pinned containerlab release and load the kernel modules the
+  containerlab topology needs. Requires the repository to be checked out.
+
+runs:
+  using: composite
+  steps:
+    # Version + checksums are pinned in the Makefile (single source of
+    # truth shared with local development): the .deb is downloaded and
+    # its sha256 verified before install, replacing the unpinned
+    # `curl | bash` installer.
+    - name: Install containerlab
+      shell: bash
+      run: make e2e-install-tools
+
+    # The gwnode image uses kernel OVS so OVN's BFD-driven cr-lrp
+    # election over geneve tunnels actually converges, and the entrypoint
+    # creates a vrf-provider kernel VRF for the agent's veth-leak design.
+    # The gwnode containers only inherit CAP_NET_ADMIN (no CAP_SYS_MODULE),
+    # so the modules must be loaded on the host before lab-up. The Azure
+    # kernel on `ubuntu-latest` ships `openvswitch` in the base modules
+    # set but `vrf` only in `linux-modules-extra-<uname>` — install it on
+    # demand. Without `vrf`, gwnode-entrypoint.sh crash-loops on
+    # `ip link add vrf-provider type vrf table 100` with "Unknown device
+    # type".
+    - name: Load required kernel modules
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo modprobe openvswitch
+        if ! sudo modprobe vrf 2>/dev/null; then
+          sudo apt-get update -qq
+          sudo apt-get install -y "linux-modules-extra-$(uname -r)"
+          sudo modprobe vrf
+        fi

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,43 @@
+{
+  "name": "main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [],
+  "rules": [
+    { "type": "deletion" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "test", "integration_id": 15368 },
+          { "context": "golangci-lint", "integration_id": 15368 },
+          { "context": "vet", "integration_id": 15368 },
+          { "context": "gofmt", "integration_id": 15368 },
+          { "context": "docs-gen", "integration_id": 15368 },
+          { "context": "verify", "integration_id": 15368 },
+          { "context": "smoke", "integration_id": 15368 }
+        ]
+      }
+    },
+    { "type": "required_signatures" }
+  ]
+}

--- a/.github/rulesets/tags.json
+++ b/.github/rulesets/tags.json
@@ -1,0 +1,16 @@
+{
+  "name": "tags",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "required_signatures" }
+  ]
+}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -12,6 +12,13 @@ permissions: read-all
 
 jobs:
   add-to-project-boards:
-    uses: osism/.github/.github/workflows/add-to-project.yml@main
+    # Pinned by SHA, not @main: this runs on pull_request_target with a
+    # cross-repo PAT, so a moved `main` upstream must not silently change
+    # what executes here. Bump deliberately (see docs/contributing/ci.md).
+    # SHA is osism/.github @main as of 2026-07-13.
+    uses: osism/.github/.github/workflows/add-to-project.yml@b57ddf3f8be8035457adb666aeef86eda8672aaa # main
     secrets:
+      # ADD_TO_PROJECT_PAT should be a fine-grained PAT scoped to the
+      # minimum: organization Projects read/write (plus the default repo
+      # metadata read). Rotating it to that scope is an org-admin task.
       ADD_TO_PROJECT_PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,10 @@
 name: Build
 
-# Only validates that the module graph is clean; the release binaries are
-# built solely by release.yml on `v*` tags. This runs on pull requests
-# and not on push to `main`: the merged commit already passed on its PR.
+# Validates the module graph and that the tree cross-compiles for every
+# release target; the release binaries themselves are built solely by
+# release.yml on `v*` tags. This runs on pull requests and not on push
+# to `main`: the branch ruleset in .github/rulesets/main.json requires
+# PRs to be up to date, so the merged commit already passed here.
 on:
   pull_request:
     branches: [main]
@@ -33,3 +35,14 @@ jobs:
         run: |
           go mod tidy
           git diff --exit-code go.mod go.sum
+
+      # arm64 is otherwise first compiled at release-tag time
+      # (release.yml builds a linux/arm64 matrix leg); surface
+      # cross-compile breakage on the PR instead. CGO_ENABLED=0 mirrors
+      # the release build.
+      - name: Cross-compile for linux/arm64
+        env:
+          CGO_ENABLED: "0"
+          GOOS: linux
+          GOARCH: arm64
+        run: go build ./...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,12 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded runs only for PRs; push/schedule runs on main are
+  # the green-main signal and must never cancel each other mid-history.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,12 @@ permissions:
   security-events: write
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded runs only for PRs; push/schedule runs on main are
+  # the green-main signal and must never cancel each other mid-history.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -8,6 +8,12 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded runs only for PRs; push/schedule runs on main are
+  # the green-main signal and must never cancel each other mid-history.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   review:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+name: Docs
+
+# Build the VitePress site on PRs that can affect it, so the dead-link
+# check fails the PR instead of the post-merge Pages deploy
+# (deploy-docs.yaml, which is push-to-main only). This workflow is
+# path-filtered and therefore MUST NOT be added to the required status
+# checks in .github/rulesets/main.json — non-docs PRs would never
+# trigger it and would wait on the required check forever.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/docs.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded runs only for PRs; push/schedule runs on main are
+  # the green-main signal and must never cancel each other mid-history.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  docs-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # `docs:build` fails on dead internal links, so this is the PR-time
+      # dead-link gate.
+      - name: Build documentation
+        run: npm run docs:build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,19 @@ name: E2E
 on:
   pull_request:
     branches: [main]
+    # E2E is deliberately NOT a required status check, so an `on.paths`
+    # filter is safe here: docs-only PRs simply do not trigger the ~10
+    # min lab suite. If E2E ever becomes required, replace this with the
+    # job-level conditional-skip pattern used in integration.yml, or the
+    # required check will hang Pending on docs-only PRs.
+    #
+    # This docs-only set (docs/**, **.md) is the same predicate the
+    # integration.yml `changes` job encodes as a shell grep. Keep the two
+    # in sync — broadening the set here means updating that grep too, or
+    # the two suites will treat the same PR inconsistently.
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,33 +39,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      # Upstream-provided one-liner. Pinned by `bash -c "$(curl ...)"`
-      # rather than a SHA-pinned action because containerlab does not
-      # publish an official GitHub Action and this is the install path
-      # the issue explicitly mandates.
-      - name: Install containerlab
-        run: bash -c "$(curl -sL https://get.containerlab.dev)"
-
-      # The gwnode image uses kernel OVS so OVN's BFD-driven cr-lrp
-      # election over geneve tunnels actually converges, and the
-      # entrypoint creates a vrf-provider kernel VRF for the agent's
-      # veth-leak design. The gwnode containers only inherit
-      # CAP_NET_ADMIN (no CAP_SYS_MODULE), so the modules must be
-      # loaded on the host before lab-up. The Azure kernel on
-      # `ubuntu-latest` ships `openvswitch` in the base modules set
-      # but `vrf` only in `linux-modules-extra-<uname>` — install it
-      # on demand. Without `vrf`, gwnode-entrypoint.sh crash-loops on
-      # `ip link add vrf-provider type vrf table 100` with "Unknown
-      # device type".
-      - name: Load required kernel modules
-        run: |
-          set -euo pipefail
-          sudo modprobe openvswitch
-          if ! sudo modprobe vrf 2>/dev/null; then
-            sudo apt-get update -qq
-            sudo apt-get install -y "linux-modules-extra-$(uname -r)"
-            sudo modprobe vrf
-          fi
+      # Install the pinned containerlab release and load the kernel
+      # modules the topology needs. The rationale for both lives in the
+      # e2e-lab-setup composite action. Placed after checkout because a
+      # local composite action needs the repository on disk.
+      - uses: ./.github/actions/e2e-lab-setup
 
       - name: Bring the lab up
         run: make e2e-up
@@ -111,19 +89,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - name: Install containerlab
-        run: bash -c "$(curl -sL https://get.containerlab.dev)"
-
-      # See the baseline job for the rationale; same modules required.
-      - name: Load required kernel modules
-        run: |
-          set -euo pipefail
-          sudo modprobe openvswitch
-          if ! sudo modprobe vrf 2>/dev/null; then
-            sudo apt-get update -qq
-            sudo apt-get install -y "linux-modules-extra-$(uname -r)"
-            sudo modprobe vrf
-          fi
+      # See the baseline job / e2e-lab-setup action for the rationale.
+      - uses: ./.github/actions/e2e-lab-setup
 
       - name: Bring the lab up
         run: make e2e-up
@@ -167,19 +134,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - name: Install containerlab
-        run: bash -c "$(curl -sL https://get.containerlab.dev)"
-
-      # See the baseline job for the rationale; same modules required.
-      - name: Load required kernel modules
-        run: |
-          set -euo pipefail
-          sudo modprobe openvswitch
-          if ! sudo modprobe vrf 2>/dev/null; then
-            sudo apt-get update -qq
-            sudo apt-get install -y "linux-modules-extra-$(uname -r)"
-            sudo modprobe vrf
-          fi
+      # See the baseline job / e2e-lab-setup action for the rationale.
+      - uses: ./.github/actions/e2e-lab-setup
 
       - name: Bring the lab up
         run: make e2e-up
@@ -229,19 +185,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - name: Install containerlab
-        run: bash -c "$(curl -sL https://get.containerlab.dev)"
-
-      # See the baseline job for the rationale; same modules required.
-      - name: Load required kernel modules
-        run: |
-          set -euo pipefail
-          sudo modprobe openvswitch
-          if ! sudo modprobe vrf 2>/dev/null; then
-            sudo apt-get update -qq
-            sudo apt-get install -y "linux-modules-extra-$(uname -r)"
-            sudo modprobe vrf
-          fi
+      # See the baseline job / e2e-lab-setup action for the rationale.
+      - uses: ./.github/actions/e2e-lab-setup
 
       - name: Bring the lab up
         run: make e2e-up
@@ -292,19 +237,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - name: Install containerlab
-        run: bash -c "$(curl -sL https://get.containerlab.dev)"
-
-      # See the baseline job for the rationale; same modules required.
-      - name: Load required kernel modules
-        run: |
-          set -euo pipefail
-          sudo modprobe openvswitch
-          if ! sudo modprobe vrf 2>/dev/null; then
-            sudo apt-get update -qq
-            sudo apt-get install -y "linux-modules-extra-$(uname -r)"
-            sudo modprobe vrf
-          fi
+      # See the baseline job / e2e-lab-setup action for the rationale.
+      - uses: ./.github/actions/e2e-lab-setup
 
       - name: Bring the lab up
         run: make e2e-up
@@ -358,19 +292,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - name: Install containerlab
-        run: bash -c "$(curl -sL https://get.containerlab.dev)"
-
-      # See the baseline job for the rationale; same modules required.
-      - name: Load required kernel modules
-        run: |
-          set -euo pipefail
-          sudo modprobe openvswitch
-          if ! sudo modprobe vrf 2>/dev/null; then
-            sudo apt-get update -qq
-            sudo apt-get install -y "linux-modules-extra-$(uname -r)"
-            sudo modprobe vrf
-          fi
+      # See the baseline job / e2e-lab-setup action for the rationale.
+      - uses: ./.github/actions/e2e-lab-setup
 
       - name: Bring the lab up
         run: make e2e-up
@@ -425,19 +348,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - name: Install containerlab
-        run: bash -c "$(curl -sL https://get.containerlab.dev)"
-
-      # See the baseline job for the rationale; same modules required.
-      - name: Load required kernel modules
-        run: |
-          set -euo pipefail
-          sudo modprobe openvswitch
-          if ! sudo modprobe vrf 2>/dev/null; then
-            sudo apt-get update -qq
-            sudo apt-get install -y "linux-modules-extra-$(uname -r)"
-            sudo modprobe vrf
-          fi
+      # See the baseline job / e2e-lab-setup action for the rationale.
+      - uses: ./.github/actions/e2e-lab-setup
 
       - name: Bring the lab up
         run: make e2e-up
@@ -504,19 +416,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - name: Install containerlab
-        run: bash -c "$(curl -sL https://get.containerlab.dev)"
-
-      # See the baseline job for the rationale; same modules required.
-      - name: Load required kernel modules
-        run: |
-          set -euo pipefail
-          sudo modprobe openvswitch
-          if ! sudo modprobe vrf 2>/dev/null; then
-            sudo apt-get update -qq
-            sudo apt-get install -y "linux-modules-extra-$(uname -r)"
-            sudo modprobe vrf
-          fi
+      # See the baseline job / e2e-lab-setup action for the rationale.
+      - uses: ./.github/actions/e2e-lab-setup
 
       - name: Bring the lab up
         run: make e2e-up

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded runs only for PRs; push/schedule runs on main are
+  # the green-main signal and must never cancel each other mid-history.
+  # A force-push that supersedes a PR can otherwise leave up to eight
+  # ~15 min lab runners churning on stale commits.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   baseline:
     name: Baseline reachability

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,33 @@
+name: govulncheck
+
+# govulncheck scans the pinned dependency graph for known vulnerabilities.
+# It runs on pull requests (the primary gate) and also on push to main and
+# a weekly schedule: a CVE published against a pinned dependency during a
+# quiet period with no PR activity must still surface within a week (issue
+# #161). It lives in its own workflow so it can carry these non-PR triggers
+# without event-gating the rest of the lint jobs. The cron is staggered off
+# the test suite's `30 5 * * 1` and codeql/scorecard's `0 6 * * 1`.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 5 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded runs only for PRs; push/schedule runs on main are
+  # the green-main signal and must never cancel each other mid-history.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1
+        with:
+          go-version-file: go.mod

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,6 +7,12 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded runs only for PRs; push/schedule runs on main are
+  # the green-main signal and must never cancel each other mid-history.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,43 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Docs-only PRs do not need the OVN/OVS/FRR smoke job. `smoke` is a
+  # required status check (its job id is a context in
+  # .github/rulesets/main.json), so this MUST be a job-level `if:` — a
+  # job skipped by `if:` still reports success to the required check,
+  # whereas an `on.paths` filter would leave the required check Pending
+  # forever on docs-only PRs and block the merge.
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Detect non-docs changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --paginate --jq '.[].filename')
+          # Docs-only predicate: mirror of e2e.yml's `paths-ignore`
+          # (docs/**, **.md). Keep the two in sync — if this set changes,
+          # update e2e.yml's paths-ignore too, or the two suites will
+          # treat the same PR inconsistently.
+          if echo "$files" | grep -qvE '^docs/|\.md$'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   smoke:
+    needs: changes
+    # Fail safe: run unless `changes` positively reported a docs-only PR.
+    # If `changes` itself fails, its output is empty (not 'false') and the
+    # required smoke gate still runs rather than being silently skipped.
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,9 @@ concurrency:
   # the green-main signal and must never cancel each other mid-history.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# The golangci-lint, vet, gofmt, and docs-gen job ids are required
+# status-check contexts in .github/rulesets/main.json — renaming any of
+# them requires a matching ruleset update, or the check goes missing.
 jobs:
   golangci-lint:
     runs-on: ubuntu-latest
@@ -56,13 +59,6 @@ jobs:
             echo "Run 'gofmt -w .' or 'make fmt' to fix."
             exit 1
           fi
-
-  govulncheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1
-        with:
-          go-version-file: go.mod
 
   docs-gen:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,12 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded runs only for PRs; push/schedule runs on main are
+  # the green-main signal and must never cancel each other mid-history.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   golangci-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,6 +10,12 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded runs only for PRs; push/schedule runs on main are
+  # the green-main signal and must never cancel each other mid-history.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   deb-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,34 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
-  id-token: write
-  attestations: write
+# Permissions are scoped per job rather than workflow-wide: only the
+# `release` job publishes artifacts, so `test` and `build` run
+# read-only and cannot inherit the write/attestation grants.
+permissions: {}
 
 jobs:
-  build:
+  # A tag can be pushed on any commit; nothing guarantees it went
+  # through a gated PR. Run the unit suite before anything is built,
+  # signed, or attested so an untested commit cannot become a release.
+  test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test -race ./...
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -53,6 +73,10 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,12 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded runs only for PRs; push/schedule runs on main are
+  # the green-main signal and must never cancel each other mid-history.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,21 @@
 name: Test
 
+# The unit suite runs on pull requests (the primary gate) and also:
+#   - push to main: the backstop for anything that reaches main outside
+#     the PR path (a direct push, or two semantically conflicting PRs
+#     merged in sequence) plus post-merge confirmation under the branch
+#     ruleset in .github/rulesets/main.json.
+#   - weekly schedule: catches runner/kernel drift, toolchain updates,
+#     and dependency rot during quiet periods with no PR activity.
+# The cron is staggered off codeql/scorecard's `0 6 * * 1` so the
+# Monday burst does not all fire at once.
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "30 5 * * 1"
 
 permissions:
   contents: read

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,102 @@
+# golangci-lint configuration. This file is the versioned contract for
+# the lint gate (issue #161): the enabled checks and every exclusion are
+# recorded here, so a linter major bump cannot silently change what the
+# gate enforces. Keep `version` in sync with the pin in
+# .github/workflows/lint.yml.
+version: "2"
+
+linters:
+  # Keep the stock v2 default set (errcheck, govet, ineffassign,
+  # staticcheck, unused) and add the gates a root-privileged agent that
+  # shells out to nft/vtysh/ovs-vsctl should have:
+  #   gosec     — security issues (command/file/permission handling)
+  #   errorlint — %w wrapping and errors.Is/As correctness
+  #   gocritic  — idiom and correctness diagnostics
+  #   revive    — golint's successor; style and doc-comment checks
+  default: standard
+  enable:
+    - errorlint
+    - gocritic
+    - gosec
+    - revive
+  exclusions:
+    # Every exclusion below is a documented, categorical false positive
+    # for THIS agent. The linters stay fully enabled for all other rules
+    # and files — new code is scanned normally. gosec emits a legacy code
+    # and a newer taint-analysis code for the same site (e.g. G204 with
+    # G702, G304 with G703), so the command/file families are excluded as
+    # a pair.
+    rules:
+      # gosec command-injection family (G204 legacy + G702 taint-based):
+      # executing nft/vtysh/ovs-vsctl IS this agent's job. ovsCmd,
+      # runVtysh, and the nft runner are the audited seams; every command
+      # is exec'd with an explicit argv built from validated config and
+      # OVN state — no shell is ever involved.
+      - path: '^(ovs|routing|nftables_linux)\.go$'
+        linters: [gosec]
+        text: '(G204|G702)'
+      # gosec file-inclusion family (G304 legacy + G703 taint-based):
+      # config.go reads the operator-supplied --config path;
+      # routing_linux.go writes a fixed procfs sysctl path; tools/docgen
+      # reads repo-local sample files. All trusted, operator-controlled
+      # inputs by design.
+      - path: '^(config\.go|routing_linux\.go|tools/docgen/)'
+        linters: [gosec]
+        text: '(G304|G703)'
+      # gosec permission rules (G306 file, G301 directory): the 0644
+      # writes are procfs sysctl toggles — the file always exists, so the
+      # create mode is never used — and tools/docgen writes generated
+      # reference docs that must be world-readable.
+      - path: '^(routing_linux\.go|nftables_linux\.go|tools/docgen/)'
+        linters: [gosec]
+        text: '(G301|G306)'
+      # gosec G404 (weak RNG): the stale-cleanup jitter is scheduling
+      # noise to de-synchronize peers, not a security primitive —
+      # math/rand is the correct tool here.
+      - path: '^agent\.go$'
+        linters: [gosec]
+        text: 'G404'
+      # gosec G118 (goroutine uses context.Background): the metrics
+      # server's shutdown goroutine is a process-lifetime fire-and-forget
+      # that blocks on ctx.Done() and then derives its own bounded
+      # timeout — it is not request-scoped.
+      - path: '^metrics\.go$'
+        linters: [gosec]
+        text: 'G118'
+      # gosec G602 (slice index out of range): transactOps ranges over
+      # opErrors, which CheckOperationResults returns index-aligned with
+      # ops, so ops[i] is always in range. gosec cannot see the
+      # correlation.
+      - path: '^ovn_gateway\.go$'
+        linters: [gosec]
+        text: 'G602'
+      # Unit tests and the E2E test scaffolding (the pf-backend fixture
+      # binary) legitimately relax the production security/idiom rules.
+      - path: '(^test/|_test\.go$)'
+        linters: [gosec, gocritic]
+      # gocritic exitAfterDefer: main() legitimately calls os.Exit on a
+      # fatal startup error; the pending `defer cancel()` is moot because
+      # the process is exiting. Reworking main into a run() error wrapper
+      # is out of scope for this CI change.
+      - path: '^main\.go$'
+        linters: [gocritic]
+        text: 'exitAfterDefer'
+      # gocritic appendAssign: append(x, y) assigned to a new local where
+      # the source slice is a throwaway not reused afterward (ovsCmd's
+      # argv, transactOps' op list).
+      - path: '^(ovs\.go|ovn_gateway\.go)$'
+        linters: [gocritic]
+        text: 'appendAssign'
+      # revive unused-parameter: the cache.EventHandler implementations
+      # in ovn.go and the *_notlinux.go build-tag stubs keep the full,
+      # named parameter list to mirror the interfaces they satisfy;
+      # renaming to `_` would obscure which callback/stub is implemented.
+      # Test command hooks and subtests keep their names for the same
+      # reason.
+      - linters: [revive]
+        text: 'unused-parameter'
+      # revive context-as-argument: a test helper takes ctx as a trailing
+      # parameter. Production code stays governed by this rule.
+      - path: '_test\.go$'
+        linters: [revive]
+        text: 'context-as-argument'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,14 @@ make test      # run the unit tests
 make fmt vet   # format and vet
 ```
 
+Run the same lint gate CI enforces (keep the version in sync with
+[`.github/workflows/lint.yml`](./.github/workflows/lint.yml)):
+
+```bash
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+golangci-lint run   # config and exclusions live in .golangci.yml
+```
+
 ## Commit conventions
 
 Commit messages follow [Conventional Commits](https://www.conventionalcommits.org):
@@ -63,6 +71,16 @@ option the agent consumes.
 | Integration     | `make test-integration`              | Linux + root (`CAP_NET_ADMIN`); see [Integration tests](https://osism.github.io/ovn-network-agent/contributing/integration-tests). |
 | E2E             | `make e2e-up` then `make e2e-<scenario>` | containerlab lab; see [Containerlab E2E harness](https://osism.github.io/ovn-network-agent/contributing/e2e-tests). |
 | Package smoke   | `test/package/smoke.sh`              | Runs on every PR via the Package workflow (see below). |
+
+### CI gates
+
+`main` is protected by a committed branch ruleset
+([`.github/rulesets/main.json`](./.github/rulesets/main.json)) that
+requires a pull request and the Test / Lint / Build / Integration status
+checks, kept up to date with `main`. The full gate map, the schedules,
+and the maintenance procedures (linter version, containerlab pin, PAT
+scope) are documented at
+[CI pipeline](https://osism.github.io/ovn-network-agent/contributing/ci).
 
 Run the package smoke test locally the way CI does. Keep the `nfpm` version
 below in sync with the pin in [`.github/workflows/`](./.github/workflows) —

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,14 @@ E2E_DRAIN       := test/e2e/scenarios/drain-hitless.sh
 E2E_GWNODE_TAG  := ovn-network-agent/gwnode:e2e
 E2E_CENTRAL_TAG := ovn-network-agent/central:e2e
 
+# Pinned containerlab release for CI and local installs. The sha256
+# values are the linux_{amd64,arm64}.deb lines from the upstream
+# release's checksums.txt. Bump the version and BOTH checksums together:
+#   https://github.com/srl-labs/containerlab/releases
+CONTAINERLAB_VERSION      := 0.77.0
+CONTAINERLAB_SHA256_amd64 := 675eea8bd4d05ea3abc4a98cfa859975c9886705d6a510fead4dfd8dbed8b793
+CONTAINERLAB_SHA256_arm64 := 9bfd89d1afbff87c316febc721eb960148420ec94f3e063ba54b13ef38e8ba60
+
 all: build
 
 build:
@@ -81,20 +89,44 @@ e2e-images:
 	docker build -f test/e2e/Dockerfile.central -t $(E2E_CENTRAL_TAG) .
 	docker build -f test/e2e/Dockerfile.gwnode  -t $(E2E_GWNODE_TAG)  .
 
-# Install the containerlab CLI when it is missing. Linux only: the
-# upstream project publishes Linux binaries and a one-line installer
-# (https://get.containerlab.dev) for Debian/RHEL hosts and ships no
-# darwin binary, so on macOS the recommended path is to run
-# containerlab inside a Linux VM — see
-# https://containerlab.dev/macos/. This target reports that and
-# exits with a non-zero status on macOS instead of pretending to
-# install something.
+# Install the containerlab CLI when it is missing. Linux/Debian only:
+# the pinned .deb (CONTAINERLAB_VERSION above) is downloaded and its
+# sha256 verified against the committed checksum before apt-get installs
+# it — replacing the unpinned `curl | bash` installer so CI and local
+# installs get a known, verified binary. This narrows the target to
+# dpkg-based distros (what CI and the documented dev setup use); on
+# other distros it errors with a pointer to the upstream install docs.
+# Upstream ships no darwin binary, so on macOS the recommended path is
+# to run containerlab inside a Linux VM (https://containerlab.dev/macos/)
+# and this target reports that instead of pretending to install
+# something.
 e2e-install-tools:
-	@if command -v containerlab >/dev/null 2>&1; then \
+	@set -e; \
+	if command -v containerlab >/dev/null 2>&1; then \
 		echo "containerlab already installed: $$(command -v containerlab)"; \
 	elif [ "$$(uname -s)" = "Linux" ]; then \
-		echo "installing containerlab via the upstream installer (needs sudo)"; \
-		bash -c "$$(curl -sL https://get.containerlab.dev)"; \
+		if ! command -v dpkg >/dev/null 2>&1 || ! command -v apt-get >/dev/null 2>&1; then \
+			echo "the pinned .deb install needs dpkg/apt-get (Debian/Ubuntu)."; \
+			echo "On other distributions install containerlab $(CONTAINERLAB_VERSION)"; \
+			echo "manually from https://containerlab.dev/install/."; \
+			exit 1; \
+		fi; \
+		arch=$$(dpkg --print-architecture); \
+		case "$$arch" in \
+			amd64) sha=$(CONTAINERLAB_SHA256_amd64) ;; \
+			arm64) sha=$(CONTAINERLAB_SHA256_arm64) ;; \
+			*) echo "no pinned containerlab .deb for dpkg architecture $$arch;"; \
+			   echo "install it manually from https://containerlab.dev/install/."; \
+			   exit 1 ;; \
+		esac; \
+		deb="containerlab_$(CONTAINERLAB_VERSION)_linux_$$arch.deb"; \
+		url="https://github.com/srl-labs/containerlab/releases/download/v$(CONTAINERLAB_VERSION)/$$deb"; \
+		tmp=$$(mktemp -d); \
+		trap 'rm -rf "$$tmp"' EXIT; \
+		echo "installing containerlab $(CONTAINERLAB_VERSION) ($$arch) from the pinned .deb (needs sudo)"; \
+		curl -fsSL -o "$$tmp/$$deb" "$$url"; \
+		echo "$$sha  $$tmp/$$deb" | sha256sum -c -; \
+		sudo apt-get install -y "$$tmp/$$deb"; \
 	elif [ "$$(uname -s)" = "Darwin" ]; then \
 		echo ""; \
 		echo "containerlab does not ship a native macOS binary."; \

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -59,6 +59,7 @@ export default defineConfig({
       {
         text: 'Contributing',
         items: [
+          { text: 'CI pipeline', link: '/contributing/ci' },
           { text: 'Integration tests', link: '/contributing/integration-tests' },
           { text: 'Containerlab E2E harness', link: '/contributing/e2e-tests' },
         ],

--- a/docs/contributing/ci.md
+++ b/docs/contributing/ci.md
@@ -1,0 +1,220 @@
+# CI pipeline
+
+This page documents the CI gates, how `main` is protected, and the
+routine maintenance a few of them need (linter version, containerlab
+pin, the cross-repo PAT). The guiding contract (issue #161) is: **it
+must be impossible for untested code to reach `main` or a release tag
+through normal Git operations, and a dependency CVE must surface within
+a week even with no PR activity.**
+
+## Gate map
+
+| Workflow | File | Triggers | Required check |
+| --- | --- | --- | --- |
+| Test | `test.yml` | PR, push `main`, weekly | **`test`** |
+| Lint | `lint.yml` | PR | **`golangci-lint`, `vet`, `gofmt`, `docs-gen`** |
+| Build | `build.yml` | PR | **`verify`** |
+| Integration | `integration.yml` | PR (skips docs-only) | **`smoke`** |
+| govulncheck | `govulncheck.yml` | PR, push `main`, weekly | no |
+| E2E | `e2e.yml` | PR (skips docs-only), dispatch | no |
+| Docs | `docs.yml` | PR touching docs | no |
+| Package | `package.yml` | PR | no |
+| CodeQL | `codeql.yml` | PR, push `main`, weekly | no |
+| Dependency Review | `dependency-review.yml` | PR | no |
+| OpenSSF Scorecard | `scorecard.yml` | push `main`, weekly | no |
+| Release | `release.yml` | tag `v*` | n/a |
+| Deploy Documentation | `deploy-docs.yaml` | push `main` (docs), dispatch | n/a |
+| Add to project | `add-to-project.yml` | issues, PR target | n/a |
+
+The seven **required** contexts are enforced by the branch ruleset
+below. They are the workflow **job ids**, not the workflow names — a
+required context named `test` is the `test:` job, `verify` is Build's
+`verify:` job, and so on. **Renaming any required job id silently
+detaches it from the ruleset**, so rename the ruleset context in the
+same change (a linter would otherwise report the check as never
+arriving).
+
+`govulncheck`, `docs-build`, the E2E jobs, `deb-smoke`, CodeQL, and
+dependency-review are deliberately **not** required: a newly published
+CVE should surface loudly rather than hard-block an unrelated PR, and
+the path-filtered workflows (`docs.yml`, `e2e.yml`) would leave a
+required check Pending forever on PRs that do not trigger them.
+
+## Branch ruleset on `main`
+
+The ruleset is committed as code at
+[`.github/rulesets/main.json`](https://github.com/osism/ovn-network-agent/blob/main/.github/rulesets/main.json).
+It enforces:
+
+- **`deletion`** — `main` cannot be deleted (the one rule that already
+  existed).
+- **`pull_request`** — changes reach `main` only through a pull request.
+  Zero required approvals: the goal is to require the *PR path and the
+  status checks*, not reviews, so a single maintainer is not deadlocked
+  by an unapprovable self-review.
+- **`required_status_checks`** with `strict_required_status_checks_policy`
+  — the seven contexts above must pass **and** the branch must be up to
+  date with `main` before merge. "Up to date" is what closes the
+  semantic-merge-conflict gap: two PRs that each pass alone but conflict
+  in behaviour cannot both merge without the second re-running against
+  the first. If serialized merges become painful, a GitHub **merge
+  queue** is the documented alternative — swap the strict policy for a
+  `merge_queue` rule.
+- **`required_signatures`** — every commit that reaches `main` must carry
+  a verified signature. This is the compensating control for the
+  zero-review decision (see the trust boundary below), so applying the
+  ruleset requires commit signing to be configured first
+  (`git config gpg.format ssh` + a `user.signingkey`, or a GPG key, plus
+  `commit.gpgsign true`).
+
+**Trust boundary.** With zero required approvals no human other than the
+author inspects a change before it merges, and the required checks are
+machine gates — they catch broken code, not malicious code. Because
+`release.yml` builds a signed, attested release from a `v*` tag, the path
+from write access to a published release has no second-party review step;
+its trust boundary rests on **GitHub account security** (protect maintainer
+accounts with a phishing-resistant second factor) plus the
+`required_signatures` rules on `main` and on release tags — a stolen token
+or hijacked session alone cannot produce a signed commit or a signed
+release tag without also holding the maintainer's signing key. If the
+project gains a second maintainer, raise `required_approving_review_count`
+to `1` to add mandatory review.
+
+Applying or changing the ruleset is a repository-admin action that a PR
+cannot perform. Because a ruleset named `main` already exists, this is
+an **update (`PUT`)**, not a create:
+
+```bash
+# List rulesets and find the id of the one named "main".
+gh api repos/osism/ovn-network-agent/rulesets --jq '.[] | {id, name}'
+
+# Update it in place from the committed JSON (replace <id>).
+gh api --method PUT repos/osism/ovn-network-agent/rulesets/<id> \
+  --input .github/rulesets/main.json
+
+# If no "main" ruleset existed yet, create it instead:
+gh api --method POST repos/osism/ovn-network-agent/rulesets \
+  --input .github/rulesets/main.json
+```
+
+The `integration_id: 15368` on each required check pins the context to
+the GitHub Actions app, so a same-named check from another app cannot
+satisfy the gate. Verify the app id for this repo with:
+
+```bash
+gh api repos/osism/ovn-network-agent/commits/main/check-runs \
+  --jq '[.check_runs[].app.id] | unique'
+```
+
+## Ruleset on release tags
+
+`release.yml` triggers on `v*` tags, so the tags are a release trust
+boundary in their own right — a tag can be pushed onto any commit. The
+committed tag ruleset at
+[`.github/rulesets/tags.json`](https://github.com/osism/ovn-network-agent/blob/main/.github/rulesets/tags.json)
+targets `refs/tags/v*` and enforces:
+
+- **`deletion`** — a published release tag cannot be removed.
+- **`required_signatures`** — a `v*` tag must be signed to be created, so
+  the release path inherits the same key-bound trust boundary as `main`
+  (configure tag signing with `git config tag.gpgsign true`).
+
+It has no pre-existing counterpart, so the first apply is a **create
+(`POST`)**:
+
+```bash
+gh api --method POST repos/osism/ovn-network-agent/rulesets \
+  --input .github/rulesets/tags.json
+```
+
+## Scheduled and push runs
+
+The unit suite (`test.yml`) and `govulncheck.yml` run on push to `main`
+and on a weekly `schedule:` (Monday, staggered around 05:00–06:00 UTC
+with CodeQL and Scorecard). These non-PR runs are the backstop the
+green-main contract needs:
+
+- **push `main`** catches anything that reaches `main` outside the PR
+  path and confirms the merged commit post-merge.
+- **weekly cron** catches runner/kernel drift, toolchain updates, and a
+  CVE published against a pinned dependency during a quiet period —
+  surfacing it within a week with no PR activity.
+
+Scheduled-run failures appear in the Actions tab and notify the
+workflow file's last committer.
+
+## Release test gate
+
+`release.yml` runs the race-enabled unit suite in a `test` job that
+`build` depends on, before any artifact is built, signed, or attested.
+A tag can be pushed on any commit, so this gate is what stops an
+untested commit from becoming a release. Permissions are scoped per
+job: only `release` holds the write/attestation grants; `test` and
+`build` are read-only.
+
+## Docs-only pull requests
+
+A PR that touches only `docs/**` or `*.md` skips the heavy suites:
+
+- **E2E** is not a required check, so `e2e.yml` uses a plain
+  `paths-ignore` filter.
+- **Integration** *is* required (`smoke`), and a check skipped by
+  `on.paths` stays Pending forever and blocks the merge. So
+  `integration.yml` instead runs a `changes` job that inspects the PR
+  file list, and `smoke` runs under a fail-safe
+  `if: !cancelled() && needs.changes.outputs.code != 'false'`: it skips
+  only when `changes` positively reports a docs-only PR, and still runs
+  if `changes` itself fails. A skipped-by-`if:` job reports success to
+  the required check, so the gate does not hang.
+- **Docs** (`docs.yml`) builds the VitePress site so a dead internal
+  link fails the PR instead of the post-merge Pages deploy.
+
+## Lint gate
+
+[`.golangci.yml`](https://github.com/osism/ovn-network-agent/blob/main/.golangci.yml)
+is the versioned contract for the lint gate: the enabled linters
+(the standard set plus `gosec`, `errorlint`, `gocritic`, `revive`) and
+every exclusion are recorded there, so a linter major bump cannot
+silently change what the gate checks. Run it locally the way CI does —
+keep the version in sync with the pin in `lint.yml`:
+
+```bash
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+golangci-lint config verify
+golangci-lint run
+```
+
+`gosec` findings on this agent's audited seams — building
+`nft`/`vtysh`/`ovs-vsctl` argv, procfs sysctl writes, world-readable
+generated docs — are documented as categorical false positives in the
+config's `exclusions`, each with a why-comment. New code is still
+scanned normally.
+
+## Containerlab pin
+
+`make e2e-install-tools` installs a pinned containerlab `.deb` and
+verifies its sha256 against the checksum committed in the `Makefile`,
+instead of piping the upstream installer into a shell. To bump the
+version:
+
+1. Pick the new release at
+   <https://github.com/srl-labs/containerlab/releases>.
+2. Set `CONTAINERLAB_VERSION` and **both** `CONTAINERLAB_SHA256_amd64`
+   and `CONTAINERLAB_SHA256_arm64` in the `Makefile` from that release's
+   `checksums.txt` (the `linux_amd64.deb` / `linux_arm64.deb` lines).
+3. Both CI and local installs share these values through the
+   `e2e-lab-setup` composite action.
+
+## Cross-repo automation PAT
+
+`add-to-project.yml` runs `osism/.github`'s reusable workflow on
+`pull_request_target` with the `ADD_TO_PROJECT_PAT` secret. Two
+maintenance notes:
+
+- The reusable workflow is **pinned by commit SHA**, not `@main`, so a
+  moved upstream branch cannot change what runs in that privileged
+  context. Bump the SHA deliberately when adopting an upstream change,
+  updating the `# main as of <date>` comment.
+- `ADD_TO_PROJECT_PAT` should be a **fine-grained PAT** scoped to the
+  minimum: organization Projects read/write (plus the default repo
+  metadata read). Rotating it to that scope is an org-admin action.

--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -841,19 +841,23 @@ docker image inspect ovn-network-agent/gwnode:e2e \
 
 ## Continuous integration
 
-The harness runs on every push to `main` and on manual
-`workflow_dispatch` via
+The harness runs on pull requests and on manual `workflow_dispatch` via
 [`.github/workflows/e2e.yml`](https://github.com/osism/ovn-network-agent/blob/main/.github/workflows/e2e.yml).
-The workflow does **not** run on pull requests: spinning the lab up
-adds ~10 minutes to CI on a green run, which is too coarse for the
-per-PR feedback loop the rest of the workflows target.
+Docs-only changes are skipped with a `paths-ignore` filter (`docs/**`,
+`**.md`) so a typo fix does not spin the lab up. The workflow does
+**not** run on push to `main`: the branch ruleset requires PRs to be up
+to date, so the merged commit already passed E2E on its PR and
+re-running the ~10 min suite post-merge would only burn runner time.
 
-Six jobs run, each on its own runner so a regression in one scenario
-is reported in isolation:
+One job runs per scenario, each on its own runner so a regression in one
+scenario is reported in isolation. Every job installs containerlab and
+loads the required kernel modules through the shared
+[`e2e-lab-setup`](https://github.com/osism/ovn-network-agent/blob/main/.github/actions/e2e-lab-setup/action.yml)
+composite action:
 
-- **`baseline`** — installs containerlab, runs `make e2e-up`, executes
-  `test/e2e/scenarios/baseline.sh`, dumps + uploads artifacts on
-  failure (`e2e-artifacts-<run id>-<attempt>`), and always tears the
+- **`baseline`** — runs the `e2e-lab-setup` action and `make e2e-up`,
+  executes `test/e2e/scenarios/baseline.sh`, dumps + uploads artifacts
+  on failure (`e2e-artifacts-<run id>-<attempt>`), and always tears the
   lab down.
 - **`failover`** (`needs: baseline`) — same shape as baseline, but
   executes `test/e2e/scenarios/failover.sh`. On failure the artifact
@@ -864,6 +868,13 @@ is reported in isolation:
   root so the before/after `cookie=0x998` `dump-flows` snapshots are
   bundled with the lab-state dump. On failure the artifact bundle
   is uploaded as `e2e-artifacts-hairpin-<run id>-<attempt>`.
+- **`multi-vlan`** (`needs: baseline`, runs in parallel with the other
+  baseline-gated jobs) — same shape, but executes
+  `test/e2e/scenarios/multi-vlan.sh`. The job points the scenario's
+  `ARTIFACTS_DIR` at the same artifact root so the per-segment
+  flow/link/route snapshots are bundled with the lab-state dump. On
+  failure the artifact bundle is uploaded as
+  `e2e-artifacts-multi-vlan-<run id>-<attempt>`.
 - **`pf-external`** (`needs: baseline`, runs in parallel with
   `failover` and `hairpin`) — same shape, but executes
   `test/e2e/scenarios/pf-external.sh`. The job points the scenario's
@@ -871,6 +882,12 @@ is reported in isolation:
   source-IP log is bundled with the lab-state dump on failure (per
   issue #109's acceptance criterion). On failure the artifact
   bundle is uploaded as `e2e-artifacts-pf-external-<run id>-<attempt>`.
+- **`pf-hairpin`** (`needs: baseline`) — same shape, but executes
+  `test/e2e/scenarios/pf-hairpin.sh`. The job points the scenario's
+  `ARTIFACTS_DIR` at the same artifact root so the phase1-off /
+  phase2-on / teardown `nft` snapshots are bundled with the lab-state
+  dump (per issue #110's acceptance criterion). On failure the artifact
+  bundle is uploaded as `e2e-artifacts-pf-hairpin-<run id>-<attempt>`.
 - **`stale-chassis`** (`needs: failover`) — same shape, but executes
   `test/e2e/scenarios/stale-chassis.sh`. The job points the
   scenario's `ARTIFACTS_DIR` at the same artifact root so the

--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -51,13 +51,22 @@ test/e2e/
 
 - A Linux host with Docker (privileged mode is required for the
   containerlab containers).
-- [containerlab](https://containerlab.dev/install/) ≥ 0.55.
+- [containerlab](https://containerlab.dev/install/). CI and
+  `make e2e-install-tools` install the pinned version (`0.77.0`); any
+  release ≥ 0.55 works locally.
 - `make`, `docker buildx`, and a Go toolchain matching `go.mod` — the
   gwnode image builds the agent from source.
 
-`make e2e-install-tools` bootstraps containerlab on Linux via the
-upstream installer (`get.containerlab.dev`). It is a no-op when
-`containerlab` is already on `PATH`.
+On Debian/Ubuntu, `make e2e-install-tools` downloads the pinned
+containerlab `.deb`, verifies its sha256 against the checksum committed
+in the `Makefile`, and installs it with `apt-get` — a known, verified
+binary instead of piping the upstream `get.containerlab.dev` installer
+into a shell. It is a no-op when `containerlab` is already on `PATH`. To
+bump the version, update `CONTAINERLAB_VERSION` and **both**
+`CONTAINERLAB_SHA256_*` values in the `Makefile` from the upstream
+release's `checksums.txt`. On non-Debian distributions the target stops
+with a pointer to the [upstream install docs](https://containerlab.dev/install/);
+install containerlab there manually.
 
 ::: warning macOS is not a supported containerlab host
 Upstream ships no darwin binary for containerlab. The supported macOS

--- a/main.go
+++ b/main.go
@@ -1,3 +1,6 @@
+// Command ovn-network-agent is an event-driven agent that keeps host
+// routing, FRR, and nftables state in sync with OVN on gateway nodes of
+// OVN-based OpenStack environments.
 package main
 
 import (

--- a/ovn.go
+++ b/ovn.go
@@ -894,8 +894,8 @@ func (h *sbEventHandler) OnAdd(table string, m model.Model) {
 	h.handleChange(table)
 }
 
-func (h *sbEventHandler) OnUpdate(table string, old, new model.Model) {
-	if h.isChassisRedirect(table, new) {
+func (h *sbEventHandler) OnUpdate(table string, old, updated model.Model) {
+	if h.isChassisRedirect(table, updated) {
 		slog.Debug("chassisredirect port updated, immediate refresh")
 		h.ovn.signalDrainWatch()
 		h.ovn.immediateStateRefresh()
@@ -941,7 +941,7 @@ func (h *nbEventHandler) OnAdd(table string, m model.Model) {
 	h.handleChange(table)
 }
 
-func (h *nbEventHandler) OnUpdate(table string, old, new model.Model) {
+func (h *nbEventHandler) OnUpdate(table string, old, updated model.Model) {
 	h.handleChange(table)
 }
 


### PR DESCRIPTION
## Summary

Closes #161

Every quality gate (test / lint / build / integration / e2e) previously triggered on `pull_request` only, on the rationale that "the merged commit already passed on its PR." That only holds if PRs are *required* and kept up to date — which the `main` ruleset did not enforce (it carried only a deletion rule). This branch enforces the green-main contract end to end and closes the scanner/build gaps the issue enumerates: it makes it structurally impossible for untested code to reach `main` or a release tag, gives dependency CVEs a non-PR path to surface, and pins the lint gate in-repo.

The change is entirely CI/build/docs plumbing plus two linter-mandated one-liners in Go source. No behavioral code change.

## Change set (in commit order)

1. **`856dd5e` — concurrency groups that cancel superseded PR runs.** Every PR-triggered workflow shares a `${{ github.workflow }}-${{ github.ref }}` group so a force-push cancels the runs it supersedes (the E2E suite alone can leave ~8 × ~15 min lab runners churning). `cancel-in-progress` is guarded on the event name so `push`/`schedule` runs on main never cancel each other mid-history — only `pull_request` runs are superseded.

2. **`15f9a9d` — run unit tests on `push: main` and weekly.** Adds a backstop for anything that reaches main outside the PR path, plus a weekly cron as a canary for runner/kernel drift and dependency rot during quiet periods.

3. **`d798496` — gate release artifact builds on the unit test suite.** `release.yml` gains a race-enabled `test` job that `build` depends on, so a tag can no longer reach the build/sign/attest path with zero test signal. Write/attestation permissions move from the workflow level down to the `release` job, leaving `test` and `build` read-only.

4. **`beae08a` — move govulncheck to its own workflow with main + weekly runs.** Splitting it out (rather than adding triggers to `lint.yml`) keeps the non-PR triggers off the other lint jobs, whose ids are required-check contexts. A new advisory against a pinned dep now surfaces within a week even with no PR activity — matching the existing CodeQL/Scorecard crons.

5. **`fb77db7` — cross-compile for `linux/arm64` on PRs.** Adds `GOOS=linux GOARCH=arm64 go build ./...` to the PR build so arm64 breakage fails the PR instead of first surfacing at release-tag time.

6. **`992bb5e` — commit a curated `.golangci.yml` and satisfy the new linters.** Versions the gate in-repo: standard v2 set plus gosec, errorlint, gocritic, and revive — the gates a root-privileged agent that shells out to `nft`/`vtysh`/`ovs-vsctl` should carry. Every exclusion is documented in-file as a categorical false positive. The only source changes the new linters demand: a package doc comment on `main` (`main.go`) and renaming a builtin-shadowing `new` parameter in the OVN event handlers (`ovn.go`).

7. **`0704ce4` — pin containerlab and hoist E2E lab setup into a composite action.** Replaces the unpinned `curl | bash` sudo install (duplicated across 8 E2E jobs and the Makefile) with a pinned `.deb` whose sha256 is verified against a checksum committed in the Makefile — the single source of truth shared with local installs. Install + modprobe boilerplate moves into a reusable `e2e-lab-setup` composite action.

8. **`748c7e5` — skip integration and e2e on docs-only PRs.** E2E (not a required check) uses a plain `paths-ignore`. The integration `smoke` job **is** required, so it can't use `on.paths` (a path-skipped required check hangs Pending forever) — instead a `changes` job inspects the PR file list and `smoke` runs under a fail-safe `if:` that skips only when `changes` positively reports a docs-only PR, and still runs if `changes` itself fails. Also corrects the stale CI section in the E2E docs.

9. **`cb6abf8` — build the docs on PRs to catch dead links early.** A path-filtered PR workflow runs `npm ci && npm run docs:build` on changes under `docs/` or the lockfiles, so a broken internal link fails the PR instead of the post-merge Pages deploy. Deliberately **not** a required check — being path-filtered, it would hang a required check Pending on non-docs PRs.

10. **`92fcc5f` — pin the add-to-project reusable workflow to a commit SHA.** `add-to-project.yml` called `osism/.github`'s reusable workflow at `@main` while running on `pull_request_target` with a cross-repo PAT. Pins it to a full SHA and documents the minimal PAT scope (organization Projects read/write) inline.

11. **`eb54a77` — drop the unused `pull-requests: write` permission.** `dependency-review.yml` granted it but never enabled `comment-summary-in-pr`, so `contents: read` suffices. Dropped for least privilege.

12. **`137d4d6` — commit the main branch ruleset and document the CI gates.** Ships the branch ruleset as importable JSON (`.github/rulesets/main.json`) requiring a PR and the Test / Lint / Build / Integration status checks, and keeping branches up to date with main — the strict policy that closes the semantic-merge-conflict gap. Adds a CI how-to page (`docs/contributing/ci.md`) with the gate map, ruleset apply/update procedure, schedules, release gate, docs-only skips, lint gate, containerlab bump, and PAT scope; registers it in the sidebar and points `CONTRIBUTING.md` at it.

## Notes for the reviewer

- **The ruleset is not self-applying.** Committing `.github/rulesets/main.json` does not enforce it — applying it is a repo-admin action a PR cannot perform. The JSON ships with the `gh api` apply/update procedure in `docs/contributing/ci.md`; a maintainer must import it for acceptance criterion #1 ("impossible for untested code to reach `main`") to actually hold.
- **A `tags.json` ruleset is included** (`refs/tags/v*`: deletion protection + required signatures). The issue's task list named only the `main` ruleset; this is a small supporting addition on the same release-gate theme (protecting the tag → release path) and, like `main.json`, must be applied by an admin to take effect.
- **govulncheck moved to its own workflow** rather than gaining triggers on the existing `lint.yml`, as the commit explains — necessary to avoid firing the required-check lint contexts on `push`/`schedule`. This is a means-level divergence from the issue's phrasing ("add weekly `schedule:` and `push: main` triggers"), not a scope change.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 01245b5 with Claude:claude-opus-4-8_
