### PR TITLE
Tests: close the drain-handshake and reconnect blind spots, make integration coverage measurable

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,7 +52,10 @@ jobs:
     # required smoke gate still runs rather than being silently skipped.
     if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 30 minutes: the instrumented (-cover -race) binary is slower than a
+    # plain build, and the >=45s reconnect outage scenario adds a couple of
+    # minutes on top of the base suite.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -63,14 +66,36 @@ jobs:
       - name: Bootstrap OVN/OVS/FRR/nftables stack
         run: sudo ./test/integration/setup.sh
 
-      - name: Build agent
-        run: make build
+      # Coverage-instrumented (-cover) and race-checked (-race) agent binary so
+      # integration-only Linux code (main(), Connect(), routing_linux.go,
+      # nftables_linux.go) shows up in the merged coverage figure and the
+      # concurrency-heavy paths run under the race detector.
+      - name: Build instrumented agent
+        run: make build-integration
 
       # The agent needs CAP_NET_ADMIN for netlink operations (see
       # routing_linux.go). Run as root via sudo, preserving the Go env so
-      # `go test` finds the toolchain installed by setup-go.
+      # `go test` finds the toolchain installed by setup-go. GOCOVERDIR
+      # collects one set of counter files per agent process that exits cleanly.
       - name: Run integration tests
         run: |
+          mkdir -p covdata
           sudo --preserve-env=PATH,GOROOT,GOPATH,GOTOOLCHAIN \
             env "OVN_AGENT_BINARY=$PWD/ovn-network-agent" \
-            "$(which go)" test -tags=integration -v -count=1 ./test/integration/...
+            "GOCOVERDIR=$PWD/covdata" \
+            "$(which go)" test -tags=integration -v -count=1 -timeout 25m ./test/integration/...
+
+      # Publish the merged integration coverage figure in the job log. This is
+      # informational (not a gate), so it tolerates a covdata dir with no
+      # counters — e.g. if every agent were SIGKILL'd rather than SIGTERM'd.
+      # The agents run as root, so make the counter files readable first.
+      - name: Report integration coverage
+        if: ${{ always() }}
+        run: |
+          sudo chmod -R a+r covdata || true
+          if ! go tool covdata percent -i covdata; then
+            echo "no integration coverage counters collected"
+            exit 0
+          fi
+          go tool covdata textfmt -i covdata -o integration-coverage.out
+          go tool cover -func=integration-coverage.out | tail -n 1

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION   ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "d
 LDFLAGS   := -s -w -X main.version=$(VERSION)
 GOFLAGS   := -trimpath
 
-.PHONY: all build build-static clean fmt vet test test-integration install docs-gen docs-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-hairpin e2e-multi-vlan e2e-pf-external e2e-pf-hairpin e2e-stale-chassis e2e-drain-hitless
+.PHONY: all build build-static build-integration clean fmt vet test test-integration install docs-gen docs-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-hairpin e2e-multi-vlan e2e-pf-external e2e-pf-hairpin e2e-stale-chassis e2e-drain-hitless
 
 # Containerlab E2E harness. See test/e2e/README.md for the topology and
 # acceptance criteria (issue #44).
@@ -37,6 +37,15 @@ build:
 build-static:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(GOFLAGS) -ldflags '$(LDFLAGS)' -o $(BINARY) .
 
+# Instrumented agent binary for the CI integration job: coverage counters
+# (-cover, so integration-only Linux code shows up in the merged figure) plus
+# the race detector (-race, which drives refreshLoop / drainWatchCh / event
+# handlers under real OVSDB event storms). -covermode=atomic is required with
+# -race, and -race needs cgo, so this builds only on a Linux host — it is not a
+# darwin cross-build.
+build-integration:
+	GOOS=linux go build $(GOFLAGS) -cover -covermode=atomic -race -ldflags '$(LDFLAGS)' -o $(BINARY) .
+
 fmt:
 	go fmt ./...
 
@@ -52,7 +61,7 @@ test:
 # https://osism.github.io/ovn-network-agent/contributing/integration-tests)
 # for local-run prerequisites.
 test-integration: build
-	OVN_AGENT_BINARY=$(CURDIR)/$(BINARY) go test -tags=integration -v -count=1 ./test/integration/...
+	OVN_AGENT_BINARY=$(CURDIR)/$(BINARY) go test -tags=integration -v -count=1 -timeout 25m ./test/integration/...
 
 clean:
 	rm -f $(BINARY)

--- a/agent_test.go
+++ b/agent_test.go
@@ -553,6 +553,90 @@ func TestReconcileSkipsMarkerWithoutLocalRouters(t *testing.T) {
 	}
 }
 
+// TestReconcileFailedAnnounceWithholdsMarker pins the failure side of the
+// takeover-readiness gate (agent.go: `announced && state.HasLocalRouters`).
+// A node that owns local routers but whose announce fails — here the FRR
+// batch add errors, so ensureRoutes returns false — must NOT stamp the
+// readiness marker, because it has attracted BGP traffic it cannot deliver.
+// A draining peer polls that marker before releasing its own FIP routes, so a
+// premature marker would blackhole traffic during the HA window this handshake
+// exists to protect.
+//
+// This is the negative twin of TestReconcileMixedFamilyAnnouncesV4AndWritesMarker
+// (which drives a successful announce and asserts the marker IS written) and of
+// TestReconcileSkipsMarkerWithoutLocalRouters (which pins the HasLocalRouters
+// half). Dropping the `announced` conjunct — the mutation `if
+// state.HasLocalRouters` — makes this test fail: the marker would be written
+// despite the failed announce.
+func TestReconcileFailedAnnounceWithholdsMarker(t *testing.T) {
+	const (
+		fip    = "198.51.100.50"
+		bridge = "ovnagent-nonexistent-br"
+		lrpMAC = "fa:16:3e:aa:aa:aa"
+	)
+	rec := newVtyshRecorder()
+	// Arm the FRR batch-add for the FIP to fail. AddFRRRoutes joins the batch
+	// errors and returns non-nil, so ensureRoutes sets announced = false.
+	rec.on([]string{"vtysh", "-c", "conf t", "-c", "vrf vrf-provider",
+		"-c", "ip route " + fip + "/32 169.254.0.1", "-c", "exit-vrf", "-c", "end"},
+		"", errors.New("test: vtysh add failed"))
+	rm := &RouteManager{
+		bridgeDev:     bridge,
+		vrfName:       "vrf-provider",
+		vethNexthop:   "169.254.0.1",
+		execVtyshHook: rec.hook(),
+		execOVSHook: func(*exec.Cmd) ([]byte, error) {
+			return nil, errors.New("test: no ovs available")
+		},
+		// Pre-seed the FIP /32 on the bridge so ensureRoutes never calls the
+		// Linux-only AddKernelRoute — the announce fails purely on the FRR add.
+		listKernelRoutesHook: func() ([]kernelRouteEntry, error) {
+			return []kernelRouteEntry{{IP: fip, Dev: bridge}}, nil
+		},
+	}
+
+	c, nb, _ := newOVNClientWithFakes(t, "host-a")
+	c.state.LocalRouters = []LocalRouterInfo{{RouterName: "r1", RouterUUID: "lr1", LRPName: "lrp-r1", LRPMAC: lrpMAC}}
+	c.state.HasLocalRouters = true
+	c.state.NATIPToRouterMAC = map[string]string{fip: lrpMAC}
+	nb.setRows("Logical_Router", &NBLogicalRouter{UUID: "lr1", Name: "r1", StaticRoutes: []string{"sr1"}})
+	nb.setRows("Logical_Router_Static_Route", &NBLogicalRouterStaticRoute{
+		UUID:     "sr1",
+		IPPrefix: "0.0.0.0/0",
+		ExternalIDs: map[string]string{
+			"ovn-network-agent":         "managed",
+			"ovn-network-agent-chassis": "host-b",
+			takeoverReadyMarkerKey:      "host-b",
+		},
+	})
+
+	a := &Agent{
+		cfg:            Config{},
+		ovn:            c,
+		routing:        rm,
+		reconcileCh:    make(chan struct{}, 1),
+		missingChassis: make(map[string]time.Time),
+	}
+	a.reconcile(context.Background(), "test")
+
+	// Vacuity guard: the failing announce path must actually have been driven —
+	// the FRR add was attempted for the FIP.
+	attempted := false
+	for _, call := range rec.calls {
+		if strings.Contains(strings.Join(call, " "), "ip route "+fip+"/32 169.254.0.1") {
+			attempted = true
+			break
+		}
+	}
+	if !attempted {
+		t.Fatalf("FRR add for %s was never attempted; calls: %v", fip, rec.calls)
+	}
+
+	if hasMarkerUpdate(nb.writeTransacts(), "host-a") {
+		t.Fatalf("reconcile stamped the takeover marker after a failed announce; writes: %v", nb.writeTransacts())
+	}
+}
+
 // hasMarkerUpdate reports whether any recorded write updates a
 // Logical_Router_Static_Route external_ids with a takeover readiness marker
 // naming chassis.

--- a/agent_test.go
+++ b/agent_test.go
@@ -781,6 +781,96 @@ func TestEnsureRoutesReturnsAnnounceOutcome(t *testing.T) {
 	})
 }
 
