### PR TITLE
test/e2e: add a seeded chaos runner for the E2E lab

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -471,3 +471,64 @@ jobs:
       - name: Tear the lab down
         if: always()
         run: make e2e-down
+
+  chaos:
+    name: Seeded chaos session
+    runs-on: ubuntu-latest
+    # Manual only. Every sibling job asserts one fault and leaves the lab
+    # baseline-green; the chaos runner injects a randomized *sequence* and
+    # deliberately leaves the master wherever the last election put it, so
+    # it is not something to hang off every PR. `workflow_dispatch` gives
+    # it a CI path — the one place `execCommander`, the `containerlab
+    # tools veth create` re-wire and the collector actually run against a
+    # real lab — without adding ~15 min to the PR suite. Still gated on
+    # baseline: a randomized run against a lab that was never green would
+    # only report noise.
+    #
+    # A fixed seed and a 3-minute duration keep the run reproducible and
+    # inside the same budget as drain-hitless: one bring-up, ~3 min of
+    # faults, plus the recovery budget of whatever action was in flight
+    # when the duration expired.
+    if: github.event_name == 'workflow_dispatch'
+    needs: baseline
+    timeout-minutes: 25
+
+    env:
+      E2E_TOPOLOGY: test/e2e/topology.clab.yml
+      LAB: ovn-e2e
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      # See the baseline job / e2e-lab-setup action for the rationale.
+      - uses: ./.github/actions/e2e-lab-setup
+
+      # Unlike the scenarios, the runner is a Go program: it needs the
+      # toolchain go.mod pins, not whatever the runner image ships.
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Bring the lab up
+        run: make e2e-up
+
+      - name: Run the chaos session
+        run: make e2e-chaos CHAOS_FLAGS="-duration 3m -seed 42 -out ${RUNNER_TEMP}/chaos"
+
+      # Uploaded on every outcome, not just failure: the journal and the
+      # run summary are the artifact the run exists to produce, and a
+      # green run's recovery durations are what a later regression is
+      # compared against. The runner dumps `lab-state/` into the same
+      # directory itself when it does not pass.
+      - name: Upload the chaos artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: e2e-artifacts-chaos-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/chaos
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Tear the lab down
+        if: always()
+        run: make e2e-down

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Binary
 ovn-network-agent
 
+# Default -out directory of the E2E chaos runner (make e2e-chaos)
+chaos-artifacts/
+
 # Documentation site (VitePress)
 node_modules/
 docs/.vitepress/cache/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION   ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "d
 LDFLAGS   := -s -w -X main.version=$(VERSION)
 GOFLAGS   := -trimpath
 
-.PHONY: all build build-static build-integration clean fmt vet test test-integration install docs-gen docs-gen-check models-gen models-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-hairpin e2e-multi-vlan e2e-pf-external e2e-pf-hairpin e2e-stale-chassis e2e-drain-hitless
+.PHONY: all build build-static build-integration clean fmt vet test test-integration install docs-gen docs-gen-check models-gen models-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-hairpin e2e-multi-vlan e2e-pf-external e2e-pf-hairpin e2e-stale-chassis e2e-drain-hitless e2e-chaos
 
 # Containerlab E2E harness. See test/e2e/README.md for the topology and
 # acceptance criteria (issue #44).
@@ -17,6 +17,7 @@ E2E_PF_EXTERNAL := test/e2e/scenarios/pf-external.sh
 E2E_PF_HAIRPIN  := test/e2e/scenarios/pf-hairpin.sh
 E2E_STALE       := test/e2e/scenarios/stale-chassis.sh
 E2E_DRAIN       := test/e2e/scenarios/drain-hitless.sh
+E2E_CHAOS       := go run ./test/e2e/chaos
 E2E_GWNODE_TAG  := ovn-network-agent/gwnode:e2e
 E2E_CENTRAL_TAG := ovn-network-agent/central:e2e
 
@@ -278,3 +279,27 @@ e2e-stale-chassis:
 # developer run leaves the lab baseline-green.
 e2e-drain-hitless:
 	$(E2E_DRAIN)
+
+# Run a seeded chaos session (issue #176) against a lab that is already
+# up. Layers the hairpin, multi-VLAN and port-forward scenario setups on
+# the bootstrap baseline, then drives the lab through a randomized fault
+# sequence: every tick waits a random interval, picks a weighted action
+# (controller-restart, gateway-kill, agent-terminate, gateway-restart),
+# checks its guardrails and executes it, while a continuous probe from
+# client-1 measures every FIP and the port-forward VIP. Defaults: seed
+# 42, 10 minutes, 10–30 s between decisions.
+#
+# Reproducibility is the contract: the seed, the duration, the tick
+# bounds and the action weights are the only inputs, and every decision
+# derives from the seed — so two runs with the same flags replay the
+# identical action sequence. Pass flags through CHAOS_FLAGS:
+#
+#   make e2e-chaos CHAOS_FLAGS="-duration 3m -seed 7 -out /tmp/chaos-a"
+#
+# The journal (every decision) and the run summary (actions, probe loss
+# over time, recovery durations, violations) land under -out; a run that
+# recorded a violation exits 1 and dumps the lab state via
+# collect-artifacts.sh, exactly like the scenario jobs do.
+CHAOS_FLAGS ?=
+e2e-chaos:
+	$(E2E_CHAOS) $(CHAOS_FLAGS)