+// inactiveRoutesGauge reads the single-series ovn_network_agent_inactive_routes
+// gauge from the test registry.
+func inactiveRoutesGauge(t *testing.T, m *metricsRegistry) float64 {
+	t.Helper()
+	got, err := m.registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather(): %v", err)
+	}
+	for _, mf := range got {
+		if mf.GetName() != "ovn_network_agent_inactive_routes" {
+			continue
+		}
+		series := mf.GetMetric()
+		if len(series) == 0 {
+			t.Fatalf("inactive_routes gauge has no series")
+		}
+		return series[0].GetGauge().GetValue()
+	}
+	t.Fatalf("metric ovn_network_agent_inactive_routes not found in registry")
+	return 0
+}
+
+// TestCheckFRRRouteActivity pins the two uncovered branches of
+// checkFRRRouteActivity (agent.go). The documented contract is that a failed
+// vtysh check leaves the inactive_routes gauge at its previous value rather
+// than falsely resetting it to zero, and that a configured-but-inactive route
+// bumps the gauge and logs an alert. Deleting the early return on the error
+// path — which would zero the alerting metric during a vtysh outage — is
+// caught by the "vtysh error keeps gauge" subtest.
+func TestCheckFRRRouteActivity(t *testing.T) {
+	const fip = "198.51.100.10"
+	const jsonCmd = "show ip route vrf vrf-provider static json"
+	newAgent := func(rec *vtyshRecorder) *Agent {
+		rm := &RouteManager{vrfName: "vrf-provider", execVtyshHook: rec.hook()}
+		return &Agent{routing: rm, cfg: Config{VRFName: "vrf-provider"}}
+	}
+
+	t.Run("vtysh error keeps gauge", func(t *testing.T) {
+		m := withTestMetrics(t)
+		logs := captureSlog(t)
+		// A prior cycle observed one inactive route. The failing check must
+		// not clobber that value with a false zero.
+		setInactiveRoutes(3)
+
+		rec := newVtyshRecorder()
+		rec.on([]string{"vtysh", "-c", jsonCmd}, "", errors.New("test: vtysh unreachable"))
+		newAgent(rec).checkFRRRouteActivity([]string{fip})
+
+		if got := inactiveRoutesGauge(t, m); got != 3 {
+			t.Errorf("gauge after failed check = %v, want 3 (unchanged)", got)
+		}
+		if !strings.Contains(logs.String(), "could not verify FRR route activity") {
+			t.Errorf("expected the check-failure warning; logs:\n%s", logs.String())
+		}
+	})
+
+	t.Run("inactive route sets gauge and logs alert", func(t *testing.T) {
+		m := withTestMetrics(t)
+		logs := captureSlog(t)
+
+		rec := newVtyshRecorder()
+		// selected/installed are omitted (FRR drops them when false), so the
+		// route is configured but not advertised.
+		rec.on([]string{"vtysh", "-c", jsonCmd},
+			`{"`+fip+`/32":[{"prefix":"`+fip+`/32","protocol":"static"}]}`, nil)
+		newAgent(rec).checkFRRRouteActivity([]string{fip})
+
+		if got := inactiveRoutesGauge(t, m); got != 1 {
+			t.Errorf("gauge with one inactive route = %v, want 1", got)
+		}
+		if !strings.Contains(logs.String(), "FRR static routes are configured but inactive") {
+			t.Errorf("expected the inactive-route alert; logs:\n%s", logs.String())
+		}
+	})
+
+	t.Run("healthy route resets gauge", func(t *testing.T) {
+		m := withTestMetrics(t)
+		setInactiveRoutes(3)
+
+		rec := newVtyshRecorder()
+		rec.on([]string{"vtysh", "-c", jsonCmd},
+			`{"`+fip+`/32":[{"prefix":"`+fip+`/32","protocol":"static","selected":true,"installed":true}]}`, nil)
+		newAgent(rec).checkFRRRouteActivity([]string{fip})
+
+		if got := inactiveRoutesGauge(t, m); got != 0 {
+			t.Errorf("gauge with a healthy route = %v, want 0", got)
+		}
+	})
+}
+
 // TestRemoveAllRoutesWithStubbedFRRList exercises the FRR-driven removal
 // path: a stub vtysh hook reports two managed routes, the agent batches
 // the deletion, and a BGP soft-refresh follows because routes were removed.

--- a/docs/contributing/ci.md
+++ b/docs/contributing/ci.md
@@ -169,6 +169,24 @@ A PR that touches only `docs/**` or `*.md` skips the heavy suites:
 - **Docs** (`docs.yml`) builds the VitePress site so a dead internal
   link fails the PR instead of the post-merge Pages deploy.
 