--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -41,6 +41,15 @@ test/e2e/
     stale-chassis.sh        — stale chassis cleanup scenario, hard kill (issue #111)
     drain-hitless.sh        — graceful drain vs hard kill, hitless comparison (issue #113)
     collect-artifacts.sh    — dump lab state for offline triage
+  chaos/                    — seeded chaos runner, `make e2e-chaos` (issue #176)
+    main.go                 — flags, wiring, exit codes, artifact collection
+    engine.go               — the seeded tick loop: draw, guardrails, execute, converge
+    actions.go              — the fault registry (four starter actions)
+    lab.go                  — the single seam to docker / containerlab
+    state.go                — the combined start state and the node-restore path
+    probe.go                — continuous reachability probe from client-1
+    checks.go               — baseline invariants (agents alive, no dual claim)
+    journal.go              — the JSONL journal and the run record
   pf-backend/
     main.go                 — tiny HTTP responder shipped at /usr/local/bin/pf-backend
                               in the gwnode image; logs each connection's source IP
@@ -217,6 +226,7 @@ Between bring-up and teardown, each scenario is its own `make` target:
 | Scenario | `make` target | What it asserts | Issue |
 | --- | --- | --- | --- |
 | [Baseline](#baseline) | `e2e-baseline` | An external client reaches a FIP once the agent reconciles. | [#45](https://github.com/osism/ovn-network-agent/issues/45) |
+| [Chaos runner](#chaos-runner) | `e2e-chaos` | Under a seeded, randomized fault sequence the agents stay alive, reachability recovers within budget, and no gateway port is claimed twice. | [#176](https://github.com/osism/ovn-network-agent/issues/176) |
 | [Drain-hitless](#drain-hitless) | `e2e-drain-hitless` | A graceful `SIGTERM` drain loses fewer packets than a hard `docker kill` of the same chassis. | [#113](https://github.com/osism/ovn-network-agent/issues/113) |
 | [Failover](#failover) | `e2e-failover` | `cr-lr0-public` re-elects to a surviving chassis after the master is lost. | [#105](https://github.com/osism/ovn-network-agent/issues/105) |
 | [Hairpin](#hairpin) | `e2e-hairpin` | The `cookie=0x998` hairpin flow reflects FIP-to-FIP traffic on `br-ex`. | [#108](https://github.com/osism/ovn-network-agent/issues/108) |
@@ -226,9 +236,10 @@ Between bring-up and teardown, each scenario is its own `make` target:
 | [Stale chassis](#stale-chassis) | `e2e-stale-chassis` | Surviving peers garbage-collect the NB rows of a hard-killed chassis. | [#111](https://github.com/osism/ovn-network-agent/issues/111) |
 
 Every scenario except `baseline` runs the baseline first as a sanity
-gate; set `SANITY_GATE=0` to skip it. The subsections below describe
-what each scenario does and which environment variables it accepts for
-triage.
+gate; set `SANITY_GATE=0` to skip it. The [chaos runner](#chaos-runner)
+is the one exception: it gates on its own combined start state instead,
+which is a superset of the baseline. The subsections below describe what
+each scenario does and which environment variables it accepts for triage.
 
 ### Baseline
 
@@ -847,6 +858,202 @@ would otherwise silently double.
 `PROBE_INTERVAL`, `PROBE_COUNT`, `PROBE_PRELUDE`, `FAILOVER_TIMEOUT`,
 `GRACEFUL_MAX_OUTAGE_MS`, `SKIP_RECYCLE`, `RECYCLE_ON_EXIT`,
 `SANITY_GATE`.
+
+### Chaos runner
+
+```sh
+make e2e-chaos
+make e2e-chaos CHAOS_FLAGS="-duration 3m -seed 7 -out /tmp/chaos-a"
+```
+
+[`chaos/`](https://github.com/osism/ovn-network-agent/tree/main/test/e2e/chaos)
+is not a scenario but a driver. The eight scenarios each prove one fault
+in isolation; production faults overlap and repeat. The runner drives the
+same lab through a *randomized* fault sequence for a bounded duration and
+leaves a journal you can triage from — and replay.
+
+It is a Go `main` package rather than another bash script for two
+reasons: `$RANDOM` is not stable across bash versions, which would break
+the replay contract outright, and the run needs concurrent probing plus
+structured artifacts. Its unit tests run under `make test` on any
+platform (they drive the real engine against a fake `docker`).
+
+**Inputs — and the replay contract.** The seed, the duration, the tick
+bounds and the action weights are the *only* inputs, and every decision
+the engine makes is drawn from a PCG stream seeded by `-seed` alone:
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `-seed` | `42` | Seeds every decision: the tick interval, the action, the target, the hold. |
+| `-duration` | `10m` | How long to keep injecting faults. Must be at least `1s`. |
+| `-tick-min` / `-tick-max` | `10s` / `30s` | Bounds of the interval between decisions. `-tick-min` must be at least `100ms`: a tick interval near zero spins the loop and grows the journal without bound, on a run where no fault fits between two ticks. |
+| `-weights` | registry defaults | `name=n,…`; an unknown action name is rejected. `-weights gateway-kill=0` disables a fault. |
+| `-lab` | `ovn-e2e` | containerlab lab name. |
+| `-out` | `chaos-artifacts` | Where the journal, the run record and the lab-state dump land. |
+| `-collect` | `test/e2e/scenarios/collect-artifacts.sh` | The lab-state collector, run into `<out>/lab-state` when the run does not pass. The default is repo-relative, so run the binary from the repo root (`make e2e-chaos` does). |
+
+Two runs with identical inputs against identically-behaving labs replay
+the identical action sequence. Diff them:
+
+```sh
+make e2e-up && make e2e-chaos CHAOS_FLAGS="-duration 3m -out /tmp/chaos-a"
+make e2e-down && make e2e-up
+make e2e-chaos CHAOS_FLAGS="-duration 3m -out /tmp/chaos-b"
+
+diff \
+  <(jq -c 'select(.event=="decision") | {tick,action,target,interval_ms,hold_ms}' /tmp/chaos-a/journal.jsonl) \
+  <(jq -c 'select(.event=="decision") | {tick,action,target,interval_ms,hold_ms}' /tmp/chaos-b/journal.jsonl)
+```
+
+Each tick draws exactly four values — interval, action, target, hold —
+**before** the guardrails are consulted, so a guardrail skip cannot shift
+the stream: the run that skipped a decision draws the same values
+afterwards as the run that executed it. Wall clock only bounds *how many*
+ticks fit in `-duration`, so a slower lab truncates the tail of the
+sequence rather than changing it.
+
+**Combined start state.** The runner layers the existing scenarios'
+setups onto the bootstrap baseline, so one run exercises all of them at
+once: `hairpin.sh`'s second FIP (`192.0.2.12` with a `vm2` responder),
+`multi-vlan.sh`'s two VLAN provider networks (tags 101/102, routers
+pinned to `gateway-1`), and `pf-external.sh`'s `Load_Balancer` VIP
+(`192.0.2.50:80` in front of the `vm1` backend). The layering is
+idempotent, which is what makes it reusable as the post-fault restore
+path. If the start state is not green within 120 s the run aborts with
+exit code 2 — a fault injected into a lab that was not green to begin
+with would report false violations for the rest of the run.
+
+**Probes.** A goroutine per target samples reachability from `client-1`
+once a second for the whole run, so loss *during* a fault hold is
+recorded even while the engine is blocked:
+
+| Probe | Target |
+| --- | --- |
+| `fip-vm1` | `ping 192.0.2.10` |
+| `fip-vm2` | `ping 192.0.2.12` |
+| `fip-vlan101` | `ping 198.51.100.10` |
+| `fip-vlan102` | `ping 203.0.113.10` |
+| `pf-vip` | `curl http://192.0.2.50:80/` |
+
+The baseline lab's second FIP, `192.0.2.11`, is deliberately **not**
+probed: `bootstrap.sh` seeds its NAT row but nothing answers behind
+`192.168.10.11`, so it would be red for the whole run.
+
+**Actions.** The starter set reuses the fault mechanics the scenarios
+already prove. The registry order and the weights are part of the replay
+contract — a new action is appended, never inserted.
+
+| Action | Weight | Hold | Recovery budget | Mechanic |
+| --- | --- | --- | --- | --- |
+| `controller-restart` | 3 | 10–30 s | 90 s | `ovn-ctl stop_controller` / `start_controller` ([failover](#failover)) |
+| `gateway-kill` | 1 | 15–45 s | 180 s | `docker kill -s KILL`, then `docker start` ([stale chassis](#stale-chassis)) |
+| `agent-terminate` | 2 | 10–30 s | 180 s | `kill -TERM 1` — the agent is PID 1 ([drain-hitless](#drain-hitless)) |
+| `gateway-restart` | 2 | — | 180 s | `docker restart` ([pf-hairpin](#port-forward-hairpin-masquerade)) |
+
+Every action that kills a container first runs `docker update
+--restart=no`, exactly as `drain-hitless.sh` does — containerlab deploys
+with `restart: always`, so without it docker revives the node before the
+fault is observable at all. The policy is restored on the way back.
+
+`agent-terminate` only exercises the agent's *drain* path when the lab
+was deployed with `E2E_DRAIN_ON_SHUTDOWN=true` (see
+[Drain-hitless](#drain-hitless)); otherwise the SIGTERM is just a
+graceful exit. The fault is the same either way — the drain only changes
+how much the run loses.
+
+**Guardrails** keep a run meaningful. A decision is skipped (and
+journaled with its `skip_reason`) when the target has not returned and
+converged since it was last hit, or when it is the last healthy gateway.
+
+**Convergence and recovery budgets.** After each restore the runner polls
+the node back to health: the container healthy, its chassis back in SB,
+and every probe green. Budget expiry is a `recovery-timeout` violation
+and parks the node — it is never targeted again and the run fails. A park
+also ends the run early (journaled as `run-aborted`): the parked node's
+data path stays dark, and since convergence gates on *every* probe being
+green, no later action could converge either — the rest of the duration
+would produce nothing but violations derived from the first one.
+Budgets are measured from the *restore*, not from the injection:
+resources pinned to the node under fault (the VLAN routers and the VIP on
+`gateway-1`, every responder on `gateway-3`) are legitimately dark while
+it is held down. The probe-loss buckets still record what happened
+mid-hold.
+
+**Baseline checks** sweep every 10 s, independently of what the engine is
+doing: every node the run considers healthy must be running an agent, and
+no `chassisredirect` port may be claimed by two chassis at once
+(`chassis` ∪ `additional_chassis`). A sweep the runner could not answer —
+central under load, the `sbctl --timeout=5` expiring — is journaled as
+`check-error` and counted, not swallowed. The counts are the record's
+evidence that the invariants were evaluated at all: a run whose every
+dual-claim lookup failed asserted nothing, and fails with a
+`checks-never-ran` violation instead of reporting a clean pass.
+
+::: details Why the runner re-wires the containerlab veth
+Any container exit destroys the containerlab veth
+`gateway-N:eth1 ↔ upstream:ethN`, and `docker start` does not bring it
+back — which is why [failover](#failover) stops only `ovn-controller` and
+why [stale-chassis](#stale-chassis) and [drain-hitless](#drain-hitless)
+tell you to recycle the whole lab. A chaos runner cannot recycle: the
+guardrails only re-target a node that has *returned*. So `restoreNode`
+re-creates the link with `containerlab tools veth create`, re-applies the
+underlay `/30` and the BGP session `bootstrap.sh` seeds, and — on
+`gateway-3` — rebuilds the netns responders and the port-forward backend
+its destroyed network namespace took with it. This needs the same
+privileges `containerlab deploy` already does.
+:::
+
+::: details Why the runner re-points the port-forward VIP
+`pf-external.sh` pins the VIP's two routes (the forward route on
+`upstream`, the scope-link route on `br-ex`) to `gateway-1`, because the
+agent does not propagate `Load_Balancer` VIPs into the underlay. A chaos
+run migrates the master, so the runner re-points both at whichever
+chassis currently owns `cr-lr0-public` — the job an external orchestrator
+does in production — and journals it as `vip-repoint`. Without it the VIP
+probe would go permanently red on the first re-election and every later
+violation would be noise.
+:::
+
+::: warning Destructive — recycle the lab afterwards
+A chaos run leaves the lab wherever the anti-flap election landed:
+`cr-lr0-public` is generally **not** back on `gateway-1`, and the runner
+deliberately never re-asserts priorities mid-run. Chain
+`make e2e-down && make e2e-up` before running scenarios that assume the
+bootstrap master.
+:::
+
+**Artifacts.** Both land under `-out`:
+
+```
+<out>/
+  journal.jsonl   — one JSON object per decision and phase, in order
+  summary.json    — the run record (schema chaos-run-record/v1)
+  lab-state/      — collect-artifacts.sh dump, on a non-zero exit only
+```
+
+`journal.jsonl` carries `run-start` (the echoed inputs), `state-applied`,
+one `decision` per tick (with the drawn values and either `executed` or a
+`skip_reason`), `inject` / `restore` / `converged`, `node-state`,
+`probe-transition`, `vip-repoint`, `violation` and `run-end`.
+`summary.json` aggregates the run: inputs, tick and decision counts,
+actions by name, how many baseline sweeps ran and how many of them
+evaluated the dual-claim invariant, per-probe sent/lost plus 10-second
+loss buckets, the per-action recovery durations, and every violation.
+
+**Exit codes:** `0` the run passed, `1` the run recorded a violation,
+`2` the runner could not set the run up (bad flags, a start state that
+never went green). On any non-zero exit the lab's existing
+`collect-artifacts.sh` bundle is dumped into `<out>/lab-state`.
+
+**In CI.** The `chaos` job in
+[`e2e.yml`](https://github.com/osism/ovn-network-agent/blob/main/.github/workflows/e2e.yml)
+runs on `workflow_dispatch` only, with `-seed 42 -duration 3m`, and
+uploads the journal, the summary and the lab-state dump on every outcome.
+It is not on the PR path: the sibling scenarios each assert one fault and
+leave the lab baseline-green, while a chaos run is a randomized sequence
+that deliberately leaves the master wherever the last election put it.
+Dispatch it from the Actions tab when you touch the agent's failover,
+drain or chassis-cleanup paths.
 
 ### Manual setup for triage
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -15,5 +15,6 @@ make e2e-install-tools   # one-time, installs containerlab on Linux
 make e2e-up              # build images, deploy topology, seed OVN NB
 make e2e-baseline        # run the baseline reachability scenario
 make e2e-failover        # run the HA failover scenario (master chassis loss)
+make e2e-chaos           # run a seeded 10-minute chaos session
 make e2e-down            # destroy the lab
 ```

--- a/test/e2e/chaos/actions.go
+++ b/test/e2e/chaos/actions.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"time"
+)
+
+// agentExitTimeout is how long a SIGTERM'ed agent gets to take its
+// container down before agent-terminate gives up on the graceful path.
+const agentExitTimeout = 30 * time.Second
+
+// starterActions is the action registry, in the order the weighted pick
+// walks it. Both the order and the weights are part of the replay
+// contract: the same seed and the same weights replay the same sequence,
+// so a new action is appended, never inserted.
+//
+// Each fault reuses the mechanics an existing scenario already proves:
+//
+//	controller-restart — failover.sh's clean chassis-loss simulation
+//	gateway-kill       — stale-chassis.sh's SIGKILL
+//	agent-terminate    — drain-hitless.sh's SIGTERM to PID 1
+//	gateway-restart    — pf-hairpin.sh's `docker restart`
+//
+// The recovery budgets differ because the faults differ: stopping
+// ovn-controller costs a re-election, while any container lifecycle
+// event costs a full daemon bring-up plus the underlay re-wire.
+func starterActions() []*action {
+	return []*action{
+		{
+			name:           "controller-restart",
+			weight:         3,
+			holdMin:        10 * time.Second,
+			holdMax:        30 * time.Second,
+			recoveryBudget: 90 * time.Second,
+			inject: func(ctx context.Context, l *lab, gw string) error {
+				return l.stopController(ctx, gw)
+			},
+			restore: func(ctx context.Context, l *lab, gw string) error {
+				return l.startController(ctx, gw)
+			},
+		},
+		{
+			name:           "gateway-kill",
+			weight:         1,
+			holdMin:        15 * time.Second,
+			holdMax:        45 * time.Second,
+			recoveryBudget: 180 * time.Second,
+			inject:         injectGatewayKill,
+			restore:        startAndRestoreGateway,
+		},
+		{
+			name:           "agent-terminate",
+			weight:         2,
+			holdMin:        10 * time.Second,
+			holdMax:        30 * time.Second,
+			recoveryBudget: 180 * time.Second,
+			inject:         injectAgentTerminate,
+			restore:        startAndRestoreGateway,
+		},
+		{
+			name:   "gateway-restart",
+			weight: 2,
+			// No hold: `docker restart` is the fault and its own undo.
+			holdMin:        0,
+			holdMax:        0,
+			recoveryBudget: 180 * time.Second,
+			inject: func(ctx context.Context, l *lab, gw string) error {
+				return l.restartGateway(ctx, gw)
+			},
+			restore: restoreNode,
+		},
+	}
+}
+
+// injectGatewayKill hard-kills the container. containerlab deploys with
+// `restart: always`, so the policy is flipped off first — otherwise
+// docker revives the node before the fault is observable at all.
+func injectGatewayKill(ctx context.Context, l *lab, gw string) error {
+	if err := l.setRestartPolicy(ctx, gw, "no"); err != nil {
+		return err
+	}
+	return l.killGateway(ctx, gw)
+}
+
+// injectAgentTerminate signals the agent (PID 1) and waits for the container
+// to follow it down. Whether the agent drains its gateway chassis before
+// exiting depends on how the lab was deployed — the fault is the same
+// either way, and the drain only changes how much the run loses.
+func injectAgentTerminate(ctx context.Context, l *lab, gw string) error {
+	if err := l.setRestartPolicy(ctx, gw, "no"); err != nil {
+		return err
+	}
+	if err := l.terminateAgent(ctx, gw); err != nil {
+		return err
+	}
+	return l.waitContainerExit(ctx, gw, agentExitTimeout)
+}
+
+// startAndRestoreGateway brings a killed container back: start it,
+// restore the restart policy containerlab set, then put the node back in
+// service (underlay veth, BGP, node-local workloads).
+//
+// The policy is put back even when the start failed: the inject pinned it
+// to "no" so docker would not revive the node mid-fault, and leaving it
+// there hands the lab a gateway docker will never bring back up.
+func startAndRestoreGateway(ctx context.Context, l *lab, gw string) error {
+	startErr := l.startGateway(ctx, gw)
+	policyErr := l.setRestartPolicy(ctx, gw, "always")
+	if startErr != nil {
+		return startErr
+	}
+	if policyErr != nil {
+		return policyErr
+	}
+	return restoreNode(ctx, l, gw)
+}

--- a/test/e2e/chaos/actions_test.go
+++ b/test/e2e/chaos/actions_test.go
@@ -1,0 +1,357 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func actionNamed(t *testing.T, name string) *action {
+	t.Helper()
+	for _, a := range starterActions() {
+		if a.name == name {
+			return a
+		}
+	}
+	t.Fatalf("no action named %q in the registry", name)
+	return nil
+}
+
+// The registry order and the weights are part of the replay contract: a
+// new action is appended, never inserted, or every recorded seed replays
+// a different sequence.
+func TestStarterRegistryOrderIsStable(t *testing.T) {
+	want := []string{"controller-restart", "gateway-kill", "agent-terminate", "gateway-restart"}
+
+	var got []string
+	for _, a := range starterActions() {
+		got = append(got, a.name)
+		if a.weight <= 0 {
+			t.Fatalf("action %s ships with weight %d", a.name, a.weight)
+		}
+		if a.holdMax < a.holdMin {
+			t.Fatalf("action %s has holdMax %s below holdMin %s", a.name, a.holdMax, a.holdMin)
+		}
+		if a.recoveryBudget <= 0 {
+			t.Fatalf("action %s has no recovery budget", a.name)
+		}
+	}
+	if len(got) != len(want) {
+		t.Fatalf("registry = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("registry = %v, want %v", got, want)
+		}
+	}
+}
+
+// containerlab deploys the gateways with `restart: always`. Killing one
+// without disabling the policy first means docker revives it before the
+// fault is observable at all — the kill would measure nothing.
+func TestGatewayKillDisablesTheRestartPolicyBeforeTheKill(t *testing.T) {
+	cmd := &fakeCommander{}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := actionNamed(t, "gateway-kill").inject(context.Background(), l, "gateway-2"); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	disable := cmd.indexOf("update --restart=no clab-ovn-e2e-gateway-2")
+	kill := cmd.indexOf("kill -s KILL clab-ovn-e2e-gateway-2")
+	if disable < 0 || kill < 0 {
+		t.Fatalf("kill did not disable the restart policy and SIGKILL the node: %v", cmd.lines())
+	}
+	if disable > kill {
+		t.Fatalf("the restart policy was disabled after the kill: %v", cmd.lines())
+	}
+}
+
+// Restoring a killed node has to put back what `docker start` does not:
+// the containerlab veth to `upstream`, the underlay address, the BGP
+// session, and the restart policy containerlab set.
+func TestGatewayKillRestoreRewiresTheUnderlay(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := actionNamed(t, "gateway-kill").restore(context.Background(), l, "gateway-2"); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	for _, want := range []string{
+		"docker start clab-ovn-e2e-gateway-2",
+		"docker update --restart=always clab-ovn-e2e-gateway-2",
+		"containerlab tools veth create -a clab-ovn-e2e-gateway-2:eth1 -b clab-ovn-e2e-upstream:eth2",
+		"ip addr replace 100.64.2.2/30 dev eth1",
+		"ip addr replace 100.64.2.1/30 dev eth2",
+		"router bgp 65000 vrf vrf-provider",
+	} {
+		if !cmd.called(want) {
+			t.Fatalf("restore did not issue %q: %v", want, cmd.lines())
+		}
+	}
+	start := cmd.indexOf("docker start clab-ovn-e2e-gateway-2")
+	rewire := cmd.indexOf("containerlab tools veth create")
+	if start > rewire {
+		t.Fatalf("the veth was re-created before the container was started: %v", cmd.lines())
+	}
+}
+
+// The veth survives an ovn-controller restart, so it must not be
+// re-created when it is still there — `veth create` would fail on an
+// existing interface.
+func TestRewireSkipsTheVethWhenTheInterfaceSurvived(t *testing.T) {
+	// Unlike healthyLabResponses, this lab still has its eth1.
+	cmd := &fakeCommander{}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := l.rewireUnderlay(context.Background(), "gateway-1"); err != nil {
+		t.Fatalf("rewireUnderlay: %v", err)
+	}
+
+	if cmd.called("containerlab tools veth create") {
+		t.Fatalf("re-created a veth that was still present: %v", cmd.lines())
+	}
+}
+
+// controller-restart is the soft fault: it never touches the container,
+// so the containerlab veths stay up and no re-wire is needed.
+func TestControllerRestartUsesOvnCtlAndTouchesNoContainer(t *testing.T) {
+	cmd := &fakeCommander{}
+	l := newTestLab(cmd, newFakeClock())
+	act := actionNamed(t, "controller-restart")
+
+	if err := act.inject(context.Background(), l, "gateway-1"); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if err := act.restore(context.Background(), l, "gateway-1"); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	want := []string{
+		"docker exec clab-ovn-e2e-gateway-1 /usr/share/ovn/scripts/ovn-ctl stop_controller",
+		"docker exec clab-ovn-e2e-gateway-1 /usr/share/ovn/scripts/ovn-ctl start_controller",
+	}
+	got := cmd.lines()
+	if len(got) != len(want) {
+		t.Fatalf("issued %d commands, want exactly the two ovn-ctl calls: %v", len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("command %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// The gwnode entrypoint execs the agent, so it is PID 1 — the SIGTERM
+// goes to the container's init, and the container follows it down.
+func TestAgentTerminateSignalsPID1AndWaitsForTheExit(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := actionNamed(t, "agent-terminate").inject(context.Background(), l, "gateway-3"); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	if !cmd.called("docker exec clab-ovn-e2e-gateway-3 kill -TERM 1") {
+		t.Fatalf("the agent was not signalled as PID 1: %v", cmd.lines())
+	}
+	if !cmd.called("{{.State.Running}}") {
+		t.Fatalf("the runner did not wait for the container to exit: %v", cmd.lines())
+	}
+}
+
+// An agent that ignores its SIGTERM leaves the node in a state the run
+// cannot reason about; the engine turns that error into a violation.
+func TestAgentTerminateFailsWhenTheContainerStaysUp(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "{{.State.Running}}") {
+			return "true\n", nil
+		}
+		return "", nil
+	}}
+	l := newTestLab(cmd, newFakeClock())
+
+	err := actionNamed(t, "agent-terminate").inject(context.Background(), l, "gateway-3")
+	if err == nil {
+		t.Fatal("a container that never exited was reported as a clean termination")
+	}
+	if !strings.Contains(err.Error(), "still running") {
+		t.Fatalf("error %q does not say the container stayed up", err)
+	}
+}
+
+// The restart policy is pinned to "no" for the duration of the fault, so
+// docker cannot revive the node behind the runner's back. A start that
+// fails must still put it back — otherwise the lab keeps a gateway docker
+// will never bring up again, long after the run is over.
+func TestStartAndRestoreGatewayRestoresThePolicyWhenTheStartFails(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "docker start") {
+			return "", errBoom
+		}
+		return healthyLabResponses(argv)
+	}}
+	l := newTestLab(cmd, newFakeClock())
+
+	err := startAndRestoreGateway(context.Background(), l, "gateway-2")
+
+	if err == nil {
+		t.Fatal("a container that could not be started was reported as restored")
+	}
+	if !cmd.called("update --restart=always clab-ovn-e2e-gateway-2") {
+		t.Fatalf("the restart policy was left disabled after a failed start: %v", cmd.lines())
+	}
+}
+
+// gateway-restart is the odd one out twice over: `docker restart` is not
+// a kill, so the restart policy must stay untouched, and the action has
+// no hold — inject and restore run back to back, so the restore re-wires
+// a container docker is still bringing up.
+func TestGatewayRestartRecyclesTheContainerAndRestoresTheNode(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	l := newTestLab(cmd, newFakeClock())
+	act := actionNamed(t, "gateway-restart")
+
+	if err := act.inject(context.Background(), l, workloadHost); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if err := act.restore(context.Background(), l, workloadHost); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	if !cmd.called("docker restart clab-ovn-e2e-gateway-3") {
+		t.Fatalf("the container was not recycled: %v", cmd.lines())
+	}
+	if cmd.called("--restart=no") {
+		t.Fatalf("`docker restart` is not a kill — the restart policy must stay as containerlab set it: %v",
+			cmd.lines())
+	}
+	rewire := cmd.indexOf("containerlab tools veth create")
+	responder := cmd.indexOf("external_ids:iface-id=ls0-vm1")
+	if rewire < 0 || responder < 0 {
+		t.Fatalf("restore did not re-wire the underlay and rebuild the responders: %v", cmd.lines())
+	}
+	if rewire > responder {
+		t.Fatalf("the responders were rebuilt before the underlay came back: %v", cmd.lines())
+	}
+}
+
+// A container lifecycle event on the workload host destroys its network
+// namespace: every responder behind a FIP and the port-forward backend
+// have to be re-created. No other gateway carries node-local workloads.
+func TestReprovisionRebuildsTheWorkloadHostOnly(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := reprovisionNode(context.Background(), l, workloadHost); err != nil {
+		t.Fatalf("reprovision %s: %v", workloadHost, err)
+	}
+
+	for _, want := range []string{
+		"external_ids:iface-id=ls0-vm1",
+		"external_ids:iface-id=ls0-vm2",
+		"external_ids:iface-id=vm101",
+		"external_ids:iface-id=vm102",
+		"/usr/local/bin/pf-backend -addr :8080 -log /tmp/pf-backend.log",
+	} {
+		if !cmd.called(want) {
+			t.Fatalf("reprovision did not restore %q: %v", want, cmd.lines())
+		}
+	}
+
+	peer := &fakeCommander{respond: healthyLabResponses}
+	if err := reprovisionNode(context.Background(), newTestLab(peer, newFakeClock()), "gateway-2"); err != nil {
+		t.Fatalf("reprovision gateway-2: %v", err)
+	}
+	if len(peer.lines()) != 0 {
+		t.Fatalf("reprovision touched a gateway with no node-local workloads: %v", peer.lines())
+	}
+}
+
+// The port-forward backend is restarted, not started alongside a stale
+// instance, and the run waits for it to bind before probing the VIP.
+func TestStartPFBackendReplacesAnyRunningInstance(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := startPFBackend(context.Background(), l); err != nil {
+		t.Fatalf("startPFBackend: %v", err)
+	}
+
+	kill := cmd.indexOf("pkill -f /usr/local/bin/pf-backend")
+	start := cmd.indexOf("exec -d clab-ovn-e2e-gateway-3")
+	listen := cmd.indexOf("sport = :8080")
+	if kill < 0 || start < 0 || listen < 0 {
+		t.Fatalf("backend was not reset, started and waited for: %v", cmd.lines())
+	}
+	if kill > start || start > listen {
+		t.Fatalf("backend steps ran out of order: %v", cmd.lines())
+	}
+}
+
+// A backend that never binds must fail the layering rather than let the
+// VIP probe report a false violation for the rest of the run.
+func TestStartPFBackendFailsWhenTheListenerNeverBinds(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "sport = :8080") {
+			return "", errBoom
+		}
+		return "", nil
+	}}
+	l := newTestLab(cmd, newFakeClock())
+
+	err := startPFBackend(context.Background(), l)
+	if err == nil {
+		t.Fatal("a backend that never bound was accepted")
+	}
+	if !strings.Contains(err.Error(), "did not bind") {
+		t.Fatalf("error %q does not say the listener never came up", err)
+	}
+}
+
+// The VLAN provider networks the start state layers on must land with
+// their localnet tag and their router pinned, or the FIPs behind them
+// never answer and every fault reads as a violation.
+func TestVLANLayerTagsTheLocalnetPortAndPinsTheRouter(t *testing.T) {
+	cmd := &fakeCommander{}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := applyVLANLayer(context.Background(), l, vlanNetworks[0]); err != nil {
+		t.Fatalf("applyVLANLayer: %v", err)
+	}
+
+	for _, want := range []string{
+		"lsp-set-options ln-vlan101 network_name=physnet1",
+		"set Logical_Switch_Port ln-vlan101 tag=101",
+		"lrp-set-gateway-chassis lr-vlan101-public gateway-1 30",
+		"lr-nat-add lr-vlan101 dnat_and_snat 198.51.100.10 192.168.101.10",
+	} {
+		if !cmd.called(want) {
+			t.Fatalf("vlan layer did not issue %q: %v", want, cmd.lines())
+		}
+	}
+}
+
+func TestVLANLayerReportsANBFailure(t *testing.T) {
+	cmd := &fakeCommander{respond: func([]string) (string, error) { return "", errBoom }}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := applyVLANLayer(context.Background(), l, vlanNetworks[1]); err == nil {
+		t.Fatal("a failed ovn-nbctl call was swallowed")
+	}
+}
+
+// 192.0.2.11 is seeded by bootstrap.sh as a NAT row with nothing behind
+// it. Probing it would be red for the whole run and every recovery gate
+// would time out, so it must stay out of the probe set.
+func TestProbeTargetsExcludeTheBackendlessFIP(t *testing.T) {
+	for _, target := range probeTargets {
+		if strings.Contains(target.addr, "192.0.2.11") {
+			t.Fatalf("probe target %q has no responder behind it", target.name)
+		}
+	}
+	if len(probeTargets) != 5 {
+		t.Fatalf("probe set = %v, want the four FIPs plus the port-forward VIP", probeTargets)
+	}
+}

--- a/test/e2e/chaos/checks.go
+++ b/test/e2e/chaos/checks.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// checkInterval is the cadence of the baseline sweep. It runs for the
+// whole run, alongside the prober and independently of what the engine
+// is doing, so an invariant broken during a fault hold is caught.
+const checkInterval = 10 * time.Second
+
+// baselineChecks are the invariants that must hold across the whole run,
+// no matter which faults the engine picked:
+//
+//   - agent-alive: every node the engine considers healthy runs an agent.
+//     Nodes under fault are skipped — having no agent is the fault.
+//   - dual-claim: no chassisredirect port is claimed by two chassis at
+//     once. A split gateway port forwards the same traffic twice and is
+//     the failure mode HA re-election exists to avoid.
+//
+// Reachability recovery after each action is the engine's own gate (see
+// converge), because only it knows the action's budget.
+type baselineChecks struct {
+	lab    *lab
+	engine *engine
+
+	// counts is what the sweeps actually evaluated. Only the sweep
+	// goroutine touches it; drive reads it after joining that goroutine.
+	counts checkCounts
+}
+
+// run sweeps until ctx is cancelled. The first sweep runs immediately, so
+// even a run shorter than the sweep interval evaluates the invariants
+// once — finalize now holds the run to having done so.
+func (c *baselineChecks) run(ctx context.Context) {
+	c.sweep(ctx)
+	ticker := time.NewTicker(checkInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.sweep(ctx)
+		}
+	}
+}
+
+func (c *baselineChecks) sweep(ctx context.Context) {
+	c.counts.Sweeps++
+	c.checkAgentsAlive(ctx)
+	c.checkNoDualClaim(ctx)
+}
+
+// finalize records what the sweeps evaluated, and fails the run when the
+// dual-claim invariant was never evaluated at all.
+//
+// It is the single most important thing this harness asserts, and every
+// one of its sweeps can fail for reasons that have nothing to do with the
+// lab — central under load, the sbctl --timeout=5 expiring. A run whose
+// every sweep failed that way checked nothing, and without this it would
+// report zero violations and a clean pass, with the check-error lines
+// that say otherwise buried in a ten-minute journal nobody reads on green.
+func (c *baselineChecks) finalize() {
+	c.engine.recordChecks(c.counts)
+	if c.counts.DualClaim > 0 {
+		return
+	}
+	c.engine.violate(violationRecord{
+		Kind: violationChecksNeverRan,
+		Detail: fmt.Sprintf("the dual-claim invariant was never evaluated: %d sweeps, %d check errors",
+			c.counts.Sweeps, c.counts.Errors),
+	})
+}
+
+// checkError records a check the runner could not answer. It is a
+// runner-side problem, not a broken lab invariant — but the invariant
+// went unevaluated, so it is counted (finalize holds the run to the
+// count) and journaled rather than swallowed. A cancelled run is not a
+// failed check: every in-flight command fails on ctx.Done() by design.
+func (c *baselineChecks) checkError(ctx context.Context, kind string, err error) {
+	if ctx.Err() != nil {
+		return
+	}
+	c.counts.Errors++
+	c.engine.jrnl.emit(event{Event: evCheckError, Kind: kind, Detail: err.Error()})
+}
+
+func (c *baselineChecks) checkAgentsAlive(ctx context.Context) {
+	for _, gw := range c.engine.healthyNodes() {
+		if ctx.Err() != nil {
+			return
+		}
+		alive, err := c.lab.agentAlive(ctx, gw)
+		if err != nil {
+			// The question could not be asked — a docker daemon under load,
+			// an expired command timeout. Reading that as "no agent" would
+			// fail the run over a node that is perfectly healthy.
+			c.checkError(ctx, violationAgentDown, err)
+			continue
+		}
+		if alive {
+			continue
+		}
+		// Re-read the node state: the engine may have started a fault on
+		// this node between the snapshot and the probe, in which case a
+		// dead agent is expected, not a violation.
+		if c.engine.nodeState(gw) != nodeHealthy {
+			continue
+		}
+		c.engine.violate(violationRecord{
+			Kind: violationAgentDown, Target: gw,
+			Detail: "no ovn-network-agent process on a node the run considers healthy",
+		})
+	}
+}
+
+func (c *baselineChecks) checkNoDualClaim(ctx context.Context) {
+	claims, err := c.lab.crPortClaims(ctx)
+	if err != nil {
+		c.checkError(ctx, violationDualClaim, err)
+		return
+	}
+	c.counts.DualClaim++
+	for _, claim := range claims {
+		if len(claim.chassis) < 2 {
+			continue
+		}
+		names := make([]string, 0, len(claim.chassis))
+		for _, uuid := range claim.chassis {
+			names = append(names, c.lab.chassisName(ctx, uuid))
+		}
+		c.engine.violate(violationRecord{
+			Kind: violationDualClaim, Target: claim.port,
+			Detail: fmt.Sprintf("%s claimed by %d chassis at once: %s",
+				claim.port, len(names), strings.Join(names, ", ")),
+		})
+	}
+}

--- a/test/e2e/chaos/checks_test.go
+++ b/test/e2e/chaos/checks_test.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTestChecks wires the baseline checks against a fake lab and an
+// engine whose node states the test controls, and hands back the run
+// record and the journal both write into.
+func newTestChecks(cmd commander, nodes map[string]string) (*baselineChecks, *runRecord, *bytes.Buffer) {
+	clock := newFakeClock()
+	rec := &runRecord{ActionsByName: map[string]int{}}
+	buf := &bytes.Buffer{}
+	e := newEngine(newTestLab(cmd, clock), nil, greenProbes{}, newJournal(buf, clock.now), rec)
+	e.now = clock.now
+	if nodes != nil {
+		e.nodes = nodes
+	}
+	return &baselineChecks{lab: e.lab, engine: e}, rec, buf
+}
+
+// The agent staying alive is one of the run's invariants: a node the run
+// considers healthy but that has no agent process is a violation.
+func TestCheckAgentsAliveFlagsAHealthyNodeWithNoAgent(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		line := strings.Join(argv, " ")
+		// pgrep finds nothing on gateway-2: it exits 1, and that is the
+		// answer, not a failure.
+		if strings.Contains(line, "pgrep") && strings.Contains(line, "gateway-2") {
+			return "", errExit(t, 1)
+		}
+		if strings.Contains(line, "pgrep") {
+			return "1\n", nil
+		}
+		return healthyLabResponses(argv)
+	}}
+	checks, rec, _ := newTestChecks(cmd, nil)
+
+	checks.checkAgentsAlive(context.Background())
+
+	if len(rec.Violations) != 1 {
+		t.Fatalf("violations = %+v, want exactly one", rec.Violations)
+	}
+	v := rec.Violations[0]
+	if v.Kind != violationAgentDown || v.Target != "gateway-2" {
+		t.Fatalf("violation = %+v, want %s on gateway-2", v, violationAgentDown)
+	}
+}
+
+// A probe that could not be answered is not a dead agent. The runner
+// drives docker hard — the prober fires five execs a second while the
+// engine is issuing `docker update`, `kill`, `start` and `inspect` — so a
+// `docker exec` on a loaded runner can fail for reasons that have nothing
+// to do with the agent. Read as "no agent" it would fail the run against a
+// node that is perfectly healthy, and point the report at a bug in the
+// agent that never happened.
+func TestCheckAgentsAliveDoesNotReadAFailedProbeAsADeadAgent(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "pgrep") {
+			return "", errBoom // the docker daemon could not answer
+		}
+		return healthyLabResponses(argv)
+	}}
+	checks, rec, buf := newTestChecks(cmd, nil)
+
+	checks.checkAgentsAlive(context.Background())
+
+	if len(rec.Violations) != 0 {
+		t.Fatalf("a probe the runner could not answer was recorded as a violation: %+v", rec.Violations)
+	}
+	if checks.counts.Errors != len(gatewayNames()) {
+		t.Fatalf("counted %d check errors for %d unanswerable probes",
+			checks.counts.Errors, len(gatewayNames()))
+	}
+	var journaled int
+	for _, ev := range eventsIn(t, buf.String()) {
+		if ev.Event == evCheckError && ev.Kind == violationAgentDown {
+			journaled++
+		}
+	}
+	if journaled == 0 {
+		t.Fatalf("the unanswerable probe was swallowed instead of journaled: %q", buf.String())
+	}
+}
+
+// A node under fault is *meant* to have no agent — that is the fault.
+// Holding it to the invariant would report every injected fault as a
+// violation.
+func TestCheckAgentsAliveSkipsNodesUnderFault(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "pgrep") {
+			return "", errBoom // no agent anywhere
+		}
+		return healthyLabResponses(argv)
+	}}
+	checks, rec, _ := newTestChecks(cmd, map[string]string{
+		"gateway-1": nodeDisrupted,
+		"gateway-2": nodeConverging,
+		"gateway-3": nodeUnconverged,
+	})
+
+	checks.checkAgentsAlive(context.Background())
+
+	if len(rec.Violations) != 0 {
+		t.Fatalf("violations = %+v, want none — every node is under fault", rec.Violations)
+	}
+	if cmd.called("pgrep") {
+		t.Fatalf("the check probed a node that is not in service: %v", cmd.lines())
+	}
+}
+
+// Two chassis forwarding for the same gateway port at once is the split
+// HA re-election exists to avoid. The claim set is the `chassis` column
+// plus every member of `additional_chassis`.
+func TestCheckNoDualClaimFlagsASplitGatewayPort(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		line := strings.Join(argv, " ")
+		switch {
+		case strings.Contains(line, "type=chassisredirect"):
+			return `{"headings":["logical_port","chassis","additional_chassis"],
+			         "data":[["cr-lr0-public",["uuid","uuid-a"],["set",[["uuid","uuid-b"]]]]]}`, nil
+		case strings.Contains(line, "list Chassis uuid-a"):
+			return "gateway-1\n", nil
+		case strings.Contains(line, "list Chassis uuid-b"):
+			return "gateway-2\n", nil
+		}
+		return "", nil
+	}}
+	checks, rec, _ := newTestChecks(cmd, nil)
+
+	checks.checkNoDualClaim(context.Background())
+
+	if len(rec.Violations) != 1 {
+		t.Fatalf("violations = %+v, want exactly one", rec.Violations)
+	}
+	v := rec.Violations[0]
+	if v.Kind != violationDualClaim {
+		t.Fatalf("violation kind = %q, want %q", v.Kind, violationDualClaim)
+	}
+	// The detail must name the chassis, not their UUIDs — that is what
+	// makes the journal triageable.
+	if !strings.Contains(v.Detail, "gateway-1") || !strings.Contains(v.Detail, "gateway-2") {
+		t.Fatalf("violation detail %q does not name both claiming chassis", v.Detail)
+	}
+}
+
+func TestCheckNoDualClaimAcceptsASinglyClaimedPort(t *testing.T) {
+	cmd := &fakeCommander{respond: func([]string) (string, error) {
+		return `{"headings":["logical_port","chassis","additional_chassis"],
+		         "data":[["cr-lr0-public",["uuid","uuid-a"],["set",[]]]]}`, nil
+	}}
+	checks, rec, _ := newTestChecks(cmd, nil)
+
+	checks.checkNoDualClaim(context.Background())
+
+	if len(rec.Violations) != 0 {
+		t.Fatalf("violations = %+v, want none — the port has one owner", rec.Violations)
+	}
+	if checks.counts.DualClaim != 1 {
+		t.Fatalf("evaluated the dual-claim invariant %d times, want once", checks.counts.DualClaim)
+	}
+}
+
+// A sweep that could not query SB checked nothing. That is a runner-side
+// problem, not a broken lab invariant — but it must show up in the
+// journal rather than pass silently.
+func TestCheckNoDualClaimJournalsALookupFailure(t *testing.T) {
+	cmd := &fakeCommander{respond: func([]string) (string, error) { return "", errBoom }}
+	checks, rec, buf := newTestChecks(cmd, nil)
+
+	checks.checkNoDualClaim(context.Background())
+
+	if len(rec.Violations) != 0 {
+		t.Fatalf("a failed lookup was recorded as a lab violation: %+v", rec.Violations)
+	}
+	if checks.counts.DualClaim != 0 {
+		t.Fatalf("a failed lookup was counted as an evaluation of the invariant")
+	}
+	var journaled bool
+	for _, ev := range eventsIn(t, buf.String()) {
+		if ev.Event == evCheckError && ev.Kind == violationDualClaim {
+			journaled = true
+		}
+	}
+	if !journaled {
+		t.Fatalf("the skipped check was swallowed instead of journaled: %q", buf.String())
+	}
+}
+
+// The dual-claim invariant is the single most important thing the run
+// asserts, and every sweep of it can fail for reasons that have nothing to
+// do with the lab. A run where every sweep failed that way has zero
+// violations — and used to report a clean pass on that basis, with the
+// check-error lines buried in a journal nobody reads on green.
+func TestARunThatNeverEvaluatedTheDualClaimDoesNotPass(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "type=chassisredirect") {
+			return "", errBoom // central never answers
+		}
+		return healthyLabResponses(argv)
+	}}
+	checks, rec, _ := newTestChecks(cmd, nil)
+
+	checks.sweep(context.Background())
+	checks.sweep(context.Background())
+	checks.finalize()
+	rec.finalize(time.Now())
+
+	if rec.Result != resultFail {
+		t.Fatalf("result = %q, want %q — the invariant was never evaluated", rec.Result, resultFail)
+	}
+	if len(rec.Violations) != 1 || rec.Violations[0].Kind != violationChecksNeverRan {
+		t.Fatalf("violations = %+v, want a %s", rec.Violations, violationChecksNeverRan)
+	}
+	// The record has to carry the evidence, not just the verdict.
+	if rec.Checks.Sweeps != 2 || rec.Checks.DualClaim != 0 || rec.Checks.Errors != 2 {
+		t.Fatalf("checks = %+v, want 2 sweeps, 0 evaluations and 2 errors", rec.Checks)
+	}
+}
+
+// The counterpart: a run whose sweeps did evaluate the invariant and found
+// nothing passes, and says how much it looked at.
+func TestARunThatEvaluatedTheDualClaimPasses(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "type=chassisredirect") {
+			return `{"headings":["logical_port","chassis","additional_chassis"],
+			         "data":[["cr-lr0-public",["uuid","uuid-a"],["set",[]]]]}`, nil
+		}
+		return healthyLabResponses(argv)
+	}}
+	checks, rec, _ := newTestChecks(cmd, nil)
+
+	checks.sweep(context.Background())
+	checks.finalize()
+	rec.finalize(time.Now())
+
+	if rec.Result != resultPass {
+		t.Fatalf("result = %q, want %q: %+v", rec.Result, resultPass, rec.Violations)
+	}
+	if rec.Checks.Sweeps != 1 || rec.Checks.DualClaim != 1 || rec.Checks.Errors != 0 {
+		t.Fatalf("checks = %+v, want 1 sweep, 1 evaluation and no errors", rec.Checks)
+	}
+}
+
+// drive() cancels the sweep loop and then joins its goroutine. A run that
+// did not return on ctx.Done() would hang the runner forever, after the
+// engine has already finished.
+func TestChecksStopWithTheirContext(t *testing.T) {
+	checks, _, _ := newTestChecks(&fakeCommander{respond: healthyLabResponses}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		checks.run(ctx)
+	}()
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the baseline checks did not stop when their context was cancelled")
+	}
+}
+
+// The sweep runs both checks.
+func TestSweepRunsBothChecks(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	checks, _, _ := newTestChecks(cmd, nil)
+
+	checks.sweep(context.Background())
+
+	if !cmd.called("pgrep -f /usr/local/bin/ovn-network-agent") {
+		t.Fatalf("the sweep did not check that the agents are alive: %v", cmd.lines())
+	}
+	if !cmd.called("type=chassisredirect") {
+		t.Fatalf("the sweep did not check for a dual claim: %v", cmd.lines())
+	}
+}

--- a/test/e2e/chaos/engine.go
+++ b/test/e2e/chaos/engine.go
@@ -1,0 +1,531 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Node lifecycle. A node is only eligible as a fault target while it is
+// `healthy` — the issue's "a node is only re-killed after it has
+// returned and converged". A node the runner could not bring back is
+// parked in `unconverged` and never targeted again; the run fails on the
+// violation that put it there and stops injecting (see park).
+const (
+	nodeHealthy     = "healthy"
+	nodeDisrupted   = "disrupted"
+	nodeConverging  = "converging"
+	nodeUnconverged = "unconverged"
+)
+
+// Guardrail skip reasons, journaled on the decision they blocked.
+const (
+	skipTargetNotHealthy = "target-not-healthy"
+	skipNoHealthyPeer    = "no-healthy-peer"
+	skipNoWeightedAction = "no-weighted-action"
+)
+
+// Violation kinds.
+const (
+	violationRecoveryTimeout = "recovery-timeout"
+	violationActionFailed    = "action-failed"
+	violationAgentDown       = "agent-down"
+	violationDualClaim       = "dual-claim"
+	violationStartState      = "start-state-not-green"
+	violationChecksNeverRan  = "checks-never-ran"
+)
+
+// convergePollInterval is how often the engine re-checks a recovering
+// node against its recovery budget.
+const convergePollInterval = 5 * time.Second
+
+// restoreTimeout backstops one restore. It is deliberately not the
+// action's recovery budget: the budget is the SLO the *lab* is held to
+// once the node is back, while the restore is the runner reassembling
+// what a container lifecycle event destroyed. The longest restore path
+// (a gateway-kill on the workload host) chains four wait loops that sum
+// to 190s on their own — bounding it by the 180s budget would cut a slow
+// but healthy bring-up off half-way and report the runner's own
+// arithmetic as an action the lab could not recover from. Every command
+// underneath is bounded by cmdTimeout, so this is a backstop against a
+// wedged restore, not the thing that paces it.
+const restoreTimeout = 5 * time.Minute
+
+// action is one fault the engine can inject. inject and restore are the
+// two halves of the fault; between them the engine holds the fault for a
+// seeded duration drawn from [holdMin, holdMax].
+type action struct {
+	name           string
+	weight         int
+	holdMin        time.Duration
+	holdMax        time.Duration
+	recoveryBudget time.Duration
+	inject         func(ctx context.Context, l *lab, target string) error
+	restore        func(ctx context.Context, l *lab, target string) error
+}
+
+// probeSource is the slice of the prober the engine consumes.
+type probeSource interface {
+	allGreen() bool
+	redTargets() []string
+	recoverySince(anchor time.Time) map[string]int64
+}
+
+// engine drives one chaos run. Every decision it makes is drawn from
+// `rng`, which is seeded from the run's inputs alone — so identical
+// inputs replay the identical decision sequence.
+type engine struct {
+	rng      *rand.Rand
+	lab      *lab
+	actions  []*action
+	probes   probeSource
+	jrnl     *journal
+	rec      *runRecord
+	duration time.Duration
+	tickMin  time.Duration
+	tickMax  time.Duration
+
+	// wait blocks for a duration unless ctx is cancelled first. Every wait
+	// the tick loop makes goes through it, so a Ctrl-C is observed while
+	// the engine is idling out a tick interval or holding a fault instead
+	// of only after that wait has run its course.
+	wait func(ctx context.Context, d time.Duration) bool
+	now  func() time.Time
+
+	// abort ends the tick loop early: set by park, read by run, both on
+	// the engine's own goroutine.
+	abort bool
+
+	mu    sync.Mutex
+	nodes map[string]string
+
+	// vipOwner is the master the port-forward VIP routes currently point
+	// at, so a re-point is only issued (and journaled) when it moves.
+	vipOwner string
+}
+
+func newEngine(l *lab, actions []*action, probes probeSource, jrnl *journal, rec *runRecord) *engine {
+	e := &engine{
+		rng:      rand.New(rand.NewPCG(uint64(rec.Inputs.Seed), 0)),
+		lab:      l,
+		actions:  actions,
+		probes:   probes,
+		jrnl:     jrnl,
+		rec:      rec,
+		duration: time.Duration(rec.Inputs.DurationMS) * time.Millisecond,
+		tickMin:  time.Duration(rec.Inputs.TickMinMS) * time.Millisecond,
+		tickMax:  time.Duration(rec.Inputs.TickMaxMS) * time.Millisecond,
+		wait:     waitFor,
+		now:      time.Now,
+		nodes:    map[string]string{},
+	}
+	for _, gw := range gatewayNames() {
+		e.nodes[gw] = nodeHealthy
+	}
+	return e
+}
+
+// waitFor blocks for d, reporting whether the full duration elapsed. It
+// returns false the moment ctx is cancelled.
+func waitFor(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func (e *engine) nodeState(gw string) string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.nodes[gw]
+}
+
+func (e *engine) setNodeState(gw, state string) {
+	e.mu.Lock()
+	e.nodes[gw] = state
+	e.mu.Unlock()
+	e.jrnl.emit(event{Event: evNodeState, Target: gw, State: state})
+}
+
+// healthyNodes snapshots the nodes currently in service. The baseline
+// checks only hold these to the agent-alive invariant — a node under
+// fault is meant to have no agent.
+func (e *engine) healthyNodes() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	var healthy []string
+	for _, gw := range gatewayNames() {
+		if e.nodes[gw] == nodeHealthy {
+			healthy = append(healthy, gw)
+		}
+	}
+	return healthy
+}
+
+func (e *engine) violate(v violationRecord) {
+	v.TS = e.now().UTC().Format(time.RFC3339Nano)
+	e.mu.Lock()
+	e.rec.Violations = append(e.rec.Violations, v)
+	e.mu.Unlock()
+	e.jrnl.emit(event{
+		Event: evViolation, Kind: v.Kind, Tick: v.Tick,
+		Action: v.Action, Target: v.Target, Detail: v.Detail,
+	})
+}
+
+// recordChecks folds what the baseline sweep evaluated into the run
+// record, so a reader of summary.json can tell a run that asserted the
+// invariants from one that never got to.
+func (e *engine) recordChecks(counts checkCounts) {
+	e.mu.Lock()
+	e.rec.Checks = counts
+	e.mu.Unlock()
+}
+
+// decision is what one tick draws from the seeded stream, before any
+// guardrail is consulted.
+type decision struct {
+	tick     int
+	interval time.Duration
+	action   *action
+	target   string
+	hold     time.Duration
+}
+
+// draw takes exactly four values from the stream, in a fixed order:
+// interval, action, target, hold. The count is fixed so that a guardrail
+// skip cannot shift the stream — the run that skips a decision draws the
+// same values afterwards as the run that executed it, which is what
+// makes a replay comparable across labs that behaved differently.
+func (e *engine) draw(tick int) decision {
+	d := decision{tick: tick}
+	d.interval = e.drawDuration(e.tickMin, e.tickMax)
+
+	total := 0
+	for _, a := range e.actions {
+		total += a.weight
+	}
+	if total == 0 {
+		// Probe-and-check-only run: no action to pick, so no target and
+		// no hold to draw either.
+		return d
+	}
+	pick := e.rng.IntN(total)
+	for _, a := range e.actions {
+		if pick < a.weight {
+			d.action = a
+			break
+		}
+		pick -= a.weight
+	}
+	gateways := gatewayNames()
+	d.target = gateways[e.rng.IntN(len(gateways))]
+	d.hold = e.drawDuration(d.action.holdMin, d.action.holdMax)
+	return d
+}
+
+// drawDuration takes one value from the stream even when the bounds
+// collapse, so the draw count per action never depends on its bounds.
+func (e *engine) drawDuration(low, high time.Duration) time.Duration {
+	span := high - low
+	if span < 0 {
+		span = 0
+	}
+	return low + time.Duration(e.rng.Int64N(int64(span)+1))
+}
+
+// guardrails decides whether a drawn decision may execute. They keep a
+// run meaningful: the fault target must have returned and converged
+// since it was last hit, and at least one other gateway must stay
+// healthy so the lab always has somewhere to fail over to.
+func (e *engine) guardrails(d decision) string {
+	if d.action == nil {
+		return skipNoWeightedAction
+	}
+	if e.nodeState(d.target) != nodeHealthy {
+		return skipTargetNotHealthy
+	}
+	for _, gw := range e.healthyNodes() {
+		if gw != d.target {
+			return ""
+		}
+	}
+	return skipNoHealthyPeer
+}
+
+// run is the tick loop: draw, wait, check the guardrails, execute,
+// record — until the duration expires. After the deadline no further
+// fault is injected; an action already in flight runs to completion.
+func (e *engine) run(ctx context.Context) {
+	deadline := e.now().Add(e.duration)
+	for tick := 1; e.now().Before(deadline); tick++ {
+		d := e.draw(tick)
+		if !e.wait(ctx, d.interval) || !e.now().Before(deadline) {
+			return
+		}
+
+		e.rec.Ticks = tick
+		e.rec.Decisions.Total++
+		skip := e.guardrails(d)
+		ev := event{
+			Event:      evDecision,
+			Tick:       tick,
+			IntervalMS: d.interval.Milliseconds(),
+			Executed:   boolPtr(skip == ""),
+			SkipReason: skip,
+		}
+		if d.action != nil {
+			ev.Action = d.action.name
+			ev.Target = d.target
+			ev.HoldMS = d.hold.Milliseconds()
+		}
+		e.jrnl.emit(ev)
+
+		if skip != "" {
+			e.rec.Decisions.Skipped++
+			continue
+		}
+		e.rec.Decisions.Executed++
+		e.rec.ActionsByName[d.action.name]++
+		e.execute(ctx, d)
+		if e.abort {
+			return
+		}
+	}
+}
+
+// execute injects the fault, holds it, restores it, then gates on
+// convergence before the node is eligible again.
+func (e *engine) execute(ctx context.Context, d decision) {
+	e.setNodeState(d.target, nodeDisrupted)
+
+	injectedAt := e.now()
+	e.jrnl.emit(event{Event: evInject, Tick: d.tick, Action: d.action.name, Target: d.target})
+	if err := d.action.inject(ctx, e.lab, d.target); err != nil {
+		e.undo(ctx, d, err)
+		return
+	}
+
+	// The hold is interruptible, but a cancelled run still has to undo the
+	// fault it is holding — so it falls through to the restore below
+	// rather than returning here.
+	e.wait(ctx, d.hold)
+
+	// An injected fault must be undone even when the run is cancelled, or
+	// the lab is left with a dead gateway whose restart policy is off and
+	// no scenario after it can run. A cancelled ctx would kill every
+	// docker invocation on sight, and the restore is long enough to be
+	// interrupted half-way through — startAndRestoreGateway waits out two
+	// daemon bring-ups and pushes BGP — so it always runs on a context of
+	// its own, detached from the signal and bounded by restoreTimeout.
+	restoreCtx, cancelRestore := context.WithTimeout(
+		context.WithoutCancel(ctx), restoreTimeout)
+	defer cancelRestore()
+
+	e.jrnl.emit(event{Event: evRestore, Tick: d.tick, Action: d.action.name, Target: d.target})
+	if err := d.action.restore(restoreCtx, e.lab, d.target); err != nil {
+		e.failAction(d, "restore", err)
+		return
+	}
+	if ctx.Err() != nil {
+		return
+	}
+	restoredAt := e.now()
+	e.setNodeState(d.target, nodeConverging)
+
+	e.converge(ctx, d, injectedAt, restoredAt)
+}
+
+// undo restores a fault whose inject failed half-way, then fails the
+// action.
+//
+// An inject is not atomic: injectGatewayKill and injectAgentTerminate
+// both pin the docker restart policy to "no" before the step that can
+// fail, so bailing out on the error would hand the lab a gateway docker
+// will never revive — with its containerlab veth to `upstream` gone for
+// good — and only `make e2e-down && make e2e-up` gets it back. The
+// restore is the one path that puts the policy back (and re-wires the
+// underlay), so it runs even here: on the same detached, bounded context
+// the held-fault restore uses, since the inject may well have failed
+// because the run was cancelled underneath it.
+func (e *engine) undo(ctx context.Context, d decision, injectErr error) {
+	restoreCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), restoreTimeout)
+	defer cancel()
+
+	detail := "undo after a failed inject"
+	if err := d.action.restore(restoreCtx, e.lab, d.target); err != nil {
+		detail += ": " + err.Error()
+	}
+	e.jrnl.emit(event{
+		Event: evRestore, Tick: d.tick, Action: d.action.name,
+		Target: d.target, Detail: detail,
+	})
+	e.failAction(d, "inject", injectErr)
+}
+
+// failAction parks the node: a fault the runner could not inject or undo
+// leaves the lab in a state it cannot reason about, so the node is never
+// targeted again and the run fails.
+func (e *engine) failAction(d decision, phase string, err error) {
+	e.violate(violationRecord{
+		Kind: violationActionFailed, Tick: d.tick,
+		Action: d.action.name, Target: d.target,
+		Detail: fmt.Sprintf("%s: %v", phase, err),
+	})
+	e.park(d.target)
+}
+
+// park takes a node out of the run for good and stops the tick loop.
+//
+// Whatever the parked node was carrying stays dark for the rest of the
+// run — it is never re-targeted and never re-healed — and converged()
+// gates on *every* probe being green. So no later action against any
+// other gateway could converge either: each one would burn its full
+// recovery budget on a condition that can no longer be satisfied, park
+// its own target, and fill the record with violations derived from this
+// one. The violation that got here has already failed the run; stopping
+// leaves an artifact bundle that shows the original fault instead of the
+// cascade.
+func (e *engine) park(gw string) {
+	e.setNodeState(gw, nodeUnconverged)
+	e.abort = true
+	e.jrnl.emit(event{
+		Event: evRunAborted, Target: gw,
+		Detail: "node parked: no later action could converge with its data path down",
+	})
+}
+
+// converge polls the restored node back to health within the action's
+// recovery budget: the container healthy, the chassis back in SB, the
+// VIP routes following the current master, and every probe target green.
+// Budget expiry is the reachability-recovery violation the run asserts
+// against.
+func (e *engine) converge(ctx context.Context, d decision, injectedAt, restoredAt time.Time) {
+	deadline := restoredAt.Add(d.action.recoveryBudget)
+	for e.now().Before(deadline) {
+		if ctx.Err() != nil {
+			return
+		}
+		if e.converged(ctx, d.target) {
+			e.setNodeState(d.target, nodeHealthy)
+			fromRestore := e.probes.recoverySince(restoredAt)
+			e.rec.Recoveries = append(e.rec.Recoveries, recoveryRecord{
+				Tick:          d.tick,
+				Action:        d.action.name,
+				Target:        d.target,
+				BudgetMS:      d.action.recoveryBudget.Milliseconds(),
+				ConvergedMS:   e.now().Sub(restoredAt).Milliseconds(),
+				FromInjectMS:  e.probes.recoverySince(injectedAt),
+				FromRestoreMS: fromRestore,
+				CROwnerAfter:  e.vipOwner,
+			})
+			e.jrnl.emit(event{
+				Event: evConverged, Tick: d.tick, Action: d.action.name,
+				Target: d.target, CROwner: e.vipOwner, RecoveryMS: fromRestore,
+			})
+			return
+		}
+		e.wait(ctx, convergePollInterval)
+	}
+	e.violate(violationRecord{
+		Kind: violationRecoveryTimeout, Tick: d.tick,
+		Action: d.action.name, Target: d.target,
+		Detail: fmt.Sprintf("not converged within %s; red probes: %s",
+			d.action.recoveryBudget, strings.Join(e.probes.redTargets(), ",")),
+	})
+	e.park(d.target)
+}
+
+// converged reports whether the restored node is back in service and the
+// data path is green again.
+func (e *engine) converged(ctx context.Context, gw string) bool {
+	if e.lab.containerHealth(ctx, gw) != "healthy" {
+		return false
+	}
+	if !e.lab.chassisInSB(ctx, gw) {
+		return false
+	}
+	e.followMaster(ctx)
+	return e.probes.allGreen()
+}
+
+// followMaster keeps the port-forward VIP's hand-plumbed routes pointed
+// at whichever chassis currently owns cr-lr0-public. Re-election is the
+// whole point of the fault set, and the agent does not manage
+// Load_Balancer VIP routes — so without this the VIP probe would stay
+// red for the rest of the run after the first migration.
+func (e *engine) followMaster(ctx context.Context) {
+	master := e.lab.currentMaster(ctx)
+	if master == "" || master == e.vipOwner {
+		return
+	}
+	if err := e.lab.ensureVIPRouting(ctx, master); err != nil {
+		e.jrnl.emit(event{Event: evVIPRepoint, Target: master, Detail: err.Error()})
+		return
+	}
+	e.vipOwner = master
+	e.jrnl.emit(event{Event: evVIPRepoint, Target: master})
+}
+
+// parseWeights parses the `-weights name=n,...` flag against the action
+// registry, rejecting names the registry does not know. Unnamed actions
+// keep their default weight.
+func parseWeights(spec string, actions []*action) (map[string]int, error) {
+	weights := map[string]int{}
+	for _, a := range actions {
+		weights[a.name] = a.weight
+	}
+	for _, pair := range strings.Split(spec, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		name, value, ok := strings.Cut(pair, "=")
+		if !ok {
+			return nil, fmt.Errorf("weight %q is not name=value", pair)
+		}
+		name = strings.TrimSpace(name)
+		if _, known := weights[name]; !known {
+			return nil, fmt.Errorf("unknown action %q in -weights (known: %s)",
+				name, strings.Join(actionNames(actions), ", "))
+		}
+		weight, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil {
+			return nil, fmt.Errorf("weight for %q: %w", name, err)
+		}
+		if weight < 0 {
+			return nil, fmt.Errorf("weight for %q is negative", name)
+		}
+		weights[name] = weight
+	}
+	return weights, nil
+}
+
+func actionNames(actions []*action) []string {
+	names := make([]string, 0, len(actions))
+	for _, a := range actions {
+		names = append(names, a.name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// applyWeights overrides the registry's default weights in place. The
+// registry order is untouched: the weighted pick walks it in order, so
+// the order is part of the replay contract.
+func applyWeights(actions []*action, weights map[string]int) {
+	for _, a := range actions {
+		if w, ok := weights[a.name]; ok {
+			a.weight = w
+		}
+	}
+}

--- a/test/e2e/chaos/engine_test.go
+++ b/test/e2e/chaos/engine_test.go
@@ -1,0 +1,817 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// runEngine drives a full engine run against the fakes and returns the
+// journal it wrote plus the run record it filled in.
+func runEngine(t *testing.T, seed int64, duration time.Duration,
+	actions []*action, mutate func(*engine)) (string, *runRecord) {
+	t.Helper()
+
+	clock := newFakeClock()
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	var buf bytes.Buffer
+	jrnl := newJournal(&buf, clock.now)
+
+	rec := &runRecord{
+		Inputs: runInputs{
+			Seed:       seed,
+			DurationMS: duration.Milliseconds(),
+			TickMinMS:  (10 * time.Second).Milliseconds(),
+			TickMaxMS:  (30 * time.Second).Milliseconds(),
+			Lab:        "ovn-e2e",
+		},
+		ActionsByName: map[string]int{},
+	}
+	e := newEngine(newTestLab(cmd, clock), actions, greenProbes{}, jrnl, rec)
+	e.wait = clock.wait
+	e.now = clock.now
+	if mutate != nil {
+		mutate(e)
+	}
+	e.run(context.Background())
+	rec.finalize(clock.now())
+	return buf.String(), rec
+}
+
+func TestSameSeedReplaysIdenticalSequence(t *testing.T) {
+	first, firstRec := runEngine(t, 42, 20*time.Minute,
+		noopActions("controller-restart", "gateway-kill", "agent-terminate"), nil)
+	second, secondRec := runEngine(t, 42, 20*time.Minute,
+		noopActions("controller-restart", "gateway-kill", "agent-terminate"), nil)
+
+	a, b := decisionsIn(t, first), decisionsIn(t, second)
+	if len(a) == 0 {
+		t.Fatal("the run made no decisions at all")
+	}
+	if len(a) != len(b) {
+		t.Fatalf("same inputs produced %d and %d decisions", len(a), len(b))
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("decision %d diverged: %q vs %q", i+1, a[i], b[i])
+		}
+	}
+	if firstRec.Decisions != secondRec.Decisions {
+		t.Fatalf("decision counts diverged: %+v vs %+v", firstRec.Decisions, secondRec.Decisions)
+	}
+}
+
+func TestDifferentSeedsDiverge(t *testing.T) {
+	first, _ := runEngine(t, 42, 20*time.Minute,
+		noopActions("controller-restart", "gateway-kill", "agent-terminate"), nil)
+	second, _ := runEngine(t, 43, 20*time.Minute,
+		noopActions("controller-restart", "gateway-kill", "agent-terminate"), nil)
+
+	a, b := decisionsIn(t, first), decisionsIn(t, second)
+	if len(a) == len(b) && slicesEqual(a, b) {
+		t.Fatal("seeds 42 and 43 produced the same decision sequence")
+	}
+}
+
+// A guardrail skip must not consume a different number of random values
+// than an execution, or a replay against a lab that behaved differently
+// would diverge from the first decision the guardrail blocked onwards —
+// and the journal would be useless for triage.
+func TestGuardrailSkipDoesNotShiftDraws(t *testing.T) {
+	healthy, _ := runEngine(t, 42, 20*time.Minute,
+		noopActions("controller-restart", "gateway-kill"), nil)
+	// gateway-2 never came back from an earlier fault: every decision
+	// that targets it is skipped.
+	parked, parkedRec := runEngine(t, 42, 20*time.Minute,
+		noopActions("controller-restart", "gateway-kill"), func(e *engine) {
+			e.nodes["gateway-2"] = nodeUnconverged
+		})
+
+	a, b := decisionsIn(t, healthy), decisionsIn(t, parked)
+	if len(b) < len(a) {
+		t.Fatalf("the run with skips fit fewer decisions (%d) than the all-healthy run (%d)", len(b), len(a))
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("decision %d diverged after a guardrail skip: %q vs %q", i+1, a[i], b[i])
+		}
+	}
+	if parkedRec.Decisions.Skipped == 0 {
+		t.Fatal("no decision was skipped even though gateway-2 was parked")
+	}
+	var skipped bool
+	for _, e := range eventsIn(t, parked) {
+		if e.Event == evDecision && e.SkipReason == skipTargetNotHealthy && e.Target == "gateway-2" {
+			skipped = true
+		}
+	}
+	if !skipped {
+		t.Fatalf("no decision was journaled with skip_reason=%s for gateway-2", skipTargetNotHealthy)
+	}
+}
+
+func TestWeightedPickNeverDrawsAZeroWeightAction(t *testing.T) {
+	actions := noopActions("controller-restart", "gateway-kill", "agent-terminate")
+	applyWeights(actions, map[string]int{"gateway-kill": 0, "controller-restart": 3})
+
+	_, rec := runEngine(t, 42, 30*time.Minute, actions, nil)
+
+	if rec.ActionsByName["gateway-kill"] != 0 {
+		t.Fatalf("a zero-weight action was drawn %d times", rec.ActionsByName["gateway-kill"])
+	}
+	if rec.ActionsByName["controller-restart"] == 0 {
+		t.Fatal("the highest-weighted action was never drawn")
+	}
+	if rec.ActionsByName["agent-terminate"] == 0 {
+		t.Fatal("a positively-weighted action was never drawn")
+	}
+}
+
+// With no action carrying weight the engine degrades to a probe-and-
+// check-only run: it still ticks, but injects nothing.
+func TestZeroWeightRegistryInjectsNothing(t *testing.T) {
+	actions := noopActions("controller-restart", "gateway-kill")
+	applyWeights(actions, map[string]int{"controller-restart": 0, "gateway-kill": 0})
+
+	journal, rec := runEngine(t, 42, 5*time.Minute, actions, nil)
+
+	if rec.Decisions.Executed != 0 {
+		t.Fatalf("executed %d actions with an all-zero-weight registry", rec.Decisions.Executed)
+	}
+	if rec.Decisions.Skipped == 0 {
+		t.Fatal("the run made no decisions at all")
+	}
+	for _, e := range eventsIn(t, journal) {
+		if e.Event == evDecision && e.SkipReason != skipNoWeightedAction {
+			t.Fatalf("decision skipped for %q, want %q", e.SkipReason, skipNoWeightedAction)
+		}
+	}
+}
+
+func TestGuardrailsBlockUnhealthyTargetAndLastGateway(t *testing.T) {
+	act := noopActions("controller-restart")[0]
+
+	tests := []struct {
+		name  string
+		nodes map[string]string
+		want  string
+	}{
+		{
+			name:  "all nodes healthy",
+			nodes: map[string]string{"gateway-1": nodeHealthy, "gateway-2": nodeHealthy, "gateway-3": nodeHealthy},
+			want:  "",
+		},
+		{
+			name:  "target still converging from an earlier fault",
+			nodes: map[string]string{"gateway-1": nodeConverging, "gateway-2": nodeHealthy, "gateway-3": nodeHealthy},
+			want:  skipTargetNotHealthy,
+		},
+		{
+			name:  "target never came back",
+			nodes: map[string]string{"gateway-1": nodeUnconverged, "gateway-2": nodeHealthy, "gateway-3": nodeHealthy},
+			want:  skipTargetNotHealthy,
+		},
+		{
+			name:  "target is the last healthy gateway",
+			nodes: map[string]string{"gateway-1": nodeHealthy, "gateway-2": nodeUnconverged, "gateway-3": nodeUnconverged},
+			want:  skipNoHealthyPeer,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			clock := newFakeClock()
+			e := newEngine(newTestLab(&fakeCommander{}, clock), []*action{act},
+				greenProbes{}, newJournal(&bytes.Buffer{}, clock.now),
+				&runRecord{ActionsByName: map[string]int{}})
+			e.nodes = tc.nodes
+
+			got := e.guardrails(decision{action: act, target: "gateway-1"})
+			if got != tc.want {
+				t.Fatalf("guardrails = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunStopsAtDuration(t *testing.T) {
+	actions := noopActions("controller-restart")
+	// Pin the tick interval so the number of decisions that fit is exact:
+	// ticks land at 10s, 20s and 30s, and the tick that would land at 40s
+	// is past the 35s deadline.
+	clock := newFakeClock()
+	var buf bytes.Buffer
+	rec := &runRecord{
+		Inputs: runInputs{
+			Seed:       42,
+			DurationMS: (35 * time.Second).Milliseconds(),
+			TickMinMS:  (10 * time.Second).Milliseconds(),
+			TickMaxMS:  (10 * time.Second).Milliseconds(),
+		},
+		ActionsByName: map[string]int{},
+	}
+	e := newEngine(newTestLab(&fakeCommander{respond: healthyLabResponses}, clock),
+		actions, greenProbes{}, newJournal(&buf, clock.now), rec)
+	e.wait, e.now = clock.wait, clock.now
+	// The action holds for 0s so only the tick interval advances the clock.
+	actions[0].holdMin, actions[0].holdMax = 0, 0
+
+	e.run(context.Background())
+	rec.finalize(clock.now())
+
+	if got := len(decisionsIn(t, buf.String())); got != 3 {
+		t.Fatalf("made %d decisions in a 35s run at a 10s tick, want 3", got)
+	}
+	if rec.Result != resultPass {
+		t.Fatalf("result = %q, want %q — nothing went wrong", rec.Result, resultPass)
+	}
+
+	// The per-action recovery durations are what the run exists to
+	// produce: a passing run that shipped an empty `recoveries` would be
+	// indistinguishable from one that measured nothing.
+	if rec.Decisions.Executed == 0 {
+		t.Fatal("the run executed no action at all")
+	}
+	if len(rec.Recoveries) != rec.Decisions.Executed {
+		t.Fatalf("recorded %d recoveries for %d executed actions",
+			len(rec.Recoveries), rec.Decisions.Executed)
+	}
+	for _, r := range rec.Recoveries {
+		if r.Action != actions[0].name {
+			t.Fatalf("recovery %+v names an action the run never executed", r)
+		}
+		if e.nodeState(r.Target) != nodeHealthy {
+			t.Fatalf("recovery recorded for %s, which is not back in service", r.Target)
+		}
+		if r.BudgetMS != actions[0].recoveryBudget.Milliseconds() {
+			t.Fatalf("recovery budget = %d ms, want the action's %s",
+				r.BudgetMS, actions[0].recoveryBudget)
+		}
+		if r.ConvergedMS < 0 || r.ConvergedMS > r.BudgetMS {
+			t.Fatalf("converged in %d ms, outside the %d ms budget it was gated on",
+				r.ConvergedMS, r.BudgetMS)
+		}
+	}
+	var converged int
+	for _, ev := range eventsIn(t, buf.String()) {
+		if ev.Event == evConverged {
+			converged++
+		}
+	}
+	if converged != rec.Decisions.Executed {
+		t.Fatalf("journaled %d %s events for %d executed actions",
+			converged, evConverged, rec.Decisions.Executed)
+	}
+}
+
+// A run cancelled mid-hold must still undo the fault it is holding.
+// Otherwise the lab is left with a SIGKILLed gateway whose restart policy
+// is pinned to "no" and whose containerlab veth is gone — and every
+// scenario after it runs against a broken lab.
+func TestCancelledRunRestoresTheFaultItIsHolding(t *testing.T) {
+	clock := newFakeClock()
+	rec := &runRecord{
+		Inputs: runInputs{
+			Seed:       42,
+			DurationMS: time.Minute.Milliseconds(),
+			TickMinMS:  (10 * time.Second).Milliseconds(),
+			TickMaxMS:  (10 * time.Second).Milliseconds(),
+		},
+		ActionsByName: map[string]int{},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	actions := noopActions("gateway-kill")
+	// The operator hits Ctrl-C while the fault is held.
+	actions[0].inject = func(context.Context, *lab, string) error {
+		cancel()
+		return nil
+	}
+	var restores int
+	var restoreCtxErr error
+	actions[0].restore = func(rctx context.Context, _ *lab, _ string) error {
+		restores++
+		restoreCtxErr = rctx.Err()
+		return nil
+	}
+
+	e := newEngine(newTestLab(&fakeCommander{respond: healthyLabResponses}, clock),
+		actions, greenProbes{}, newJournal(&bytes.Buffer{}, clock.now), rec)
+	e.wait, e.now = clock.wait, clock.now
+
+	e.run(ctx)
+
+	if restores != 1 {
+		t.Fatalf("the held fault was restored %d times, want exactly once", restores)
+	}
+	// A restore handed the cancelled context would have every docker
+	// command killed on sight, so it must run on a context of its own.
+	if restoreCtxErr != nil {
+		t.Fatalf("the restore ran on the cancelled context (%v)", restoreCtxErr)
+	}
+}
+
+// The signal can just as well land while the restore is already running,
+// and a restore is long enough for that to be likely: a gateway-kill
+// restore starts the container, waits out two daemon bring-ups and pushes
+// BGP, which is minutes. Cancelled half-way through it leaves the same
+// wreckage as one that never ran, so the restore must not be riding on
+// the run's context at all.
+func TestCancelDuringTheRestoreDoesNotKillIt(t *testing.T) {
+	clock := newFakeClock()
+	rec := &runRecord{
+		Inputs: runInputs{
+			Seed:       42,
+			DurationMS: time.Minute.Milliseconds(),
+			TickMinMS:  (10 * time.Second).Milliseconds(),
+			TickMaxMS:  (10 * time.Second).Milliseconds(),
+		},
+		ActionsByName: map[string]int{},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	actions := noopActions("gateway-kill")
+	var restoreCtxErr error
+	var bounded bool
+	actions[0].restore = func(rctx context.Context, _ *lab, _ string) error {
+		// The operator hits Ctrl-C while the restore is in flight.
+		cancel()
+		restoreCtxErr = rctx.Err()
+		_, bounded = rctx.Deadline()
+		return nil
+	}
+
+	e := newEngine(newTestLab(&fakeCommander{respond: healthyLabResponses}, clock),
+		actions, greenProbes{}, newJournal(&bytes.Buffer{}, clock.now), rec)
+	e.wait, e.now = clock.wait, clock.now
+
+	e.run(ctx)
+
+	if restoreCtxErr != nil {
+		t.Fatalf("the signal killed the restore that was already running (%v)", restoreCtxErr)
+	}
+	// Detached from the signal, but not unbounded: a restore that hangs
+	// would keep the runner alive until CI's job timeout.
+	if !bounded {
+		t.Fatal("the restore ran on a context with no deadline of its own")
+	}
+}
+
+// An action the runner cannot undo is worse than one it cannot inject:
+// the lab is left genuinely broken. The node is parked and the run fails.
+func TestFailedRestoreParksTheNodeAndFailsTheRun(t *testing.T) {
+	actions := noopActions("controller-restart")
+	actions[0].restore = func(context.Context, *lab, string) error {
+		return errBoom
+	}
+
+	journal, rec := runEngine(t, 42, 5*time.Minute, actions, nil)
+
+	if rec.Result != resultFail {
+		t.Fatalf("result = %q, want %q", rec.Result, resultFail)
+	}
+	if len(rec.Violations) == 0 || rec.Violations[0].Kind != violationActionFailed {
+		t.Fatalf("violations = %+v, want a %s", rec.Violations, violationActionFailed)
+	}
+	if !strings.Contains(rec.Violations[0].Detail, "restore") {
+		t.Fatalf("violation detail %q does not name the phase that failed", rec.Violations[0].Detail)
+	}
+	if !parkedIn(t, journal, rec.Violations[0].Target) {
+		t.Fatalf("%s was not parked after a fault the runner could not undo",
+			rec.Violations[0].Target)
+	}
+}
+
+// converged() has three gates. The container-health one is driven by
+// TestRecoveryBudgetExpiryIsAViolation; these are the other two. Each is
+// the only thing between a node that came back wrong — its chassis never
+// re-registered, or its data path never came back — and being declared
+// healthy and re-targeted.
+func TestConvergenceGatesOnTheChassisAndTheDataPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*engine)
+	}{
+		{
+			name: "the node is up but its chassis never re-registers in SB",
+			mutate: func(e *engine) {
+				e.lab.cmd = &fakeCommander{respond: func(argv []string) (string, error) {
+					if strings.Contains(strings.Join(argv, " "), "find Chassis name=") {
+						return "\n", nil
+					}
+					return healthyLabResponses(argv)
+				}}
+			},
+		},
+		{
+			name:   "the node is up but its data path stays red",
+			mutate: func(e *engine) { e.probes = redProbes{} },
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			journal, rec := runEngine(t, 42, 5*time.Minute, noopActions("gateway-kill"), tc.mutate)
+
+			if len(rec.Violations) == 0 || rec.Violations[0].Kind != violationRecoveryTimeout {
+				t.Fatalf("violations = %+v, want a %s", rec.Violations, violationRecoveryTimeout)
+			}
+			if rec.Result != resultFail {
+				t.Fatalf("result = %q, want %q", rec.Result, resultFail)
+			}
+			if !parkedIn(t, journal, rec.Violations[0].Target) {
+				t.Fatalf("%s was declared converged and left in service",
+					rec.Violations[0].Target)
+			}
+		})
+	}
+}
+
+// A parked node is never re-healed, and converged() gates on every probe
+// being green — so once one node is parked, no action against any other
+// gateway can converge either. Left running, the engine would spend the
+// rest of the duration burning recovery budgets on a condition that is
+// structurally unsatisfiable, park every remaining gateway, and bury the
+// original fault under violations derived from it. It stops at the first
+// park instead.
+func TestAParkedNodeStopsTheRun(t *testing.T) {
+	// The node comes back up, but its data path never does.
+	journal, rec := runEngine(t, 42, 20*time.Minute, noopActions("gateway-kill"),
+		func(e *engine) { e.probes = redProbes{} })
+
+	if rec.Decisions.Executed != 1 {
+		t.Fatalf("executed %d actions, want exactly the one that parked its target: "+
+			"every later action can only time out on the same red probes",
+			rec.Decisions.Executed)
+	}
+	if len(rec.Violations) != 1 || rec.Violations[0].Kind != violationRecoveryTimeout {
+		t.Fatalf("violations = %+v, want exactly one %s and no violation derived from it",
+			rec.Violations, violationRecoveryTimeout)
+	}
+
+	// The operator reading the journal must see why the run stopped short
+	// of its duration.
+	var aborted []event
+	for _, ev := range eventsIn(t, journal) {
+		if ev.Event == evRunAborted {
+			aborted = append(aborted, ev)
+		}
+	}
+	if len(aborted) != 1 || aborted[0].Target != rec.Violations[0].Target {
+		t.Fatalf("journaled %+v, want one %s naming the parked node %s",
+			aborted, evRunAborted, rec.Violations[0].Target)
+	}
+}
+
+// The VIP's routes are re-pointed at whichever chassis owns
+// cr-lr0-public, and only when it moves — the agent does not manage them,
+// so without the re-point the VIP probe goes permanently red on the first
+// re-election and every later violation is noise.
+func TestFollowMasterRepointsTheVIPWhenTheMasterMoves(t *testing.T) {
+	master := "gateway-1"
+	var routesFail bool
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		line := strings.Join(argv, " ")
+		switch {
+		case routesFail && strings.Contains(line, "ip route replace"):
+			return "", errBoom
+		case strings.Contains(line, "--columns=name list Chassis"):
+			return master + "\n", nil
+		}
+		return healthyLabResponses(argv)
+	}}
+	clock := newFakeClock()
+	var buf bytes.Buffer
+	e := newEngine(newTestLab(cmd, clock), nil, greenProbes{},
+		newJournal(&buf, clock.now), &runRecord{ActionsByName: map[string]int{}})
+	e.now = clock.now
+
+	e.followMaster(context.Background())
+
+	if e.vipOwner != "gateway-1" {
+		t.Fatalf("vipOwner = %q after the first master was seen, want gateway-1", e.vipOwner)
+	}
+	if got := cmd.count("ip route replace"); got != 2 {
+		t.Fatalf("issued %d route commands, want the forward route on upstream and "+
+			"the scope-link route on the master: %v", got, cmd.lines())
+	}
+
+	// The master has not moved: nothing is issued and nothing is
+	// journaled, which is what keeps the journal readable.
+	e.followMaster(context.Background())
+
+	if got := cmd.count("ip route replace"); got != 2 {
+		t.Fatalf("re-pointed the VIP at a master that never moved: %v", cmd.lines())
+	}
+
+	// Re-election, and the re-point fails: the owner must stay where the
+	// routes actually point, and the failure must be journaled.
+	master, routesFail = "gateway-2", true
+	e.followMaster(context.Background())
+
+	if e.vipOwner != "gateway-1" {
+		t.Fatalf("vipOwner = %q after a failed re-point, want the routes' real owner gateway-1", e.vipOwner)
+	}
+
+	var repoints []event
+	for _, ev := range eventsIn(t, buf.String()) {
+		if ev.Event == evVIPRepoint {
+			repoints = append(repoints, ev)
+		}
+	}
+	if len(repoints) != 2 {
+		t.Fatalf("journaled %d %s events, want one per master change: %+v",
+			len(repoints), evVIPRepoint, repoints)
+	}
+	if repoints[0].Target != "gateway-1" || repoints[0].Detail != "" {
+		t.Fatalf("the successful re-point was journaled as %+v", repoints[0])
+	}
+	if repoints[1].Target != "gateway-2" || repoints[1].Detail == "" {
+		t.Fatalf("the failed re-point was journaled without a reason: %+v", repoints[1])
+	}
+}
+
+// parkedIn reports whether the journal shows gw parked as unconverged —
+// the state that keeps a node out of every later draw.
+func parkedIn(t *testing.T, journal, gw string) bool {
+	t.Helper()
+	for _, ev := range eventsIn(t, journal) {
+		if ev.Event == evNodeState && ev.Target == gw && ev.State == nodeUnconverged {
+			return true
+		}
+	}
+	return false
+}
+
+// An action the runner cannot inject leaves the lab in a state it cannot
+// reason about: the node is parked, never targeted again, and the run
+// fails.
+func TestFailedInjectParksTheNodeAndFailsTheRun(t *testing.T) {
+	actions := noopActions("controller-restart")
+	actions[0].inject = func(context.Context, *lab, string) error {
+		return errBoom
+	}
+
+	_, rec := runEngine(t, 42, 5*time.Minute, actions, nil)
+
+	if rec.Result != resultFail {
+		t.Fatalf("result = %q, want %q", rec.Result, resultFail)
+	}
+	if len(rec.Violations) == 0 || rec.Violations[0].Kind != violationActionFailed {
+		t.Fatalf("violations = %+v, want a %s", rec.Violations, violationActionFailed)
+	}
+	if !strings.Contains(rec.Violations[0].Detail, "inject") {
+		t.Fatalf("violation detail %q does not name the phase that failed", rec.Violations[0].Detail)
+	}
+}
+
+// An inject is not atomic: the destructive ones pin the docker restart
+// policy to "no" before the step that can fail. Bailing out on that error
+// without undoing it leaves a gateway docker will never revive — the very
+// wreckage the restore path exists to prevent — so the restore runs even
+// when it is the inject that failed.
+func TestAFailedInjectIsUndone(t *testing.T) {
+	actions := noopActions("agent-terminate")
+	actions[0].inject = func(context.Context, *lab, string) error { return errBoom }
+	var restores int
+	var restoreCtxErr error
+	var bounded bool
+	actions[0].restore = func(rctx context.Context, _ *lab, _ string) error {
+		restores++
+		restoreCtxErr = rctx.Err()
+		_, bounded = rctx.Deadline()
+		return nil
+	}
+
+	journal, rec := runEngine(t, 42, 5*time.Minute, actions, nil)
+
+	if restores != 1 {
+		t.Fatalf("the half-injected fault was undone %d times, want exactly once", restores)
+	}
+	// The inject can fail *because* the run was cancelled underneath it, so
+	// the undo runs on the same detached, bounded context the held-fault
+	// restore uses.
+	if restoreCtxErr != nil {
+		t.Fatalf("the undo ran on a context that was already done (%v)", restoreCtxErr)
+	}
+	if !bounded {
+		t.Fatal("the undo ran on a context with no deadline of its own")
+	}
+	// The action still failed, and it still failed on the inject.
+	if len(rec.Violations) == 0 || rec.Violations[0].Kind != violationActionFailed {
+		t.Fatalf("violations = %+v, want a %s", rec.Violations, violationActionFailed)
+	}
+	if !strings.Contains(rec.Violations[0].Detail, "inject") {
+		t.Fatalf("violation detail %q does not name the phase that failed", rec.Violations[0].Detail)
+	}
+	var undone bool
+	for _, ev := range eventsIn(t, journal) {
+		if ev.Event == evRestore && strings.Contains(ev.Detail, "undo") {
+			undone = true
+		}
+	}
+	if !undone {
+		t.Fatalf("the undo was not journaled: %q", journal)
+	}
+}
+
+// The same invariant against the real registry, which is where it bites:
+// agent-terminate disables the restart policy and then waits for the
+// container to follow the agent down. A draining agent can outlive
+// agentExitTimeout, and that wait is the step that fails. The gateway must
+// not be left pinned to `restart: no` with its containerlab veth gone —
+// nothing would ever bring it back, and every scenario after the run would
+// need `make e2e-down && make e2e-up` first.
+func TestAFailedAgentTerminateHandsTheRestartPolicyBack(t *testing.T) {
+	clock := newFakeClock()
+	// The container never follows the agent down, so waitContainerExit runs
+	// out its budget and the inject fails.
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "{{.State.Running}}") {
+			return "true\n", nil
+		}
+		return healthyLabResponses(argv)
+	}}
+	rec := &runRecord{
+		Inputs: runInputs{
+			Seed:       42,
+			DurationMS: (5 * time.Minute).Milliseconds(),
+			TickMinMS:  (10 * time.Second).Milliseconds(),
+			TickMaxMS:  (10 * time.Second).Milliseconds(),
+		},
+		ActionsByName: map[string]int{},
+	}
+	e := newEngine(newTestLab(cmd, clock), []*action{actionNamed(t, "agent-terminate")},
+		greenProbes{}, newJournal(&bytes.Buffer{}, clock.now), rec)
+	e.wait, e.now = clock.wait, clock.now
+
+	e.run(context.Background())
+
+	if !cmd.called("update --restart=no") {
+		t.Fatalf("the fault was never injected at all: %v", cmd.lines())
+	}
+	if !cmd.called("update --restart=always") {
+		t.Fatalf("the gateway was left pinned to restart=no after a failed inject: %v", cmd.lines())
+	}
+	if !cmd.called("containerlab tools veth create") {
+		t.Fatalf("the underlay veth was not re-created after a failed inject: %v", cmd.lines())
+	}
+	if len(rec.Violations) == 0 || rec.Violations[0].Kind != violationActionFailed {
+		t.Fatalf("violations = %+v, want a %s", rec.Violations, violationActionFailed)
+	}
+}
+
+// The tick loop idles out its interval on the real clock. Waited out with
+// a bare time.Sleep, a Ctrl-C would only be observed once the current
+// interval (up to -tick-max) had run its course.
+func TestACancelledRunDoesNotWaitOutItsTickInterval(t *testing.T) {
+	rec := &runRecord{
+		Inputs: runInputs{
+			Seed:       42,
+			DurationMS: time.Minute.Milliseconds(),
+			TickMinMS:  (30 * time.Second).Milliseconds(),
+			TickMaxMS:  (30 * time.Second).Milliseconds(),
+		},
+		ActionsByName: map[string]int{},
+	}
+	// The engine keeps its real clock: what is under test is that the wait
+	// itself is interruptible, not that a fake one can be advanced past it.
+	e := newEngine(newLab("ovn-e2e", &fakeCommander{respond: healthyLabResponses}),
+		noopActions("controller-restart"), greenProbes{},
+		newJournal(&bytes.Buffer{}, time.Now), rec)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		e.run(ctx)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the cancelled run kept sleeping out its 30s tick interval")
+	}
+	if rec.Decisions.Executed != 0 {
+		t.Fatalf("a cancelled run executed %d actions", rec.Decisions.Executed)
+	}
+}
+
+// A node that does not come back inside its budget is a
+// reachability-recovery violation, and is never re-targeted.
+func TestRecoveryBudgetExpiryIsAViolation(t *testing.T) {
+	actions := noopActions("gateway-kill")
+	actions[0].recoveryBudget = 30 * time.Second
+
+	clock := newFakeClock()
+	var buf bytes.Buffer
+	rec := &runRecord{
+		Inputs: runInputs{
+			Seed:       42,
+			DurationMS: (2 * time.Minute).Milliseconds(),
+			TickMinMS:  (10 * time.Second).Milliseconds(),
+			TickMaxMS:  (10 * time.Second).Milliseconds(),
+		},
+		ActionsByName: map[string]int{},
+	}
+	// The lab is reachable, but the restarted container never reports
+	// healthy — convergence can never be declared.
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "{{.State.Health.Status}}") {
+			return "starting\n", nil
+		}
+		return healthyLabResponses(argv)
+	}}
+	e := newEngine(newTestLab(cmd, clock), actions, greenProbes{}, newJournal(&buf, clock.now), rec)
+	e.wait, e.now = clock.wait, clock.now
+
+	e.run(context.Background())
+	rec.finalize(clock.now())
+
+	if len(rec.Violations) == 0 || rec.Violations[0].Kind != violationRecoveryTimeout {
+		t.Fatalf("violations = %+v, want a %s", rec.Violations, violationRecoveryTimeout)
+	}
+	if rec.Result != resultFail {
+		t.Fatalf("result = %q, want %q", rec.Result, resultFail)
+	}
+	if state := e.nodeState(rec.Violations[0].Target); state != nodeUnconverged {
+		t.Fatalf("node %s left in state %q, want %q", rec.Violations[0].Target, state, nodeUnconverged)
+	}
+}
+
+func TestParseWeights(t *testing.T) {
+	actions := noopActions("controller-restart", "gateway-kill")
+
+	tests := []struct {
+		name    string
+		spec    string
+		want    map[string]int
+		wantErr string
+	}{
+		{
+			name: "empty spec keeps the registry defaults",
+			spec: "",
+			want: map[string]int{"controller-restart": 1, "gateway-kill": 1},
+		},
+		{
+			name: "named actions are overridden",
+			spec: "gateway-kill=0, controller-restart=5",
+			want: map[string]int{"controller-restart": 5, "gateway-kill": 0},
+		},
+		{
+			name:    "unknown action is rejected",
+			spec:    "gateway-melt=3",
+			wantErr: `unknown action "gateway-melt"`,
+		},
+		{
+			name:    "malformed pair is rejected",
+			spec:    "gateway-kill",
+			wantErr: "is not name=value",
+		},
+		{
+			name:    "non-numeric weight is rejected",
+			spec:    "gateway-kill=lots",
+			wantErr: `weight for "gateway-kill"`,
+		},
+		{
+			name:    "negative weight is rejected",
+			spec:    "gateway-kill=-1",
+			wantErr: "is negative",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseWeights(tc.spec, actions)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("parseWeights(%q) = %v, want an error", tc.spec, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q does not mention %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseWeights(%q): %v", tc.spec, err)
+			}
+			for name, want := range tc.want {
+				if got[name] != want {
+					t.Fatalf("weight[%s] = %d, want %d", name, got[name], want)
+				}
+			}
+		})
+	}
+}
+
+func slicesEqual(a, b []string) bool {
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/test/e2e/chaos/fakes_test.go
+++ b/test/e2e/chaos/fakes_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// errBoom is the canned failure the tests inject at the commander seam.
+// It stands for the failures that are not the command's own verdict — a
+// docker daemon under load, an expired cmdTimeout, a container that is
+// gone.
+var errBoom = errors.New("boom")
+
+// errExit is what the real commander hands back when the command *inside*
+// the container exits non-zero: an *exec.ExitError carrying the code,
+// wrapped the way execCommander wraps it. pgrep's exit 1 ("nothing
+// matched") is an answer; errBoom is a question that could not be asked.
+func errExit(t *testing.T, code int) error {
+	t.Helper()
+	err := exec.Command("sh", "-c", fmt.Sprintf("exit %d", code)).Run()
+	if err == nil {
+		t.Fatalf("sh -c 'exit %d' reported success", code)
+	}
+	return fmt.Errorf("docker exec: %w: ", err)
+}
+
+// fakeCommander stands in for the docker / containerlab CLIs. It is the
+// only seam the tests replace: the engine, the actions and the state
+// layering all run for real against it, so what the tests assert on is
+// the argv the runner would have executed.
+type fakeCommander struct {
+	mu      sync.Mutex
+	calls   [][]string
+	respond func(argv []string) (string, error)
+}
+
+func (f *fakeCommander) run(_ context.Context, name string, args ...string) (string, error) {
+	argv := append([]string{name}, args...)
+	f.mu.Lock()
+	f.calls = append(f.calls, argv)
+	respond := f.respond
+	f.mu.Unlock()
+	if respond == nil {
+		return "", nil
+	}
+	return respond(argv)
+}
+
+// lines renders every recorded call as a single string, in order.
+func (f *fakeCommander) lines() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.calls))
+	for _, argv := range f.calls {
+		out = append(out, strings.Join(argv, " "))
+	}
+	return out
+}
+
+// indexOf returns the position of the first recorded call containing
+// substr, or -1. Ordering assertions ("the restart policy is disabled
+// before the kill") compare two of these.
+func (f *fakeCommander) indexOf(substr string) int {
+	for i, line := range f.lines() {
+		if strings.Contains(line, substr) {
+			return i
+		}
+	}
+	return -1
+}
+
+func (f *fakeCommander) called(substr string) bool { return f.indexOf(substr) >= 0 }
+
+// count is how many recorded calls contain substr — "the second call
+// issued nothing new" is an assertion on this.
+func (f *fakeCommander) count(substr string) int {
+	n := 0
+	for _, line := range f.lines() {
+		if strings.Contains(line, substr) {
+			n++
+		}
+	}
+	return n
+}
+
+// healthyLabResponses answers every query the runner makes about a lab
+// that is behaving: daemons up, chassis registered, cr-lr0-public bound.
+// The one thing it models as gone is eth1 — a container lifecycle event
+// destroys the containerlab veth, which is the whole reason the restore
+// path exists.
+func healthyLabResponses(argv []string) (string, error) {
+	line := strings.Join(argv, " ")
+	switch {
+	case strings.Contains(line, "{{.State.Health.Status}}"):
+		return "healthy\n", nil
+	case strings.Contains(line, "{{.State.Running}}"):
+		return "false\n", nil // a killed container stays down until started
+	case strings.Contains(line, "ip link show eth1"):
+		return "Device \"eth1\" does not exist.", errBoom
+	case strings.Contains(line, "pgrep -f /usr/local/bin/ovn-network-agent"):
+		return "1\n", nil
+	case strings.Contains(line, "find Chassis name="):
+		return strings.TrimPrefix(argv[len(argv)-1], "name=") + "\n", nil
+	case strings.Contains(line, "--columns=chassis find Port_Binding"):
+		return "0e3d-master-uuid\n", nil
+	case strings.Contains(line, "--columns=name list Chassis"):
+		return "gateway-1\n", nil
+	}
+	return "", nil
+}
+
+// fakeClock advances only when the code under test sleeps, so a
+// ten-minute run takes microseconds and the tick loop stays
+// deterministic.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{t: time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) sleep(d time.Duration) {
+	c.mu.Lock()
+	c.t = c.t.Add(d)
+	c.mu.Unlock()
+}
+
+// wait is the engine's ctx-aware wait on fake time: a cancelled run does
+// not idle out the rest of its tick interval or its fault hold.
+func (c *fakeClock) wait(ctx context.Context, d time.Duration) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	c.sleep(d)
+	return ctx.Err() == nil
+}
+
+// greenProbes is a probeSource whose targets are always up.
+type greenProbes struct{}
+
+func (greenProbes) allGreen() bool       { return true }
+func (greenProbes) redTargets() []string { return nil }
+func (greenProbes) recoverySince(time.Time) map[string]int64 {
+	return map[string]int64{"fip-vm1": 0}
+}
+
+// redProbes is a probeSource whose data path never comes back: the node
+// is up, but nothing behind it answers.
+type redProbes struct{}
+
+func (redProbes) allGreen() bool       { return false }
+func (redProbes) redTargets() []string { return []string{"fip-vm1"} }
+func (redProbes) recoverySince(time.Time) map[string]int64 {
+	return map[string]int64{"fip-vm1": 0}
+}
+
+// newTestLab wires a lab against the fake commander and the fake clock.
+func newTestLab(cmd commander, clock *fakeClock) *lab {
+	return &lab{name: "ovn-e2e", cmd: cmd, sleep: clock.sleep, now: clock.now}
+}
+
+// noopActions builds a registry whose faults do nothing but record that
+// they ran — the engine's decisions are what the engine tests are about.
+func noopActions(names ...string) []*action {
+	actions := make([]*action, 0, len(names))
+	for _, name := range names {
+		actions = append(actions, &action{
+			name:           name,
+			weight:         1,
+			holdMin:        5 * time.Second,
+			holdMax:        5 * time.Second,
+			recoveryBudget: 60 * time.Second,
+			inject:         func(context.Context, *lab, string) error { return nil },
+			restore:        func(context.Context, *lab, string) error { return nil },
+		})
+	}
+	return actions
+}
+
+// decisionsIn extracts the drawn decisions from a journal, in order.
+// Two runs with identical inputs must produce identical slices — that is
+// the reproducibility contract.
+func decisionsIn(t *testing.T, journal string) []string {
+	t.Helper()
+	var out []string
+	for _, line := range strings.Split(strings.TrimSpace(journal), "\n") {
+		if line == "" {
+			continue
+		}
+		var e event
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("journal line is not valid JSON: %v (%q)", err, line)
+		}
+		if e.Event != evDecision {
+			continue
+		}
+		out = append(out, strings.Join([]string{
+			e.Action, e.Target,
+			time.Duration(e.IntervalMS).String(),
+			time.Duration(e.HoldMS).String(),
+		}, "|"))
+	}
+	return out
+}
+
+func eventsIn(t *testing.T, journal string) []event {
+	t.Helper()
+	var out []event
+	for _, line := range strings.Split(strings.TrimSpace(journal), "\n") {
+		if line == "" {
+			continue
+		}
+		var e event
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("journal line is not valid JSON: %v (%q)", err, line)
+		}
+		out = append(out, e)
+	}
+	return out
+}

--- a/test/e2e/chaos/journal.go
+++ b/test/e2e/chaos/journal.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// The two machine-readable artifacts a run leaves behind:
+//
+//	<out>/journal.jsonl — one JSON object per decision and phase, in the
+//	                      order the engine made them. Replaying a run
+//	                      means diffing the `decision` lines of two runs.
+//	<out>/summary.json  — the run record: inputs, what was executed,
+//	                      probe loss over time, recovery durations,
+//	                      violations.
+const (
+	journalFile  = "journal.jsonl"
+	summaryFile  = "summary.json"
+	recordSchema = "chaos-run-record/v1"
+)
+
+// Journal event names.
+const (
+	evRunStart        = "run-start"
+	evStateApplied    = "state-applied"
+	evDecision        = "decision"
+	evInject          = "inject"
+	evRestore         = "restore"
+	evConverged       = "converged"
+	evNodeState       = "node-state"
+	evProbeTransition = "probe-transition"
+	evVIPRepoint      = "vip-repoint"
+	evViolation       = "violation"
+	evCheckError      = "check-error"
+	evRunAborted      = "run-aborted"
+	evRunEnd          = "run-end"
+)
+
+// event is one journal line. Every field is optional except ts/event, so
+// one flat struct describes the whole event vocabulary and consumers can
+// branch on `event`.
+type event struct {
+	TS         string           `json:"ts"`
+	Event      string           `json:"event"`
+	Tick       int              `json:"tick,omitempty"`
+	Action     string           `json:"action,omitempty"`
+	Target     string           `json:"target,omitempty"`
+	IntervalMS int64            `json:"interval_ms,omitempty"`
+	HoldMS     int64            `json:"hold_ms,omitempty"`
+	Executed   *bool            `json:"executed,omitempty"`
+	SkipReason string           `json:"skip_reason,omitempty"`
+	Probe      string           `json:"probe,omitempty"`
+	Up         *bool            `json:"up,omitempty"`
+	State      string           `json:"state,omitempty"`
+	CROwner    string           `json:"cr_owner,omitempty"`
+	RecoveryMS map[string]int64 `json:"recovery_ms,omitempty"`
+	Kind       string           `json:"kind,omitempty"`
+	Detail     string           `json:"detail,omitempty"`
+	Result     string           `json:"result,omitempty"`
+	Inputs     *runInputs       `json:"inputs,omitempty"`
+}
+
+// runInputs is the reproducibility contract: identical inputs replay the
+// identical decision sequence. It is echoed into the `run-start` event
+// and into the run record.
+type runInputs struct {
+	Seed       int64          `json:"seed"`
+	DurationMS int64          `json:"duration_ms"`
+	TickMinMS  int64          `json:"tick_min_ms"`
+	TickMaxMS  int64          `json:"tick_max_ms"`
+	Weights    map[string]int `json:"weights"`
+	Lab        string         `json:"lab"`
+}
+
+// journal is the append-only JSONL writer. The prober writes transitions
+// from its own goroutines, so writes are serialized.
+type journal struct {
+	mu  sync.Mutex
+	w   io.Writer
+	now func() time.Time
+	err error
+}
+
+func newJournal(w io.Writer, now func() time.Time) *journal {
+	return &journal{w: w, now: now}
+}
+
+// emit appends one event. A write error is recorded and surfaced by
+// Err() at the end of the run rather than aborting the tick loop: a full
+// disk must not be reported as a lab failure.
+func (j *journal) emit(e event) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	e.TS = j.now().UTC().Format(time.RFC3339Nano)
+	line, err := json.Marshal(e)
+	if err != nil {
+		j.err = fmt.Errorf("marshal %s event: %w", e.Event, err)
+		return
+	}
+	if _, err := fmt.Fprintf(j.w, "%s\n", line); err != nil && j.err == nil {
+		j.err = fmt.Errorf("write %s event: %w", e.Event, err)
+	}
+}
+
+func (j *journal) Err() error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.err
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// lossBucket is one 10-second slice of a probe's history — the
+// "probe loss over time" series in the run record.
+type lossBucket struct {
+	OffsetMS int64 `json:"offset_ms"`
+	Sent     int   `json:"sent"`
+	Lost     int   `json:"lost"`
+}
+
+type probeSummary struct {
+	Target      string       `json:"target"`
+	Sent        int          `json:"sent"`
+	Lost        int          `json:"lost"`
+	Transitions int          `json:"transitions"`
+	Buckets     []lossBucket `json:"buckets"`
+}
+
+// recoveryRecord is how long each probe target took to come back after
+// one action. Measured from two anchors: the fault injection and the
+// restore. Resources pinned to the node under fault are legitimately
+// dark while it is held down, so the restore anchor is the one the
+// recovery budget is enforced against.
+type recoveryRecord struct {
+	Tick          int              `json:"tick"`
+	Action        string           `json:"action"`
+	Target        string           `json:"target"`
+	BudgetMS      int64            `json:"budget_ms"`
+	ConvergedMS   int64            `json:"converged_ms"`
+	FromInjectMS  map[string]int64 `json:"from_inject_ms"`
+	FromRestoreMS map[string]int64 `json:"from_restore_ms"`
+	CROwnerAfter  string           `json:"cr_owner_after"`
+}
+
+type violationRecord struct {
+	TS     string `json:"ts"`
+	Kind   string `json:"kind"`
+	Tick   int    `json:"tick,omitempty"`
+	Action string `json:"action,omitempty"`
+	Target string `json:"target,omitempty"`
+	Detail string `json:"detail"`
+}
+
+type decisionCounts struct {
+	Total    int `json:"total"`
+	Executed int `json:"executed"`
+	Skipped  int `json:"skipped"`
+}
+
+// checkCounts is how much the baseline sweep actually did — the record's
+// evidence that the invariants were evaluated at all, and not just that
+// nothing was found. A run that could never reach SB and a run where the
+// split-brain never happened are both "zero violations"; only these
+// counts tell them apart.
+type checkCounts struct {
+	Sweeps    int `json:"sweeps"`
+	DualClaim int `json:"dual_claim_evaluated"`
+	Errors    int `json:"errors"`
+}
+
+// runRecord is <out>/summary.json.
+type runRecord struct {
+	Schema        string                  `json:"schema"`
+	Inputs        runInputs               `json:"inputs"`
+	StartedAt     string                  `json:"started_at"`
+	EndedAt       string                  `json:"ended_at"`
+	Result        string                  `json:"result"`
+	Ticks         int                     `json:"ticks"`
+	Decisions     decisionCounts          `json:"decisions"`
+	Checks        checkCounts             `json:"checks"`
+	ActionsByName map[string]int          `json:"actions_by_name"`
+	Probes        map[string]probeSummary `json:"probes"`
+	Recoveries    []recoveryRecord        `json:"recoveries"`
+	Violations    []violationRecord       `json:"violations"`
+}
+
+const (
+	resultPass = "pass"
+	resultFail = "fail"
+)
+
+// finalize stamps the result: any violation fails the run.
+func (r *runRecord) finalize(endedAt time.Time) {
+	r.Schema = recordSchema
+	r.EndedAt = endedAt.UTC().Format(time.RFC3339Nano)
+	r.Result = resultPass
+	if len(r.Violations) > 0 {
+		r.Result = resultFail
+	}
+	if r.ActionsByName == nil {
+		r.ActionsByName = map[string]int{}
+	}
+	if r.Probes == nil {
+		r.Probes = map[string]probeSummary{}
+	}
+	if r.Recoveries == nil {
+		r.Recoveries = []recoveryRecord{}
+	}
+	if r.Violations == nil {
+		r.Violations = []violationRecord{}
+	}
+}
+
+func (r *runRecord) write(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(r); err != nil {
+		return fmt.Errorf("write run record: %w", err)
+	}
+	return nil
+}

--- a/test/e2e/chaos/journal_test.go
+++ b/test/e2e/chaos/journal_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestJournalWritesOneValidJSONObjectPerEvent(t *testing.T) {
+	clock := newFakeClock()
+	var buf bytes.Buffer
+	j := newJournal(&buf, clock.now)
+
+	j.emit(event{Event: evRunStart, Inputs: &runInputs{Seed: 42, Lab: "ovn-e2e"}})
+	j.emit(event{Event: evDecision, Tick: 1, Action: "gateway-kill", Target: "gateway-2",
+		IntervalMS: 12000, HoldMS: 20000, Executed: boolPtr(false), SkipReason: skipNoHealthyPeer})
+	j.emit(event{Event: evProbeTransition, Probe: "pf-vip", Up: boolPtr(false)})
+
+	if err := j.Err(); err != nil {
+		t.Fatalf("journal: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("wrote %d lines for 3 events", len(lines))
+	}
+	for _, line := range lines {
+		var raw map[string]any
+		if err := json.Unmarshal([]byte(line), &raw); err != nil {
+			t.Fatalf("line is not valid JSON: %v (%q)", err, line)
+		}
+		if raw["ts"] == "" || raw["event"] == "" {
+			t.Fatalf("line is missing ts/event: %q", line)
+		}
+	}
+
+	events := eventsIn(t, buf.String())
+	// A skipped decision must record the skip and the values it drew:
+	// they are what a replay is diffed on.
+	d := events[1]
+	if d.Executed == nil || *d.Executed {
+		t.Fatalf("decision executed = %v, want false", d.Executed)
+	}
+	if d.SkipReason != skipNoHealthyPeer || d.IntervalMS != 12000 || d.HoldMS != 20000 {
+		t.Fatalf("skipped decision lost its draw: %+v", d)
+	}
+	// `up: false` must survive the round trip — with a plain bool it
+	// would be dropped by omitempty and a red probe would read as absent.
+	if events[2].Up == nil || *events[2].Up {
+		t.Fatalf("probe transition up = %v, want false", events[2].Up)
+	}
+}
+
+// A journal that cannot be written must surface the error instead of
+// pretending the run was recorded.
+func TestJournalSurfacesWriteErrors(t *testing.T) {
+	j := newJournal(failingWriter{}, newFakeClock().now)
+	j.emit(event{Event: evRunStart})
+
+	if err := j.Err(); err == nil {
+		t.Fatal("a failed write was not reported")
+	}
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, errBoom }
+
+func TestSummaryFailsOnViolation(t *testing.T) {
+	clock := newFakeClock()
+
+	clean := &runRecord{}
+	clean.finalize(clock.now())
+	if clean.Result != resultPass {
+		t.Fatalf("result = %q, want %q", clean.Result, resultPass)
+	}
+
+	dirty := &runRecord{Violations: []violationRecord{{Kind: violationDualClaim, Detail: "cr-lr0-public"}}}
+	dirty.finalize(clock.now())
+	if dirty.Result != resultFail {
+		t.Fatalf("result = %q, want %q", dirty.Result, resultFail)
+	}
+	if dirty.Schema != recordSchema {
+		t.Fatalf("schema = %q, want %q", dirty.Schema, recordSchema)
+	}
+
+	var buf bytes.Buffer
+	if err := dirty.write(&buf); err != nil {
+		t.Fatalf("write run record: %v", err)
+	}
+	var decoded runRecord
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("run record is not valid JSON: %v", err)
+	}
+	if decoded.Result != resultFail || len(decoded.Violations) != 1 {
+		t.Fatalf("run record lost the violation: %+v", decoded)
+	}
+}
+
+// The run record's "probe loss over time" is the per-target 10s buckets;
+// recovery is dated from the moment the target came back.
+func TestSummaryAggregatesLossBucketsAndRecoveries(t *testing.T) {
+	clock := newFakeClock()
+	p := newProber(nil, []probeTarget{{"pf-vip", probeHTTP, vipURL}},
+		newJournal(&bytes.Buffer{}, clock.now), clock.now)
+
+	anchor := clock.now()
+	// 0–10s: green. 10–20s: the VIP goes dark. 20s: it comes back.
+	for range 10 {
+		p.record("pf-vip", true)
+		clock.sleep(time.Second)
+	}
+	for range 10 {
+		p.record("pf-vip", false)
+		clock.sleep(time.Second)
+	}
+	p.record("pf-vip", true)
+
+	sum := p.summary()["pf-vip"]
+	if sum.Sent != 21 || sum.Lost != 10 {
+		t.Fatalf("sent/lost = %d/%d, want 21/10", sum.Sent, sum.Lost)
+	}
+	if sum.Transitions != 2 {
+		t.Fatalf("transitions = %d, want 2 (green→red→green)", sum.Transitions)
+	}
+	if len(sum.Buckets) != 3 {
+		t.Fatalf("buckets = %+v, want three 10s slices", sum.Buckets)
+	}
+	if sum.Buckets[0].Lost != 0 || sum.Buckets[1].Lost != 10 || sum.Buckets[2].Lost != 0 {
+		t.Fatalf("loss did not land in the middle bucket: %+v", sum.Buckets)
+	}
+
+	// The target went red after `anchor` and came back 20s later.
+	if got := p.recoverySince(anchor)["pf-vip"]; got != 20_000 {
+		t.Fatalf("recovery since the anchor = %dms, want 20000", got)
+	}
+	// A target that never went red after the anchor recovers in 0ms.
+	if got := p.recoverySince(clock.now())["pf-vip"]; got != 0 {
+		t.Fatalf("recovery for a target that stayed green = %dms, want 0", got)
+	}
+	if !p.allGreen() {
+		t.Fatal("the target is up again but allGreen reports red")
+	}
+}
+
+func TestProberReportsRedTargets(t *testing.T) {
+	clock := newFakeClock()
+	targets := []probeTarget{{"fip-vm1", probePing, "192.0.2.10"}, {"pf-vip", probeHTTP, vipURL}}
+	p := newProber(nil, targets, newJournal(&bytes.Buffer{}, clock.now), clock.now)
+
+	p.record("fip-vm1", false)
+
+	if p.allGreen() {
+		t.Fatal("allGreen reports green with a red target")
+	}
+	if red := p.redTargets(); len(red) != 1 || red[0] != "fip-vm1" {
+		t.Fatalf("redTargets = %v, want [fip-vm1]", red)
+	}
+}

--- a/test/e2e/chaos/lab.go
+++ b/test/e2e/chaos/lab.go
@@ -1,0 +1,566 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// commander is the seam between the chaos runner and the host CLIs it
+// drives (docker, containerlab). Everything the runner does to the lab
+// funnels through here, so the unit tests replace exactly this one
+// interface and exercise the real engine, actions and state layering
+// against recorded argv.
+type commander interface {
+	run(ctx context.Context, name string, args ...string) (string, error)
+}
+
+// cmdTimeout bounds one host CLI invocation. The runner drives a lab it
+// is actively breaking, where a `docker exec` can hang for good — and
+// none of the contexts reaching here carries a deadline of its own. An
+// unbounded invocation would wedge whichever goroutine issued it: a
+// prober frozen mid-sample keeps reporting its last value, so a data path
+// that is actually dead reads as green and the engine declares the node
+// converged.
+const cmdTimeout = 30 * time.Second
+
+// execCommander runs the host CLIs. timeout bounds one invocation; the
+// zero value uses cmdTimeout.
+type execCommander struct {
+	timeout time.Duration
+}
+
+// run returns the command's stdout. stderr is kept out of it and only
+// folded into the error: every caller parses the output (OVSDB JSON,
+// docker -f templates, chassis names), and ovn-sbctl logs its ovsdb-idl
+// reconnect and transaction warnings to stderr while still exiting 0 —
+// exactly what a chassis the runner has just SIGKILLed provokes. Merged
+// into stdout, one WARN line turns a healthy lookup into a parse error or
+// a corrupted UUID.
+func (c execCommander) run(ctx context.Context, name string, args ...string) (string, error) {
+	timeout := c.timeout
+	if timeout == 0 {
+		timeout = cmdTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return stdout.String(), fmt.Errorf("%s %s: %w: %s", name,
+			strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), nil
+}
+
+// underlayLink mirrors one row of the UNDERLAY_LINKS table in
+// bootstrap.sh: the /30 point-to-point link between a gateway's eth1
+// (in vrf-provider) and its dedicated interface on `upstream`.
+type underlayLink struct {
+	gateway       string
+	gatewayCIDR   string
+	upstreamIface string
+	upstreamCIDR  string
+}
+
+var underlayLinks = []underlayLink{
+	{"gateway-1", "100.64.1.2/30", "eth1", "100.64.1.1/30"},
+	{"gateway-2", "100.64.2.2/30", "eth2", "100.64.2.1/30"},
+	{"gateway-3", "100.64.3.2/30", "eth3", "100.64.3.1/30"},
+}
+
+func linkFor(gateway string) (underlayLink, bool) {
+	for _, l := range underlayLinks {
+		if l.gateway == gateway {
+			return l, true
+		}
+	}
+	return underlayLink{}, false
+}
+
+func gatewayNames() []string {
+	names := make([]string, 0, len(underlayLinks))
+	for _, l := range underlayLinks {
+		names = append(names, l.gateway)
+	}
+	return names
+}
+
+const (
+	// The lab's fixed cast, as bootstrap.sh seeds it.
+	centralNode  = "central"
+	upstreamNode = "upstream"
+	clientNode   = "client-1"
+	workloadHost = "gateway-3"
+	crPort       = "cr-lr0-public"
+
+	// The port-forward VIP from pf-external.sh. The agent does not
+	// propagate Load_Balancer VIPs into the underlay, so the runner
+	// keeps the two routes pointed at the current master itself — see
+	// ensureVIPRouting.
+	vipAddr = "192.0.2.50"
+	vipURL  = "http://192.0.2.50:80/"
+
+	// Readiness budget for the daemons a restarted gateway brings back
+	// up (OVS, then FRR) before rewireUnderlay may talk to them.
+	daemonReadyTimeout = 60 * time.Second
+)
+
+// lab drives one deployed containerlab lab. Poll loops take their clock
+// from sleep/now so the unit tests can run them without wall-clock time.
+type lab struct {
+	name  string
+	cmd   commander
+	sleep func(time.Duration)
+	now   func() time.Time
+}
+
+func newLab(name string, cmd commander) *lab {
+	return &lab{name: name, cmd: cmd, sleep: time.Sleep, now: time.Now}
+}
+
+// node maps a topology node name to its container name.
+func (l *lab) node(name string) string { return "clab-" + l.name + "-" + name }
+
+func (l *lab) docker(ctx context.Context, args ...string) (string, error) {
+	return l.cmd.run(ctx, "docker", args...)
+}
+
+// exec runs argv inside a lab container.
+func (l *lab) exec(ctx context.Context, node string, argv ...string) (string, error) {
+	return l.docker(ctx, append([]string{"exec", l.node(node)}, argv...)...)
+}
+
+// sh runs a shell snippet inside a lab container. Every snippet in this
+// package is assembled from the static tables above, never from
+// operator input, so the argv-level `sh -euc` form is safe and keeps
+// the commander seam to a single method.
+func (l *lab) sh(ctx context.Context, node, script string) (string, error) {
+	return l.exec(ctx, node, "sh", "-euc", script)
+}
+
+func (l *lab) nbctl(ctx context.Context, args ...string) (string, error) {
+	return l.exec(ctx, centralNode, append([]string{"ovn-nbctl"}, args...)...)
+}
+
+func (l *lab) sbctl(ctx context.Context, args ...string) (string, error) {
+	return l.exec(ctx, centralNode, append([]string{"ovn-sbctl"}, args...)...)
+}
+
+// stopController / startController reproduce failover.sh's chassis-loss
+// simulation: a clean ovn-controller shutdown releases the claim on
+// cr-lr0-public without tearing the container (and its containerlab
+// veths) down.
+func (l *lab) stopController(ctx context.Context, gw string) error {
+	if _, err := l.exec(ctx, gw, "/usr/share/ovn/scripts/ovn-ctl", "stop_controller"); err != nil {
+		return fmt.Errorf("stop ovn-controller on %s: %w", gw, err)
+	}
+	return nil
+}
+
+func (l *lab) startController(ctx context.Context, gw string) error {
+	if _, err := l.exec(ctx, gw, "/usr/share/ovn/scripts/ovn-ctl", "start_controller"); err != nil {
+		return fmt.Errorf("start ovn-controller on %s: %w", gw, err)
+	}
+	return nil
+}
+
+// setRestartPolicy flips the container's docker restart policy.
+// containerlab deploys with `restart: always`, so a kill would be
+// undone by docker before the runner observes the outage —
+// drain-hitless.sh disables the policy for the same reason.
+func (l *lab) setRestartPolicy(ctx context.Context, gw, policy string) error {
+	if _, err := l.docker(ctx, "update", "--restart="+policy, l.node(gw)); err != nil {
+		return fmt.Errorf("set restart policy %q on %s: %w", policy, gw, err)
+	}
+	return nil
+}
+
+func (l *lab) killGateway(ctx context.Context, gw string) error {
+	if _, err := l.docker(ctx, "kill", "-s", "KILL", l.node(gw)); err != nil {
+		return fmt.Errorf("kill %s: %w", gw, err)
+	}
+	return nil
+}
+
+// terminateAgent signals the agent with SIGTERM. The gwnode entrypoint
+// execs the agent, so it is PID 1 — the same handle drain-hitless.sh
+// uses. Whether the agent drains before exiting depends on how the lab
+// was deployed (E2E_DRAIN_ON_SHUTDOWN).
+func (l *lab) terminateAgent(ctx context.Context, gw string) error {
+	if _, err := l.exec(ctx, gw, "kill", "-TERM", "1"); err != nil {
+		return fmt.Errorf("terminate agent on %s: %w", gw, err)
+	}
+	return nil
+}
+
+func (l *lab) startGateway(ctx context.Context, gw string) error {
+	if _, err := l.docker(ctx, "start", l.node(gw)); err != nil {
+		return fmt.Errorf("start %s: %w", gw, err)
+	}
+	return nil
+}
+
+func (l *lab) restartGateway(ctx context.Context, gw string) error {
+	if _, err := l.docker(ctx, "restart", l.node(gw)); err != nil {
+		return fmt.Errorf("restart %s: %w", gw, err)
+	}
+	return nil
+}
+
+// containerRunning reports whether the container is up. Used to wait
+// for a SIGTERM'ed agent (PID 1) to actually take the container down. An
+// inspect docker could not answer is not an exit — the error is handed
+// to the caller rather than folded into the verdict.
+func (l *lab) containerRunning(ctx context.Context, gw string) (bool, error) {
+	out, err := l.docker(ctx, "inspect", "-f", "{{.State.Running}}", l.node(gw))
+	if err != nil {
+		return true, err
+	}
+	return strings.TrimSpace(out) == "true", nil
+}
+
+// waitContainerExit polls until the container is down or the budget
+// expires. A failed inspect keeps the poll going — reading it as an exit
+// would report a container that never stopped as cleanly terminated, and
+// the restore would then `docker start` a running node.
+func (l *lab) waitContainerExit(ctx context.Context, gw string, budget time.Duration) error {
+	deadline := l.now().Add(budget)
+	var lastErr error
+	for l.now().Before(deadline) {
+		running, err := l.containerRunning(ctx, gw)
+		if err == nil && !running {
+			return nil
+		}
+		lastErr = err
+		l.sleep(time.Second)
+	}
+	if lastErr != nil {
+		return fmt.Errorf("container %s could not be inspected within %s after SIGTERM: %w",
+			gw, budget, lastErr)
+	}
+	return fmt.Errorf("container %s still running %s after SIGTERM", gw, budget)
+}
+
+// containerHealth returns the docker healthcheck verdict. The gwnode
+// image's HEALTHCHECK covers exactly the three daemons a converged node
+// needs (ovs-vswitchd, ovn-controller, the agent), so it is the
+// per-node convergence signal.
+func (l *lab) containerHealth(ctx context.Context, gw string) string {
+	out, err := l.docker(ctx, "inspect", "-f", "{{.State.Health.Status}}", l.node(gw))
+	if err != nil {
+		return "unknown"
+	}
+	return strings.TrimSpace(out)
+}
+
+// agentAlive reports whether the agent process is running on gw. pgrep
+// exits 1 when nothing matches — the condition under test, and a negative
+// answer. Every other failure means the question could not be asked at
+// all: a docker daemon under load, a container-state error, the 30s
+// cmdTimeout expiring. Folding those into "no agent" would turn a busy
+// runner into an agent-down violation and fail the run over a lab that
+// was fine, so they are returned as an error.
+func (l *lab) agentAlive(ctx context.Context, gw string) (bool, error) {
+	out, err := l.exec(ctx, gw, "pgrep", "-f", "/usr/local/bin/ovn-network-agent")
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+		return false, err
+	}
+	return strings.TrimSpace(out) != "", nil
+}
+
+// chassisInSB reports whether gw still has (or has re-registered) its
+// SB Chassis row.
+func (l *lab) chassisInSB(ctx context.Context, gw string) bool {
+	out, err := l.sbctl(ctx, "--timeout=5", "--bare", "--columns=name",
+		"find", "Chassis", "name="+gw)
+	return err == nil && strings.TrimSpace(out) == gw
+}
+
+// currentMaster resolves the chassis anchoring cr-lr0-public. The
+// Port_Binding.chassis column is a UUID reference, so it takes a second
+// lookup against the Chassis table — the same two-step failover.sh
+// does. An empty name means the port is currently unbound (re-election
+// in flight).
+func (l *lab) currentMaster(ctx context.Context) string {
+	uuid, err := l.sbctl(ctx, "--timeout=5", "--bare", "--columns=chassis",
+		"find", "Port_Binding", "logical_port="+crPort)
+	if err != nil || strings.TrimSpace(uuid) == "" {
+		return ""
+	}
+	name, err := l.sbctl(ctx, "--timeout=5", "--bare", "--columns=name",
+		"list", "Chassis", strings.TrimSpace(uuid))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(name)
+}
+
+// crClaim is one chassisredirect Port_Binding and the set of chassis
+// claiming it.
+type crClaim struct {
+	port    string
+	chassis []string
+}
+
+// crPortClaims lists every chassisredirect Port_Binding with the chassis
+// referenced by its `chassis` and `additional_chassis` columns. More
+// than one distinct chassis on a port means two nodes are forwarding for
+// the same gateway port at once — the split-brain the run must never
+// observe.
+func (l *lab) crPortClaims(ctx context.Context) ([]crClaim, error) {
+	out, err := l.sbctl(ctx, "--timeout=5", "--format=json",
+		"--columns=logical_port,chassis,additional_chassis",
+		"find", "Port_Binding", "type=chassisredirect")
+	if err != nil {
+		return nil, fmt.Errorf("list chassisredirect port bindings: %w", err)
+	}
+	rows, err := parseOVSDBTable(out)
+	if err != nil {
+		return nil, fmt.Errorf("parse chassisredirect port bindings: %w", err)
+	}
+	claims := make([]crClaim, 0, len(rows))
+	for _, row := range rows {
+		claim := crClaim{port: strings.Join(row["logical_port"], "")}
+		seen := map[string]bool{}
+		for _, col := range []string{"chassis", "additional_chassis"} {
+			for _, uuid := range row[col] {
+				if uuid != "" && !seen[uuid] {
+					seen[uuid] = true
+					claim.chassis = append(claim.chassis, uuid)
+				}
+			}
+		}
+		claims = append(claims, claim)
+	}
+	return claims, nil
+}
+
+// chassisName resolves an SB Chassis UUID to its name, so a dual-claim
+// violation names the nodes instead of their UUIDs. Falls back to the
+// UUID when the row is gone.
+func (l *lab) chassisName(ctx context.Context, uuid string) string {
+	out, err := l.sbctl(ctx, "--timeout=5", "--bare", "--columns=name", "list", "Chassis", uuid)
+	if err != nil || strings.TrimSpace(out) == "" {
+		return uuid
+	}
+	return strings.TrimSpace(out)
+}
+
+// parseOVSDBTable flattens `ovn-sbctl --format=json` output into one
+// map per row, each column reduced to the plain strings it carries.
+// OVSDB renders a cell as a scalar, as ["uuid", "<id>"], or as
+// ["set", [<cell>, ...]] — all three collapse to a list of strings
+// here, which is all the callers need.
+func parseOVSDBTable(out string) ([]map[string][]string, error) {
+	var table struct {
+		Headings []string            `json:"headings"`
+		Data     [][]json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(out), &table); err != nil {
+		return nil, fmt.Errorf("decode ovsdb json: %w", err)
+	}
+	rows := make([]map[string][]string, 0, len(table.Data))
+	for _, data := range table.Data {
+		row := map[string][]string{}
+		for i, heading := range table.Headings {
+			if i >= len(data) {
+				break
+			}
+			row[heading] = flattenOVSDBCell(data[i])
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func flattenOVSDBCell(raw json.RawMessage) []string {
+	var scalar string
+	if err := json.Unmarshal(raw, &scalar); err == nil {
+		if scalar == "" {
+			return nil
+		}
+		return []string{scalar}
+	}
+	var tuple []json.RawMessage
+	if err := json.Unmarshal(raw, &tuple); err != nil || len(tuple) != 2 {
+		return nil
+	}
+	var kind string
+	if err := json.Unmarshal(tuple[0], &kind); err != nil {
+		return nil
+	}
+	switch kind {
+	case "uuid", "named-uuid":
+		var value string
+		if err := json.Unmarshal(tuple[1], &value); err != nil {
+			return nil
+		}
+		return []string{value}
+	case "set":
+		var members []json.RawMessage
+		if err := json.Unmarshal(tuple[1], &members); err != nil {
+			return nil
+		}
+		var values []string
+		for _, member := range members {
+			values = append(values, flattenOVSDBCell(member)...)
+		}
+		return values
+	default:
+		return nil
+	}
+}
+
+// rewireUnderlay re-establishes the containerlab veth
+// `gateway-N:eth1 ↔ upstream:ethN` that any container exit destroys, and
+// re-applies the underlay + BGP config bootstrap.sh seeds on top of it.
+// Without this a killed or restarted gateway comes back with no
+// underlay, no BGP session and no FIP advertisement — which is why the
+// existing scenarios either avoid container lifecycle events or recycle
+// the whole lab instead of returning a node to service.
+func (l *lab) rewireUnderlay(ctx context.Context, gw string) error {
+	link, ok := linkFor(gw)
+	if !ok {
+		return fmt.Errorf("no underlay link known for %s", gw)
+	}
+	if _, err := l.exec(ctx, gw, "ip", "link", "show", "eth1"); err != nil {
+		if _, err := l.cmd.run(ctx, "containerlab", "tools", "veth", "create",
+			"-a", l.node(gw)+":eth1",
+			"-b", l.node(upstreamNode)+":"+link.upstreamIface); err != nil {
+			return fmt.Errorf("re-create underlay veth for %s: %w", gw, err)
+		}
+	}
+
+	if err := l.waitReady(ctx, gw, "ovs-vsctl show"); err != nil {
+		return fmt.Errorf("wait for OVS on %s: %w", gw, err)
+	}
+	// Mirrors wire_gateway_underlay in bootstrap.sh.
+	if _, err := l.sh(ctx, gw, strings.Join([]string{
+		"ovs-vsctl --if-exists del-port br-ex eth1",
+		"ip link set eth1 down",
+		"ip link set eth1 master vrf-provider",
+		"ip link set eth1 up",
+		"ip addr replace " + link.gatewayCIDR + " dev eth1",
+	}, "; ")); err != nil {
+		return fmt.Errorf("wire %s underlay: %w", gw, err)
+	}
+	// Mirrors configure_upstream in bootstrap.sh for this one link.
+	if _, err := l.sh(ctx, upstreamNode, strings.Join([]string{
+		"ip link set " + link.upstreamIface + " up",
+		"ip addr replace " + link.upstreamCIDR + " dev " + link.upstreamIface,
+	}, "; ")); err != nil {
+		return fmt.Errorf("wire upstream side of %s: %w", gw, err)
+	}
+
+	if err := l.waitReady(ctx, gw, "vtysh -c 'show version'"); err != nil {
+		return fmt.Errorf("wait for FRR on %s: %w", gw, err)
+	}
+	return l.configureGatewayBGP(ctx, gw, link)
+}
+
+// configureGatewayBGP replaces the placeholder BGP config the gwnode
+// entrypoint pushes on every container start with the real session
+// against this gateway's upstream /30 — configure_gateway_frr in
+// bootstrap.sh. The block opens with `no router bgp ...`, so re-applying
+// it is self-cleaning.
+func (l *lab) configureGatewayBGP(ctx context.Context, gw string, link underlayLink) error {
+	upstreamIP := addrOf(link.upstreamCIDR)
+	routerID := addrOf(link.gatewayCIDR)
+	config := strings.Join([]string{
+		"configure terminal",
+		"no router bgp 65000 vrf vrf-provider",
+		"router bgp 65000 vrf vrf-provider",
+		" bgp router-id " + routerID,
+		" no bgp default ipv4-unicast",
+		" no bgp ebgp-requires-policy",
+		" neighbor " + upstreamIP + " remote-as 65001",
+		" address-family ipv4 unicast",
+		"  redistribute static",
+		"  neighbor " + upstreamIP + " activate",
+		"  neighbor " + upstreamIP + " prefix-list ANNOUNCED-NETWORKS out",
+		" exit-address-family",
+		"end",
+		"write memory",
+	}, "\n")
+	if _, err := l.sh(ctx, gw, "printf '%s\\n' "+shellQuote(config)+" | vtysh"); err != nil {
+		return fmt.Errorf("configure BGP on %s: %w", gw, err)
+	}
+	return nil
+}
+
+// waitReady polls a readiness command inside a container until it
+// succeeds or daemonReadyTimeout expires. It gives up as soon as ctx is
+// done: a restore chains several of these, and the context that bounds
+// the whole restore expires long before the last one's own clock would —
+// left unwatched, each remaining loop would spin out its 60s against
+// commands the dead context fails instantly.
+func (l *lab) waitReady(ctx context.Context, node, probe string) error {
+	deadline := l.now().Add(daemonReadyTimeout)
+	for l.now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("waiting for %q on %s: %w", probe, node, err)
+		}
+		if _, err := l.sh(ctx, node, probe); err == nil {
+			return nil
+		}
+		l.sleep(2 * time.Second)
+	}
+	return fmt.Errorf("%q on %s did not succeed within %s", probe, node, daemonReadyTimeout)
+}
+
+// ensureVIPRouting points the port-forward VIP's two hand-plumbed routes
+// at `master`. pf-external.sh pins them to gateway-1 because the agent
+// does not propagate Load_Balancer VIPs into the underlay; a chaos run
+// migrates the master, so the runner re-points them — the job an
+// external orchestrator would do in production. Without it the VIP probe
+// would go permanently red on the first migration and every later
+// violation would be noise.
+func (l *lab) ensureVIPRouting(ctx context.Context, master string) error {
+	link, ok := linkFor(master)
+	if !ok {
+		return fmt.Errorf("no underlay link known for master %s", master)
+	}
+	nexthop := addrOf(link.gatewayCIDR)
+	if _, err := l.exec(ctx, upstreamNode, "ip", "route", "replace",
+		vipAddr+"/32", "via", nexthop); err != nil {
+		return fmt.Errorf("point %s at %s on upstream: %w", vipAddr, master, err)
+	}
+	if _, err := l.exec(ctx, master, "ip", "route", "replace",
+		vipAddr+"/32", "dev", "br-ex", "scope", "link"); err != nil {
+		return fmt.Errorf("add %s scope-link route on %s: %w", vipAddr, master, err)
+	}
+	return nil
+}
+
+// ping / httpGet are the two probe primitives, both sourced from
+// client-1 — the external vantage point every scenario probes from.
+func (l *lab) ping(ctx context.Context, addr string) error {
+	_, err := l.exec(ctx, clientNode, "ping", "-c", "1", "-W", "1", addr)
+	return err
+}
+
+func (l *lab) httpGet(ctx context.Context, url string) error {
+	_, err := l.exec(ctx, clientNode, "curl", "--silent", "--max-time", "3",
+		"--output", "/dev/null", url)
+	return err
+}
+
+// addrOf strips the prefix length from one of the table's CIDRs.
+func addrOf(cidr string) string { return strings.SplitN(cidr, "/", 2)[0] }
+
+// shellQuote wraps s in single quotes for the container-side `sh -c`.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/test/e2e/chaos/lab_test.go
+++ b/test/e2e/chaos/lab_test.go
@@ -1,0 +1,436 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseOVSDBTableFlattensUUIDsAndSets(t *testing.T) {
+	tests := []struct {
+		name    string
+		out     string
+		want    map[string][]string
+		wantErr bool
+	}{
+		{
+			name: "a single-chassis claim",
+			out: `{"headings":["logical_port","chassis","additional_chassis"],
+			       "data":[["cr-lr0-public",["uuid","abc"],["set",[]]]]}`,
+			want: map[string][]string{
+				"logical_port":       {"cr-lr0-public"},
+				"chassis":            {"abc"},
+				"additional_chassis": nil,
+			},
+		},
+		{
+			name: "an unbound port during re-election",
+			out: `{"headings":["logical_port","chassis","additional_chassis"],
+			       "data":[["cr-lr0-public",["set",[]],["set",[]]]]}`,
+			want: map[string][]string{
+				"logical_port":       {"cr-lr0-public"},
+				"chassis":            nil,
+				"additional_chassis": nil,
+			},
+		},
+		{
+			name: "two chassis on one port",
+			out: `{"headings":["logical_port","chassis","additional_chassis"],
+			       "data":[["cr-lr0-public",["uuid","abc"],["set",[["uuid","def"],["uuid","ghi"]]]]]}`,
+			want: map[string][]string{
+				"logical_port":       {"cr-lr0-public"},
+				"chassis":            {"abc"},
+				"additional_chassis": {"def", "ghi"},
+			},
+		},
+		{
+			name:    "not JSON at all",
+			out:     "ovn-sbctl: unix:/var/run/ovn/ovnsb_db.sock: database connection failed",
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rows, err := parseOVSDBTable(tc.out)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseOVSDBTable(%q) = %v, want an error", tc.out, rows)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseOVSDBTable: %v", err)
+			}
+			if len(rows) != 1 {
+				t.Fatalf("parsed %d rows, want 1", len(rows))
+			}
+			for col, want := range tc.want {
+				got := rows[0][col]
+				if len(got) != len(want) {
+					t.Fatalf("column %s = %v, want %v", col, got, want)
+				}
+				for i := range want {
+					if got[i] != want[i] {
+						t.Fatalf("column %s = %v, want %v", col, got, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+// The dual-claim check must see both the `chassis` column and every
+// member of `additional_chassis` — a port claimed by two chassis at once
+// is the split the run must never observe.
+func TestCRPortClaimsCollectsEveryClaimingChassis(t *testing.T) {
+	cmd := &fakeCommander{respond: func([]string) (string, error) {
+		return `{"headings":["logical_port","chassis","additional_chassis"],
+		         "data":[["cr-lr0-public",["uuid","abc"],["set",[["uuid","def"]]]]]}`, nil
+	}}
+	l := newTestLab(cmd, newFakeClock())
+
+	claims, err := l.crPortClaims(context.Background())
+	if err != nil {
+		t.Fatalf("crPortClaims: %v", err)
+	}
+	if len(claims) != 1 {
+		t.Fatalf("got %d claims, want 1", len(claims))
+	}
+	if claims[0].port != crPort {
+		t.Fatalf("port = %q, want %q", claims[0].port, crPort)
+	}
+	if len(claims[0].chassis) != 2 {
+		t.Fatalf("chassis = %v, want the chassis column plus the additional one", claims[0].chassis)
+	}
+}
+
+func TestCRPortClaimsReportsALookupFailure(t *testing.T) {
+	cmd := &fakeCommander{respond: func([]string) (string, error) { return "", errBoom }}
+	l := newTestLab(cmd, newFakeClock())
+
+	if _, err := l.crPortClaims(context.Background()); err == nil {
+		t.Fatal("a failed sbctl lookup was reported as no claims at all")
+	}
+}
+
+// currentMaster resolves the chassis UUID on the Port_Binding to a name.
+// An unbound port (re-election in flight) is an empty name, not an error
+// — the caller polls until it settles.
+func TestCurrentMaster(t *testing.T) {
+	tests := []struct {
+		name string
+		uuid string
+		want string
+	}{
+		{name: "bound to a chassis", uuid: "abc\n", want: "gateway-2"},
+		{name: "unbound during re-election", uuid: "\n", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+				line := strings.Join(argv, " ")
+				if strings.Contains(line, "--columns=chassis find Port_Binding") {
+					return tc.uuid, nil
+				}
+				return "gateway-2\n", nil
+			}}
+			l := newTestLab(cmd, newFakeClock())
+
+			if got := l.currentMaster(context.Background()); got != tc.want {
+				t.Fatalf("currentMaster = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The VIP's two hand-plumbed routes follow the master: the forward route
+// on `upstream` points at the new master's underlay IP, and the
+// scope-link route is installed on the new master itself.
+func TestEnsureVIPRoutingFollowsTheMaster(t *testing.T) {
+	cmd := &fakeCommander{}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := l.ensureVIPRouting(context.Background(), "gateway-2"); err != nil {
+		t.Fatalf("ensureVIPRouting: %v", err)
+	}
+
+	want := []string{
+		"docker exec clab-ovn-e2e-upstream ip route replace 192.0.2.50/32 via 100.64.2.2",
+		"docker exec clab-ovn-e2e-gateway-2 ip route replace 192.0.2.50/32 dev br-ex scope link",
+	}
+	got := cmd.lines()
+	if len(got) != len(want) {
+		t.Fatalf("issued %d commands, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("command %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestEnsureVIPRoutingRejectsAnUnknownMaster(t *testing.T) {
+	l := newTestLab(&fakeCommander{}, newFakeClock())
+
+	if err := l.ensureVIPRouting(context.Background(), "gateway-9"); err == nil {
+		t.Fatal("a master with no underlay link was accepted")
+	}
+}
+
+// Every lab primitive must wrap a failed command with what it was
+// trying to do and on which node — a bare exec error in the journal
+// names neither.
+func TestLabPrimitivesWrapFailuresWithContext(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(*lab) error
+		want string
+	}{
+		{"stop the controller", func(l *lab) error { return l.stopController(ctxT(), "gateway-1") }, "stop ovn-controller on gateway-1"},
+		{"start the controller", func(l *lab) error { return l.startController(ctxT(), "gateway-1") }, "start ovn-controller on gateway-1"},
+		{"kill the container", func(l *lab) error { return l.killGateway(ctxT(), "gateway-2") }, "kill gateway-2"},
+		{"start the container", func(l *lab) error { return l.startGateway(ctxT(), "gateway-2") }, "start gateway-2"},
+		{"restart the container", func(l *lab) error { return l.restartGateway(ctxT(), "gateway-3") }, "restart gateway-3"},
+		{"signal the agent", func(l *lab) error { return l.terminateAgent(ctxT(), "gateway-3") }, "terminate agent on gateway-3"},
+		{"set the restart policy", func(l *lab) error { return l.setRestartPolicy(ctxT(), "gateway-1", "no") }, `set restart policy "no" on gateway-1`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := &fakeCommander{respond: func([]string) (string, error) { return "", errBoom }}
+
+			err := tc.call(newTestLab(cmd, newFakeClock()))
+
+			if err == nil {
+				t.Fatalf("%s: a failed command was reported as success", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not say %q", err, tc.want)
+			}
+			if !errors.Is(err, errBoom) {
+				t.Fatalf("error %q dropped the cause from the chain", err)
+			}
+		})
+	}
+}
+
+// A daemon that never comes back must fail the re-wire, not let it push
+// config at a container that cannot accept it.
+func TestWaitReadyGivesUpOnADaemonThatNeverComesBack(t *testing.T) {
+	cmd := &fakeCommander{respond: func([]string) (string, error) { return "", errBoom }}
+	l := newTestLab(cmd, newFakeClock())
+
+	err := l.waitReady(context.Background(), "gateway-1", "ovs-vsctl show")
+	if err == nil {
+		t.Fatal("waitReady returned success for a daemon that never answered")
+	}
+	if !strings.Contains(err.Error(), "ovs-vsctl show") || !strings.Contains(err.Error(), "gateway-1") {
+		t.Fatalf("error %q names neither the probe nor the node", err)
+	}
+}
+
+// docker inspect fails on a container that is gone; the run must read
+// that as "not healthy", never as healthy.
+func TestContainerHealthOfAMissingContainerIsNotHealthy(t *testing.T) {
+	cmd := &fakeCommander{respond: func([]string) (string, error) { return "", errBoom }}
+	l := newTestLab(cmd, newFakeClock())
+
+	if got := l.containerHealth(context.Background(), "gateway-1"); got == "healthy" {
+		t.Fatalf("containerHealth = %q for a container docker cannot inspect", got)
+	}
+}
+
+// The convergence gate only lets a node back into service once its
+// chassis is registered in SB again. A lookup that could not be answered
+// is not a registration.
+func TestChassisInSB(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		err  error
+		want bool
+	}{
+		{name: "the chassis is registered", out: "gateway-2\n", want: true},
+		{name: "the chassis has not come back", out: "\n", want: false},
+		{name: "the lookup failed", err: errBoom, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := &fakeCommander{respond: func([]string) (string, error) { return tc.out, tc.err }}
+			l := newTestLab(cmd, newFakeClock())
+
+			if got := l.chassisInSB(context.Background(), "gateway-2"); got != tc.want {
+				t.Fatalf("chassisInSB = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// docker inspect can fail on a busy daemon. Reading that as an exit would
+// report a container that never stopped as a clean termination — and the
+// restore would then `docker start` a node that is still running, fail,
+// and record a fabricated violation against a lab that was fine.
+func TestWaitContainerExitDoesNotReadAFailedInspectAsAnExit(t *testing.T) {
+	cmd := &fakeCommander{respond: func([]string) (string, error) { return "", errBoom }}
+	l := newTestLab(cmd, newFakeClock())
+
+	err := l.waitContainerExit(context.Background(), "gateway-3", 5*time.Second)
+
+	if err == nil {
+		t.Fatal("a container docker could not inspect was reported as exited")
+	}
+	if !errors.Is(err, errBoom) {
+		t.Fatalf("error %q dropped the inspect failure from the chain", err)
+	}
+}
+
+// A dual-claim violation names the chassis. When the SB row is already
+// gone the UUID is better than nothing — but it must not be silently
+// dropped.
+func TestChassisNameFallsBackToTheUUID(t *testing.T) {
+	cmd := &fakeCommander{respond: func([]string) (string, error) { return "", errBoom }}
+	l := newTestLab(cmd, newFakeClock())
+
+	if got := l.chassisName(context.Background(), "abc-uuid"); got != "abc-uuid" {
+		t.Fatalf("chassisName = %q, want the UUID back", got)
+	}
+}
+
+// A `docker exec` against a lab the runner is actively breaking can hang
+// for good, and no context reaching the commander carries a deadline of
+// its own. An invocation that never returns wedges its caller: a prober
+// frozen mid-sample keeps reporting the value it last saw, so a data path
+// that is dead reads as green and the engine declares the node converged.
+func TestExecCommanderBoundsAWedgedCommand(t *testing.T) {
+	cmd := execCommander{timeout: 50 * time.Millisecond}
+
+	start := time.Now()
+	_, err := cmd.run(context.Background(), "sleep", "10")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("a command that never returned on its own was reported as success")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("the command ran for %s past its 50ms budget", elapsed)
+	}
+}
+
+func ctxT() context.Context { return context.Background() }
+
+// pgrep exits 1 when nothing matches — that is the condition under test,
+// and an answer. Every other failure means the question could not be
+// asked: a docker daemon under load, an expired cmdTimeout. Collapsing
+// those into "no agent" turns a busy runner into a false agent-down
+// violation and fails the run over a lab that was fine.
+func TestAgentAlive(t *testing.T) {
+	tests := []struct {
+		name    string
+		out     string
+		err     func(*testing.T) error
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "the agent is running",
+			out:  "1\n",
+			want: true,
+		},
+		{
+			name: "pgrep matched nothing",
+			err:  func(t *testing.T) error { return errExit(t, 1) },
+			want: false,
+		},
+		{
+			name:    "the probe could not be answered at all",
+			err:     func(t *testing.T) error { return errBoom },
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := &fakeCommander{respond: func([]string) (string, error) {
+				if tc.err != nil {
+					return "", tc.err(t)
+				}
+				return tc.out, nil
+			}}
+			l := newTestLab(cmd, newFakeClock())
+
+			got, err := l.agentAlive(context.Background(), "gateway-1")
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("a probe the runner could not answer was reported as a dead agent")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("agentAlive: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("agentAlive = %v, want %v", got, tc.want)
+			}
+			if !cmd.called("pgrep -f /usr/local/bin/ovn-network-agent") {
+				t.Fatalf("agentAlive did not pgrep for the agent: %v", cmd.lines())
+			}
+		})
+	}
+}
+
+// Every caller parses the command's output — OVSDB JSON, docker -f
+// templates, chassis names. ovn-sbctl logs its ovsdb-idl reconnect and
+// transaction warnings to stderr while still exiting 0, which is exactly
+// what a chassis the runner has just SIGKILLed provokes. Merged into
+// stdout, one WARN line is a JSON parse error or a corrupted UUID.
+func TestExecCommanderKeepsStderrOutOfTheOutput(t *testing.T) {
+	cmd := execCommander{}
+
+	out, err := cmd.run(context.Background(), "sh", "-c",
+		`echo "ovsdb-idl|WARN|reconnecting" >&2; printf '%s' '{"headings":[]}'`)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out != `{"headings":[]}` {
+		t.Fatalf("output = %q, want stdout alone", out)
+	}
+
+	// A failure still has to say what the command complained about.
+	_, err = cmd.run(context.Background(), "sh", "-c", "echo 'no such container' >&2; exit 1")
+	if err == nil || !strings.Contains(err.Error(), "no such container") {
+		t.Fatalf("error = %v, want one carrying the command's stderr", err)
+	}
+}
+
+// A restore chains four of these wait loops inside one bounded context.
+// One that never looks at the context keeps spinning out its own 60s
+// clock against commands that the dead context fails instantly — so the
+// restore overruns the deadline that was supposed to bound it, and the
+// run records the runner's own arithmetic as a failed action.
+func TestWaitReadyGivesUpOnADeadContext(t *testing.T) {
+	cmd := &fakeCommander{respond: func([]string) (string, error) { return "", errBoom }}
+	clock := newFakeClock()
+	l := newTestLab(cmd, clock)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	started := clock.now()
+	err := l.waitReady(ctx, "gateway-1", "ovs-vsctl show")
+
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitReady = %v, want the context's own error", err)
+	}
+	if clock.now() != started {
+		t.Fatalf("waitReady kept polling for %s on a context that was already done",
+			clock.now().Sub(started))
+	}
+	if len(cmd.lines()) != 0 {
+		t.Fatalf("waitReady probed the node on a dead context: %v", cmd.lines())
+	}
+}

--- a/test/e2e/chaos/main.go
+++ b/test/e2e/chaos/main.go
@@ -1,0 +1,263 @@
+// chaos is a seeded chaos runner for the containerlab E2E lab (issue
+// #176). It drives an already-deployed lab through a randomized fault
+// sequence for a bounded duration and reports what it did.
+//
+// One run: layer the existing scenarios' setups (hairpin, multi-VLAN,
+// port-forward) on top of the bootstrap baseline, start a continuous
+// reachability probe from client-1, then tick until the duration
+// expires — wait a randomized interval, pick a weighted action, check
+// its guardrails, execute it, wait for the node to converge, record it.
+//
+// Reproducibility is the contract: the seed, the duration, the tick
+// bounds and the action weights are the only inputs, and every decision
+// the engine makes is drawn from a PCG stream seeded by -seed alone. Two
+// runs with identical inputs replay the identical decision sequence —
+// diff the `decision` lines of their journals to see it.
+//
+// Usage (against a lab that is already up — `make e2e-up`):
+//
+//	go run ./test/e2e/chaos [flags]
+//	make e2e-chaos CHAOS_FLAGS="-duration 3m -seed 7"
+//
+// Exit codes: 0 the run passed, 1 the run recorded a violation, 2 the
+// runner could not set the run up. On a non-zero exit the lab's existing
+// artifact collector is invoked into <out>/lab-state.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+const (
+	exitPass       = 0
+	exitViolations = 1
+	exitFatal      = 2
+)
+
+// minTick is the floor under -tick-min. A tick interval near zero spins
+// the loop as fast as the CPU allows and writes a decision line per
+// iteration, so the journal grows without bound on a run that measures
+// nothing: the faults never get a chance to land between two ticks.
+const minTick = 100 * time.Millisecond
+
+// minDuration is the floor under -duration. The run inputs are journaled
+// (and the engine's clocks derived) in milliseconds, so a sub-millisecond
+// duration would truncate to a zero-tick run reporting "pass".
+const minDuration = time.Second
+
+// collectTimeout bounds the lab-state collector: it runs against a lab
+// that is already broken, where a `docker exec` can hang for good.
+const collectTimeout = 2 * time.Minute
+
+// config is one run's inputs, as parsed from the flags.
+type config struct {
+	seed       int64
+	duration   time.Duration
+	tickMin    time.Duration
+	tickMax    time.Duration
+	weightSpec string
+	labName    string
+	outDir     string
+	collect    string
+}
+
+func main() {
+	var cfg config
+	flag.Int64Var(&cfg.seed, "seed", 42, "seed for every decision the engine makes")
+	flag.DurationVar(&cfg.duration, "duration", 10*time.Minute, "how long to keep injecting faults")
+	flag.DurationVar(&cfg.tickMin, "tick-min", 10*time.Second, "lower bound of the interval between decisions")
+	flag.DurationVar(&cfg.tickMax, "tick-max", 30*time.Second, "upper bound of the interval between decisions")
+	flag.StringVar(&cfg.weightSpec, "weights", "", "override action weights, e.g. `gateway-kill=0,controller-restart=5`")
+	flag.StringVar(&cfg.labName, "lab", "ovn-e2e", "containerlab lab name")
+	flag.StringVar(&cfg.outDir, "out", "chaos-artifacts", "directory for the journal, the run record and the lab-state dump")
+	flag.StringVar(&cfg.collect, "collect", "test/e2e/scenarios/collect-artifacts.sh",
+		"lab-state collector, run into <out>/lab-state when the run does not pass")
+	flag.Parse()
+
+	code, err := run(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[chaos] %v\n", err)
+	}
+	os.Exit(code)
+}
+
+func run(cfg config) (int, error) {
+	if cfg.tickMin < minTick {
+		return exitFatal, fmt.Errorf("-tick-min %s is below the %s floor", cfg.tickMin, minTick)
+	}
+	if cfg.tickMax < cfg.tickMin {
+		return exitFatal, fmt.Errorf("-tick-max %s is below -tick-min %s", cfg.tickMax, cfg.tickMin)
+	}
+	if cfg.duration < minDuration {
+		return exitFatal, fmt.Errorf("-duration %s is below the %s floor", cfg.duration, minDuration)
+	}
+
+	actions := starterActions()
+	weights, err := parseWeights(cfg.weightSpec, actions)
+	if err != nil {
+		return exitFatal, err
+	}
+	applyWeights(actions, weights)
+
+	if err := os.MkdirAll(cfg.outDir, 0o755); err != nil {
+		return exitFatal, fmt.Errorf("create %s: %w", cfg.outDir, err)
+	}
+	journalPath := filepath.Join(cfg.outDir, journalFile)
+	jf, err := os.Create(journalPath)
+	if err != nil {
+		return exitFatal, fmt.Errorf("create %s: %w", journalPath, err)
+	}
+	defer func() { _ = jf.Close() }()
+
+	// SIGINT/SIGTERM cancel the run; the summary is still written, so an
+	// interrupted session is still triageable.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	// The first signal hands the signals straight back to their default
+	// disposition, so a second one kills the runner. Cancelling only starts
+	// the unwind: the engine still has to undo the fault it is holding, and
+	// that restore is detached from the signal and can take minutes. An
+	// operator who does not want to wait it out must have something better
+	// than SIGKILL, which would lose summary.json entirely.
+	go func() {
+		<-ctx.Done()
+		stop()
+	}()
+
+	started := time.Now()
+	jrnl := newJournal(jf, time.Now)
+	l := newLab(cfg.labName, execCommander{})
+	rec := &runRecord{
+		Inputs: runInputs{
+			Seed:       cfg.seed,
+			DurationMS: cfg.duration.Milliseconds(),
+			TickMinMS:  cfg.tickMin.Milliseconds(),
+			TickMaxMS:  cfg.tickMax.Milliseconds(),
+			Weights:    weights,
+			Lab:        cfg.labName,
+		},
+		StartedAt:     started.UTC().Format(time.RFC3339Nano),
+		ActionsByName: map[string]int{},
+	}
+	jrnl.emit(event{Event: evRunStart, Inputs: &rec.Inputs})
+
+	code := drive(ctx, l, actions, jrnl, rec)
+
+	// The run is over and the engine has undone whatever it injected, so
+	// the signals go back to their default disposition: everything below
+	// only writes artifacts, and an operator who interrupts it must not
+	// have to SIGKILL the runner to get out.
+	stop()
+
+	rec.finalize(time.Now())
+	jrnl.emit(event{Event: evRunEnd, Result: rec.Result})
+	if err := jrnl.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "[chaos] journal: %v\n", err)
+	}
+	if err := writeRecord(rec, filepath.Join(cfg.outDir, summaryFile)); err != nil {
+		return exitFatal, err
+	}
+	if rec.Result == resultFail && code == exitPass {
+		code = exitViolations
+	}
+	fmt.Fprintf(os.Stderr, "[chaos] %s: %d ticks, %d executed, %d skipped, %d violations (%s, %s)\n",
+		rec.Result, rec.Ticks, rec.Decisions.Executed, rec.Decisions.Skipped,
+		len(rec.Violations), journalPath, filepath.Join(cfg.outDir, summaryFile))
+	if code != exitPass {
+		collectLabState(cfg.collect, cfg.labName, cfg.outDir)
+	}
+	return code, nil
+}
+
+// drive builds the start state, starts the prober and the baseline
+// checks, and runs the engine to completion. It returns the exit code
+// for a failure the run record cannot express (a start state that never
+// came up green).
+func drive(ctx context.Context, l *lab, actions []*action, jrnl *journal, rec *runRecord) int {
+	if err := applyStartState(ctx, l); err != nil {
+		rec.Violations = append(rec.Violations, violationRecord{
+			TS:     time.Now().UTC().Format(time.RFC3339Nano),
+			Kind:   violationStartState,
+			Detail: err.Error(),
+		})
+		jrnl.emit(event{Event: evViolation, Kind: violationStartState, Detail: err.Error()})
+		fmt.Fprintf(os.Stderr, "[chaos] start state: %v\n", err)
+		return exitFatal
+	}
+	jrnl.emit(event{Event: evStateApplied, Detail: "hairpin + multi-vlan + port-forward layered on the bootstrap baseline"})
+
+	// The prober and the baseline checks run for the whole run, alongside
+	// the engine. Both are cancelled and then *waited for* before the run
+	// record is read: a sweep still in flight would otherwise be
+	// appending violations while the summary is being written.
+	sideCtx, stopSide := context.WithCancel(ctx)
+	defer stopSide()
+
+	probes := newProber(l, probeTargets, jrnl, time.Now)
+	probes.start(sideCtx)
+
+	e := newEngine(l, actions, probes, jrnl, rec)
+	e.followMaster(ctx)
+
+	checks := &baselineChecks{lab: l, engine: e}
+	checksDone := make(chan struct{})
+	go func() {
+		defer close(checksDone)
+		checks.run(sideCtx)
+	}()
+
+	e.run(ctx)
+
+	stopSide()
+	probes.stop()
+	<-checksDone
+	checks.finalize()
+	rec.Probes = probes.summary()
+	return exitPass
+}
+
+func writeRecord(rec *runRecord, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	return rec.write(f)
+}
+
+// collectLabState reuses the lab's existing artifact collector so a
+// failed chaos run leaves the same bundle every scenario leaves.
+// Best-effort: a missing collector must not mask the run's own verdict.
+//
+// It only runs when the lab is already in a bad state, which is exactly
+// when one of its `docker exec`s can wedge — hence the deadline. Without
+// it the runner would hang with its exit code undelivered until CI kills
+// the job, and no artifacts would be uploaded at all.
+func collectLabState(collect, labName, outDir string) {
+	dest := filepath.Join(outDir, "lab-state")
+	ctx, cancel := context.WithTimeout(context.Background(), collectTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, collect, dest)
+	// The collector resolves its containers as clab-${LAB:-ovn-e2e}-<node>,
+	// and -lab is the runner's own name for the same lab. Without it a run
+	// against a non-default lab collects a bundle of empty files — every
+	// command in the script is best-effort, so it still exits 0 and the
+	// runner still reports the bundle as collected.
+	cmd.Env = append(os.Environ(), "LAB="+labName)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "[chaos] lab-state collection failed: %v\n", err)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "[chaos] lab state collected into %s\n", dest)
+}

--- a/test/e2e/chaos/main_test.go
+++ b/test/e2e/chaos/main_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Bad inputs must fail before a single fault is injected: a run built on
+// a contradiction cannot be replayed and is not worth a lab.
+func TestRunRejectsInvalidInputs(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+		tickMin  time.Duration
+		tickMax  time.Duration
+		weights  string
+		wantErr  string
+	}{
+		{
+			name:     "tick bounds inverted",
+			duration: time.Minute,
+			tickMin:  30 * time.Second,
+			tickMax:  10 * time.Second,
+			wantErr:  "below -tick-min",
+		},
+		// A tick interval near zero spins the loop and writes a decision
+		// line per iteration: gigabytes of journal on a run that measures
+		// nothing, because no fault fits between two ticks.
+		{
+			name:     "tick interval below the floor",
+			duration: time.Minute,
+			tickMin:  0,
+			tickMax:  0,
+			wantErr:  "below the 100ms floor",
+		},
+		{
+			name:     "tick interval well below the floor but not zero",
+			duration: time.Minute,
+			tickMin:  time.Millisecond,
+			tickMax:  5 * time.Millisecond,
+			wantErr:  "below the 100ms floor",
+		},
+		// The inputs are journaled in milliseconds, so a sub-millisecond
+		// duration would truncate to a zero-tick run reporting "pass".
+		{
+			name:     "duration below the floor",
+			duration: 500 * time.Microsecond,
+			tickMin:  10 * time.Second,
+			tickMax:  30 * time.Second,
+			wantErr:  "below the 1s floor",
+		},
+		{
+			name:     "unknown action in the weights",
+			duration: time.Minute,
+			tickMin:  10 * time.Second,
+			tickMax:  30 * time.Second,
+			weights:  "gateway-melt=1",
+			wantErr:  "unknown action",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := t.TempDir()
+
+			code, err := run(config{
+				seed:       42,
+				duration:   tc.duration,
+				tickMin:    tc.tickMin,
+				tickMax:    tc.tickMax,
+				weightSpec: tc.weights,
+				labName:    "ovn-e2e",
+				outDir:     out,
+				collect:    "/nonexistent",
+			})
+
+			if code != exitFatal {
+				t.Fatalf("exit code = %d, want %d", code, exitFatal)
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %v, want one mentioning %q", err, tc.wantErr)
+			}
+			// Nothing was set up, so nothing was written.
+			if entries, _ := os.ReadDir(out); len(entries) != 0 {
+				t.Fatalf("a rejected run left artifacts behind: %v", entries)
+			}
+		})
+	}
+}
+
+func TestWriteRecordProducesTheRunSummary(t *testing.T) {
+	path := filepath.Join(t.TempDir(), summaryFile)
+	rec := &runRecord{
+		Inputs:     runInputs{Seed: 42, Lab: "ovn-e2e", Weights: map[string]int{"gateway-kill": 1}},
+		Violations: []violationRecord{{Kind: violationRecoveryTimeout, Target: "gateway-2", Detail: "budget"}},
+	}
+	rec.finalize(time.Now())
+
+	if err := writeRecord(rec, path); err != nil {
+		t.Fatalf("writeRecord: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var decoded runRecord
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("%s is not valid JSON: %v", summaryFile, err)
+	}
+	if decoded.Schema != recordSchema {
+		t.Fatalf("schema = %q, want %q", decoded.Schema, recordSchema)
+	}
+	if decoded.Result != resultFail {
+		t.Fatalf("result = %q, want %q — the run recorded a violation", decoded.Result, resultFail)
+	}
+	if decoded.Inputs.Seed != 42 || decoded.Inputs.Weights["gateway-kill"] != 1 {
+		t.Fatalf("the record did not echo its inputs: %+v", decoded.Inputs)
+	}
+}
+
+// The collector resolves its containers as clab-${LAB:-ovn-e2e}-<node>,
+// and -lab is the runner's own name for the same lab. Without the
+// hand-off, a run against a non-default lab dumps its bundle for
+// containers that do not exist — and because every command in the
+// collector is best-effort, it exits 0 and the runner reports a directory
+// of empty files as collected lab state, on the exact run that produced a
+// violation.
+func TestCollectLabStateHandsTheLabNameToTheCollector(t *testing.T) {
+	dir := t.TempDir()
+	collector := filepath.Join(dir, "collect.sh")
+	script := "#!/bin/sh\nmkdir -p \"$1\"\nprintf '%s' \"${LAB:-ovn-e2e}\" >\"$1/lab\"\n"
+	if err := os.WriteFile(collector, []byte(script), 0o755); err != nil {
+		t.Fatalf("write the fake collector: %v", err)
+	}
+
+	collectLabState(collector, "my-lab", dir)
+
+	got, err := os.ReadFile(filepath.Join(dir, "lab-state", "lab"))
+	if err != nil {
+		t.Fatalf("the collector did not run: %v", err)
+	}
+	if string(got) != "my-lab" {
+		t.Fatalf("the collector resolved containers for lab %q, want the runner's -lab", got)
+	}
+}
+
+func TestWriteRecordReportsAnUnwritablePath(t *testing.T) {
+	rec := &runRecord{}
+	rec.finalize(time.Now())
+
+	err := writeRecord(rec, filepath.Join(t.TempDir(), "no-such-dir", summaryFile))
+	if err == nil {
+		t.Fatal("a run record that could not be written was reported as written")
+	}
+}

--- a/test/e2e/chaos/probe.go
+++ b/test/e2e/chaos/probe.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"time"
+)
+
+const (
+	probeInterval   = time.Second
+	lossBucketWidth = 10 * time.Second
+)
+
+type probeKind int
+
+const (
+	probePing probeKind = iota
+	probeHTTP
+)
+
+// probeTarget is one continuously-measured reachability check from
+// client-1.
+type probeTarget struct {
+	name string
+	kind probeKind
+	addr string
+}
+
+// targetState is one probe's live status and history.
+type targetState struct {
+	up          bool
+	sent        int
+	lost        int
+	transitions int
+	// lastUpAt is when the target most recently went from red to green.
+	// The engine dates recovery from it.
+	lastUpAt time.Time
+	buckets  map[int64]*lossBucket
+}
+
+// prober measures every probe target continuously — one goroutine per
+// target — for the whole run, so loss during a fault hold is recorded
+// even though the engine is blocked executing the action.
+type prober struct {
+	lab       *lab
+	targets   []probeTarget
+	jrnl      *journal
+	now       func() time.Time
+	startedAt time.Time
+
+	mu    sync.Mutex
+	state map[string]*targetState
+	wg    sync.WaitGroup
+}
+
+func newProber(l *lab, targets []probeTarget, jrnl *journal, now func() time.Time) *prober {
+	p := &prober{
+		lab:       l,
+		targets:   targets,
+		jrnl:      jrnl,
+		now:       now,
+		startedAt: now(),
+		state:     make(map[string]*targetState, len(targets)),
+	}
+	for _, t := range targets {
+		// Start green: a target that is already down when the run
+		// begins produces a transition on its first sample, which is
+		// exactly what the operator wants to see in the journal.
+		p.state[t.name] = &targetState{up: true, buckets: map[int64]*lossBucket{}}
+	}
+	return p
+}
+
+// start launches one sampling goroutine per target and returns. They
+// exit when ctx is cancelled; stop() waits for them. Unlike engine.run
+// and baselineChecks.run, this one does not block.
+func (p *prober) start(ctx context.Context) {
+	for _, t := range p.targets {
+		p.wg.Add(1)
+		go func() {
+			defer p.wg.Done()
+			ticker := time.NewTicker(probeInterval)
+			defer ticker.Stop()
+			for {
+				p.sample(ctx, t)
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+				}
+			}
+		}()
+	}
+}
+
+func (p *prober) stop() { p.wg.Wait() }
+
+// sample runs one probe and folds the result into the target's state.
+func (p *prober) sample(ctx context.Context, t probeTarget) {
+	var err error
+	switch t.kind {
+	case probeHTTP:
+		err = p.lab.httpGet(ctx, t.addr)
+	case probePing:
+		err = p.lab.ping(ctx, t.addr)
+	}
+	if ctx.Err() != nil {
+		// The run is over; a probe cancelled mid-flight is not loss.
+		return
+	}
+	p.record(t.name, err == nil)
+}
+
+func (p *prober) record(name string, up bool) {
+	now := p.now()
+
+	p.mu.Lock()
+	st, ok := p.state[name]
+	if !ok {
+		p.mu.Unlock()
+		return
+	}
+	st.sent++
+	if !up {
+		st.lost++
+	}
+	offset := now.Sub(p.startedAt) / lossBucketWidth * lossBucketWidth
+	bucket, ok := st.buckets[offset.Milliseconds()]
+	if !ok {
+		bucket = &lossBucket{OffsetMS: offset.Milliseconds()}
+		st.buckets[offset.Milliseconds()] = bucket
+	}
+	bucket.Sent++
+	if !up {
+		bucket.Lost++
+	}
+	changed := st.up != up
+	if changed {
+		st.up = up
+		st.transitions++
+		if up {
+			st.lastUpAt = now
+		}
+	}
+	p.mu.Unlock()
+
+	if changed {
+		p.jrnl.emit(event{Event: evProbeTransition, Probe: name, Up: boolPtr(up)})
+	}
+}
+
+// allGreen reports whether every target is currently up.
+func (p *prober) allGreen() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, st := range p.state {
+		if !st.up {
+			return false
+		}
+	}
+	return true
+}
+
+// redTargets names the targets that are currently down — the detail a
+// recovery-timeout violation carries.
+func (p *prober) redTargets() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var red []string
+	for _, t := range p.targets {
+		if st := p.state[t.name]; st != nil && !st.up {
+			red = append(red, t.name)
+		}
+	}
+	return red
+}
+
+// recoverySince reports, per target, how long after `anchor` it came
+// back. A target that never went red after the anchor recovers in 0 ms.
+func (p *prober) recoverySince(anchor time.Time) map[string]int64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make(map[string]int64, len(p.targets))
+	for _, t := range p.targets {
+		st := p.state[t.name]
+		if st == nil {
+			continue
+		}
+		if st.lastUpAt.After(anchor) {
+			out[t.name] = st.lastUpAt.Sub(anchor).Milliseconds()
+			continue
+		}
+		out[t.name] = 0
+	}
+	return out
+}
+
+// summary renders the per-target run-record section, buckets ordered by
+// offset so "probe loss over time" reads as a series.
+func (p *prober) summary() map[string]probeSummary {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make(map[string]probeSummary, len(p.targets))
+	for _, t := range p.targets {
+		st := p.state[t.name]
+		if st == nil {
+			continue
+		}
+		sum := probeSummary{
+			Target:      t.addr,
+			Sent:        st.sent,
+			Lost:        st.lost,
+			Transitions: st.transitions,
+			Buckets:     []lossBucket{},
+		}
+		offsets := make([]int64, 0, len(st.buckets))
+		for offset := range st.buckets {
+			offsets = append(offsets, offset)
+		}
+		slices.Sort(offsets)
+		for _, offset := range offsets {
+			sum.Buckets = append(sum.Buckets, *st.buckets[offset])
+		}
+		out[t.name] = sum
+	}
+	return out
+}

--- a/test/e2e/chaos/probe_test.go
+++ b/test/e2e/chaos/probe_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The probe primitives are what every reachability verdict in the run
+// rests on: both are sourced from client-1, the external vantage point
+// the scenarios probe from.
+func TestProbesAreSourcedFromTheClient(t *testing.T) {
+	cmd := &fakeCommander{}
+	l := newTestLab(cmd, newFakeClock())
+	p := newProber(l, probeTargets, newJournal(&bytes.Buffer{}, newFakeClock().now), newFakeClock().now)
+
+	for _, target := range probeTargets {
+		p.sample(context.Background(), target)
+	}
+
+	want := []string{
+		"docker exec clab-ovn-e2e-client-1 ping -c 1 -W 1 192.0.2.10",
+		"docker exec clab-ovn-e2e-client-1 ping -c 1 -W 1 192.0.2.12",
+		"docker exec clab-ovn-e2e-client-1 ping -c 1 -W 1 198.51.100.10",
+		"docker exec clab-ovn-e2e-client-1 ping -c 1 -W 1 203.0.113.10",
+		"docker exec clab-ovn-e2e-client-1 curl --silent --max-time 3 --output /dev/null http://192.0.2.50:80/",
+	}
+	got := cmd.lines()
+	if len(got) != len(want) {
+		t.Fatalf("issued %d probes for %d targets: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("probe %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// A failing probe is loss, and the red→green edge is journaled so a
+// reader can line the outage up against the fault that caused it.
+func TestSampleRecordsLossAndJournalsTransitions(t *testing.T) {
+	var down bool
+	cmd := &fakeCommander{respond: func([]string) (string, error) {
+		if down {
+			return "", errBoom
+		}
+		return "", nil
+	}}
+	clock := newFakeClock()
+	var buf bytes.Buffer
+	target := probeTarget{"fip-vm1", probePing, "192.0.2.10"}
+	p := newProber(newTestLab(cmd, clock), []probeTarget{target},
+		newJournal(&buf, clock.now), clock.now)
+
+	p.sample(context.Background(), target) // green
+	down = true
+	p.sample(context.Background(), target) // red
+	down = false
+	p.sample(context.Background(), target) // green again
+
+	sum := p.summary()["fip-vm1"]
+	if sum.Sent != 3 || sum.Lost != 1 {
+		t.Fatalf("sent/lost = %d/%d, want 3/1", sum.Sent, sum.Lost)
+	}
+	if sum.Transitions != 2 {
+		t.Fatalf("transitions = %d, want 2", sum.Transitions)
+	}
+	var down1, up1 bool
+	for _, ev := range eventsIn(t, buf.String()) {
+		if ev.Event != evProbeTransition || ev.Probe != "fip-vm1" || ev.Up == nil {
+			continue
+		}
+		if *ev.Up {
+			up1 = true
+		} else {
+			down1 = true
+		}
+	}
+	if !down1 || !up1 {
+		t.Fatalf("both probe transitions were not journaled: %q", buf.String())
+	}
+}
+
+// A probe cancelled mid-flight because the run ended is not loss — it
+// would otherwise pollute the final loss bucket of every run.
+func TestSampleIgnoresACancelledProbe(t *testing.T) {
+	cmd := &fakeCommander{respond: func([]string) (string, error) { return "", errBoom }}
+	clock := newFakeClock()
+	target := probeTarget{"fip-vm1", probePing, "192.0.2.10"}
+	p := newProber(newTestLab(cmd, clock), []probeTarget{target},
+		newJournal(&bytes.Buffer{}, clock.now), clock.now)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	p.sample(ctx, target)
+
+	if sum := p.summary()["fip-vm1"]; sum.Sent != 0 || sum.Lost != 0 {
+		t.Fatalf("a cancelled probe was counted: sent/lost = %d/%d", sum.Sent, sum.Lost)
+	}
+}
+
+// The sampling goroutines must stop when the run does, or the runner
+// would never exit.
+func TestProberStopsWithItsContext(t *testing.T) {
+	cmd := &fakeCommander{}
+	clock := newFakeClock()
+	p := newProber(newTestLab(cmd, clock), probeTargets,
+		newJournal(&bytes.Buffer{}, clock.now), clock.now)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p.start(ctx)
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		p.stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the prober did not stop when its context was cancelled")
+	}
+
+	// Every target was sampled at least once before the shutdown.
+	for _, target := range probeTargets {
+		if !cmd.called(target.addr) && !cmd.called(strings.TrimPrefix(target.addr, "http://")) {
+			t.Fatalf("target %s was never probed: %v", target.name, cmd.lines())
+		}
+	}
+}

--- a/test/e2e/chaos/state.go
+++ b/test/e2e/chaos/state.go
@@ -1,0 +1,333 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// The combined start state layers the setups of three existing scenarios
+// on top of the bootstrap baseline, so one chaos run exercises all of
+// them at once:
+//
+//   - hairpin.sh      — a second FIP (192.0.2.12) with a vm2 responder,
+//     so the master carries two FIPs and the hairpin flow is live.
+//   - multi-vlan.sh   — two VLAN provider networks (tags 101/102), each
+//     with a router pinned to gateway-1 and a FIP behind a responder.
+//   - pf-external.sh  — a Load_Balancer VIP (192.0.2.50:80) in front of
+//     the vm1 backend, plus the two routes the agent does not manage.
+//
+// The bootstrap baseline itself (HA router, FIP 192.0.2.10, the vm1
+// workload) is assumed — the runner drives a lab that `make e2e-up`
+// already brought up.
+//
+// Everything below mirrors the command blocks in those scripts. The
+// layering is idempotent for the same reason theirs is (--may-exist,
+// `ip ... replace`, guarded `ip link add`), which is what makes it
+// reusable as the post-fault restore path.
+
+// startStateTimeout is how long the layered state gets to come up green
+// before the run is abandoned — a start state that never went green
+// would report every later fault as a false violation.
+const startStateTimeout = 120 * time.Second
+
+// probeTargets is what the run measures continuously from client-1.
+//
+// The baseline lab's second FIP, 192.0.2.11, is deliberately absent:
+// bootstrap.sh seeds its NAT row but nothing answers behind
+// 192.168.10.11, so probing it would be red for the whole run.
+var probeTargets = []probeTarget{
+	{"fip-vm1", probePing, "192.0.2.10"},
+	{"fip-vm2", probePing, "192.0.2.12"},
+	{"fip-vlan101", probePing, "198.51.100.10"},
+	{"fip-vlan102", probePing, "203.0.113.10"},
+	{"pf-vip", probeHTTP, vipURL},
+}
+
+// vlanNetwork is one row of multi-vlan.sh's NETWORKS table.
+type vlanNetwork struct {
+	tag    string
+	pub    string // public /24 prefix
+	tenant string // tenant /24 prefix
+	hex    string // MAC octet
+}
+
+var vlanNetworks = []vlanNetwork{
+	{"101", "198.51.100", "192.168.101", "65"},
+	{"102", "203.0.113", "192.168.102", "66"},
+}
+
+// netns is a kernel-side responder on the workload host: a veth pair
+// with the host end on br-int carrying the OVN logical port's iface-id,
+// and the peer end in a netns with the tenant address.
+type netns struct {
+	name string
+	lsp  string
+	mac  string
+	cidr string
+	gw   string
+}
+
+// responders is every netns the start state needs on gateway-3 — the
+// bootstrap vm1 plus the ones the three layers add. reprovisionNode
+// re-creates all of them after gateway-3 has been through a container
+// lifecycle event, which destroys its network namespace.
+func responders() []netns {
+	all := []netns{
+		// bootstrap.sh:ensure_workload_netns
+		{"vm1", "ls0-vm1", "02:00:00:00:0a:0a", "192.168.10.10/24", "192.168.10.1"},
+		// hairpin.sh:ensure_fip_b_responder
+		{"vm2", "ls0-vm2", "02:00:00:00:0a:0b", "192.168.10.12/24", "192.168.10.1"},
+	}
+	// multi-vlan.sh:ensure_responder
+	for _, n := range vlanNetworks {
+		all = append(all, netns{
+			name: "vm" + n.tag,
+			lsp:  "vm" + n.tag,
+			mac:  "02:00:00:" + n.hex + ":0a:0a",
+			cidr: n.tenant + ".10/24",
+			gw:   n.tenant + ".1",
+		})
+	}
+	return all
+}
+
+// applyStartState layers the three scenario setups onto the baseline and
+// waits for every probe target to answer.
+func applyStartState(ctx context.Context, l *lab) error {
+	if err := applyHairpinLayer(ctx, l); err != nil {
+		return err
+	}
+	for _, n := range vlanNetworks {
+		if err := applyVLANLayer(ctx, l, n); err != nil {
+			return err
+		}
+	}
+	if err := ensureResponders(ctx, l); err != nil {
+		return err
+	}
+	if err := applyPortForwardLayer(ctx, l); err != nil {
+		return err
+	}
+	return waitStartStateGreen(ctx, l)
+}
+
+// applyHairpinLayer mirrors ensure_fip_b_lsp / ensure_fip_b_nat in
+// hairpin.sh. The responder itself is created by ensureResponders.
+func applyHairpinLayer(ctx context.Context, l *lab) error {
+	steps := [][]string{
+		{"--may-exist", "lsp-add", "ls0", "ls0-vm2"},
+		{"lsp-set-addresses", "ls0-vm2", "02:00:00:00:0a:0b 192.168.10.12"},
+		{"--may-exist", "lr-nat-add", "lr0", "dnat_and_snat", "192.0.2.12", "192.168.10.12"},
+	}
+	for _, args := range steps {
+		if _, err := l.nbctl(ctx, args...); err != nil {
+			return fmt.Errorf("hairpin layer: %w", err)
+		}
+	}
+	return nil
+}
+
+// applyVLANLayer mirrors ensure_network in multi-vlan.sh: a VLAN
+// provider network on physnet1, a gatewayless public subnet, a router
+// pinned to gateway-1, and a FIP with a backing LSP.
+func applyVLANLayer(ctx context.Context, l *lab, n vlanNetwork) error {
+	lsPub := "ls-vlan" + n.tag
+	lnLSP := "ln-vlan" + n.tag
+	lsTenant := "ls-vlan" + n.tag + "-t"
+	lr := "lr-vlan" + n.tag
+	lrpPub := "lr-vlan" + n.tag + "-public"
+	lrpTen := "lr-vlan" + n.tag + "-tenant"
+	vm := "vm" + n.tag
+
+	steps := [][]string{
+		{"--may-exist", "ls-add", lsPub},
+		{"--may-exist", "lsp-add", lsPub, lnLSP},
+		{"lsp-set-type", lnLSP, "localnet"},
+		{"lsp-set-addresses", lnLSP, "unknown"},
+		{"lsp-set-options", lnLSP, "network_name=physnet1"},
+		{"set", "Logical_Switch_Port", lnLSP, "tag=" + n.tag},
+
+		{"--may-exist", "ls-add", lsTenant},
+		{"--may-exist", "lr-add", lr},
+
+		{"--may-exist", "lrp-add", lr, lrpTen, "02:00:00:" + n.hex + ":01:01", n.tenant + ".1/24"},
+		{"--may-exist", "lsp-add", lsTenant, lsTenant + "-" + lr},
+		{"lsp-set-type", lsTenant + "-" + lr, "router"},
+		{"lsp-set-addresses", lsTenant + "-" + lr, "router"},
+		{"lsp-set-options", lsTenant + "-" + lr, "router-port=" + lrpTen},
+
+		{"--may-exist", "lrp-add", lr, lrpPub, "02:00:00:" + n.hex + ":02:01", n.pub + ".1/24"},
+		{"--may-exist", "lsp-add", lsPub, lsPub + "-" + lr},
+		{"lsp-set-type", lsPub + "-" + lr, "router"},
+		{"lsp-set-addresses", lsPub + "-" + lr, "router"},
+		{"lsp-set-options", lsPub + "-" + lr, "router-port=" + lrpPub},
+
+		// The VLAN routers stay pinned to gateway-1 the way the scenario
+		// pins them. A chaos run migrates cr-lr0-public around, but these
+		// routers have a single candidate chassis — so a fault on
+		// gateway-1 legitimately darkens both VLAN FIPs until it is back.
+		{"lrp-set-gateway-chassis", lrpPub, "gateway-1", "30"},
+
+		{"--may-exist", "lr-nat-add", lr, "dnat_and_snat", n.pub + ".10", n.tenant + ".10"},
+		{"--may-exist", "lsp-add", lsTenant, vm},
+		{"lsp-set-addresses", vm, "02:00:00:" + n.hex + ":0a:0a " + n.tenant + ".10"},
+	}
+	for _, args := range steps {
+		if _, err := l.nbctl(ctx, args...); err != nil {
+			return fmt.Errorf("vlan %s layer: %w", n.tag, err)
+		}
+	}
+	return nil
+}
+
+// applyPortForwardLayer mirrors pf-external.sh: the backend in the vm1
+// netns, the Load_Balancer, and the two routes the agent does not manage
+// (which ensureVIPRouting keeps pointed at the current master from here
+// on).
+func applyPortForwardLayer(ctx context.Context, l *lab) error {
+	if err := startPFBackend(ctx, l); err != nil {
+		return err
+	}
+	if _, err := l.nbctl(ctx, "--may-exist", "lb-add", "pf-external",
+		vipAddr+":80", "192.168.10.10:8080", "tcp"); err != nil {
+		return fmt.Errorf("port-forward layer: %w", err)
+	}
+	if _, err := l.nbctl(ctx, "--may-exist", "lr-lb-add", "lr0", "pf-external"); err != nil {
+		return fmt.Errorf("port-forward layer: %w", err)
+	}
+	master := l.currentMaster(ctx)
+	if master == "" {
+		return fmt.Errorf("port-forward layer: %s is unbound, cannot point the VIP anywhere", crPort)
+	}
+	if err := l.ensureVIPRouting(ctx, master); err != nil {
+		return fmt.Errorf("port-forward layer: %w", err)
+	}
+	return nil
+}
+
+// startPFBackend (re)starts the HTTP responder behind the VIP in the vm1
+// netns and waits for it to bind — start_backend in pf-external.sh. Any
+// previous instance is killed first, so this doubles as the restore path
+// after gateway-3 has been recycled.
+func startPFBackend(ctx context.Context, l *lab) error {
+	if _, err := l.sh(ctx, workloadHost,
+		"pkill -f /usr/local/bin/pf-backend || true; : >/tmp/pf-backend.log"); err != nil {
+		return fmt.Errorf("reset pf-backend on %s: %w", workloadHost, err)
+	}
+	if _, err := l.docker(ctx, "exec", "-d", l.node(workloadHost),
+		"ip", "netns", "exec", "vm1", "/usr/local/bin/pf-backend",
+		"-addr", ":8080", "-log", "/tmp/pf-backend.log"); err != nil {
+		return fmt.Errorf("start pf-backend on %s: %w", workloadHost, err)
+	}
+	deadline := l.now().Add(10 * time.Second)
+	for l.now().Before(deadline) {
+		if _, err := l.sh(ctx, workloadHost,
+			"ip netns exec vm1 ss -ltn 'sport = :8080' | grep -q LISTEN"); err == nil {
+			return nil
+		}
+		l.sleep(time.Second)
+	}
+	return fmt.Errorf("pf-backend did not bind on :8080 within 10s")
+}
+
+// ensureResponders (re)creates every kernel-side responder on the
+// workload host. Idempotent, and the shape is lifted verbatim from
+// ensure_workload_netns in bootstrap.sh.
+func ensureResponders(ctx context.Context, l *lab) error {
+	for _, n := range responders() {
+		hostVeth := n.name + "-host"
+		nsVeth := n.name + "-eth0"
+		script := strings.Join([]string{
+			fmt.Sprintf("ip link show %s >/dev/null 2>&1 || ip link add %s type veth peer name %s",
+				hostVeth, hostVeth, nsVeth),
+			fmt.Sprintf("ovs-vsctl --may-exist add-port br-int %s -- set Interface %s external_ids:iface-id=%s",
+				hostVeth, hostVeth, n.lsp),
+			fmt.Sprintf("ip link set %s up", hostVeth),
+			fmt.Sprintf("ip netns list | awk '{print $1}' | grep -qx %s || ip netns add %s", n.name, n.name),
+			fmt.Sprintf("ip -n %s link show %s >/dev/null 2>&1 || ip link set %s netns %s",
+				n.name, nsVeth, nsVeth, n.name),
+			fmt.Sprintf("ip -n %s link set lo up", n.name),
+			fmt.Sprintf("ip -n %s link set %s address %s", n.name, nsVeth, n.mac),
+			fmt.Sprintf("ip -n %s link set %s up", n.name, nsVeth),
+			fmt.Sprintf("ip -n %s addr replace %s dev %s", n.name, n.cidr, nsVeth),
+			fmt.Sprintf("ip -n %s route replace default via %s", n.name, n.gw),
+		}, "; ")
+		if _, err := l.sh(ctx, workloadHost, script); err != nil {
+			return fmt.Errorf("provision responder %s on %s: %w", n.name, workloadHost, err)
+		}
+	}
+	return nil
+}
+
+// restoreNode returns a gateway to service after a container lifecycle
+// event. Two things are gone that `docker start` does not bring back:
+//
+//   - the containerlab veth `gateway-N:eth1 ↔ upstream:ethN`, and with
+//     it the underlay and the BGP session (rewireUnderlay), and
+//   - on the workload host, every netns and veth behind the FIPs, plus
+//     the port-forward backend (reprovisionNode).
+//
+// This is the path the existing scenarios avoid — they either leave the
+// container up or recycle the whole lab. A chaos run has to put the node
+// back, because the guardrails only re-target a node that has returned
+// and converged.
+func restoreNode(ctx context.Context, l *lab, gw string) error {
+	if err := l.rewireUnderlay(ctx, gw); err != nil {
+		return err
+	}
+	return reprovisionNode(ctx, l, gw)
+}
+
+// reprovisionNode re-creates the node-local state a container restart
+// wiped. Only the workload host carries any — the VIP's scope-link route
+// is re-applied by ensureVIPRouting during convergence, wherever the
+// master happens to be by then.
+func reprovisionNode(ctx context.Context, l *lab, gw string) error {
+	if gw != workloadHost {
+		return nil
+	}
+	if err := l.waitReady(ctx, gw, "ovs-vsctl br-exists br-int"); err != nil {
+		return fmt.Errorf("wait for br-int on %s: %w", gw, err)
+	}
+	if err := ensureResponders(ctx, l); err != nil {
+		return err
+	}
+	return startPFBackend(ctx, l)
+}
+
+// waitStartStateGreen holds the run until every probe target answers, so
+// a fault is never injected into a lab that was not green to begin with.
+func waitStartStateGreen(ctx context.Context, l *lab) error {
+	deadline := l.now().Add(startStateTimeout)
+	for l.now().Before(deadline) {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		red := redStartTargets(ctx, l)
+		if len(red) == 0 {
+			return nil
+		}
+		l.sleep(2 * time.Second)
+	}
+	return fmt.Errorf("start state not green within %s: %s",
+		startStateTimeout, strings.Join(redStartTargets(ctx, l), ", "))
+}
+
+func redStartTargets(ctx context.Context, l *lab) []string {
+	var red []string
+	for _, t := range probeTargets {
+		var err error
+		switch t.kind {
+		case probeHTTP:
+			err = l.httpGet(ctx, t.addr)
+		case probePing:
+			err = l.ping(ctx, t.addr)
+		}
+		if err != nil {
+			red = append(red, t.name)
+		}
+	}
+	return red
+}

--- a/test/e2e/chaos/state_test.go
+++ b/test/e2e/chaos/state_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// The start state is the union of three scenarios' setups on top of the
+// bootstrap baseline. All of it has to land, or the faults are injected
+// into a lab the probes cannot measure.
+func TestApplyStartStateLayersEveryScenarioSetup(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := applyStartState(context.Background(), l); err != nil {
+		t.Fatalf("applyStartState: %v", err)
+	}
+
+	for _, want := range []string{
+		// hairpin.sh: the second FIP and its backend LSP.
+		"lr-nat-add lr0 dnat_and_snat 192.0.2.12 192.168.10.12",
+		"lsp-set-addresses ls0-vm2 02:00:00:00:0a:0b 192.168.10.12",
+		// multi-vlan.sh: both provider networks.
+		"set Logical_Switch_Port ln-vlan101 tag=101",
+		"set Logical_Switch_Port ln-vlan102 tag=102",
+		// pf-external.sh: the Load_Balancer and the two hand-plumbed routes.
+		"lb-add pf-external 192.0.2.50:80 192.168.10.10:8080 tcp",
+		"lr-lb-add lr0 pf-external",
+		"ip route replace 192.0.2.50/32 via 100.64.1.2",
+		"ip route replace 192.0.2.50/32 dev br-ex scope link",
+		// Every responder behind a probed FIP.
+		"external_ids:iface-id=ls0-vm2",
+		"external_ids:iface-id=vm101",
+		"external_ids:iface-id=vm102",
+	} {
+		if !cmd.called(want) {
+			t.Fatalf("the start state did not issue %q", want)
+		}
+	}
+}
+
+// A lab that was never green cannot tell a fault apart from a
+// pre-existing break, so the run is abandoned instead of reporting false
+// violations for ten minutes.
+func TestApplyStartStateFailsWhenTheLabNeverGoesGreen(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		line := strings.Join(argv, " ")
+		// The VLAN FIP never answers — its router never came up.
+		if strings.Contains(line, "ping -c 1 -W 1 198.51.100.10") {
+			return "", errBoom
+		}
+		return healthyLabResponses(argv)
+	}}
+	l := newTestLab(cmd, newFakeClock())
+
+	err := applyStartState(context.Background(), l)
+	if err == nil {
+		t.Fatal("a start state with a dead FIP was accepted")
+	}
+	if !strings.Contains(err.Error(), "not green") || !strings.Contains(err.Error(), "fip-vlan101") {
+		t.Fatalf("error %q does not name the target that stayed red", err)
+	}
+}
+
+// The VIP has to be pointed somewhere. An unbound cr-lr0-public means
+// the lab has no master at all — worth failing loudly rather than
+// leaving the VIP probe red for the whole run.
+func TestPortForwardLayerFailsWhenTheGatewayPortIsUnbound(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "--columns=chassis find Port_Binding") {
+			return "\n", nil
+		}
+		return healthyLabResponses(argv)
+	}}
+	l := newTestLab(cmd, newFakeClock())
+
+	err := applyPortForwardLayer(context.Background(), l)
+	if err == nil {
+		t.Fatal("the VIP was plumbed even though no chassis owns the gateway port")
+	}
+	if !strings.Contains(err.Error(), crPort) {
+		t.Fatalf("error %q does not name the unbound port", err)
+	}
+}
+
+// restoreNode is the whole reason a killed node can be returned to
+// service: the underlay first, then the node-local workloads.
+func TestRestoreNodeRewiresBeforeReprovisioning(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := restoreNode(context.Background(), l, workloadHost); err != nil {
+		t.Fatalf("restoreNode: %v", err)
+	}
+
+	rewire := cmd.indexOf("containerlab tools veth create")
+	responder := cmd.indexOf("external_ids:iface-id=ls0-vm1")
+	if rewire < 0 || responder < 0 {
+		t.Fatalf("restore did not rewire and reprovision: %v", cmd.lines())
+	}
+	if rewire > responder {
+		t.Fatalf("the workloads were rebuilt before the underlay was back: %v", cmd.lines())
+	}
+}
+
+func TestRestoreNodeReportsAFailedRewire(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "containerlab tools veth create") {
+			return "", errBoom
+		}
+		return healthyLabResponses(argv)
+	}}
+	l := newTestLab(cmd, newFakeClock())
+
+	err := restoreNode(context.Background(), l, "gateway-2")
+	if err == nil {
+		t.Fatal("a failed veth re-create was reported as a successful restore")
+	}
+	if !strings.Contains(err.Error(), "re-create underlay veth") {
+		t.Fatalf("error %q does not name the step that failed", err)
+	}
+}
+
+// Every responder the probe set depends on must be in the table that
+// reprovisionNode rebuilds — a FIP whose responder is not restored would
+// stay red after its host is recycled and fail the next recovery gate.
+func TestEveryProbedFIPHasARestoredResponder(t *testing.T) {
+	lsps := map[string]bool{}
+	for _, n := range responders() {
+		lsps[n.lsp] = true
+	}
+	for _, want := range []string{"ls0-vm1", "ls0-vm2", "vm101", "vm102"} {
+		if !lsps[want] {
+			t.Fatalf("responder for %s is not rebuilt after its host is recycled", want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #176

Adds a seeded chaos runner that drives the existing containerlab E2E lab through a randomized fault sequence for a bounded duration. The eight scenarios each prove one fault in isolation; this is the driver that makes faults overlap and repeat, and it is the base the follow-up packages (profiles, extended faults, the invariant oracle) plug into.

## The change set, in commit order

**`a0af509` test/e2e: add a seeded chaos runner for the E2E lab** — the new `test/e2e/chaos` Go package (`go run ./test/e2e/chaos`):

- **`main.go`** — flags and the run lifecycle. Inputs are `-seed` (42), `-duration` (10m), `-tick-min`/`-tick-max` (10–30s), `-weights`, `-lab`, `-out`. Exit codes: `0` passed, `1` recorded a violation, `2` could not set the run up; a non-zero exit dumps lab state via the existing `collect-artifacts.sh`.
- **`engine.go`** — the tick loop: wait a randomized interval, pick a weighted action, check guardrails, execute, wait for the node to converge, record. Guardrails keep a run meaningful (at least one gateway stays healthy; a node is only re-targeted once it has returned *and* converged). Note the replay detail: all four draws per tick happen *before* the guardrails are consulted, so a skipped decision cannot shift the PCG stream — that is what makes "same inputs, same sequence" hold.
- **`actions.go`** — the four starter actions, each reusing a fault mechanic an existing scenario already proves: `controller-restart` (failover.sh), `gateway-kill` (stale-chassis.sh SIGKILL), `agent-terminate` (drain-hitless.sh SIGTERM to PID 1), `gateway-restart` (pf-hairpin.sh `docker restart`). Recovery budgets differ per action because container-lifecycle faults cost a full daemon bring-up, not just a re-election. The registry order is part of the replay contract — new actions get appended, never inserted.
- **`state.go`** — the combined start state, layering the hairpin, multi-VLAN and port-forward scenario setups on the bootstrap baseline. The layering is idempotent (`--may-exist`, `ip … replace`, guarded `ip link add`), which is what lets it double as the post-fault restore path.
- **`probe.go` / `checks.go`** — a continuous probe of all four FIPs and the port-forward VIP from `client-1`, plus the always-on baseline sweep (`agent-alive`, `dual-claim`: no chassisredirect port claimed by two chassis at once).
- **`journal.go`** — the two artifacts: `journal.jsonl` (one object per decision/phase, in order) and `summary.json` (inputs, actions executed, probe loss over time, recovery durations, violations).
- **`lab.go`** — the `commander` seam over `docker`/`containerlab`. Every host CLI call funnels through it, bounded by a timeout, so the tests swap exactly this interface and exercise the *real* engine, actions and state layering against recorded argv. The tests are therefore hermetic and run under `make test` on any platform.

**`e14dc06` build: add the `e2e-chaos` make target** — runs the runner against a lab that is already up, mirroring the per-scenario `e2e-*` targets. `CHAOS_FLAGS` passes flags through, so a replay is "same flags, same decision sequence".

**`557db84` docs: document the E2E chaos runner** — harness layout, scenario table, the inputs and the replay contract (including the two-run `jq` diff recipe), the combined start state, the four actions with their guardrails and budgets, artifacts and exit codes.

## Divergences from the issue worth a reviewer's attention

- **A CI job is included, though the issue scoped CI to a later package.** `.github/workflows/e2e.yml` gains a `chaos` job that is **`workflow_dispatch`-only** and gated on `baseline`. The reasoning (in the job's comment): this is the only place `execCommander`, the `containerlab tools veth create` re-wire and the artifact collector run against a real lab, and a manual job gives them a CI path without adding ~15 min to every PR. It deliberately does not run per-PR, because a chaos run leaves the master wherever the last election put it. If you would rather this land with the CI package instead, it is a self-contained block to drop.
- **`restoreNode` re-creates the containerlab veth.** Any container exit destroys the veth to upstream. The other scenarios sidestep this by recycling the whole lab; a chaos run has to bring a killed node *back*, so it re-creates the veth, re-applies the underlay and BGP, and rebuilds the workload host's netns responders and port-forward backend. This contradicts the "recycle the lab" guidance elsewhere in the E2E docs and is called out there.
- **The port-forward VIP's two routes are re-pointed at the current master.** `pf-external.sh` pins them to `gateway-1` because the agent does not manage `Load_Balancer` VIP routes. A chaos run migrates the master, so without this the VIP probe would go permanently red on the first re-election and every later violation would be noise.
- **`192.0.2.11` is not probed** — documented in the docs commit.

## Testing

Unit tests for every file in the package (~2.5k lines of test against ~2.4k of source), driving the real engine/actions/state against a fake docker. No live lab is required for `make test`; the runner itself is exercised against a real lab via `make e2e-chaos` and the manual CI job.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 01245b5 with Claude:claude-opus-4-8_