+## Integration coverage
+
+The `smoke` job builds the agent with `make build-integration`
+(`go build -cover -covermode=atomic -race`) rather than a plain binary, so
+integration-only Linux code — `main()`, `Connect()`, `routing_linux.go`,
+`nftables_linux.go` — is counted, and the concurrency-heavy paths
+(`refreshLoop`, `drainWatchCh`, event handlers) run under the race detector.
+Each agent process writes counter files to `GOCOVERDIR`; a post-test step
+merges them with `go tool covdata` and prints the total in the job log. This
+figure is **informational**, not a gate — the merge tolerates a run where no
+counters were collected so it never fails the required check.
+
+The enforced coverage floor (`COVERAGE_FLOOR` in `test.yml`) is deliberately
+left unchanged: it gates the **unit** suite, and raising it needs the merged
+unit-plus-integration numbers this instrumentation first makes visible. Revisit
+the floor once those numbers have stabilised across a few runs (issue #160's
+"afterwards revisit" step).
+
 ## Lint gate
 
 [`.golangci.yml`](https://github.com/osism/ovn-network-agent/blob/main/.golangci.yml)

--- a/docs/contributing/integration-tests.md
+++ b/docs/contributing/integration-tests.md
@@ -14,8 +14,8 @@ test/integration/
   scenarios_helpers_test.go                   — shared per-scenario boilerplate (startScenario, readyAgent)
   scenario_fip_test.go                        — FIP add/remove, gatewayless gw, multi-router on one chassis
   scenario_failover_test.go                   — failover, stale-chassis cleanup (incl. multi-stale + one-stale-one-returning), drain & restore-drained
-  scenario_reconnect_test.go                  — OVN database pause/resume resilience (#64 scenario 1)
-  scenario_drain_edges_test.go                — drain edge cases (timeout, no local routers, cleanup_on_shutdown=false)
+  scenario_reconnect_test.go                  — OVN pause/resume resilience + reconnect through the 30s inactivity probe (#64, #160)
+  scenario_drain_edges_test.go                — drain edge cases (timeout, no local routers, cleanup_on_shutdown=false, stuck NB write)
   scenario_drift_test.go                      — periodic-reconcile + verifyRoutes drift recovery (#55)
   scenario_network_cidrs_test.go              — manual network_cidr override vs. auto-discovery, empty-filter sweep
   scenario_gateway_port_test.go               — legacy single-router gateway_port filter (#62)
@@ -33,7 +33,7 @@ test/integration/
   scenario_router_masquerade_ordering_test.go — router_masquerade configured before SNAT NAT exists (#88 item 4)
   scenario_same_batch_fip_test.go             — single OVSDB transaction adds + removes FIPs (#88 item 5)
   scenario_partial_failure_retry_test.go      — FRR write fails, kernel untouched, only FRR re-added (#88 item 6)
-  testenv/                                    — Setup, Teardown, RunAgent, MakeLocalRouter, Assert*, ScrapeMetrics, WithFailingTool, …
+  testenv/                                    — Setup, Teardown, RunAgent, MakeLocalRouter, Assert*, ScrapeMetrics, WithFailingTool, StartDrainRebind, StopOVNDatabases, StopNBDatabase, …
 ```
 
 The failure-injection scenarios all share the `TestScenario_FailureInjection_`
@@ -121,4 +121,29 @@ Run `setup.sh` if you see skip messages for the bridge or binaries.
 ## CI
 
 `.github/workflows/integration.yml` runs the same flow on `ubuntu-latest`:
-`setup.sh` → `make build` → `go test -tags=integration ...` under sudo.
+`setup.sh` → `make build-integration` → `go test -tags=integration ...`
+under sudo, then a coverage-report step.
+
+## Coverage instrumentation
+
+CI builds the agent with `make build-integration`
+(`go build -cover -covermode=atomic -race`) so integration-only Linux code
+(`main()`, `Connect()`, `routing_linux.go`, `nftables_linux.go`) is counted
+and the concurrency-heavy paths run under the race detector. Each agent
+process writes per-process counter files to the directory named by
+`GOCOVERDIR`, which `testenv.RunAgent` propagates to the subprocess; only
+agents that exit cleanly on SIGTERM emit their counters (a SIGKILL loses
+them, which is acceptable best-effort).
+
+To collect and read the merged figure locally:
+
+```sh
+make build-integration
+mkdir -p covdata
+sudo OVN_AGENT_BINARY=$PWD/ovn-network-agent GOCOVERDIR=$PWD/covdata \
+    go test -tags=integration -count=1 -timeout 25m ./test/integration/...
+go tool covdata percent -i covdata
+```
+
+The published figure is informational; the enforced unit-coverage floor
+lives in `test.yml` (see the CI docs for why it is tracked separately).

--- a/ovn.go
+++ b/ovn.go
@@ -134,6 +134,7 @@ type NBGatewayChassis struct {
 type ovsdbClient interface {
 	Connect(context.Context) error
 	Close()
+	Connected() bool
 	Cache() *cache.TableCache
 	NewMonitor(...client.MonitorOption) *client.Monitor
 	Monitor(context.Context, *client.Monitor) (client.MonitorCookie, error)
@@ -374,8 +375,44 @@ func (o *OVNClient) Connect(ctx context.Context) error {
 		o.refreshLoop(ctx)
 	}()
 
+	// Mirror each client's live connection status into the
+	// ovn_connection_state gauge. Capture the client values now (not
+	// o.sbClient/o.nbClient) so a concurrent closeClients() nil-ing the
+	// fields cannot race the poller. The watcher shares refreshLoop's ctx,
+	// which Run cancels before Close() runs, so it never outlives the client.
+	go watchConnectionState(ctx, o.sbClient, o.nbClient, connStatePollInterval)
+
 	success = true
 	return nil
+}
+
+// connStatePollInterval is how often watchConnectionState samples each client's
+// connection status. One second is fine-grained enough to catch a transient
+// outage while adding negligible load.
+const connStatePollInterval = time.Second
+
+// watchConnectionState mirrors the live connection status of the SB and NB
+// clients into the ovn_connection_state gauge until ctx is cancelled.
+//
+// The gauge is otherwise only cleared by closeClients(), so a transient OVSDB
+// outage would never show in the metric: libovsdb's reconnect path
+// re-establishes the monitors and repopulates the cache internally and only
+// signals DisconnectNotify on a terminal (non-reconnect) close, so there is no
+// event to hook for a drop-and-recover cycle. Polling Connected() is the only
+// reliable mirror of the outage, which is what lets an operator alert on a lost
+// OVN connection and what the reconnect integration scenario asserts on.
+func watchConnectionState(ctx context.Context, sb, nb ovsdbClient, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			setOVNConnectionState("sb", sb.Connected())
+			setOVNConnectionState("nb", nb.Connected())
+		}
+	}
 }
 
 func (o *OVNClient) Close() {

--- a/ovn_cache.go
+++ b/ovn_cache.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 )
@@ -205,11 +206,26 @@ func serverKeySet[T any](
 	return set, nil
 }
 
+// consistencySelectTimeout bounds every consistency-guard select. The guard's
+// contract is to degrade to the monitor cache when the server cannot answer,
+// but under client.WithReconnect a Transact against an unresponsive server
+// (SIGSTOP'd, network blackhole) does not fail — it blocks on the caller's
+// context while holding the libovsdb client's rpc mutex read-side. Unbounded,
+// that stalls reconciliation for the whole outage and blocks the inactivity
+// probe's Disconnect (a write-lock acquisition) indefinitely, so the client
+// can never even begin reconnecting. The bound must sit well under the 30s
+// inactivity probe so a stuck select releases the mutex before the probe
+// needs it; a healthy projection select answers in milliseconds. A var so the
+// unit test can shrink it.
+var consistencySelectTimeout = 5 * time.Second
+
 // directSelect runs an OVSDB select on table, bypassing the monitor cache.
 // With columns nil every column is returned; otherwise only the named ones.
 // Where is left empty — Operation.MarshalJSON encodes a conditionless select
 // as the match-everything form.
 func directSelect(ctx context.Context, c ovsdbClient, table string, columns []string) ([]ovsdb.Row, error) {
+	ctx, cancel := context.WithTimeout(ctx, consistencySelectTimeout)
+	defer cancel()
 	op := ovsdb.Operation{
 		Op:      ovsdb.OperationSelect,
 		Table:   table,

--- a/ovn_cache_test.go
+++ b/ovn_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 )
@@ -94,6 +95,50 @@ func TestAuthoritativeListServerSelectErrorTrustsCache(t *testing.T) {
 		keyOfSBChassis, decodeSBChassis)
 	if !reflect.DeepEqual(got, cached) {
 		t.Errorf("got %+v, want cache snapshot %+v on select error", got, cached)
+	}
+}
+
+// blockingTransactClient models an OVSDB server that is reachable at the TCP
+// level but never answers — a SIGSTOP'd ovsdb-server or a blackholed network.
+// Under client.WithReconnect a real Transact blocks on its context in exactly
+// this way instead of returning an error.
+type blockingTransactClient struct {
+	*fakeOVSDBClient
+}
+
+func (b *blockingTransactClient) Transact(ctx context.Context, _ ...ovsdb.Operation) ([]ovsdb.OperationResult, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// TestAuthoritativeListBoundsStuckServerSelect: a select against an
+// unresponsive server must degrade to the monitor cache within
+// consistencySelectTimeout instead of blocking on the caller's context. An
+// unbounded select stalls reconciliation for the whole outage, and — because
+// a blocked Transact holds the libovsdb client mutex read-side — blocks the
+// inactivity probe's Disconnect, so the client can never start reconnecting.
+// TestScenario_OVNReconnectAfterLongOutage pins the full path in CI.
+func TestAuthoritativeListBoundsStuckServerSelect(t *testing.T) {
+	_, _, sb := newOVNClientWithFakes(t, "host-a")
+	blocked := &blockingTransactClient{fakeOVSDBClient: sb}
+
+	old := consistencySelectTimeout
+	consistencySelectTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { consistencySelectTimeout = old })
+
+	cached := []SBChassis{{UUID: "ch-1", Name: "ch-1", Hostname: "host-a"}}
+	done := make(chan []SBChassis, 1)
+	go func() {
+		done <- authoritativeList(context.Background(), blocked, "Chassis", chCheckColumns,
+			cached, keyOfSBChassis, decodeSBChassis)
+	}()
+	select {
+	case got := <-done:
+		if !reflect.DeepEqual(got, cached) {
+			t.Errorf("got %+v, want cache snapshot %+v on stuck select", got, cached)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("authoritativeList still blocked after 5s: the consistency select is not bounded")
 	}
 }
 

--- a/ovn_fake_test.go
+++ b/ovn_fake_test.go
@@ -57,6 +57,11 @@ type fakeOVSDBClient struct {
 	// outside the row lock so the hook may block other List operations.
 	// Used by coalescing tests to hold a refresh in-flight.
 	onList func()
+
+	// connected backs Connected(); flipped by setConnected. Guarded by mu so
+	// watchConnectionState's polling goroutine and the test goroutine do not
+	// race under -race.
+	connected bool
 }
 
 func newFakeOVSDBClient(dbm model.ClientDBModel) *fakeOVSDBClient {
@@ -192,6 +197,20 @@ func modelToRow(m model.Model) ovsdb.Row {
 func (f *fakeOVSDBClient) Connect(context.Context) error { return nil }
 func (f *fakeOVSDBClient) Close()                        {}
 func (f *fakeOVSDBClient) Cache() *cache.TableCache      { return nil }
+
+// Connected reports the fake's simulated connection status. setConnected drives
+// it so tests can exercise watchConnectionState's drop/recover mirroring.
+func (f *fakeOVSDBClient) Connected() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.connected
+}
+
+func (f *fakeOVSDBClient) setConnected(v bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.connected = v
+}
 
 func (f *fakeOVSDBClient) NewMonitor(_ ...client.MonitorOption) *client.Monitor {
 	return &client.Monitor{}

--- a/ovn_test.go
+++ b/ovn_test.go
@@ -1314,3 +1314,79 @@ func TestImmediateStateRefreshFollowUpRuns(t *testing.T) {
 		t.Errorf("expected exactly 2 refresh passes (in-flight + follow-up), got %d", got)
 	}
 }
+
+// TestWatchConnectionStateMirrorsConnected verifies watchConnectionState
+// tracks each client's Connected() into the ovn_connection_state gauge in
+// both directions — the drop-and-recover cycle a transient OVSDB outage
+// produces. This is the unit-level analog of the reconnect integration
+// scenario, which asserts the same 1->0->1 transition against a real server.
+func TestWatchConnectionStateMirrorsConnected(t *testing.T) {
+	m := withTestMetrics(t)
+	_, nb, sb := newOVNClientWithFakes(t, "host-a")
+
+	sb.setConnected(true)
+	nb.setConnected(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		watchConnectionState(ctx, sb, nb, time.Millisecond)
+	}()
+
+	waitConnGauge(t, m, "sb", 1)
+	waitConnGauge(t, m, "nb", 1)
+
+	// A transient NB outage: the gauge must drop while SB stays up.
+	nb.setConnected(false)
+	waitConnGauge(t, m, "nb", 0)
+	waitConnGauge(t, m, "sb", 1)
+
+	// Recovery: the gauge must climb back to 1.
+	nb.setConnected(true)
+	waitConnGauge(t, m, "nb", 1)
+
+	cancel()
+	<-done
+}
+
+// waitConnGauge polls the ovn_connection_state{database=db} gauge in the test
+// registry until it equals want or the timeout expires.
+func waitConnGauge(t *testing.T, m *metricsRegistry, db string, want float64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	var last float64
+	var found bool
+	for time.Now().Before(deadline) {
+		last, found = connGaugeValue(t, m, db)
+		if found && last == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("ovn_connection_state{database=%q} = %v (found=%v), want %v", db, last, found, want)
+}
+
+// connGaugeValue reads the ovn_connection_state gauge for the given database
+// label from the test registry.
+func connGaugeValue(t *testing.T, m *metricsRegistry, db string) (float64, bool) {
+	t.Helper()
+	got, err := m.registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather(): %v", err)
+	}
+	for _, mf := range got {
+		if mf.GetName() != "ovn_network_agent_ovn_connection_state" {
+			continue
+		}
+		for _, item := range mf.GetMetric() {
+			for _, l := range item.GetLabel() {
+				if l.GetName() == "database" && l.GetValue() == db {
+					return item.GetGauge().GetValue(), true
+				}
+			}
+		}
+	}
+	return 0, false
+}

--- a/test/integration/scenario_drain_edges_test.go
+++ b/test/integration/scenario_drain_edges_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"context"
 	"os/exec"
 	"strings"
 	"testing"
@@ -180,81 +179,22 @@ func TestScenario_DrainKeepsRoutesWhenCleanupDisabled(t *testing.T) {
 	peerUUID := testenv.MakeChassis(t, ctx, sb, "drainkeep-peer")
 	gcName := "lrp-" + router.Name + "_" + testenv.LocalHostname(t)
 
-	// Goroutine: when NB shows priority=0 for our local Gateway_Chassis,
-	// rebind the CR Port_Binding to the peer so countLocalCRPorts → 0 and
-	// drain completes without hitting drain_timeout.
-	errCh := make(chan error, 1)
-	pctx, pcancel := context.WithCancel(ctx)
-	defer pcancel()
-	go func() {
-		tick := time.NewTicker(50 * time.Millisecond)
-		defer tick.Stop()
-		for {
-			select {
-			case <-pctx.Done():
-				return
-			case <-tick.C:
-				var entries []testenv.NBGatewayChassis
-				if err := nb.List(ctx, &entries); err != nil {
-					select {
-					case errCh <- err:
-					default:
-					}
-					return
-				}
-				for _, gc := range entries {
-					if gc.Name != gcName || gc.Priority != 0 {
-						continue
-					}
-					rebind := &testenv.SBPortBinding{UUID: router.CRPortUUID, Chassis: &peerUUID}
-					ops, opErr := sb.Where(rebind).Update(rebind, &rebind.Chassis)
-					if opErr != nil {
-						select {
-						case errCh <- opErr:
-						default:
-						}
-						return
-					}
-					if _, opErr := sb.Transact(ctx, ops...); opErr != nil {
-						select {
-						case errCh <- opErr:
-						default:
-						}
-						return
-					}
-					// The takeover node has "arrived": stamp the readiness
-					// marker on the managed default route so the leaving node's
-					// handshake releases on the marker, not at drain_timeout.
-					mark := &testenv.NBLogicalRouterStaticRoute{UUID: managedRoute.UUID, ExternalIDs: markerExtIDs}
-					mops, mErr := nb.Where(mark).Update(mark, &mark.ExternalIDs)
-					if mErr != nil {
-						select {
-						case errCh <- mErr:
-						default:
-						}
-						return
-					}
-					if _, mErr := nb.Transact(ctx, mops...); mErr != nil {
-						select {
-						case errCh <- mErr:
-						default:
-						}
-					}
-					return
-				}
-			}
-		}
-	}()
+	// When NB shows priority=0 for our local Gateway_Chassis, the helper
+	// rebinds the CR Port_Binding to the peer so countLocalCRPorts → 0 and
+	// stamps the readiness marker so drain completes without hitting
+	// drain_timeout.
+	d := testenv.StartDrainRebind(t, ctx, nb, sb, testenv.DrainRebindOpts{
+		GatewayChassisName: gcName,
+		CRPortUUID:         router.CRPortUUID,
+		PeerChassisUUID:    peerUUID,
+		MarkerRouteUUID:    managedRoute.UUID,
+		MarkerExternalIDs:  markerExtIDs,
+	})
 
 	if err := a.Stop(45 * time.Second); err != nil {
 		t.Fatalf("agent stop: %v", err)
 	}
-	pcancel()
-	select {
-	case err := <-errCh:
-		t.Fatalf("drain helper goroutine error: %v", err)
-	default:
-	}
+	d.Finish(t)
 
 	// Drain happened: NB Gateway_Chassis priority is 0.
 	gc, ok := testenv.FindGatewayChassis(t, ctx, nb, gcName)
@@ -327,59 +267,19 @@ func TestScenario_DrainSettleTimeoutFallback(t *testing.T) {
 	peerUUID := testenv.MakeChassis(t, ctx, sb, "drainfallback-peer")
 	gcName := "lrp-" + router.Name + "_" + testenv.LocalHostname(t)
 
-	errCh := make(chan error, 1)
-	pctx, pcancel := context.WithCancel(ctx)
-	defer pcancel()
-	go func() {
-		tick := time.NewTicker(50 * time.Millisecond)
-		defer tick.Stop()
-		for {
-			select {
-			case <-pctx.Done():
-				return
-			case <-tick.C:
-				var entries []testenv.NBGatewayChassis
-				if err := nb.List(ctx, &entries); err != nil {
-					select {
-					case errCh <- err:
-					default:
-					}
-					return
-				}
-				for _, gc := range entries {
-					if gc.Name != gcName || gc.Priority != 0 {
-						continue
-					}
-					rebind := &testenv.SBPortBinding{UUID: router.CRPortUUID, Chassis: &peerUUID}
-					ops, opErr := sb.Where(rebind).Update(rebind, &rebind.Chassis)
-					if opErr != nil {
-						select {
-						case errCh <- opErr:
-						default:
-						}
-						return
-					}
-					if _, opErr := sb.Transact(ctx, ops...); opErr != nil {
-						select {
-						case errCh <- opErr:
-						default:
-						}
-					}
-					return
-				}
-			}
-		}
-	}()
+	// Rebind the CR port once priority hits 0 so the migration wait completes,
+	// but deliberately stamp NO readiness marker (MarkerRouteUUID empty),
+	// forcing the handshake to fall back at drain_timeout.
+	d := testenv.StartDrainRebind(t, ctx, nb, sb, testenv.DrainRebindOpts{
+		GatewayChassisName: gcName,
+		CRPortUUID:         router.CRPortUUID,
+		PeerChassisUUID:    peerUUID,
+	})
 
 	if err := a.Stop(15 * time.Second); err != nil {
 		t.Fatalf("agent stop: %v", err)
 	}
-	pcancel()
-	select {
-	case err := <-errCh:
-		t.Fatalf("drain helper goroutine error: %v", err)
-	default:
-	}
+	d.Finish(t)
 
 	logs := a.LogTail(100000)
 	if !strings.Contains(logs, "takeover readiness marker not observed before timeout") {

--- a/test/integration/scenario_drain_edges_test.go
+++ b/test/integration/scenario_drain_edges_test.go
@@ -290,21 +290,76 @@ func TestScenario_DrainSettleTimeoutFallback(t *testing.T) {
 	testenv.AssertNoKernelRoute(t, "198.51.100.11", 5*time.Second)
 }
 
-// TestScenario_DrainStuckNBWrite (#59 scenario 4, optional):
+// TestScenario_DrainStuckNBWrite (#59 scenario 4 / #160):
 //
-// Pausing ovsdb-server (NB) mid-drain to verify drain_timeout is honoured
-// even when NB writes hang would catch a regression where the agent waits
-// for a transaction to complete past the deadline. Implementing this
-// cleanly on Ubuntu requires pausing only the NB DB without taking SB down
-// — ovn-ctl on Ubuntu (`ovn-ctl pause`) toggles both. Without a way to
-// pause NB in isolation the test would be flaky (paused-SB cascades into
-// ovn-controller restarting our chassis row, etc.), so we skip pending a
-// harness primitive that can pause NB alone.
+// The drain code must honour drain_timeout even when NB writes hang. On
+// shutdown, DrainGateways lowers the local Gateway_Chassis priority to 0 via
+// an NB transaction bounded by drain_timeout; if that transaction blocks
+// forever the whole Stop would block past the deadline.
+//
+// StopNBDatabase SIGSTOPs only the NB ovsdb-server, leaving SB responsive so
+// ovn-controller does not cascade (which is what previously made this scenario
+// impossible to run without flakes). With NB stalled, the priority-lower write
+// hits its 3s deadline, DrainGateways returns an error, and the agent logs
+// "drain failed" and proceeds — so Stop returns cleanly well under its ceiling.
+// We assert the "drain failed" (ctx-deadline) line rather than "drain: timeout
+// exceeded", which is only reached when the write succeeds but ports never
+// migrate.
 //
 // Future contributors: do not "fix" this by inserting time.Sleep or a
-// stop-the-world SIGSTOP loop on ovsdb-server. The drain code is supposed
-// to honour drain_timeout regardless of NB write hangs; assert via metrics
-// once the drain outcome label is exposed (#39).
+// stop-the-world SIGSTOP loop on all of ovsdb-server. The point is a stalled
+// NB write bounded by drain_timeout, which StopNBDatabase reproduces
+// deterministically.
 func TestScenario_DrainStuckNBWrite(t *testing.T) {
-	t.Skip("scenario 4: no clean way to pause NB ovsdb-server alone on the Ubuntu harness")
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "drainstuck",
+		LRPNetworks: []string{"198.51.100.11/24"},
+		GatewayChassis: []testenv.GatewayChassisEntry{
+			{ChassisName: testenv.LocalHostname(t), Priority: 5},
+		},
+	})
+	_ = router
+
+	cfg := testenv.Defaults()
+	on := true
+	off := false
+	cfg.DrainOnShutdown = &on
+	cfg.CleanupOnShutdown = &off // keep the shutdown path off NB reads/writes it can hang on
+	cfg.DrainTimeout = "3s"
+	cfg.ReconcileInterval = "2s"
+	a := readyAgent(t, cfg)
+
+	// Route must be installed before we stall NB, so the drain has real work
+	// (a Gateway_Chassis at priority 5) to lower.
+	testenv.AssertKernelRoute(t, "198.51.100.11", 15*time.Second)
+
+	// SIGSTOP only the NB ovsdb-server. SB stays up so ovn-controller does not
+	// cascade. The agent's drain now cannot complete its priority-lower NB
+	// write and must abort it at drain_timeout (3s).
+	resume := testenv.StopNBDatabase(t)
+
+	stopStart := time.Now()
+	if err := a.Stop(30 * time.Second); err != nil {
+		t.Fatalf("agent stop with NB stalled: %v", err)
+	}
+	stopElapsed := time.Since(stopStart)
+	// Restore NB immediately so the end-of-scenario ResetOVNState cleanup (an
+	// NB write) does not itself hang; the cleanup registered by StopNBDatabase
+	// would also resume it, but doing it here keeps the ordering obvious.
+	resume()
+
+	// Bound: 3s drain-transact deadline + up to 10s post-drain refreshState +
+	// teardown, comfortably under the 30s Stop ceiling. A regression that lets
+	// an NB write block past its deadline would push Stop toward SIGKILL.
+	if stopElapsed > 25*time.Second {
+		t.Errorf("Stop took %s with NB stalled; drain_timeout was not honoured", stopElapsed)
+	}
+
+	logs := a.LogTail(100000)
+	if !strings.Contains(logs, "drain failed") {
+		t.Errorf("expected the drain-failed log line (NB write hit its deadline); last logs:\n%s", a.LogTail(40))
+	}
 }

--- a/test/integration/scenario_failover_test.go
+++ b/test/integration/scenario_failover_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"context"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -289,90 +288,25 @@ func TestScenario_DrainOnShutdown(t *testing.T) {
 	peerUUID := testenv.MakeChassis(t, ctx, sb, "drain-peer")
 	gcName := "lrp-" + router.Name + "_" + testenv.LocalHostname(t)
 
-	// Goroutine: poll NB for priority==0, record its timestamp, rebind the CR
-	// port_binding to the peer so countLocalCRPorts returns 0, then stamp the
-	// takeover readiness marker on the managed default route so the leaving
-	// node's handshake releases on the marker instead of the drain timeout.
-	// We do not call t.Fatalf from this goroutine — testing.T methods are
-	// only safe on the test's own goroutine. Errors are surfaced via errCh.
-	var (
-		priorityZeroAt = make(chan time.Time, 1)
-		errCh          = make(chan error, 1)
-	)
-	pctx, pcancel := context.WithCancel(ctx)
-	defer pcancel()
-	go func() {
-		tick := time.NewTicker(50 * time.Millisecond)
-		defer tick.Stop()
-		for {
-			select {
-			case <-pctx.Done():
-				return
-			case <-tick.C:
-				var entries []testenv.NBGatewayChassis
-				if err := nb.List(ctx, &entries); err != nil {
-					select {
-					case errCh <- err:
-					default:
-					}
-					return
-				}
-				for _, gc := range entries {
-					if gc.Name != gcName || gc.Priority != 0 {
-						continue
-					}
-					select {
-					case priorityZeroAt <- time.Now():
-					default:
-					}
-					rebind := &testenv.SBPortBinding{UUID: router.CRPortUUID, Chassis: &peerUUID}
-					ops, opErr := sb.Where(rebind).Update(rebind, &rebind.Chassis)
-					if opErr != nil {
-						select {
-						case errCh <- opErr:
-						default:
-						}
-						return
-					}
-					if _, opErr := sb.Transact(ctx, ops...); opErr != nil {
-						select {
-						case errCh <- opErr:
-						default:
-						}
-						return
-					}
-					mark := &testenv.NBLogicalRouterStaticRoute{UUID: managedRoute.UUID, ExternalIDs: markerExtIDs}
-					mops, mErr := nb.Where(mark).Update(mark, &mark.ExternalIDs)
-					if mErr != nil {
-						select {
-						case errCh <- mErr:
-						default:
-						}
-						return
-					}
-					if _, mErr := nb.Transact(ctx, mops...); mErr != nil {
-						select {
-						case errCh <- mErr:
-						default:
-						}
-					}
-					return
-				}
-			}
-		}
-	}()
+	// A takeover-peer goroutine watches for priority 0, records the moment,
+	// rebinds the CR Port_Binding to the peer so countLocalCRPorts returns 0,
+	// then stamps the readiness marker on the managed default route so the
+	// leaving node's handshake releases on the marker instead of the drain
+	// timeout.
+	d := testenv.StartDrainRebind(t, ctx, nb, sb, testenv.DrainRebindOpts{
+		GatewayChassisName: gcName,
+		CRPortUUID:         router.CRPortUUID,
+		PeerChassisUUID:    peerUUID,
+		MarkerRouteUUID:    managedRoute.UUID,
+		MarkerExternalIDs:  markerExtIDs,
+	})
 
 	stopStart := time.Now()
 	if err := a.Stop(45 * time.Second); err != nil {
 		t.Fatalf("agent stop: %v", err)
 	}
 	stopElapsed := time.Since(stopStart)
-	pcancel()
-	select {
-	case err := <-errCh:
-		t.Fatalf("drain helper goroutine error: %v", err)
-	default:
-	}
+	d.Finish(t)
 
 	// The settle ended on the marker, not on a timer: Stop finished well under
 	// the 30s drain_timeout, and the handshake logged the marker observation.
@@ -393,7 +327,7 @@ func TestScenario_DrainOnShutdown(t *testing.T) {
 	}, 30*time.Second, 50*time.Millisecond, "kernel route for LRP IP must eventually be removed")
 
 	select {
-	case prioAt := <-priorityZeroAt:
+	case prioAt := <-d.PriorityZeroAt:
 		if !prioAt.Before(routeGoneAt) {
 			t.Fatalf("priority=0 must be observed before route removal: prio=%s route_gone=%s",
 				prioAt.Format(time.StampMilli), routeGoneAt.Format(time.StampMilli))

--- a/test/integration/scenario_metrics_test.go
+++ b/test/integration/scenario_metrics_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -124,78 +123,18 @@ func TestScenario_MetricsDrainOutcomeCompleted(t *testing.T) {
 	peerUUID := testenv.MakeChassis(t, ctx, sb, "metdrain-peer")
 	gcName := "lrp-" + router.Name + "_" + testenv.LocalHostname(t)
 
-	errCh := make(chan error, 1)
-	pctx, pcancel := context.WithCancel(ctx)
-	defer pcancel()
-	go func() {
-		tick := time.NewTicker(50 * time.Millisecond)
-		defer tick.Stop()
-		for {
-			select {
-			case <-pctx.Done():
-				return
-			case <-tick.C:
-				var entries []testenv.NBGatewayChassis
-				if err := nb.List(ctx, &entries); err != nil {
-					select {
-					case errCh <- err:
-					default:
-					}
-					return
-				}
-				for _, gc := range entries {
-					if gc.Name != gcName || gc.Priority != 0 {
-						continue
-					}
-					rebind := &testenv.SBPortBinding{UUID: router.CRPortUUID, Chassis: &peerUUID}
-					ops, opErr := sb.Where(rebind).Update(rebind, &rebind.Chassis)
-					if opErr != nil {
-						select {
-						case errCh <- opErr:
-						default:
-						}
-						return
-					}
-					if _, opErr := sb.Transact(ctx, ops...); opErr != nil {
-						select {
-						case errCh <- opErr:
-						default:
-						}
-						return
-					}
-					// The takeover node has "arrived": stamp the readiness marker on
-					// the managed default route so the leaving node's handshake releases
-					// on the marker instead of blocking until drain_timeout.
-					mark := &testenv.NBLogicalRouterStaticRoute{UUID: managedRoute.UUID, ExternalIDs: markerExtIDs}
-					mops, mErr := nb.Where(mark).Update(mark, &mark.ExternalIDs)
-					if mErr != nil {
-						select {
-						case errCh <- mErr:
-						default:
-						}
-						return
-					}
-					if _, mErr := nb.Transact(ctx, mops...); mErr != nil {
-						select {
-						case errCh <- mErr:
-						default:
-						}
-					}
-					return
-				}
-			}
-		}
-	}()
+	d := testenv.StartDrainRebind(t, ctx, nb, sb, testenv.DrainRebindOpts{
+		GatewayChassisName: gcName,
+		CRPortUUID:         router.CRPortUUID,
+		PeerChassisUUID:    peerUUID,
+		MarkerRouteUUID:    managedRoute.UUID,
+		MarkerExternalIDs:  markerExtIDs,
+	})
 
 	if err := a.Stop(45 * time.Second); err != nil {
 		t.Fatalf("agent stop: %v", err)
 	}
-	pcancel()
-	select {
-	case err := <-errCh:
-		t.Fatalf("drain helper goroutine error: %v", err)
-	default:
-	}
+	d.Finish(t)
 
 	// Drain success path: log line is emitted on the same branch that
 	// records drain_total{outcome="completed"}.

--- a/test/integration/scenario_reconnect_test.go
+++ b/test/integration/scenario_reconnect_test.go
@@ -28,10 +28,9 @@ import (
 //
 // The pause window (10s) is intentionally shorter than libovsdb's 30s
 // inactivity probe: this scenario covers the "stall and recover" path,
-// not the "TCP reconnect" path. Exercising reconnection through a longer
-// outage is the natural follow-up once the ovn_connection_state metric
-// can be asserted to drop and recover (the issue calls this out
-// conditionally on "once metrics is wired").
+// not the "TCP reconnect" path. Reconnection through a longer outage —
+// with ovn_connection_state asserted to drop and recover — is covered by
+// TestScenario_OVNReconnectAfterLongOutage below.
 func TestScenario_OVNDatabasePauseResume(t *testing.T) {
 	ctx, cancel, nb, sb := startScenario(t)
 	defer cancel()
@@ -76,6 +75,110 @@ func TestScenario_OVNDatabasePauseResume(t *testing.T) {
 
 	if !a.Alive() {
 		t.Fatalf("agent exited after DB resume — clean reconnect contract violated (last logs:\n%s)",
+			a.LogTail(60))
+	}
+}
+
+// TestScenario_OVNReconnectAfterLongOutage (#160):
+//
+// TestScenario_OVNDatabasePauseResume keeps its outage under libovsdb's 30s
+// inactivity probe, so it never exercises a real disconnect/reconnect. This
+// scenario holds the outage past the probe (>=45s), so libovsdb actually tears
+// the connection down and re-establishes it. It pins the full reconnect
+// surface a long-running daemon must survive:
+//
+//   - ovn_connection_state drops to 0 for both DBs — the proof the inactivity
+//     probe fired and libovsdb disconnected rather than merely stalling — and
+//     recovers to 1 after resume,
+//   - the agent stays alive across the whole outage,
+//   - the FIP route installed before the outage survives it, and
+//   - a NB change made AFTER reconnect still drives reconciliation, proving
+//     the monitors were re-established and the cache repopulated.
+//
+// It is event-driven (assert on the observed metric / kernel route) rather
+// than sleep-calibrated, with a single deterministic hold to the >30s floor,
+// so it stays green and non-flaky. The agent's metrics endpoint is served by a
+// goroutine independent of OVSDB, so it keeps answering scrapes throughout the
+// outage.
+func TestScenario_OVNReconnectAfterLongOutage(t *testing.T) {
+	// 3-minute ceiling: the outage runs ~60s (the probe-driven disconnect
+	// asserted below) and recovery is asserted with generous budgets, all
+	// comfortably inside it.
+	ctx, cancel, nb, sb := startScenarioWithTimeout(t, 3*time.Minute)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "reconnectlong",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+	const fip1 = "198.51.100.67"
+	testenv.AddFIP(t, ctx, nb, router, fip1, "10.0.0.67")
+
+	cfg := testenv.FastDefaults()
+	addr := testenv.FreeLoopbackAddr(t)
+	cfg.MetricsListen = addr
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	assertConnState := func(db string, want float64, timeout time.Duration) {
+		t.Helper()
+		testenv.AssertMetricEventually(t, addr,
+			"ovn_network_agent_ovn_connection_state",
+			map[string]string{"database": db},
+			func(v float64, present bool) bool { return present && v == want },
+			timeout)
+	}
+
+	// Pre-condition: the route landed and both DB connections read as up.
+	testenv.AssertKernelRoute(t, fip1, 15*time.Second)
+	assertConnState("nb", 1, 10*time.Second)
+	assertConnState("sb", 1, 10*time.Second)
+
+	if !a.Alive() {
+		t.Fatalf("agent exited before the outage; setup is broken (last logs:\n%s)", a.LogTail(40))
+	}
+
+	// Open the outage and hold it past the 30s inactivity probe.
+	start := time.Now()
+	resume := testenv.StopOVNDatabases(t)
+
+	// Both gauges must drop to 0 — the proof the probe fired and libovsdb
+	// disconnected. The drop takes up to ~60s from the last pre-outage
+	// traffic: 30s of silence arm the probe, and the probe echo then gets
+	// options.inactivityTimeout (another 30s) to time out against the
+	// stopped server — WithInactivityCheck's second argument is the
+	// reconnect dial timeout, not the echo timeout. 90s adds real margin.
+	assertConnState("nb", 0, 90*time.Second)
+	assertConnState("sb", 0, 90*time.Second)
+
+	// Honour the >40s outage floor deterministically by holding the remainder
+	// of 45s (the gauge-drop asserts above already consumed most of it).
+	if held := time.Since(start); held < 45*time.Second {
+		time.Sleep(45*time.Second - held)
+	}
+
+	if !a.Alive() {
+		t.Fatalf("agent exited during the OVN outage — resilience contract violated (last logs:\n%s)",
+			a.LogTail(60))
+	}
+
+	resume()
+
+	// Recovery: both gauges climb back to 1.
+	assertConnState("nb", 1, 45*time.Second)
+	assertConnState("sb", 1, 45*time.Second)
+
+	// The pre-outage route survived the disconnect/reconnect.
+	testenv.AssertKernelRoute(t, fip1, 15*time.Second)
+
+	// A NB change made after reconnect still drives reconciliation — the
+	// monitors were re-established and the cache repopulated, not left stale.
+	const fip2 = "198.51.100.68"
+	testenv.AddFIP(t, ctx, nb, router, fip2, "10.0.0.68")
+	testenv.AssertKernelRoute(t, fip2, 30*time.Second)
+
+	if !a.Alive() {
+		t.Fatalf("agent exited after OVN recovery — clean reconnect contract violated (last logs:\n%s)",
 			a.LogTail(60))
 	}
 }

--- a/test/integration/scenarios_helpers_test.go
+++ b/test/integration/scenarios_helpers_test.go
@@ -28,14 +28,17 @@ func readBridgeMAC(t *testing.T) string {
 	return mac
 }
 
-// scenarioCtx is a per-test context with a hard 90s ceiling. All scenarios
-// in this suite are sub-3-minute by design, so they should never need more.
-func scenarioCtx(t *testing.T) (context.Context, context.CancelFunc) {
+// startScenario is startScenarioWithTimeout with the default 90s context
+// ceiling. Almost every reconciliation test in this suite is sub-3-minute by
+// design and fits inside it; the long-outage reconnect scenario passes a
+// larger ceiling explicitly.
+func startScenario(t *testing.T) (context.Context, context.CancelFunc, client.Client, client.Client) {
 	t.Helper()
-	return context.WithTimeout(context.Background(), 90*time.Second)
+	return startScenarioWithTimeout(t, 90*time.Second)
 }
 
-// startScenario performs the boilerplate every reconciliation test shares:
+// startScenarioWithTimeout performs the boilerplate every reconciliation test
+// shares, with a caller-chosen per-test context ceiling:
 //
 //   - testenv.Setup (host preconditions)
 //   - PauseOVNNorthd so direct SB writes survive
@@ -47,14 +50,14 @@ func scenarioCtx(t *testing.T) (context.Context, context.CancelFunc) {
 //
 // Returns the per-test context, the NB client, and the SB client. The caller
 // is responsible for spawning the agent and asserting the scenario.
-func startScenario(t *testing.T) (context.Context, context.CancelFunc, client.Client, client.Client) {
+func startScenarioWithTimeout(t *testing.T, timeout time.Duration) (context.Context, context.CancelFunc, client.Client, client.Client) {
 	t.Helper()
 	testenv.Setup(t)
 	testenv.PauseOVNNorthd(t)
 	testenv.PauseOVNController(t)
 	testenv.EnsureBridgePatchPort(t)
 
-	ctx, cancel := scenarioCtx(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	nb := testenv.NewNBClient(t, ctx)
 	sb := testenv.NewSBClient(t, ctx)
 	testenv.ResetOVNState(t, ctx, nb, sb)
@@ -62,7 +65,7 @@ func startScenario(t *testing.T) (context.Context, context.CancelFunc, client.Cl
 
 	// On failure, dump enough state for postmortem diagnosis without an
 	// operator having to ssh in and re-run commands. ctx may be cancelled
-	// by the time cleanup runs (the scenario context has a 90s ceiling),
+	// by the time cleanup runs (the scenario context has a bounded ceiling),
 	// so use a fresh background context for the OVN dump.
 	t.Cleanup(func() {
 		if t.Failed() {

--- a/test/integration/testenv/agent.go
+++ b/test/integration/testenv/agent.go
@@ -159,6 +159,14 @@ func RunAgent(t *testing.T, cfg AgentConfig) *AgentProc {
 	bin := AgentBinary(t)
 	cmd := exec.Command(bin, "--config", configPath)
 	cmd.Env = append(os.Environ(), "GOTRACEBACK=all")
+	// A -cover-built agent (see `make build-integration`) writes per-process
+	// coverage counter files to GOCOVERDIR on clean (SIGTERM) exit. os.Environ()
+	// already carries it when the CI job sets it, but propagate it explicitly so
+	// the contract is visible at the spawn site. A SIGKILL'd agent loses its
+	// counters, which is acceptable best-effort.
+	if dir := os.Getenv("GOCOVERDIR"); dir != "" {
+		cmd.Env = append(cmd.Env, "GOCOVERDIR="+dir)
+	}
 	// ExtraEnv must REPLACE existing entries with the same key, not append.
 	// Linux's getenv() returns the first matching entry, so a trailing
 	// "PATH=<shim>:..." would be ignored — the agent would still resolve

--- a/test/integration/testenv/drain.go
+++ b/test/integration/testenv/drain.go
@@ -1,0 +1,146 @@
+//go:build integration
+
+package testenv
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ovn-kubernetes/libovsdb/client"
+)
+
+// DrainRebindOpts configures StartDrainRebind, the shared "simulate the
+// takeover peer" goroutine that the drain scenarios drive. Once the watched
+// Gateway_Chassis row reaches priority 0 (the leaving agent has lowered its
+// own priority), the goroutine rebinds the chassisredirect Port_Binding to a
+// peer so the leaving node's countLocalCRPorts drops to 0, then optionally
+// stamps the takeover readiness marker so the leaving node's settle releases
+// on the marker instead of at drain_timeout.
+type DrainRebindOpts struct {
+	// GatewayChassisName is the NB Gateway_Chassis row (name) whose priority
+	// the goroutine watches; it acts once that row reaches priority 0.
+	GatewayChassisName string
+	// CRPortUUID is the SB chassisredirect Port_Binding that is rebound to the
+	// peer.
+	CRPortUUID string
+	// PeerChassisUUID is the SB Chassis the CR port is rebound to.
+	PeerChassisUUID string
+
+	// MarkerRouteUUID, when non-empty, is the NB Logical_Router_Static_Route
+	// the readiness marker (MarkerExternalIDs) is stamped onto after the
+	// rebind. Empty leaves the marker unwritten — the timeout-fallback
+	// scenario, where the leaving node must settle at drain_timeout instead.
+	MarkerRouteUUID   string
+	MarkerExternalIDs map[string]string
+}
+
+// DrainRebind is a handle to a running StartDrainRebind goroutine.
+type DrainRebind struct {
+	// PriorityZeroAt receives the moment the goroutine first observed the
+	// watched Gateway_Chassis at priority 0, sent before the rebind, so a
+	// caller can assert priority-0 was observed before route removal.
+	// Buffered (cap 1); callers that do not need the timestamp ignore it.
+	PriorityZeroAt <-chan time.Time
+
+	cancel context.CancelFunc
+	errCh  chan error
+	done   chan struct{}
+}
+
+// StartDrainRebind spawns the takeover-peer goroutine and returns immediately.
+// The goroutine polls NB every 50ms until opts.GatewayChassisName shows
+// priority 0, then performs the rebind (and optional marker stamp) exactly
+// once and exits. testing.T methods are never called from the goroutine —
+// errors are surfaced via the handle's Finish, which the caller must invoke.
+func StartDrainRebind(t *testing.T, ctx context.Context, nb, sb client.Client, opts DrainRebindOpts) *DrainRebind {
+	t.Helper()
+
+	priorityZeroAt := make(chan time.Time, 1)
+	errCh := make(chan error, 1)
+	done := make(chan struct{})
+	pctx, pcancel := context.WithCancel(ctx)
+
+	go func() {
+		defer close(done)
+		tick := time.NewTicker(50 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-pctx.Done():
+				return
+			case <-tick.C:
+				var entries []NBGatewayChassis
+				if err := nb.List(ctx, &entries); err != nil {
+					sendErr(errCh, err)
+					return
+				}
+				for _, gc := range entries {
+					if gc.Name != opts.GatewayChassisName || gc.Priority != 0 {
+						continue
+					}
+					// Record the observation before rebinding so an ordering
+					// assertion (priority_zero < route_removed) has signal.
+					select {
+					case priorityZeroAt <- time.Now():
+					default:
+					}
+					peer := opts.PeerChassisUUID
+					rebind := &SBPortBinding{UUID: opts.CRPortUUID, Chassis: &peer}
+					ops, err := sb.Where(rebind).Update(rebind, &rebind.Chassis)
+					if err != nil {
+						sendErr(errCh, err)
+						return
+					}
+					if _, err := sb.Transact(ctx, ops...); err != nil {
+						sendErr(errCh, err)
+						return
+					}
+					if opts.MarkerRouteUUID != "" {
+						mark := &NBLogicalRouterStaticRoute{UUID: opts.MarkerRouteUUID, ExternalIDs: opts.MarkerExternalIDs}
+						mops, err := nb.Where(mark).Update(mark, &mark.ExternalIDs)
+						if err != nil {
+							sendErr(errCh, err)
+							return
+						}
+						if _, err := nb.Transact(ctx, mops...); err != nil {
+							sendErr(errCh, err)
+						}
+					}
+					return
+				}
+			}
+		}
+	}()
+
+	return &DrainRebind{
+		PriorityZeroAt: priorityZeroAt,
+		cancel:         pcancel,
+		errCh:          errCh,
+		done:           done,
+	}
+}
+
+// Finish stops the goroutine, waits for it to exit, and fails the test if it
+// recorded an OVSDB error. Waiting for the goroutine to exit before reading
+// errCh closes the race the inlined copies had, where a cancel followed by a
+// non-blocking read could miss an in-flight transaction error.
+func (d *DrainRebind) Finish(t *testing.T) {
+	t.Helper()
+	d.cancel()
+	<-d.done
+	select {
+	case err := <-d.errCh:
+		t.Fatalf("drain-rebind helper: %v", err)
+	default:
+	}
+}
+
+// sendErr performs a non-blocking send so the goroutine never deadlocks on a
+// full (cap-1) error channel — the first error is enough to fail the test.
+func sendErr(ch chan error, err error) {
+	select {
+	case ch <- err:
+	default:
+	}
+}

--- a/test/integration/testenv/services.go
+++ b/test/integration/testenv/services.go
@@ -5,6 +5,7 @@ package testenv
 import (
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -149,23 +150,89 @@ func isNorthdUnreachable(out string) bool {
 		strings.Contains(out, "cannot connect")
 }
 
+// stopMatchingProcs SIGSTOPs the processes matched by the pkill args in
+// stopArgs and returns a resume func that SIGCONTs them via contArgs. The
+// resume is idempotent (a sync.Once) and is also registered via t.Cleanup, so
+// a test failure or panic between stop and resume can never leave a process
+// suspended. When pkill matches nothing (exit code 1) the test is skipped: the
+// outage contract cannot be exercised without the target process, and a
+// packaging change that renames it degrades to a skip rather than a red gate.
+// desc is used in the log/skip/fatal messages.
+func stopMatchingProcs(t *testing.T, desc string, stopArgs, contArgs []string) func() {
+	t.Helper()
+
+	if _, err := exec.LookPath("pkill"); err != nil {
+		t.Skipf("pkill not found in PATH: %v", err)
+	}
+
+	t.Logf("%s (SIGSTOP)", desc)
+	if out, err := exec.Command("pkill", stopArgs...).CombinedOutput(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			t.Skipf("%s: no matching process found; cannot exercise the outage contract", desc)
+		}
+		t.Fatalf("%s: %v (output: %s)", desc, err, strings.TrimSpace(string(out)))
+	}
+
+	var once sync.Once
+	resume := func() {
+		once.Do(func() {
+			t.Logf("%s (SIGCONT / resume)", desc)
+			if out, err := exec.Command("pkill", contArgs...).CombinedOutput(); err != nil {
+				t.Logf("%s: SIGCONT failed: %v (output: %s)", desc, err, strings.TrimSpace(string(out)))
+			}
+		})
+	}
+	t.Cleanup(resume)
+	return resume
+}
+
+// StopOVNDatabases suspends every ovsdb-server process with SIGSTOP and returns
+// a resume func that SIGCONTs them. Unlike PauseOVNDatabases it does not block,
+// so a scenario can hold the outage open — long enough to trip libovsdb's 30s
+// inactivity probe — while it scrapes metrics or asserts the agent stays alive,
+// then call resume when it is ready. If no ovsdb-server process is found the
+// test is skipped.
+func StopOVNDatabases(t *testing.T) (resume func()) {
+	t.Helper()
+	return stopMatchingProcs(t, "SIGSTOP all ovsdb-server processes",
+		[]string{"-STOP", "-x", "ovsdb-server"},
+		[]string{"-CONT", "-x", "ovsdb-server"})
+}
+
+// StopNBDatabase suspends only the NB ovsdb-server with SIGSTOP, leaving the SB
+// server responsive so ovn-controller does not cascade (clearing our hand-set
+// Port_Binding.chassis) while the agent's NB writes hang. Returns a resume func.
+//
+// ovn-ctl names the NB server's pid/sock/ctl/db files ovnnb_db.*, so
+// `pkill -f ovnnb_db` matches its argv — and not the SB ovsdb-server, whose
+// files are ovnsb_db.*. It also matches ovn-northd (which references the same
+// ovnnb_db socket); that is harmless for callers, which pause northd's
+// processing loop via PauseOVNNorthd beforehand. If nothing matches, the test
+// is skipped rather than failed.
+func StopNBDatabase(t *testing.T) (resume func()) {
+	t.Helper()
+	return stopMatchingProcs(t, "SIGSTOP the NB ovsdb-server (pkill -f ovnnb_db)",
+		[]string{"-STOP", "-f", "ovnnb_db"},
+		[]string{"-CONT", "-f", "ovnnb_db"})
+}
+
 // PauseOVNDatabases suspends every ovsdb-server process via SIGSTOP for the
 // duration d, then SIGCONTs them. This simulates a transient OVN disconnect:
 // the TCP socket stays open but reads stall, which is the same shape a
 // production-side network blip or a paused remote presents to libovsdb.
 //
 // Ubuntu's ovn-ctl runs the NB ovsdb-server, the SB ovsdb-server, and
-// ovn-northd under the single ovn-central unit. There is no clean way to
-// pause only the NB server without taking the SB server down with it (see
-// the comment on TestScenario_DrainStuckNBWrite in scenario_drain_edges_test.go),
-// so this helper pauses both. The contract being tested by callers is "the
-// agent does NOT exit when its only DB endpoint becomes unresponsive" —
-// pausing both DBs is a strictly harder version of the scenario than the
-// single-DB pause described in #64, so the test still proves the contract.
+// ovn-northd under the single ovn-central unit, so this helper pauses both
+// databases. The contract being tested by callers is "the agent does NOT exit
+// when its DB endpoints become unresponsive" — pausing both DBs is a strictly
+// harder version of the single-DB pause described in #64, so the test still
+// proves the contract. (StopNBDatabase pauses the NB server alone when a
+// scenario needs SB to stay responsive.)
 //
 // The function blocks for d while the DBs are paused. Tests should keep d
 // well under libovsdb's inactivity timeout (production: 30s) so reconnect
-// logic does not kick in mid-pause — that is a separate scenario.
+// logic does not kick in mid-pause — that path is covered by
+// TestScenario_OVNReconnectAfterLongOutage via StopOVNDatabases.
 //
 // PauseOVNDatabases is a synchronous primitive on purpose: scenarios that
 // run direct OVSDB transactions against the test driver's NB/SB clients
@@ -173,38 +240,9 @@ func isNorthdUnreachable(out string) bool {
 // call and all post-resume assertions after it.
 func PauseOVNDatabases(t *testing.T, d time.Duration) {
 	t.Helper()
-
-	if _, err := exec.LookPath("pkill"); err != nil {
-		t.Skipf("pkill not found in PATH: %v", err)
-	}
-
-	t.Logf("SIGSTOP all ovsdb-server processes for %s", d)
-	if out, err := exec.Command("pkill", "-STOP", "-x", "ovsdb-server").CombinedOutput(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
-			t.Skip("PauseOVNDatabases: no ovsdb-server process found; cannot exercise reconnect contract")
-			return
-		}
-		t.Fatalf("SIGSTOP ovsdb-server: %v (output: %s)", err, strings.TrimSpace(string(out)))
-	}
-	// Resume is registered as a cleanup before we sleep, so a test failure
-	// or panic inside the sleep window does not leave ovsdb-server stopped.
-	resumed := false
-	t.Cleanup(func() {
-		if resumed {
-			return
-		}
-		if out, err := exec.Command("pkill", "-CONT", "-x", "ovsdb-server").CombinedOutput(); err != nil {
-			t.Logf("cleanup SIGCONT ovsdb-server: %v (output: %s)", err, strings.TrimSpace(string(out)))
-		}
-	})
-
+	resume := StopOVNDatabases(t)
 	time.Sleep(d)
-
-	t.Logf("SIGCONT all ovsdb-server processes (resume)")
-	if out, err := exec.Command("pkill", "-CONT", "-x", "ovsdb-server").CombinedOutput(); err != nil {
-		t.Fatalf("SIGCONT ovsdb-server: %v (output: %s)", err, strings.TrimSpace(string(out)))
-	}
-	resumed = true
+	resume()
 }
 
 // PauseOVNController suspends ovn-controller's main processing loop for the


### PR DESCRIPTION
## Summary

Closes #160

A targeted mutation-check pass found two central behaviors the entire suite failed to catch when mutated, plus two structural blind spots. This branch closes all four: it pins the two failed mutation checks with unit tests, makes a real (>30s) OVSDB reconnect a green non-flaky integration scenario, and makes integration-exercised Linux code measurable in CI coverage. Along the way it de-duplicates the drain-rebind test harness and adds the OVSDB pause primitives the new scenarios need.

All nine commits trace directly to a task or acceptance criterion in the issue; the change set does not diverge from #160.

## Change set, in commit order

**`4b68f7a` test: prove a failed announce withholds the takeover marker**
Adds `TestReconcileFailedAnnounceWithholdsMarker`. Arms the FRR batch add to fail (`ensureRoutes` returns false) with `HasLocalRouters=true`, then asserts the add was attempted but no readiness marker is written. Kills the mutation that drops the `announced` conjunct from the `announced && state.HasLocalRouters` takeover gate — the HA window where a node that attracted BGP traffic it cannot yet deliver must never signal readiness to a draining peer. (Issue blind spot #1.)

**`38e3e30` test: cover checkFRRRouteActivity error and alert branches**
Adds `TestCheckFRRRouteActivity` with three subtests driven through the vtysh hook: a vtysh error leaves a pre-seeded gauge unchanged and logs the warning (kills the removed-early-return mutant that would zero the alerting metric during a vtysh outage); a not-installed route sets the gauge to 1 and logs the alert; a healthy route resets the gauge to 0. (Issue blind spot #2.)

**`2b02b29` ovn: mirror live OVSDB connection state into the metric**
The only production change in the branch. `ovn_connection_state` was previously cleared only by `closeClients()`, so a transient outage never surfaced — libovsdb re-establishes monitors and repopulates the cache internally and only signals `DisconnectNotify` on a terminal close. Adds a `watchConnectionState` poller (started alongside `refreshLoop`, sharing its ctx) that samples each client's `Connected()` once a second and writes the gauge, making a lost-and-recovered connection observable for operator alerting and for the reconnect scenario to assert on. Grows the `ovsdbClient` interface with `Connected()` (the real client already has it) and the fake with a mutex-guarded flag.

**`8436d7b` test/integration: extract the drain-rebind goroutine into testenv**
Four drain scenarios each carried a ~55-line copy of the same takeover-peer goroutine (poll NB until the local `Gateway_Chassis` reaches priority 0, rebind the chassisredirect `Port_Binding` to a peer, usually stamp the readiness marker). Extracts it into `testenv.StartDrainRebind` + `DrainRebind.Finish`; the optional `PriorityZeroAt` channel serves the failover ordering assertion and an empty `MarkerRouteUUID` serves the timeout-fallback scenario. `Finish` waits for the goroutine to exit before reading its error channel, closing the cancel-then-nonblocking-read race the inlined copies had. (Issue task: extract the 4× duplicated goroutine.)

**`e2ff389` test/integration: add non-blocking OVSDB pause primitives**
Adds `StopOVNDatabases` (SIGSTOP all `ovsdb-server`, returns a resume func) and `StopNBDatabase` (SIGSTOP only NB via `pkill -f ovnnb_db`, leaving SB responsive), both on a shared `stopMatchingProcs` helper with an idempotent, cleanup-registered resume. Unlike the blocking `PauseOVNDatabases`, these let a scenario scrape metrics and assert liveness mid-outage and isolate NB. `PauseOVNDatabases` is reimplemented on top so the existing 10s scenario is unchanged. (Enables the two scenarios below.)

**`bfdc20d` test/integration: cover reconnect through the 30s inactivity probe**
Adds `TestScenario_OVNReconnectAfterLongOutage`: holds the outage past libovsdb's 30s inactivity probe (>=45s) via `StopOVNDatabases`, asserts `ovn_connection_state` 1→0→1 for both DBs, that the agent stays alive and its pre-outage route survives, and that a NB change made after reconnect still drives reconciliation. Parameterizes `startScenario`'s context ceiling (`startScenarioWithTimeout`) so the long scenario gets headroom the 90s default can't give. Event-driven with a single deterministic hold to the floor, so it stays non-flaky. (Issue task: extend reconnect past the probe; acceptance criterion #2.)

**`fc2c578` test/integration: unskip the stuck-NB-write drain scenario**
`TestScenario_DrainStuckNBWrite` was skipped for want of a way to pause NB alone. With `StopNBDatabase` in place, implements the real scenario: only NB stalled, the drain's priority-lower NB write hits its 3s `drain_timeout`, `DrainGateways` returns an error, and the agent logs "drain failed" and exits cleanly under the Stop ceiling. Asserts the ctx-deadline ("drain failed") path and bounds the elapsed Stop time so a regression letting an NB write outlive its deadline fails the test. (Issue stretch task.)

**`b63a0fc` ci: instrument the integration binary for coverage and races**
The integration job ran a plain binary with no `GOCOVERDIR`, so every path only integration exercises — `main()`, `Connect()`, `routing_linux.go`, `nftables_linux.go` — was invisible in coverage. Adds a `build-integration` Makefile target building the agent with `-cover -covermode=atomic -race`; the job builds it, propagates `GOCOVERDIR` through `testenv.RunAgent` to each agent process, and merges the per-process profiles with `go tool covdata` into a figure published in the job log. The `-race` variant drives the concurrency-heavy paths (`refreshLoop`, `drainWatchCh`, event handlers) under the detector in the same job. Raises the job timeout to 30m and adds `-timeout 25m` for the slower instrumented binary and the >=45s scenario. (Issue tasks: coverage instrumentation + optional -race variant; acceptance criterion #3.)

**`12e81ae` docs: document integration coverage and new harness primitives**
Updates `docs/contributing/integration-tests.md` for the long-outage reconnect and stuck-NB-write scenarios and the new testenv primitives, and adds a Coverage instrumentation section (`make build-integration`, `GOCOVERDIR` propagation, the local `covdata` recipe). Adds an Integration coverage note to the CI docs explaining the `-cover -race` smoke build and the informational merged figure.

## Note on the 68% unit floor

The issue lists "afterwards revisit the 68% floor" as a follow-up. The branch deliberately leaves the `test.yml` unit floor untouched: raising it needs the merged integration+unit numbers this branch first makes visible in CI. `b63a0fc` and the CI docs call this out explicitly as a deliberate later revisit rather than an omission.

## Verification

CI runs the instrumented `-cover -race` integration build (30m timeout) plus the unit suite; the new reconnect scenario is the long pole and is event-driven to stay non-flaky.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 01245b5 with Claude:claude-opus-4-8_
