### PR TITLE
test/e2e: drive chaos runs from configuration profiles

### DIFF
--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -226,7 +226,7 @@ Between bring-up and teardown, each scenario is its own `make` target:
 | Scenario | `make` target | What it asserts | Issue |
 | --- | --- | --- | --- |
 | [Baseline](#baseline) | `e2e-baseline` | An external client reaches a FIP once the agent reconciles. | [#45](https://github.com/osism/ovn-network-agent/issues/45) |
-| [Chaos runner](#chaos-runner) | `e2e-chaos` | Under a seeded, randomized fault sequence the agents stay alive, reachability recovers within budget, and no gateway port is claimed twice. | [#176](https://github.com/osism/ovn-network-agent/issues/176) |
+| [Chaos runner](#chaos-runner) | `e2e-chaos` | Under a seeded, randomized fault sequence — in any of six agent [configuration profiles](#configuration-profiles) — the agents stay alive, reachability recovers within budget, and no gateway port is claimed twice. | [#176](https://github.com/osism/ovn-network-agent/issues/176), [#177](https://github.com/osism/ovn-network-agent/issues/177) |
 | [Drain-hitless](#drain-hitless) | `e2e-drain-hitless` | A graceful `SIGTERM` drain loses fewer packets than a hard `docker kill` of the same chassis. | [#113](https://github.com/osism/ovn-network-agent/issues/113) |
 | [Failover](#failover) | `e2e-failover` | `cr-lr0-public` re-elects to a surviving chassis after the master is lost. | [#105](https://github.com/osism/ovn-network-agent/issues/105) |
 | [Hairpin](#hairpin) | `e2e-hairpin` | The `cookie=0x998` hairpin flow reflects FIP-to-FIP traffic on `br-ex`. | [#108](https://github.com/osism/ovn-network-agent/issues/108) |
@@ -864,13 +864,17 @@ would otherwise silently double.
 ```sh
 make e2e-chaos
 make e2e-chaos CHAOS_FLAGS="-duration 3m -seed 7 -out /tmp/chaos-a"
+make e2e-chaos CHAOS_FLAGS="-profile pf-only -duration 3m"
 ```
 
 [`chaos/`](https://github.com/osism/ovn-network-agent/tree/main/test/e2e/chaos)
 is not a scenario but a driver. The eight scenarios each prove one fault
-in isolation; production faults overlap and repeat. The runner drives the
-same lab through a *randomized* fault sequence for a bounded duration and
-leaves a journal you can triage from — and replay.
+in isolation, in one agent configuration; production faults overlap and
+repeat, and the configuration is not the same on every gateway or on
+every day. The runner drives the same lab through a *randomized* fault
+sequence, in a named [configuration profile](#configuration-profiles),
+for a bounded duration — and leaves a journal you can triage from, and
+replay.
 
 It is a Go `main` package rather than another bash script for two
 reasons: `$RANDOM` is not stable across bash versions, which would break
@@ -878,22 +882,28 @@ the replay contract outright, and the run needs concurrent probing plus
 structured artifacts. Its unit tests run under `make test` on any
 platform (they drive the real engine against a fake `docker`).
 
-**Inputs — and the replay contract.** The seed, the duration, the tick
-bounds and the action weights are the *only* inputs, and every decision
-the engine makes is drawn from a PCG stream seeded by `-seed` alone:
+**Inputs — and the replay contract.** The profile, the seed, the
+duration, the tick bounds and the action weights are the *only* inputs,
+and every decision the engine makes is drawn from a PCG stream seeded by
+`-seed` alone:
 
 | Flag | Default | Meaning |
 | --- | --- | --- |
-| `-seed` | `42` | Seeds every decision: the tick interval, the action, the target, the hold. |
+| `-seed` | `42` | Seeds every decision: the tick interval, the action, the target, the hold, the flip. |
+| `-profile` | `everything-on` | The [configuration profile](#configuration-profiles): the start topology and the agent configuration each gateway runs. An unknown name is rejected. |
 | `-duration` | `10m` | How long to keep injecting faults. Must be at least `1s`. |
 | `-tick-min` / `-tick-max` | `10s` / `30s` | Bounds of the interval between decisions. `-tick-min` must be at least `100ms`: a tick interval near zero spins the loop and grows the journal without bound, on a run where no fault fits between two ticks. |
 | `-weights` | registry defaults | `name=n,…`; an unknown action name is rejected. `-weights gateway-kill=0` disables a fault. |
 | `-lab` | `ovn-e2e` | containerlab lab name. |
 | `-out` | `chaos-artifacts` | Where the journal, the run record and the lab-state dump land. |
 | `-collect` | `test/e2e/scenarios/collect-artifacts.sh` | The lab-state collector, run into `<out>/lab-state` when the run does not pass. The default is repo-relative, so run the binary from the repo root (`make e2e-chaos` does). |
+| `-gwnode-config` | `test/e2e/gwnode-config.yaml` | The baked gateway agent config a profile's overlays are layered over. Also repo-relative. |
 
 Two runs with identical inputs against identically-behaving labs replay
-the identical action sequence. Diff them:
+the identical action sequence. **Profile and seed together** identify a
+run: the same seed under a different profile is a different run, and both
+are recorded in `journal.jsonl`'s `run-start` event and in
+`summary.json`. Diff two runs:
 
 ```sh
 make e2e-up && make e2e-chaos CHAOS_FLAGS="-duration 3m -out /tmp/chaos-a"
@@ -901,47 +911,143 @@ make e2e-down && make e2e-up
 make e2e-chaos CHAOS_FLAGS="-duration 3m -out /tmp/chaos-b"
 
 diff \
-  <(jq -c 'select(.event=="decision") | {tick,action,target,interval_ms,hold_ms}' /tmp/chaos-a/journal.jsonl) \
-  <(jq -c 'select(.event=="decision") | {tick,action,target,interval_ms,hold_ms}' /tmp/chaos-b/journal.jsonl)
+  <(jq -c 'select(.event=="decision") | {tick,action,target,interval_ms,hold_ms,flip}' /tmp/chaos-a/journal.jsonl) \
+  <(jq -c 'select(.event=="decision") | {tick,action,target,interval_ms,hold_ms,flip}' /tmp/chaos-b/journal.jsonl)
 ```
 
-Each tick draws exactly four values — interval, action, target, hold —
-**before** the guardrails are consulted, so a guardrail skip cannot shift
-the stream: the run that skipped a decision draws the same values
-afterwards as the run that executed it. Wall clock only bounds *how many*
-ticks fit in `-duration`, so a slower lab truncates the tail of the
-sequence rather than changing it.
+Each tick draws exactly five values — interval, action, target, hold,
+flip — **before** the guardrails are consulted, so a guardrail skip
+cannot shift the stream: the run that skipped a decision draws the same
+values afterwards as the run that executed it. The flip is drawn on every
+tick even though only `config-flip` reads it, for that same reason. Wall
+clock only bounds *how many* ticks fit in `-duration`, so a slower lab
+truncates the tail of the sequence rather than changing it.
 
-**Combined start state.** The runner layers the existing scenarios'
-setups onto the bootstrap baseline, so one run exercises all of them at
-once: `hairpin.sh`'s second FIP (`192.0.2.12` with a `vm2` responder),
+::: warning Sequences are versioned by the build, not by the seed alone
+A recorded seed replays the sequence it recorded only against the same
+runner. Adding an action to the registry, or a flip to the whitelist,
+changes the weighted pick and the number of values drawn per tick — so
+seeds from an older build replay differently. Both registries are
+append-only, which keeps the *change* mechanical; it does not make old
+sequences reproducible.
+:::
+
+**Start state.** The runner layers the existing scenarios' setups onto
+the bootstrap baseline, so one run can exercise all of them at once:
+`hairpin.sh`'s second FIP (`192.0.2.12` with a `vm2` responder),
 `multi-vlan.sh`'s two VLAN provider networks (tags 101/102, routers
 pinned to `gateway-1`), and `pf-external.sh`'s `Load_Balancer` VIP
-(`192.0.2.50:80` in front of the `vm1` backend). The layering is
-idempotent, which is what makes it reusable as the post-fault restore
-path. If the start state is not green within 120 s the run aborts with
-exit code 2 — a fault injected into a lab that was not green to begin
-with would report false violations for the rest of the run.
+(`192.0.2.50:80` in front of the `vm1` backend). Which of them a run puts
+up is the profile's call. The layering is idempotent, which is what makes
+it reusable as the post-fault restore path. If the start state is not
+green within 120 s the run aborts with exit code 2 — a fault injected
+into a lab that was not green to begin with would report false violations
+for the rest of the run.
 
 **Probes.** A goroutine per target samples reachability from `client-1`
 once a second for the whole run, so loss *during* a fault hold is
-recorded even while the engine is blocked:
+recorded even while the engine is blocked. The profile decides which
+targets a run measures — a target behind a layer the profile did not put
+up has no responder and would be red for the whole run:
 
-| Probe | Target |
-| --- | --- |
-| `fip-vm1` | `ping 192.0.2.10` |
-| `fip-vm2` | `ping 192.0.2.12` |
-| `fip-vlan101` | `ping 198.51.100.10` |
-| `fip-vlan102` | `ping 203.0.113.10` |
-| `pf-vip` | `curl http://192.0.2.50:80/` |
+| Probe | Target | Put up by |
+| --- | --- | --- |
+| `fip-vm1` | `ping 192.0.2.10` | the bootstrap baseline |
+| `fip-vm2` | `ping 192.0.2.12` | the hairpin layer |
+| `fip-vlan101` | `ping 198.51.100.10` | the VLAN layers |
+| `fip-vlan102` | `ping 203.0.113.10` | the VLAN layers |
+| `pf-vip` | `curl http://192.0.2.50:80/` | the port-forward layer (an OVN `Load_Balancer`) |
+| `api-vip` | `curl http://192.0.2.80:8080/` | the **agent's own** DNAT (`port_forwards`), on the gateways a profile configures it on |
 
 The baseline lab's second FIP, `192.0.2.11`, is deliberately **not**
 probed: `bootstrap.sh` seeds its NAT row but nothing answers behind
 `192.168.10.11`, so it would be red for the whole run.
 
+### Configuration profiles
+
+A profile is the run's *configuration* input (issue
+[#177](https://github.com/osism/ovn-network-agent/issues/177)): it names
+both the start topology and the agent configuration each gateway runs, as
+an overlay on the config the gwnode image bakes in
+(`test/e2e/gwnode-config.yaml`). The agent has six behaviour-changing
+configuration dimensions, and several of them change what it has to do
+entirely — port-forward-only mode skips all OVN work, a CIDR filter must
+*exclude* routes rather than add them — so a single-configuration chaos
+run leaves whole codepaths untested under fault load.
+
+The set is curated, not combinatorial:
+
+| `-profile` | Start topology | Agent configuration | Probes |
+| --- | --- | --- | --- |
+| `everything-on` (default) | hairpin + VLAN + port-forward | the baked lab config, unchanged | the four FIPs + `pf-vip` |
+| `flat-minimal` | baseline only | `cleanup_on_shutdown: true` | `fip-vm1` |
+| `flat-dnat` | hairpin + port-forward | the API VIP (`port_forwards` + `port_forward_l3mdev_accept`) | `fip-vm1`, `fip-vm2`, `pf-vip`, `api-vip` |
+| `vlan-no-dnat` | hairpin + VLAN | the baked lab config, unchanged | `fip-vm1`, `fip-vm2`, both VLAN FIPs |
+| `pf-only` | baseline only | **no OVN remotes** + the API VIP + `network_cidr` | `api-vip` |
+| `heterogeneous` | hairpin + VLAN + port-forward | `gateway-1` baked, `gateway-2` API VIP + drain, `gateway-3` manual `network_cidr` + 15 s cadence + cleanup | the four FIPs + `pf-vip` + `api-vip` |
+
+The **API VIP** (`192.0.2.80:8080`) is the agent's own DNAT path, as
+opposed to `pf-vip`, which is an OVN `Load_Balancer`. Its backend is a
+`pf-backend` responder in the gateway's *default* network namespace,
+reached via the gateway's own management address — which is why those
+gateways get `port_forward_l3mdev_accept` (the socket is in the default
+VRF while the VIP traffic ingresses `vrf-provider`). It lives inside
+`192.0.2.0/24` because the agent reconciles the FRR prefix-list to
+exactly the effective networks: a VIP outside every covered prefix is
+never announced. In `pf-only` that filter has to be set by hand
+(`network_cidr`) — without OVN there is nothing to discover it from.
+
+Under `heterogeneous`, `api-vip` is announced by `gateway-2` alone, so it
+is legitimately dark while `gateway-2` is held down — the same
+pinned-resource semantics the VLAN FIPs already have on `gateway-1`.
+
+**How a profile is applied.** No image rebuild, no redeploy: the config
+file is the only thing that changes, and the gwnode entrypoint `exec`s
+the agent, so `docker restart` is the reload.
+
+1. Render each gateway's config — the profile's overlay, key by key, over
+   the baked one.
+2. Write it to `/etc/ovn-network-agent/config.next.yaml` and validate it
+   with the agent's **own** `--check-config`, on *every* gateway, before a
+   single live file is touched. A rejected config aborts the run (exit
+   code 2) with the agent's reason and the live configs untouched.
+3. Roll the gateways one at a time: write the profile marker, `mv` the
+   staged config over the live one, `docker restart`, re-wire the node
+   (the same `restoreNode` the faults use), then gate on the container
+   being healthy and the chassis back in SB before the next gateway is
+   touched.
+
+A gateway already running the rendered config is **skipped** — no
+restart, no gate. On a fresh lab that is exactly what `everything-on`
+does: it renders the baked bytes verbatim and restarts nothing.
+
+::: details Why a marker file, and what it does to the drain
+`topology.clab.yml` sets `OVN_NETWORK_DRAIN_ON_SHUTDOWN` on every
+gateway, and the agent's environment layer beats its config file — so a
+profile that turns the drain *on* would never see it take effect. When a
+profile owns a gateway's config, the applier drops
+`/etc/ovn-network-agent/chaos-profile` next to it, and the entrypoint
+unsets the variable when it finds it. No marker, no change: every
+existing scenario, `drain-hitless` included, keeps the deploy-time
+switch. A gateway the profile leaves on the baked config has the marker
+removed.
+
+Chaos assumes the default deploy (`E2E_DRAIN_ON_SHUTDOWN` unset). Against
+a lab deployed with the drain forced on, the applier's view of a gateway
+that it has not reconfigured is wrong until the first flip writes the
+marker.
+:::
+
+::: warning Profiles add OVN topology, they never remove it
+Applying `flat-minimal` to a lab that already ran `everything-on` leaves
+the VLAN networks in the NB DB — unprobed, but present. Start each
+profile run from a fresh `make e2e-up` for exact semantics.
+:::
+
 **Actions.** The starter set reuses the fault mechanics the scenarios
-already prove. The registry order and the weights are part of the replay
-contract — a new action is appended, never inserted.
+already prove; `config-flip` reconfigures a gateway mid-run. The registry
+order and the weights are part of the replay contract — a new action is
+appended, never inserted.
 
 | Action | Weight | Hold | Recovery budget | Mechanic |
 | --- | --- | --- | --- | --- |
@@ -949,21 +1055,56 @@ contract — a new action is appended, never inserted.
 | `gateway-kill` | 1 | 15–45 s | 180 s | `docker kill -s KILL`, then `docker start` ([stale chassis](#stale-chassis)) |
 | `agent-terminate` | 2 | 10–30 s | 180 s | `kill -TERM 1` — the agent is PID 1 ([drain-hitless](#drain-hitless)) |
 | `gateway-restart` | 2 | — | 180 s | `docker restart` ([pf-hairpin](#port-forward-hairpin-masquerade)) |
+| `config-flip` | 2 | — | 180 s | rewrite one gateway's config and restart it onto it — see below |
 
 Every action that kills a container first runs `docker update
 --restart=no`, exactly as `drain-hitless.sh` does — containerlab deploys
 with `restart: always`, so without it docker revives the node before the
 fault is observable at all. The policy is restored on the way back.
 
-`agent-terminate` only exercises the agent's *drain* path when the lab
-was deployed with `E2E_DRAIN_ON_SHUTDOWN=true` (see
-[Drain-hitless](#drain-hitless)); otherwise the SIGTERM is just a
-graceful exit. The fault is the same either way — the drain only changes
-how much the run loses.
+`agent-terminate` exercises the agent's *drain* path whenever the target
+is running a config with `drain_on_shutdown` on — a profile that sets it,
+a `drain-toggle` flip that turned it on, or a lab deployed with
+`E2E_DRAIN_ON_SHUTDOWN=true` (see [Drain-hitless](#drain-hitless)).
+Otherwise the SIGTERM is just a graceful exit. The fault is the same
+either way — the drain only changes how much the run loses.
+
+**The `config-flip` action.** Rollouts, tuning changes and emergency flag
+flips happen on live gateways, under load, one node at a time. The action
+draws one of the whitelisted toggles below, applies it to the target's
+current config, validates the result with `--check-config`, swaps it in
+and restarts the node onto it — the same path the profile apply uses.
+
+| Flip | What it toggles | Applicable when |
+| --- | --- | --- |
+| `drain-toggle` | `drain_on_shutdown` | always |
+| `masquerade-toggle` | `hairpin_masquerade` on the API VIP | the gateway's config carries the API VIP |
+| `cidr-toggle` | `network_cidr` between the profile's value and the manual filter (`192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`) | the profile did not already configure that filter |
+| `cadence-toggle` | `reconcile_interval` between `5s` and `15s` | always |
+| `pf-rule-toggle` | adds/removes an unprobed port-forward VIP (`192.0.2.99:8081`) | always |
+
+Each is a *toggle*: applied twice it puts the gateway back on the config
+the profile gave it, so a long run cannot drift away from the
+configuration it says it is testing. The whitelist is append-only for the
+same reason the action registry is — the engine draws a flip by index.
+
+A config the agent **rejects** is journaled (`config-flip` with
+`rejected: true` and the agent's reason) and dropped: the gateway keeps
+running what it was running, and the run does not fail. That is the
+answer a rejected rollout gives an operator, and the whitelist is
+deliberately free to draw a combination the agent must refuse. Disable
+the action entirely with `-weights config-flip=0`.
+
+A flip on a gateway with `drain_on_shutdown` on can have its drain
+truncated: `docker restart`'s 10 s stop-grace SIGKILLs an agent that is
+still draining. That is legitimate chaos — the run only asserts that the
+node recovers — but it is worth knowing when reading a journal.
 
 **Guardrails** keep a run meaningful. A decision is skipped (and
 journaled with its `skip_reason`) when the target has not returned and
-converged since it was last hit, or when it is the last healthy gateway.
+converged since it was last hit, when it is the last healthy gateway, or
+— for `config-flip` — when the drawn flip means nothing on what the
+target is currently running (`flip-not-applicable`).
 
 **Convergence and recovery budgets.** After each restore the runner polls
 the node back to health: the container healthy, its chassis back in SB,
@@ -1031,9 +1172,13 @@ bootstrap master.
   lab-state/      — collect-artifacts.sh dump, on a non-zero exit only
 ```
 
-`journal.jsonl` carries `run-start` (the echoed inputs), `state-applied`,
-one `decision` per tick (with the drawn values and either `executed` or a
-`skip_reason`), `inject` / `restore` / `converged`, `node-state`,
+`journal.jsonl` carries `run-start` (the echoed inputs, profile included),
+one `profile-apply` per gateway (with `executed` telling a gateway that
+was restarted onto the profile from one that was already on it),
+`state-applied`, one `decision` per tick (with the drawn values — the
+flip among them — and either `executed` or a `skip_reason`), `inject` /
+`restore` / `converged`, `config-flip` (the flip, the values it moved
+between, and `rejected` when the agent refused it), `node-state`,
 `probe-transition`, `vip-repoint`, `violation` and `run-end`.
 `summary.json` aggregates the run: inputs, tick and decision counts,
 actions by name, how many baseline sweeps ran and how many of them
@@ -1041,15 +1186,18 @@ evaluated the dual-claim invariant, per-probe sent/lost plus 10-second
 loss buckets, the per-action recovery durations, and every violation.
 
 **Exit codes:** `0` the run passed, `1` the run recorded a violation,
-`2` the runner could not set the run up (bad flags, a start state that
-never went green). On any non-zero exit the lab's existing
-`collect-artifacts.sh` bundle is dumped into `<out>/lab-state`.
+`2` the runner could not set the run up (bad flags, an unknown profile, a
+configuration the agent rejected, a start state that never went green).
+On any non-zero exit the lab's existing `collect-artifacts.sh` bundle is
+dumped into `<out>/lab-state`.
 
 **In CI.** The runner has its own workflow,
 [`e2e-chaos.yml`](https://github.com/osism/ovn-network-agent/blob/main/.github/workflows/e2e-chaos.yml),
 which runs on `workflow_dispatch` only and uploads the journal, the
 summary and the lab-state dump on every outcome. The seed and duration
-are dispatch inputs defaulting to `-seed 42 -duration 3m`. It is
+are dispatch inputs defaulting to `-seed 42 -duration 3m`; the run uses
+the default profile (a profile matrix is
+[#180](https://github.com/osism/ovn-network-agent/issues/180)). It is
 deliberately not part of `e2e.yml`'s PR path: the scenarios there each
 assert one fault and leave the lab baseline-green, while a chaos run is
 a randomized sequence that deliberately leaves the master wherever the

--- a/test/e2e/chaos/actions.go
+++ b/test/e2e/chaos/actions.go
@@ -7,7 +7,13 @@ import (
 
 // agentExitTimeout is how long a SIGTERM'ed agent gets to take its
 // container down before agent-terminate gives up on the graceful path.
-const agentExitTimeout = 30 * time.Second
+//
+// It is generous because a profile (or a drain-toggle flip) can put a
+// gateway on drain_on_shutdown, and a draining agent holds its SIGTERM
+// for up to drain_timeout — 60s by default — plus the settle delay and
+// the cleanup before PID 1 finally exits. The wait returns as soon as the
+// container is down, so the larger budget costs a no-drain run nothing.
+const agentExitTimeout = 120 * time.Second
 
 // starterActions is the action registry, in the order the weighted pick
 // walks it. Both the order and the weights are part of the replay
@@ -24,7 +30,18 @@ const agentExitTimeout = 30 * time.Second
 // The recovery budgets differ because the faults differ: stopping
 // ovn-controller costs a re-election, while any container lifecycle
 // event costs a full daemon bring-up plus the underlay re-wire.
-func starterActions() []*action {
+//
+// The profile is bound into the restores because what a returning gateway
+// needs put back depends on which layers the profile put up — and, for a
+// gateway whose configuration carries the API VIP, on the responder
+// behind it.
+func starterActions(p *profile) []*action {
+	restore := func(ctx context.Context, l *lab, gw string) error {
+		return restoreNode(ctx, l, p, gw)
+	}
+	startAndRestore := func(ctx context.Context, l *lab, gw string) error {
+		return startAndRestoreGateway(ctx, l, p, gw)
+	}
 	return []*action{
 		{
 			name:           "controller-restart",
@@ -46,7 +63,7 @@ func starterActions() []*action {
 			holdMax:        45 * time.Second,
 			recoveryBudget: 180 * time.Second,
 			inject:         injectGatewayKill,
-			restore:        startAndRestoreGateway,
+			restore:        startAndRestore,
 		},
 		{
 			name:           "agent-terminate",
@@ -55,7 +72,7 @@ func starterActions() []*action {
 			holdMax:        30 * time.Second,
 			recoveryBudget: 180 * time.Second,
 			inject:         injectAgentTerminate,
-			restore:        startAndRestoreGateway,
+			restore:        startAndRestore,
 		},
 		{
 			name:   "gateway-restart",
@@ -67,7 +84,7 @@ func starterActions() []*action {
 			inject: func(ctx context.Context, l *lab, gw string) error {
 				return l.restartGateway(ctx, gw)
 			},
-			restore: restoreNode,
+			restore: restore,
 		},
 	}
 }
@@ -103,7 +120,7 @@ func injectAgentTerminate(ctx context.Context, l *lab, gw string) error {
 // The policy is put back even when the start failed: the inject pinned it
 // to "no" so docker would not revive the node mid-fault, and leaving it
 // there hands the lab a gateway docker will never bring back up.
-func startAndRestoreGateway(ctx context.Context, l *lab, gw string) error {
+func startAndRestoreGateway(ctx context.Context, l *lab, p *profile, gw string) error {
 	startErr := l.startGateway(ctx, gw)
 	policyErr := l.setRestartPolicy(ctx, gw, "always")
 	if startErr != nil {
@@ -112,5 +129,5 @@ func startAndRestoreGateway(ctx context.Context, l *lab, gw string) error {
 	if policyErr != nil {
 		return policyErr
 	}
-	return restoreNode(ctx, l, gw)
+	return restoreNode(ctx, l, p, gw)
 }

--- a/test/e2e/chaos/actions.go
+++ b/test/e2e/chaos/actions.go
@@ -49,7 +49,7 @@ func starterActions(p *profile) []*action {
 			holdMin:        10 * time.Second,
 			holdMax:        30 * time.Second,
 			recoveryBudget: 90 * time.Second,
-			inject: func(ctx context.Context, l *lab, gw string) error {
+			inject: func(ctx context.Context, l *lab, gw string, _ int) error {
 				return l.stopController(ctx, gw)
 			},
 			restore: func(ctx context.Context, l *lab, gw string) error {
@@ -81,7 +81,7 @@ func starterActions(p *profile) []*action {
 			holdMin:        0,
 			holdMax:        0,
 			recoveryBudget: 180 * time.Second,
-			inject: func(ctx context.Context, l *lab, gw string) error {
+			inject: func(ctx context.Context, l *lab, gw string, _ int) error {
 				return l.restartGateway(ctx, gw)
 			},
 			restore: restore,
@@ -89,10 +89,37 @@ func starterActions(p *profile) []*action {
 	}
 }
 
+// allActions is the registry the runner drives: the starter faults plus
+// the configuration change, appended — never inserted — so a recorded
+// seed still replays the sequence it recorded.
+//
+// config-flip is the operational fault the other four cannot express: a
+// gateway is reconfigured and restarted onto the new configuration while
+// the lab is under load, the way a rollout, a tuning change or an
+// emergency flag flip actually reaches production. Its restart is the
+// fault and its own undo, so like gateway-restart it holds nothing and
+// pays the full container-lifecycle recovery budget.
+func allActions(p *profile, ap *applier) []*action {
+	return append(starterActions(p), &action{
+		name:           "config-flip",
+		weight:         2,
+		holdMin:        0,
+		holdMax:        0,
+		recoveryBudget: 180 * time.Second,
+		applicable:     ap.applicable,
+		inject: func(ctx context.Context, _ *lab, gw string, flip int) error {
+			return ap.flip(ctx, gw, flip)
+		},
+		restore: func(ctx context.Context, l *lab, gw string) error {
+			return restoreNode(ctx, l, p, gw)
+		},
+	})
+}
+
 // injectGatewayKill hard-kills the container. containerlab deploys with
 // `restart: always`, so the policy is flipped off first — otherwise
 // docker revives the node before the fault is observable at all.
-func injectGatewayKill(ctx context.Context, l *lab, gw string) error {
+func injectGatewayKill(ctx context.Context, l *lab, gw string, _ int) error {
 	if err := l.setRestartPolicy(ctx, gw, "no"); err != nil {
 		return err
 	}
@@ -103,7 +130,7 @@ func injectGatewayKill(ctx context.Context, l *lab, gw string) error {
 // to follow it down. Whether the agent drains its gateway chassis before
 // exiting depends on how the lab was deployed — the fault is the same
 // either way, and the drain only changes how much the run loses.
-func injectAgentTerminate(ctx context.Context, l *lab, gw string) error {
+func injectAgentTerminate(ctx context.Context, l *lab, gw string, _ int) error {
 	if err := l.setRestartPolicy(ctx, gw, "no"); err != nil {
 		return err
 	}

--- a/test/e2e/chaos/actions_test.go
+++ b/test/e2e/chaos/actions_test.go
@@ -53,7 +53,7 @@ func TestGatewayKillDisablesTheRestartPolicyBeforeTheKill(t *testing.T) {
 	cmd := &fakeCommander{}
 	l := newTestLab(cmd, newFakeClock())
 
-	if err := actionNamed(t, "gateway-kill").inject(context.Background(), l, "gateway-2"); err != nil {
+	if err := actionNamed(t, "gateway-kill").inject(context.Background(), l, "gateway-2", 0); err != nil {
 		t.Fatalf("inject: %v", err)
 	}
 
@@ -121,7 +121,7 @@ func TestControllerRestartUsesOvnCtlAndTouchesNoContainer(t *testing.T) {
 	l := newTestLab(cmd, newFakeClock())
 	act := actionNamed(t, "controller-restart")
 
-	if err := act.inject(context.Background(), l, "gateway-1"); err != nil {
+	if err := act.inject(context.Background(), l, "gateway-1", 0); err != nil {
 		t.Fatalf("inject: %v", err)
 	}
 	if err := act.restore(context.Background(), l, "gateway-1"); err != nil {
@@ -149,7 +149,7 @@ func TestAgentTerminateSignalsPID1AndWaitsForTheExit(t *testing.T) {
 	cmd := &fakeCommander{respond: healthyLabResponses}
 	l := newTestLab(cmd, newFakeClock())
 
-	if err := actionNamed(t, "agent-terminate").inject(context.Background(), l, "gateway-3"); err != nil {
+	if err := actionNamed(t, "agent-terminate").inject(context.Background(), l, "gateway-3", 0); err != nil {
 		t.Fatalf("inject: %v", err)
 	}
 
@@ -172,7 +172,7 @@ func TestAgentTerminateFailsWhenTheContainerStaysUp(t *testing.T) {
 	}}
 	l := newTestLab(cmd, newFakeClock())
 
-	err := actionNamed(t, "agent-terminate").inject(context.Background(), l, "gateway-3")
+	err := actionNamed(t, "agent-terminate").inject(context.Background(), l, "gateway-3", 0)
 	if err == nil {
 		t.Fatal("a container that never exited was reported as a clean termination")
 	}
@@ -213,7 +213,7 @@ func TestGatewayRestartRecyclesTheContainerAndRestoresTheNode(t *testing.T) {
 	l := newTestLab(cmd, newFakeClock())
 	act := actionNamed(t, "gateway-restart")
 
-	if err := act.inject(context.Background(), l, workloadHost); err != nil {
+	if err := act.inject(context.Background(), l, workloadHost, 0); err != nil {
 		t.Fatalf("inject: %v", err)
 	}
 	if err := act.restore(context.Background(), l, workloadHost); err != nil {
@@ -354,5 +354,53 @@ func TestProbeTargetsExcludeTheBackendlessFIP(t *testing.T) {
 	}
 	if len(defaultProbes) != 5 {
 		t.Fatalf("probe set = %v, want the four FIPs plus the port-forward VIP", defaultProbes)
+	}
+}
+
+// config-flip is appended to the starter set, never inserted: the weighted
+// pick walks the registry in order, so an insertion would replay every
+// recorded seed as a different run.
+func TestConfigFlipIsAppendedToTheRegistry(t *testing.T) {
+	p := defaultTestProfile(t)
+	actions := allActions(p, newApplier(nil, p, nil))
+
+	want := []string{
+		"controller-restart", "gateway-kill", "agent-terminate",
+		"gateway-restart", "config-flip",
+	}
+	for i, a := range actions {
+		if i >= len(want) || a.name != want[i] {
+			t.Fatalf("registry = %v, want %v", actionNames(actions), want)
+		}
+	}
+	if len(actions) != len(want) {
+		t.Fatalf("registry = %v, want %v", actionNames(actions), want)
+	}
+
+	flip := actions[len(actions)-1]
+	if flip.weight <= 0 {
+		t.Fatalf("config-flip ships with weight %d — the weighted pick would never draw it", flip.weight)
+	}
+	if flip.applicable == nil {
+		t.Fatal("config-flip does not read the flip index the engine draws for it")
+	}
+	if flip.holdMin != 0 || flip.holdMax != 0 {
+		t.Fatalf("config-flip holds its fault for %s–%s — the restart onto the new config is its own undo",
+			flip.holdMin, flip.holdMax)
+	}
+}
+
+// The guardrail is consulted before the fault is injected, and an applier
+// that has not put a profile on the lab yet tracks no configuration — so
+// it reports every flip as inapplicable rather than flipping a
+// configuration it has never read. (run() applies the profile before the
+// engine draws anything.)
+func TestAnApplierWithoutAProfileSkipsEveryFlip(t *testing.T) {
+	ap := newApplier(nil, defaultTestProfile(t), nil)
+
+	for i := range flips() {
+		if ap.applicable("gateway-1", i) {
+			t.Fatalf("flip %s was applicable before the profile was applied", flipName(i))
+		}
 	}
 }

--- a/test/e2e/chaos/actions_test.go
+++ b/test/e2e/chaos/actions_test.go
@@ -8,7 +8,7 @@ import (
 
 func actionNamed(t *testing.T, name string) *action {
 	t.Helper()
-	for _, a := range starterActions() {
+	for _, a := range starterActions(defaultTestProfile(t)) {
 		if a.name == name {
 			return a
 		}
@@ -24,7 +24,7 @@ func TestStarterRegistryOrderIsStable(t *testing.T) {
 	want := []string{"controller-restart", "gateway-kill", "agent-terminate", "gateway-restart"}
 
 	var got []string
-	for _, a := range starterActions() {
+	for _, a := range starterActions(defaultTestProfile(t)) {
 		got = append(got, a.name)
 		if a.weight <= 0 {
 			t.Fatalf("action %s ships with weight %d", a.name, a.weight)
@@ -194,7 +194,7 @@ func TestStartAndRestoreGatewayRestoresThePolicyWhenTheStartFails(t *testing.T) 
 	}}
 	l := newTestLab(cmd, newFakeClock())
 
-	err := startAndRestoreGateway(context.Background(), l, "gateway-2")
+	err := startAndRestoreGateway(context.Background(), l, defaultTestProfile(t), "gateway-2")
 
 	if err == nil {
 		t.Fatal("a container that could not be started was reported as restored")
@@ -244,7 +244,7 @@ func TestReprovisionRebuildsTheWorkloadHostOnly(t *testing.T) {
 	cmd := &fakeCommander{respond: healthyLabResponses}
 	l := newTestLab(cmd, newFakeClock())
 
-	if err := reprovisionNode(context.Background(), l, workloadHost); err != nil {
+	if err := reprovisionNode(context.Background(), l, defaultTestProfile(t), workloadHost); err != nil {
 		t.Fatalf("reprovision %s: %v", workloadHost, err)
 	}
 
@@ -261,7 +261,8 @@ func TestReprovisionRebuildsTheWorkloadHostOnly(t *testing.T) {
 	}
 
 	peer := &fakeCommander{respond: healthyLabResponses}
-	if err := reprovisionNode(context.Background(), newTestLab(peer, newFakeClock()), "gateway-2"); err != nil {
+	if err := reprovisionNode(context.Background(), newTestLab(peer, newFakeClock()),
+		defaultTestProfile(t), "gateway-2"); err != nil {
 		t.Fatalf("reprovision gateway-2: %v", err)
 	}
 	if len(peer.lines()) != 0 {
@@ -279,7 +280,7 @@ func TestStartPFBackendReplacesAnyRunningInstance(t *testing.T) {
 		t.Fatalf("startPFBackend: %v", err)
 	}
 
-	kill := cmd.indexOf("pkill -f /usr/local/bin/pf-backend")
+	kill := cmd.indexOf("pkill -f " + pfBackendLog)
 	start := cmd.indexOf("exec -d clab-ovn-e2e-gateway-3")
 	listen := cmd.indexOf("sport = :8080")
 	if kill < 0 || start < 0 || listen < 0 {

--- a/test/e2e/chaos/actions_test.go
+++ b/test/e2e/chaos/actions_test.go
@@ -346,12 +346,12 @@ func TestVLANLayerReportsANBFailure(t *testing.T) {
 // it. Probing it would be red for the whole run and every recovery gate
 // would time out, so it must stay out of the probe set.
 func TestProbeTargetsExcludeTheBackendlessFIP(t *testing.T) {
-	for _, target := range probeTargets {
+	for _, target := range defaultProbes {
 		if strings.Contains(target.addr, "192.0.2.11") {
 			t.Fatalf("probe target %q has no responder behind it", target.name)
 		}
 	}
-	if len(probeTargets) != 5 {
-		t.Fatalf("probe set = %v, want the four FIPs plus the port-forward VIP", probeTargets)
+	if len(defaultProbes) != 5 {
+		t.Fatalf("probe set = %v, want the four FIPs plus the port-forward VIP", defaultProbes)
 	}
 }

--- a/test/e2e/chaos/apply.go
+++ b/test/e2e/chaos/apply.go
@@ -30,6 +30,13 @@ type applier struct {
 	lab     *lab
 	profile *profile
 
+	// jrnl records every configuration the applier puts on a gateway. It is
+	// set once the run has earned an artifact directory: the applier itself
+	// is built earlier, because the action registry binds config-flip to it
+	// and the -weights check runs against that registry — ahead of
+	// everything that creates a file.
+	jrnl *journal
+
 	// base is the host-side gwnode config — the document every overlay is
 	// layered over, and byte-for-byte what a fresh gateway already has.
 	base []byte
@@ -75,7 +82,7 @@ func (a *applier) discover(ctx context.Context) error {
 // completion before the first live file is swapped: a profile the agent
 // rejects on one gateway must not leave the lab half-reconfigured, with
 // two gateways rolled onto it and the third refusing to start.
-func (a *applier) applyProfile(ctx context.Context, jrnl *journal) error {
+func (a *applier) applyProfile(ctx context.Context) error {
 	rendered := make(map[string][]byte, len(gatewayNames()))
 	for _, gw := range gatewayNames() {
 		raw, err := renderConfig(a.base, a.profile.gwConfig(gw), a.mgmtIP[gw])
@@ -112,7 +119,7 @@ func (a *applier) applyProfile(ctx context.Context, jrnl *journal) error {
 		if applied {
 			detail = fmt.Sprintf("restarted onto the %s configuration", a.profile.name)
 		}
-		jrnl.emit(event{
+		a.jrnl.emit(event{
 			Event: evProfileApply, Target: gw,
 			Executed: boolPtr(applied), Detail: detail,
 		})
@@ -190,4 +197,82 @@ func (a *applier) waitBack(ctx context.Context, gw string) error {
 	}
 	return fmt.Errorf("%s did not come back within %s after its configuration was swapped",
 		gw, profileApplyTimeout)
+}
+
+// applicable reports whether a drawn flip means anything on a gateway's
+// current configuration — the masquerade flip needs a VIP to flip it on,
+// the CIDR flip a baseline to toggle back to. The engine's guardrails
+// consult it, so an inapplicable flip is a journaled skip rather than a
+// rewrite and a restart that change nothing.
+func (a *applier) applicable(gw string, idx int) bool {
+	c, ok := a.flipCtx(gw)
+	return ok && flips()[idx].applicable(c)
+}
+
+// flip rewrites one gateway's configuration mid-run: toggle a whitelisted
+// option, validate the result the way applyProfile does, and only then
+// swap the file and restart the node onto it — a rolling reconfiguration
+// under fault load.
+//
+// A configuration the agent rejects is journaled and dropped, and the
+// tracker goes back to what the gateway is still running. That is not a
+// failure of the run: it is the answer an operator gets from a rejected
+// rollout, and the whitelist is deliberately free to draw a combination
+// the agent must refuse rather than accept.
+func (a *applier) flip(ctx context.Context, gw string, idx int) error {
+	f := flips()[idx]
+	c, ok := a.flipCtx(gw)
+	if !ok {
+		return fmt.Errorf("no configuration is tracked for %s", gw)
+	}
+
+	before, err := marshalConfig(c.doc)
+	if err != nil {
+		return err
+	}
+	from, to := f.apply(c)
+	raw, err := marshalConfig(c.doc)
+	if err != nil {
+		return err
+	}
+
+	valid, detail, err := a.stage(ctx, gw, raw)
+	if err != nil {
+		return err
+	}
+	if !valid {
+		reverted, err := parseConfig(before)
+		if err != nil {
+			return err
+		}
+		a.current[gw] = reverted
+		a.jrnl.emit(event{
+			Event: evConfigFlip, Target: gw, Flip: f.name, From: from, To: to,
+			Rejected: boolPtr(true), Detail: detail,
+		})
+		return nil
+	}
+
+	// The marker goes down before the restart: from here on the file is
+	// authoritative, and the deploy-time drain override must not beat a
+	// drain the flip has just written into it.
+	if err := a.mark(ctx, gw, true); err != nil {
+		return err
+	}
+	if err := a.lab.moveFile(ctx, gw, agentConfigNextPath, agentConfigPath); err != nil {
+		return err
+	}
+	a.jrnl.emit(event{
+		Event: evConfigFlip, Target: gw, Flip: f.name, From: from, To: to,
+		Rejected: boolPtr(false),
+	})
+	return a.lab.restartGateway(ctx, gw)
+}
+
+func (a *applier) flipCtx(gw string) (flipCtx, bool) {
+	doc, ok := a.current[gw]
+	if !ok {
+		return flipCtx{}, false
+	}
+	return flipCtx{doc: doc, baseline: a.baseline[gw], mgmtIP: a.mgmtIP[gw]}, true
 }

--- a/test/e2e/chaos/apply.go
+++ b/test/e2e/chaos/apply.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// profileApplyTimeout is how long a reconfigured gateway gets to come
+// back before the run is abandoned. It matches the recovery budget of the
+// actions that recycle a container: the mechanic is the same `docker
+// restart`, and the node has to be all the way back before the roll moves
+// on to the next one.
+const profileApplyTimeout = 180 * time.Second
+
+// applier owns the agent configuration of every gateway for the length of
+// a run.
+//
+// Applying a profile to a running lab needs no image rebuild and no
+// redeploy: the config file is the only thing that changes, and the
+// gwnode entrypoint execs the agent, so `docker restart` is the reload.
+// What makes that safe is the order — render every gateway's config and
+// hand each one to the agent's own --check-config *before* a single live
+// file is touched, then roll the gateways one at a time so the lab keeps
+// forwarding while it is reconfigured.
+//
+// The same path serves the config-flip action mid-run: toggle a
+// whitelisted option, validate, swap, restart.
+type applier struct {
+	lab     *lab
+	profile *profile
+
+	// base is the host-side gwnode config — the document every overlay is
+	// layered over, and byte-for-byte what a fresh gateway already has.
+	base []byte
+
+	// mgmtIP is each gateway's management address: the backend its API
+	// VIP forwards to.
+	mgmtIP map[string]string
+
+	// baseline is the configuration the profile put on each gateway, and
+	// current is what the gateway is running now. A flip toggles between
+	// the two — "back to the base" means back to what the profile
+	// configured, not back to what the image ships.
+	baseline map[string]map[string]any
+	current  map[string]map[string]any
+}
+
+func newApplier(l *lab, p *profile, base []byte) *applier {
+	return &applier{
+		lab:      l,
+		profile:  p,
+		base:     base,
+		mgmtIP:   map[string]string{},
+		baseline: map[string]map[string]any{},
+		current:  map[string]map[string]any{},
+	}
+}
+
+// discover reads the per-gateway facts a rendered config needs.
+func (a *applier) discover(ctx context.Context) error {
+	for _, gw := range gatewayNames() {
+		ip, err := a.lab.mgmtIP(ctx, gw)
+		if err != nil {
+			return err
+		}
+		a.mgmtIP[gw] = ip
+	}
+	return nil
+}
+
+// applyProfile puts the profile's configuration on every gateway.
+//
+// Validation is a separate pass over all three gateways, and it runs to
+// completion before the first live file is swapped: a profile the agent
+// rejects on one gateway must not leave the lab half-reconfigured, with
+// two gateways rolled onto it and the third refusing to start.
+func (a *applier) applyProfile(ctx context.Context, jrnl *journal) error {
+	rendered := make(map[string][]byte, len(gatewayNames()))
+	for _, gw := range gatewayNames() {
+		raw, err := renderConfig(a.base, a.profile.gwConfig(gw), a.mgmtIP[gw])
+		if err != nil {
+			return fmt.Errorf("profile %s on %s: %w", a.profile.name, gw, err)
+		}
+		valid, detail, err := a.stage(ctx, gw, raw)
+		if err != nil {
+			return err
+		}
+		if !valid {
+			return fmt.Errorf("the agent rejected the %s configuration for %s: %s",
+				a.profile.name, gw, detail)
+		}
+		rendered[gw] = raw
+	}
+
+	for _, gw := range gatewayNames() {
+		// Two independent parses: a flip mutates `current` in place, and
+		// `baseline` is what it toggles back to.
+		for _, into := range []map[string]map[string]any{a.baseline, a.current} {
+			doc, err := parseConfig(rendered[gw])
+			if err != nil {
+				return err
+			}
+			into[gw] = doc
+		}
+
+		applied, err := a.swap(ctx, gw, rendered[gw], !a.profile.gwConfig(gw).empty())
+		if err != nil {
+			return err
+		}
+		detail := fmt.Sprintf("already on the %s configuration", a.profile.name)
+		if applied {
+			detail = fmt.Sprintf("restarted onto the %s configuration", a.profile.name)
+		}
+		jrnl.emit(event{
+			Event: evProfileApply, Target: gw,
+			Executed: boolPtr(applied), Detail: detail,
+		})
+	}
+	return nil
+}
+
+// stage writes a rendered config next to the live one and hands it to the
+// agent's own validator. Nothing live has been touched when it returns.
+func (a *applier) stage(ctx context.Context, gw string, raw []byte) (bool, string, error) {
+	if err := a.lab.writeFile(ctx, gw, agentConfigNextPath, string(raw)); err != nil {
+		return false, "", err
+	}
+	return a.lab.checkConfig(ctx, gw, agentConfigNextPath)
+}
+
+// swap puts a staged config live and restarts the gateway onto it,
+// reporting whether it had to do anything at all.
+//
+// A gateway already running the rendered config is left alone — on a
+// fresh lab the default profile renders exactly the baked bytes, so it
+// restarts nothing and costs the run no re-election.
+func (a *applier) swap(ctx context.Context, gw string, raw []byte, owned bool) (bool, error) {
+	live, err := a.lab.readFile(ctx, gw, agentConfigPath)
+	if err != nil {
+		return false, err
+	}
+	if err := a.mark(ctx, gw, owned); err != nil {
+		return false, err
+	}
+	if live == string(raw) {
+		return false, nil
+	}
+	if err := a.lab.moveFile(ctx, gw, agentConfigNextPath, agentConfigPath); err != nil {
+		return false, err
+	}
+	if err := a.lab.restartGateway(ctx, gw); err != nil {
+		return false, err
+	}
+	if err := restoreNode(ctx, a.lab, a.profile, gw); err != nil {
+		return false, err
+	}
+	return true, a.waitBack(ctx, gw)
+}
+
+// mark writes — or removes — the marker the gwnode entrypoint reads.
+//
+// topology.clab.yml sets OVN_NETWORK_DRAIN_ON_SHUTDOWN on every gateway,
+// and the agent's environment layer beats its config file, so a profile
+// that enables the drain would never see it take effect. The marker tells
+// the entrypoint that a chaos profile owns the whole file and the
+// deploy-time override has to step aside. A gateway back on the baked
+// config has the marker removed, so the lab behaves as deployed again.
+func (a *applier) mark(ctx context.Context, gw string, owned bool) error {
+	if !owned {
+		return a.lab.removeFile(ctx, gw, profileMarkerPath)
+	}
+	return a.lab.writeFile(ctx, gw, profileMarkerPath, a.profile.name)
+}
+
+// waitBack holds the roll until the reconfigured gateway is back: the
+// container healthy (the image's healthcheck covers OVS, ovn-controller
+// and the agent) and its chassis re-registered in SB. Rolling on before
+// that would have two of three gateways down at once.
+func (a *applier) waitBack(ctx context.Context, gw string) error {
+	deadline := a.lab.now().Add(profileApplyTimeout)
+	for a.lab.now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if a.lab.containerHealth(ctx, gw) == "healthy" && a.lab.chassisInSB(ctx, gw) {
+			return nil
+		}
+		a.lab.sleep(convergePollInterval)
+	}
+	return fmt.Errorf("%s did not come back within %s after its configuration was swapped",
+		gw, profileApplyTimeout)
+}

--- a/test/e2e/chaos/apply_test.go
+++ b/test/e2e/chaos/apply_test.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+// newTestApplier wires an applier against the fake commander, with the
+// management addresses already discovered — every test below is about
+// what it does with them.
+func newTestApplier(t *testing.T, cmd commander, name string) *applier {
+	t.Helper()
+	a := newApplier(newTestLab(cmd, newFakeClock()), testProfile(t, name), baseConfig(t))
+	if err := a.discover(context.Background()); err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	return a
+}
+
+// restartCmd is the container-qualified form of the restart, because the
+// baked config's own comments mention `docker restart` — a bare substring
+// match would find them in the argv that *writes* the config.
+const restartCmd = "docker restart clab-"
+
+// labWithConfig answers `cat <live config>` with what the gateway is
+// running, and everything else the way a healthy lab does.
+func labWithConfig(live string) func(argv []string) (string, error) {
+	return func(argv []string) (string, error) {
+		line := strings.Join(argv, " ")
+		switch {
+		case strings.Contains(line, "cat "+agentConfigPath):
+			return live, nil
+		case strings.Contains(line, "ip -o -4 addr show eth0"):
+			return "172.20.20.4\n", nil
+		}
+		return healthyLabResponses(argv)
+	}
+}
+
+// The whole point of the two-phase apply: a profile the agent rejects on
+// *one* gateway must not leave the lab half-reconfigured, with two
+// gateways rolled onto it and the third refusing to start. So every
+// gateway is validated before any live file is touched.
+func TestApplyProfileValidatesEveryGatewayBeforeItSwapsAnything(t *testing.T) {
+	cmd := &fakeCommander{respond: labWithConfig("stale config\n")}
+	a := newTestApplier(t, cmd, "flat-dnat")
+
+	if err := a.applyProfile(context.Background(), newJournal(&bytes.Buffer{}, newFakeClock().now)); err != nil {
+		t.Fatalf("applyProfile: %v", err)
+	}
+
+	if got := cmd.count("--check-config"); got != len(gatewayNames()) {
+		t.Fatalf("validated %d of %d gateways", got, len(gatewayNames()))
+	}
+	firstSwap := cmd.indexOf("mv " + agentConfigNextPath)
+	if firstSwap < 0 {
+		t.Fatalf("nothing was swapped at all: %v", cmd.lines())
+	}
+	for i, line := range cmd.lines() {
+		if strings.Contains(line, "--check-config") && i > firstSwap {
+			t.Fatalf("gateway %d was validated only after another one had been swapped: %v", i, cmd.lines())
+		}
+	}
+	if got := cmd.count(restartCmd); got != len(gatewayNames()) {
+		t.Fatalf("restarted %d gateways onto the new config, want all %d", got, len(gatewayNames()))
+	}
+}
+
+// A config the agent refuses is the run's own fault, not the lab's: the
+// run is abandoned before a single live file moves.
+func TestApplyProfileAbortsWhenTheAgentRejectsTheConfig(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "--check-config") {
+			return "", errExit(t, 1)
+		}
+		return labWithConfig("stale config\n")(argv)
+	}}
+	a := newTestApplier(t, cmd, "pf-only")
+
+	err := a.applyProfile(context.Background(), newJournal(&bytes.Buffer{}, newFakeClock().now))
+
+	if err == nil {
+		t.Fatal("a configuration the agent rejected was rolled out anyway")
+	}
+	if !strings.Contains(err.Error(), "rejected") || !strings.Contains(err.Error(), "pf-only") {
+		t.Fatalf("error %q names neither the rejection nor the profile", err)
+	}
+	if cmd.called("mv "+agentConfigNextPath) || cmd.called(restartCmd) {
+		t.Fatalf("a rejected profile still touched the live config: %v", cmd.lines())
+	}
+}
+
+// A check the runner could not *run* is not a rejection — it is a
+// question that went unanswered, and swapping a live config on the
+// strength of it is exactly what the gate exists to prevent.
+func TestApplyProfileAbortsWhenTheCheckCannotRun(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "--check-config") {
+			return "", errBoom
+		}
+		return labWithConfig("stale config\n")(argv)
+	}}
+	a := newTestApplier(t, cmd, "flat-minimal")
+
+	if err := a.applyProfile(context.Background(), newJournal(&bytes.Buffer{}, newFakeClock().now)); err == nil {
+		t.Fatal("a config whose validation never ran was rolled out anyway")
+	}
+	if cmd.called(restartCmd) {
+		t.Fatalf("a gateway was restarted onto an unvalidated config: %v", cmd.lines())
+	}
+}
+
+// The default profile on a fresh lab renders exactly the bytes the image
+// baked in. Restarting three gateways to install the config they are
+// already running would cost the run two re-elections and buy nothing.
+func TestApplyProfileSkipsGatewaysThatAreAlreadyOnTheConfig(t *testing.T) {
+	cmd := &fakeCommander{respond: labWithConfig(string(baseConfig(t)))}
+	a := newTestApplier(t, cmd, defaultProfileName)
+	var buf bytes.Buffer
+
+	if err := a.applyProfile(context.Background(), newJournal(&buf, newFakeClock().now)); err != nil {
+		t.Fatalf("applyProfile: %v", err)
+	}
+
+	if cmd.called(restartCmd) || cmd.called("mv "+agentConfigNextPath) {
+		t.Fatalf("a gateway already on the config was restarted anyway: %v", cmd.lines())
+	}
+	// The marker is removed, so the lab's deploy-time drain switch keeps
+	// applying to a run that changes no configuration.
+	if got := cmd.count("rm -f " + profileMarkerPath); got != len(gatewayNames()) {
+		t.Fatalf("removed the profile marker from %d gateways, want all %d", got, len(gatewayNames()))
+	}
+	for _, ev := range eventsIn(t, buf.String()) {
+		if ev.Event == evProfileApply && (ev.Executed == nil || *ev.Executed) {
+			t.Fatalf("journaled %+v, want every gateway reported as unchanged", ev)
+		}
+	}
+}
+
+// The lab has to keep forwarding while it is reconfigured, so the
+// gateways roll one at a time: each is back — container healthy, chassis
+// re-registered — before the next one is touched.
+func TestApplyProfileRollsTheGatewaysOneAtATime(t *testing.T) {
+	// gateway-1 is already on the config the heterogeneous profile leaves
+	// it on — the baked one — so only the other two have to roll.
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		line := strings.Join(argv, " ")
+		if strings.Contains(line, "cat "+agentConfigPath) && strings.Contains(line, "gateway-1") {
+			return string(baseConfig(t)), nil
+		}
+		return labWithConfig("stale config\n")(argv)
+	}}
+	a := newTestApplier(t, cmd, "heterogeneous")
+
+	if err := a.applyProfile(context.Background(), newJournal(&bytes.Buffer{}, newFakeClock().now)); err != nil {
+		t.Fatalf("applyProfile: %v", err)
+	}
+
+	firstRestart := cmd.indexOf("docker restart clab-ovn-e2e-gateway-2")
+	firstBack := cmd.indexOf("find Chassis name=gateway-2")
+	secondRestart := cmd.indexOf("docker restart clab-ovn-e2e-gateway-3")
+	if firstRestart < 0 || firstBack < 0 || secondRestart < 0 {
+		t.Fatalf("the roll did not restart and gate both overlaid gateways: %v", cmd.lines())
+	}
+	if firstBack > secondRestart {
+		t.Fatalf("gateway-3 was restarted before gateway-2 was back: %v", cmd.lines())
+	}
+	// gateway-1 runs the baked config under this profile, so it is never
+	// restarted at all.
+	if cmd.called("docker restart clab-ovn-e2e-gateway-1") {
+		t.Fatalf("a gateway the profile leaves alone was restarted: %v", cmd.lines())
+	}
+	if !cmd.called("printf '%s' 'heterogeneous' > " + profileMarkerPath) {
+		t.Fatalf("the reconfigured gateways were not marked as profile-owned: %v", cmd.lines())
+	}
+}
+
+// The API VIP forwards to a backend on the gateway's *own* management
+// address, so the rendered rule must carry the address that gateway
+// actually has — not the one another gateway has.
+func TestApplyProfileRendersEachGatewaysOwnBackendAddress(t *testing.T) {
+	addrs := map[string]string{
+		"gateway-1": "172.20.20.4",
+		"gateway-2": "172.20.20.5",
+		"gateway-3": "172.20.20.6",
+	}
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		line := strings.Join(argv, " ")
+		if strings.Contains(line, "ip -o -4 addr show eth0") {
+			for gw, addr := range addrs {
+				if strings.Contains(line, gw) {
+					return addr + "\n", nil
+				}
+			}
+		}
+		return labWithConfig("stale config\n")(argv)
+	}}
+	a := newTestApplier(t, cmd, "flat-dnat")
+
+	if err := a.applyProfile(context.Background(), newJournal(&bytes.Buffer{}, newFakeClock().now)); err != nil {
+		t.Fatalf("applyProfile: %v", err)
+	}
+
+	for gw, addr := range addrs {
+		vip := vipsIn(t, a.current[gw])[apiVIPAddr]
+		if vip == nil {
+			t.Fatalf("%s was not given the API VIP: %v", gw, a.current[gw])
+		}
+		rules, _ := vip["rules"].([]any)
+		rule, _ := rules[0].(map[string]any)
+		if rule["dest_addr"] != addr {
+			t.Fatalf("%s forwards its API VIP to %v, want its own management address %s",
+				gw, rule["dest_addr"], addr)
+		}
+	}
+}
+
+// A gateway that never comes back from its config swap leaves the lab in
+// a state the run cannot measure — the roll stops rather than taking the
+// next gateway down on top of it.
+func TestApplyProfileFailsWhenAGatewayNeverComesBack(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "{{.State.Health.Status}}") {
+			return "starting\n", nil
+		}
+		return labWithConfig("stale config\n")(argv)
+	}}
+	a := newTestApplier(t, cmd, "flat-minimal")
+
+	err := a.applyProfile(context.Background(), newJournal(&bytes.Buffer{}, newFakeClock().now))
+
+	if err == nil {
+		t.Fatal("a gateway that never came back was reported as reconfigured")
+	}
+	if !strings.Contains(err.Error(), "did not come back") {
+		t.Fatalf("error %q does not say the gateway never returned", err)
+	}
+	if got := cmd.count(restartCmd); got != 1 {
+		t.Fatalf("restarted %d gateways, want the roll to stop at the one that never came back", got)
+	}
+}

--- a/test/e2e/chaos/apply_test.go
+++ b/test/e2e/chaos/apply_test.go
@@ -9,10 +9,12 @@ import (
 
 // newTestApplier wires an applier against the fake commander, with the
 // management addresses already discovered — every test below is about
-// what it does with them.
+// what it does with them. Its journal goes nowhere; a test that reads what
+// was journaled points a.jrnl at a buffer of its own.
 func newTestApplier(t *testing.T, cmd commander, name string) *applier {
 	t.Helper()
 	a := newApplier(newTestLab(cmd, newFakeClock()), testProfile(t, name), baseConfig(t))
+	a.jrnl = newJournal(&bytes.Buffer{}, newFakeClock().now)
 	if err := a.discover(context.Background()); err != nil {
 		t.Fatalf("discover: %v", err)
 	}
@@ -47,7 +49,7 @@ func TestApplyProfileValidatesEveryGatewayBeforeItSwapsAnything(t *testing.T) {
 	cmd := &fakeCommander{respond: labWithConfig("stale config\n")}
 	a := newTestApplier(t, cmd, "flat-dnat")
 
-	if err := a.applyProfile(context.Background(), newJournal(&bytes.Buffer{}, newFakeClock().now)); err != nil {
+	if err := a.applyProfile(context.Background()); err != nil {
 		t.Fatalf("applyProfile: %v", err)
 	}
 
@@ -79,7 +81,7 @@ func TestApplyProfileAbortsWhenTheAgentRejectsTheConfig(t *testing.T) {
 	}}
 	a := newTestApplier(t, cmd, "pf-only")
 
-	err := a.applyProfile(context.Background(), newJournal(&bytes.Buffer{}, newFakeClock().now))
+	err := a.applyProfile(context.Background())
 
 	if err == nil {
 		t.Fatal("a configuration the agent rejected was rolled out anyway")
@@ -104,7 +106,7 @@ func TestApplyProfileAbortsWhenTheCheckCannotRun(t *testing.T) {
 	}}
 	a := newTestApplier(t, cmd, "flat-minimal")
 
-	if err := a.applyProfile(context.Background(), newJournal(&bytes.Buffer{}, newFakeClock().now)); err == nil {
+	if err := a.applyProfile(context.Background()); err == nil {
 		t.Fatal("a config whose validation never ran was rolled out anyway")
 	}
 	if cmd.called(restartCmd) {
@@ -119,8 +121,9 @@ func TestApplyProfileSkipsGatewaysThatAreAlreadyOnTheConfig(t *testing.T) {
 	cmd := &fakeCommander{respond: labWithConfig(string(baseConfig(t)))}
 	a := newTestApplier(t, cmd, defaultProfileName)
 	var buf bytes.Buffer
+	a.jrnl = newJournal(&buf, newFakeClock().now)
 
-	if err := a.applyProfile(context.Background(), newJournal(&buf, newFakeClock().now)); err != nil {
+	if err := a.applyProfile(context.Background()); err != nil {
 		t.Fatalf("applyProfile: %v", err)
 	}
 
@@ -154,7 +157,7 @@ func TestApplyProfileRollsTheGatewaysOneAtATime(t *testing.T) {
 	}}
 	a := newTestApplier(t, cmd, "heterogeneous")
 
-	if err := a.applyProfile(context.Background(), newJournal(&bytes.Buffer{}, newFakeClock().now)); err != nil {
+	if err := a.applyProfile(context.Background()); err != nil {
 		t.Fatalf("applyProfile: %v", err)
 	}
 
@@ -199,7 +202,7 @@ func TestApplyProfileRendersEachGatewaysOwnBackendAddress(t *testing.T) {
 	}}
 	a := newTestApplier(t, cmd, "flat-dnat")
 
-	if err := a.applyProfile(context.Background(), newJournal(&bytes.Buffer{}, newFakeClock().now)); err != nil {
+	if err := a.applyProfile(context.Background()); err != nil {
 		t.Fatalf("applyProfile: %v", err)
 	}
 
@@ -229,7 +232,7 @@ func TestApplyProfileFailsWhenAGatewayNeverComesBack(t *testing.T) {
 	}}
 	a := newTestApplier(t, cmd, "flat-minimal")
 
-	err := a.applyProfile(context.Background(), newJournal(&bytes.Buffer{}, newFakeClock().now))
+	err := a.applyProfile(context.Background())
 
 	if err == nil {
 		t.Fatal("a gateway that never came back was reported as reconfigured")
@@ -240,4 +243,129 @@ func TestApplyProfileFailsWhenAGatewayNeverComesBack(t *testing.T) {
 	if got := cmd.count(restartCmd); got != 1 {
 		t.Fatalf("restarted %d gateways, want the roll to stop at the one that never came back", got)
 	}
+}
+
+// A flip is a rolling reconfiguration: the new configuration is validated
+// with the agent's own checker, then swapped in, then the node is
+// restarted onto it. Doing any of that in the other order would restart a
+// gateway onto a config it cannot start with.
+func TestFlipValidatesThenSwapsThenRestarts(t *testing.T) {
+	cmd := &fakeCommander{respond: labWithConfig(string(baseConfig(t)))}
+	a := newTestApplier(t, cmd, defaultProfileName)
+	var buf bytes.Buffer
+	a.jrnl = newJournal(&buf, newFakeClock().now)
+	if err := a.applyProfile(context.Background()); err != nil {
+		t.Fatalf("applyProfile: %v", err)
+	}
+	before := len(cmd.lines())
+
+	if err := a.flip(context.Background(), "gateway-2", flipIndex(t, "drain-toggle")); err != nil {
+		t.Fatalf("flip: %v", err)
+	}
+
+	// The profile apply already staged and validated every gateway, so the
+	// flip's own steps are the ones after it.
+	steps := []string{
+		"--check-config",
+		"printf '%s' 'everything-on' > " + profileMarkerPath, // the file now owns the drain
+		"mv " + agentConfigNextPath,
+		"docker restart clab-ovn-e2e-gateway-2",
+	}
+	flipped := cmd.lines()[before:]
+	last := -1
+	for _, step := range steps {
+		at := -1
+		for i, line := range flipped {
+			if i > last && strings.Contains(line, step) {
+				at = i
+				break
+			}
+		}
+		if at < 0 {
+			t.Fatalf("the flip never issued %q, or issued it out of order — validate, swap, restart: %v",
+				step, flipped)
+		}
+		last = at
+	}
+	if a.current["gateway-2"]["drain_on_shutdown"] != true {
+		t.Fatalf("the tracker did not follow the flip: %v", a.current["gateway-2"])
+	}
+
+	ev := lastEventOf(t, buf.String(), evConfigFlip)
+	if ev.Flip != "drain-toggle" || ev.From != "false" || ev.To != "true" {
+		t.Fatalf("journaled %+v, want the drain flip and the values it moved between", ev)
+	}
+	if ev.Rejected == nil || *ev.Rejected {
+		t.Fatalf("an applied flip was journaled as rejected: %+v", ev)
+	}
+}
+
+// The whitelist is free to draw a configuration the agent refuses. That is
+// not a failure of the run — it is the answer an operator gets from a
+// rejected rollout — so the gateway keeps running what it was running, and
+// the tracker goes back to it rather than drifting away from the lab.
+func TestFlipRejectedByTheAgentLeavesTheGatewayUntouched(t *testing.T) {
+	staged := false
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		line := strings.Join(argv, " ")
+		// Only the flip's own validation fails: the profile has to land
+		// first, or there would be nothing to flip.
+		if staged && strings.Contains(line, "--check-config") {
+			return "", errExit(t, 1)
+		}
+		return labWithConfig(string(baseConfig(t)))(argv)
+	}}
+	a := newTestApplier(t, cmd, defaultProfileName)
+	var buf bytes.Buffer
+	a.jrnl = newJournal(&buf, newFakeClock().now)
+	if err := a.applyProfile(context.Background()); err != nil {
+		t.Fatalf("applyProfile: %v", err)
+	}
+	staged = true
+	before := len(cmd.lines())
+
+	if err := a.flip(context.Background(), "gateway-1", flipIndex(t, "cadence-toggle")); err != nil {
+		t.Fatalf("a rejected flip failed the run: %v", err)
+	}
+
+	for _, line := range cmd.lines()[before:] {
+		if strings.Contains(line, "mv "+agentConfigNextPath) || strings.Contains(line, restartCmd) {
+			t.Fatalf("a rejected config was swapped in anyway: %q", line)
+		}
+	}
+	if got := a.current["gateway-1"]["reconcile_interval"]; got != fastCadence {
+		t.Fatalf("the tracker kept a config the gateway rejected: reconcile_interval = %v", got)
+	}
+	rejected := lastEventOf(t, buf.String(), evConfigFlip)
+	if rejected.Rejected == nil || !*rejected.Rejected {
+		t.Fatalf("journaled %+v, want the flip recorded as rejected", rejected)
+	}
+	if rejected.Detail == "" {
+		t.Fatalf("the rejected flip was journaled without the agent's reason: %+v", rejected)
+	}
+}
+
+func flipIndex(t *testing.T, name string) int {
+	t.Helper()
+	for i, f := range flips() {
+		if f.name == name {
+			return i
+		}
+	}
+	t.Fatalf("no flip named %q in the whitelist", name)
+	return -1
+}
+
+func lastEventOf(t *testing.T, journal, name string) event {
+	t.Helper()
+	var found event
+	for _, ev := range eventsIn(t, journal) {
+		if ev.Event == name {
+			found = ev
+		}
+	}
+	if found.Event == "" {
+		t.Fatalf("no %s event was journaled: %s", name, journal)
+	}
+	return found
 }

--- a/test/e2e/chaos/checks_test.go
+++ b/test/e2e/chaos/checks_test.go
@@ -11,11 +11,12 @@ import (
 // newTestChecks wires the baseline checks against a fake lab and an
 // engine whose node states the test controls, and hands back the run
 // record and the journal both write into.
-func newTestChecks(cmd commander, nodes map[string]string) (*baselineChecks, *runRecord, *bytes.Buffer) {
+func newTestChecks(t *testing.T, cmd commander, nodes map[string]string) (*baselineChecks, *runRecord, *bytes.Buffer) {
+	t.Helper()
 	clock := newFakeClock()
 	rec := &runRecord{ActionsByName: map[string]int{}}
 	buf := &bytes.Buffer{}
-	e := newEngine(newTestLab(cmd, clock), nil, greenProbes{}, newJournal(buf, clock.now), rec)
+	e := newEngine(newTestLab(cmd, clock), defaultTestProfile(t), nil, greenProbes{}, newJournal(buf, clock.now), rec)
 	e.now = clock.now
 	if nodes != nil {
 		e.nodes = nodes
@@ -38,7 +39,7 @@ func TestCheckAgentsAliveFlagsAHealthyNodeWithNoAgent(t *testing.T) {
 		}
 		return healthyLabResponses(argv)
 	}}
-	checks, rec, _ := newTestChecks(cmd, nil)
+	checks, rec, _ := newTestChecks(t, cmd, nil)
 
 	checks.checkAgentsAlive(context.Background())
 
@@ -65,7 +66,7 @@ func TestCheckAgentsAliveDoesNotReadAFailedProbeAsADeadAgent(t *testing.T) {
 		}
 		return healthyLabResponses(argv)
 	}}
-	checks, rec, buf := newTestChecks(cmd, nil)
+	checks, rec, buf := newTestChecks(t, cmd, nil)
 
 	checks.checkAgentsAlive(context.Background())
 
@@ -97,7 +98,7 @@ func TestCheckAgentsAliveSkipsNodesUnderFault(t *testing.T) {
 		}
 		return healthyLabResponses(argv)
 	}}
-	checks, rec, _ := newTestChecks(cmd, map[string]string{
+	checks, rec, _ := newTestChecks(t, cmd, map[string]string{
 		"gateway-1": nodeDisrupted,
 		"gateway-2": nodeConverging,
 		"gateway-3": nodeUnconverged,
@@ -130,7 +131,7 @@ func TestCheckNoDualClaimFlagsASplitGatewayPort(t *testing.T) {
 		}
 		return "", nil
 	}}
-	checks, rec, _ := newTestChecks(cmd, nil)
+	checks, rec, _ := newTestChecks(t, cmd, nil)
 
 	checks.checkNoDualClaim(context.Background())
 
@@ -153,7 +154,7 @@ func TestCheckNoDualClaimAcceptsASinglyClaimedPort(t *testing.T) {
 		return `{"headings":["logical_port","chassis","additional_chassis"],
 		         "data":[["cr-lr0-public",["uuid","uuid-a"],["set",[]]]]}`, nil
 	}}
-	checks, rec, _ := newTestChecks(cmd, nil)
+	checks, rec, _ := newTestChecks(t, cmd, nil)
 
 	checks.checkNoDualClaim(context.Background())
 
@@ -170,7 +171,7 @@ func TestCheckNoDualClaimAcceptsASinglyClaimedPort(t *testing.T) {
 // journal rather than pass silently.
 func TestCheckNoDualClaimJournalsALookupFailure(t *testing.T) {
 	cmd := &fakeCommander{respond: func([]string) (string, error) { return "", errBoom }}
-	checks, rec, buf := newTestChecks(cmd, nil)
+	checks, rec, buf := newTestChecks(t, cmd, nil)
 
 	checks.checkNoDualClaim(context.Background())
 
@@ -203,7 +204,7 @@ func TestARunThatNeverEvaluatedTheDualClaimDoesNotPass(t *testing.T) {
 		}
 		return healthyLabResponses(argv)
 	}}
-	checks, rec, _ := newTestChecks(cmd, nil)
+	checks, rec, _ := newTestChecks(t, cmd, nil)
 
 	checks.sweep(context.Background())
 	checks.sweep(context.Background())
@@ -232,7 +233,7 @@ func TestARunThatEvaluatedTheDualClaimPasses(t *testing.T) {
 		}
 		return healthyLabResponses(argv)
 	}}
-	checks, rec, _ := newTestChecks(cmd, nil)
+	checks, rec, _ := newTestChecks(t, cmd, nil)
 
 	checks.sweep(context.Background())
 	checks.finalize()
@@ -250,7 +251,7 @@ func TestARunThatEvaluatedTheDualClaimPasses(t *testing.T) {
 // did not return on ctx.Done() would hang the runner forever, after the
 // engine has already finished.
 func TestChecksStopWithTheirContext(t *testing.T) {
-	checks, _, _ := newTestChecks(&fakeCommander{respond: healthyLabResponses}, nil)
+	checks, _, _ := newTestChecks(t, &fakeCommander{respond: healthyLabResponses}, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -270,7 +271,7 @@ func TestChecksStopWithTheirContext(t *testing.T) {
 // The sweep runs both checks.
 func TestSweepRunsBothChecks(t *testing.T) {
 	cmd := &fakeCommander{respond: healthyLabResponses}
-	checks, _, _ := newTestChecks(cmd, nil)
+	checks, _, _ := newTestChecks(t, cmd, nil)
 
 	checks.sweep(context.Background())
 

--- a/test/e2e/chaos/engine.go
+++ b/test/e2e/chaos/engine.go
@@ -36,6 +36,7 @@ const (
 	violationActionFailed    = "action-failed"
 	violationAgentDown       = "agent-down"
 	violationDualClaim       = "dual-claim"
+	violationProfileApply    = "profile-not-applied"
 	violationStartState      = "start-state-not-green"
 	violationChecksNeverRan  = "checks-never-ran"
 )
@@ -82,6 +83,7 @@ type probeSource interface {
 type engine struct {
 	rng      *rand.Rand
 	lab      *lab
+	profile  *profile
 	actions  []*action
 	probes   probeSource
 	jrnl     *journal
@@ -109,10 +111,11 @@ type engine struct {
 	vipOwner string
 }
 
-func newEngine(l *lab, actions []*action, probes probeSource, jrnl *journal, rec *runRecord) *engine {
+func newEngine(l *lab, p *profile, actions []*action, probes probeSource, jrnl *journal, rec *runRecord) *engine {
 	e := &engine{
 		rng:      rand.New(rand.NewPCG(uint64(rec.Inputs.Seed), 0)),
 		lab:      l,
+		profile:  p,
 		actions:  actions,
 		probes:   probes,
 		jrnl:     jrnl,
@@ -463,7 +466,14 @@ func (e *engine) converged(ctx context.Context, gw string) bool {
 // whole point of the fault set, and the agent does not manage
 // Load_Balancer VIP routes — so without this the VIP probe would stay
 // red for the rest of the run after the first migration.
+//
+// A profile without the port-forward layer has no Load_Balancer VIP at
+// all: there are no routes to re-point, and issuing them would plumb a
+// VIP the run never put up.
 func (e *engine) followMaster(ctx context.Context) {
+	if !e.profile.ovnLB {
+		return
+	}
 	master := e.lab.currentMaster(ctx)
 	if master == "" || master == e.vipOwner {
 		return

--- a/test/e2e/chaos/engine.go
+++ b/test/e2e/chaos/engine.go
@@ -25,9 +25,10 @@ const (
 
 // Guardrail skip reasons, journaled on the decision they blocked.
 const (
-	skipTargetNotHealthy = "target-not-healthy"
-	skipNoHealthyPeer    = "no-healthy-peer"
-	skipNoWeightedAction = "no-weighted-action"
+	skipTargetNotHealthy  = "target-not-healthy"
+	skipNoHealthyPeer     = "no-healthy-peer"
+	skipNoWeightedAction  = "no-weighted-action"
+	skipFlipNotApplicable = "flip-not-applicable"
 )
 
 // Violation kinds.
@@ -66,8 +67,16 @@ type action struct {
 	holdMin        time.Duration
 	holdMax        time.Duration
 	recoveryBudget time.Duration
-	inject         func(ctx context.Context, l *lab, target string) error
+	inject         func(ctx context.Context, l *lab, target string, flip int) error
 	restore        func(ctx context.Context, l *lab, target string) error
+
+	// applicable binds an action to the flip index every decision draws —
+	// the fifth value taken from the stream, which only config-flip reads.
+	// It is the guardrail that skips a flip meaning nothing on the drawn
+	// target's current configuration, and it is nil on every action whose
+	// behaviour does not depend on the flip — so it is also what tells the
+	// engine whether the drawn flip is worth naming in the journal.
+	applicable func(target string, flip int) bool
 }
 
 // probeSource is the slice of the prober the engine consumes.
@@ -202,13 +211,16 @@ type decision struct {
 	action   *action
 	target   string
 	hold     time.Duration
+	flip     int
 }
 
-// draw takes exactly four values from the stream, in a fixed order:
-// interval, action, target, hold. The count is fixed so that a guardrail
-// skip cannot shift the stream — the run that skips a decision draws the
-// same values afterwards as the run that executed it, which is what
-// makes a replay comparable across labs that behaved differently.
+// draw takes exactly five values from the stream, in a fixed order:
+// interval, action, target, hold, flip. The count is fixed so that a
+// guardrail skip cannot shift the stream — the run that skips a decision
+// draws the same values afterwards as the run that executed it, which is
+// what makes a replay comparable across labs that behaved differently.
+// The flip is drawn on every tick even though only config-flip reads it,
+// for the same reason.
 func (e *engine) draw(tick int) decision {
 	d := decision{tick: tick}
 	d.interval = e.drawDuration(e.tickMin, e.tickMax)
@@ -218,8 +230,8 @@ func (e *engine) draw(tick int) decision {
 		total += a.weight
 	}
 	if total == 0 {
-		// Probe-and-check-only run: no action to pick, so no target and
-		// no hold to draw either.
+		// Probe-and-check-only run: no action to pick, so no target, hold
+		// or flip to draw either.
 		return d
 	}
 	pick := e.rng.IntN(total)
@@ -233,6 +245,7 @@ func (e *engine) draw(tick int) decision {
 	gateways := gatewayNames()
 	d.target = gateways[e.rng.IntN(len(gateways))]
 	d.hold = e.drawDuration(d.action.holdMin, d.action.holdMax)
+	d.flip = e.rng.IntN(len(flips()))
 	return d
 }
 
@@ -256,6 +269,12 @@ func (e *engine) guardrails(d decision) string {
 	}
 	if e.nodeState(d.target) != nodeHealthy {
 		return skipTargetNotHealthy
+	}
+	// A flip that means nothing on what the target is currently running —
+	// a masquerade variant on a gateway with no VIP — would rewrite the
+	// same configuration and restart the node for nothing.
+	if d.action.applicable != nil && !d.action.applicable(d.target, d.flip) {
+		return skipFlipNotApplicable
 	}
 	for _, gw := range e.healthyNodes() {
 		if gw != d.target {
@@ -290,6 +309,11 @@ func (e *engine) run(ctx context.Context) {
 			ev.Action = d.action.name
 			ev.Target = d.target
 			ev.HoldMS = d.hold.Milliseconds()
+			// A flip-aware action names the drawn flip, so a decision that
+			// was skipped still says which one it would have been.
+			if d.action.applicable != nil {
+				ev.Flip = flipName(d.flip)
+			}
 		}
 		e.jrnl.emit(ev)
 
@@ -313,7 +337,7 @@ func (e *engine) execute(ctx context.Context, d decision) {
 
 	injectedAt := e.now()
 	e.jrnl.emit(event{Event: evInject, Tick: d.tick, Action: d.action.name, Target: d.target})
-	if err := d.action.inject(ctx, e.lab, d.target); err != nil {
+	if err := d.action.inject(ctx, e.lab, d.target, d.flip); err != nil {
 		e.undo(ctx, d, err)
 		return
 	}

--- a/test/e2e/chaos/engine_test.go
+++ b/test/e2e/chaos/engine_test.go
@@ -29,7 +29,7 @@ func runEngine(t *testing.T, seed int64, duration time.Duration,
 		},
 		ActionsByName: map[string]int{},
 	}
-	e := newEngine(newTestLab(cmd, clock), actions, greenProbes{}, jrnl, rec)
+	e := newEngine(newTestLab(cmd, clock), defaultTestProfile(t), actions, greenProbes{}, jrnl, rec)
 	e.wait = clock.wait
 	e.now = clock.now
 	if mutate != nil {
@@ -183,7 +183,7 @@ func TestGuardrailsBlockUnhealthyTargetAndLastGateway(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			clock := newFakeClock()
-			e := newEngine(newTestLab(&fakeCommander{}, clock), []*action{act},
+			e := newEngine(newTestLab(&fakeCommander{}, clock), defaultTestProfile(t), []*action{act},
 				greenProbes{}, newJournal(&bytes.Buffer{}, clock.now),
 				&runRecord{ActionsByName: map[string]int{}})
 			e.nodes = tc.nodes
@@ -213,7 +213,7 @@ func TestRunStopsAtDuration(t *testing.T) {
 		ActionsByName: map[string]int{},
 	}
 	e := newEngine(newTestLab(&fakeCommander{respond: healthyLabResponses}, clock),
-		actions, greenProbes{}, newJournal(&buf, clock.now), rec)
+		defaultTestProfile(t), actions, greenProbes{}, newJournal(&buf, clock.now), rec)
 	e.wait, e.now = clock.wait, clock.now
 	// The action holds for 0s so only the tick interval advances the clock.
 	actions[0].holdMin, actions[0].holdMax = 0, 0
@@ -298,7 +298,7 @@ func TestCancelledRunRestoresTheFaultItIsHolding(t *testing.T) {
 	}
 
 	e := newEngine(newTestLab(&fakeCommander{respond: healthyLabResponses}, clock),
-		actions, greenProbes{}, newJournal(&bytes.Buffer{}, clock.now), rec)
+		defaultTestProfile(t), actions, greenProbes{}, newJournal(&bytes.Buffer{}, clock.now), rec)
 	e.wait, e.now = clock.wait, clock.now
 
 	e.run(ctx)
@@ -344,7 +344,7 @@ func TestCancelDuringTheRestoreDoesNotKillIt(t *testing.T) {
 	}
 
 	e := newEngine(newTestLab(&fakeCommander{respond: healthyLabResponses}, clock),
-		actions, greenProbes{}, newJournal(&bytes.Buffer{}, clock.now), rec)
+		defaultTestProfile(t), actions, greenProbes{}, newJournal(&bytes.Buffer{}, clock.now), rec)
 	e.wait, e.now = clock.wait, clock.now
 
 	e.run(ctx)
@@ -484,7 +484,7 @@ func TestFollowMasterRepointsTheVIPWhenTheMasterMoves(t *testing.T) {
 	}}
 	clock := newFakeClock()
 	var buf bytes.Buffer
-	e := newEngine(newTestLab(cmd, clock), nil, greenProbes{},
+	e := newEngine(newTestLab(cmd, clock), defaultTestProfile(t), nil, greenProbes{},
 		newJournal(&buf, clock.now), &runRecord{ActionsByName: map[string]int{}})
 	e.now = clock.now
 
@@ -643,7 +643,7 @@ func TestAFailedAgentTerminateHandsTheRestartPolicyBack(t *testing.T) {
 		},
 		ActionsByName: map[string]int{},
 	}
-	e := newEngine(newTestLab(cmd, clock), []*action{actionNamed(t, "agent-terminate")},
+	e := newEngine(newTestLab(cmd, clock), defaultTestProfile(t), []*action{actionNamed(t, "agent-terminate")},
 		greenProbes{}, newJournal(&bytes.Buffer{}, clock.now), rec)
 	e.wait, e.now = clock.wait, clock.now
 
@@ -679,7 +679,7 @@ func TestACancelledRunDoesNotWaitOutItsTickInterval(t *testing.T) {
 	// The engine keeps its real clock: what is under test is that the wait
 	// itself is interruptible, not that a fake one can be advanced past it.
 	e := newEngine(newLab("ovn-e2e", &fakeCommander{respond: healthyLabResponses}),
-		noopActions("controller-restart"), greenProbes{},
+		defaultTestProfile(t), noopActions("controller-restart"), greenProbes{},
 		newJournal(&bytes.Buffer{}, time.Now), rec)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -725,7 +725,8 @@ func TestRecoveryBudgetExpiryIsAViolation(t *testing.T) {
 		}
 		return healthyLabResponses(argv)
 	}}
-	e := newEngine(newTestLab(cmd, clock), actions, greenProbes{}, newJournal(&buf, clock.now), rec)
+	e := newEngine(newTestLab(cmd, clock), defaultTestProfile(t), actions, greenProbes{},
+		newJournal(&buf, clock.now), rec)
 	e.wait, e.now = clock.wait, clock.now
 
 	e.run(context.Background())

--- a/test/e2e/chaos/engine_test.go
+++ b/test/e2e/chaos/engine_test.go
@@ -285,7 +285,7 @@ func TestCancelledRunRestoresTheFaultItIsHolding(t *testing.T) {
 
 	actions := noopActions("gateway-kill")
 	// The operator hits Ctrl-C while the fault is held.
-	actions[0].inject = func(context.Context, *lab, string) error {
+	actions[0].inject = func(context.Context, *lab, string, int) error {
 		cancel()
 		return nil
 	}
@@ -550,7 +550,7 @@ func parkedIn(t *testing.T, journal, gw string) bool {
 // fails.
 func TestFailedInjectParksTheNodeAndFailsTheRun(t *testing.T) {
 	actions := noopActions("controller-restart")
-	actions[0].inject = func(context.Context, *lab, string) error {
+	actions[0].inject = func(context.Context, *lab, string, int) error {
 		return errBoom
 	}
 
@@ -574,7 +574,7 @@ func TestFailedInjectParksTheNodeAndFailsTheRun(t *testing.T) {
 // when it is the inject that failed.
 func TestAFailedInjectIsUndone(t *testing.T) {
 	actions := noopActions("agent-terminate")
-	actions[0].inject = func(context.Context, *lab, string) error { return errBoom }
+	actions[0].inject = func(context.Context, *lab, string, int) error { return errBoom }
 	var restores int
 	var restoreCtxErr error
 	var bounded bool
@@ -815,4 +815,96 @@ func slicesEqual(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// The flip index is the fifth value every tick draws, and it is drawn
+// whether or not the action that was picked reads it. Two runs with the
+// same seed must therefore agree on the flips as well as on the actions —
+// the profile and the seed together are what a replay reproduces.
+func TestSameSeedReplaysTheSameFlips(t *testing.T) {
+	actions := func() []*action {
+		acts := noopActions("gateway-kill")
+		acts[0].applicable = func(string, int) bool { return true }
+		return acts
+	}
+	first, _ := runEngine(t, 7, 20*time.Minute, actions(), nil)
+	second, _ := runEngine(t, 7, 20*time.Minute, actions(), nil)
+
+	a, b := decisionsIn(t, first), decisionsIn(t, second)
+	if len(a) == 0 {
+		t.Fatal("the run made no decisions at all")
+	}
+	if len(a) != len(b) || !slicesEqual(a, b) {
+		t.Fatalf("the same seed drew different flips:\n%v\n%v", a, b)
+	}
+
+	drawn := map[string]bool{}
+	for _, ev := range eventsIn(t, first) {
+		if ev.Event == evDecision && ev.Flip != "" {
+			drawn[ev.Flip] = true
+		}
+	}
+	if len(drawn) < 2 {
+		t.Fatalf("a 20-minute run drew only %v — the flip is not being drawn per tick", drawn)
+	}
+}
+
+// A flip that means nothing on the target's current configuration — a
+// masquerade variant on a gateway with no VIP — is a guardrail skip. Like
+// every other skip it must not shift the stream: the run that skipped
+// draws the same values afterwards as the run that executed.
+func TestAnInapplicableFlipIsSkippedWithoutShiftingTheStream(t *testing.T) {
+	flippable := noopActions("config-flip")
+	flippable[0].applicable = func(string, int) bool { return true }
+
+	applied := noopActions("config-flip")
+	// gateway-2's configuration has nothing the drawn flip can change.
+	applied[0].applicable = func(gw string, _ int) bool { return gw != "gateway-2" }
+
+	open, _ := runEngine(t, 42, 20*time.Minute, flippable, nil)
+	guarded, rec := runEngine(t, 42, 20*time.Minute, applied, nil)
+
+	a, b := decisionsIn(t, open), decisionsIn(t, guarded)
+	for i := range a {
+		if i < len(b) && a[i] != b[i] {
+			t.Fatalf("decision %d diverged after an inapplicable flip was skipped: %q vs %q", i+1, a[i], b[i])
+		}
+	}
+	if rec.Decisions.Skipped == 0 {
+		t.Fatal("no decision was skipped even though every gateway-2 flip was inapplicable")
+	}
+	var skipped event
+	for _, ev := range eventsIn(t, guarded) {
+		if ev.Event == evDecision && ev.SkipReason == skipFlipNotApplicable {
+			skipped = ev
+		}
+	}
+	if skipped.Target != "gateway-2" {
+		t.Fatalf("journaled %+v, want a %s skip on gateway-2", skipped, skipFlipNotApplicable)
+	}
+	// A skipped decision still says which flip it would have been —
+	// otherwise the journal cannot explain why it was skipped.
+	if skipped.Flip == "" {
+		t.Fatalf("the skipped decision does not name the flip it drew: %+v", skipped)
+	}
+}
+
+// A profile without the port-forward layer has no Load_Balancer VIP: there
+// are no hand-plumbed routes to follow the master with, and issuing them
+// would plumb a VIP the run never put up.
+func TestFollowMasterDoesNothingWithoutTheLoadBalancerVIP(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	clock := newFakeClock()
+	e := newEngine(newTestLab(cmd, clock), testProfile(t, "pf-only"), nil, greenProbes{},
+		newJournal(&bytes.Buffer{}, clock.now), &runRecord{ActionsByName: map[string]int{}})
+	e.now = clock.now
+
+	e.followMaster(context.Background())
+
+	if len(cmd.lines()) != 0 {
+		t.Fatalf("a profile without the port-forward layer still plumbed the VIP: %v", cmd.lines())
+	}
+	if e.vipOwner != "" {
+		t.Fatalf("vipOwner = %q on a run with no Load_Balancer VIP", e.vipOwner)
+	}
 }

--- a/test/e2e/chaos/fakes_test.go
+++ b/test/e2e/chaos/fakes_test.go
@@ -169,6 +169,20 @@ func (redProbes) recoverySince(time.Time) map[string]int64 {
 	return map[string]int64{"fip-vm1": 0}
 }
 
+// testProfile resolves a profile the tests drive the runner with. Most of
+// them want the default one — every layer up, every gateway on the baked
+// config — which is what the runner did before profiles existed.
+func testProfile(t *testing.T, name string) *profile {
+	t.Helper()
+	p, err := profileByName(name)
+	if err != nil {
+		t.Fatalf("profileByName(%q): %v", name, err)
+	}
+	return p
+}
+
+func defaultTestProfile(t *testing.T) *profile { return testProfile(t, defaultProfileName) }
+
 // newTestLab wires a lab against the fake commander and the fake clock.
 func newTestLab(cmd commander, clock *fakeClock) *lab {
 	return &lab{name: "ovn-e2e", cmd: cmd, sleep: clock.sleep, now: clock.now}

--- a/test/e2e/chaos/fakes_test.go
+++ b/test/e2e/chaos/fakes_test.go
@@ -199,7 +199,7 @@ func noopActions(names ...string) []*action {
 			holdMin:        5 * time.Second,
 			holdMax:        5 * time.Second,
 			recoveryBudget: 60 * time.Second,
-			inject:         func(context.Context, *lab, string) error { return nil },
+			inject:         func(context.Context, *lab, string, int) error { return nil },
 			restore:        func(context.Context, *lab, string) error { return nil },
 		})
 	}
@@ -227,6 +227,7 @@ func decisionsIn(t *testing.T, journal string) []string {
 			e.Action, e.Target,
 			time.Duration(e.IntervalMS).String(),
 			time.Duration(e.HoldMS).String(),
+			e.Flip,
 		}, "|"))
 	}
 	return out

--- a/test/e2e/chaos/flips.go
+++ b/test/e2e/chaos/flips.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// A configuration change is a fault like any other: rollouts, tuning and
+// emergency flag flips happen on live gateways, under load, one node at a
+// time. The config-flip action draws one of the toggles below, rewrites
+// the target's configuration with it, and restarts the node onto it —
+// through the same validate-then-swap path the profile apply uses.
+//
+// The whitelist is append-only, exactly like the action registry: the
+// engine draws a flip *by index* from the seeded stream, so inserting one
+// would replay every recorded seed as a different run.
+
+// The two reconcile cadences the cadence flip toggles between. The fast
+// one is what the lab bakes in (tighter than the production default so
+// the stale-chassis cleanup lands inside the CI budget); the slow one is
+// three times that, which is enough to change how much a fault costs
+// without stalling a recovery gate.
+const (
+	fastCadence = "5s"
+	slowCadence = "15s"
+)
+
+// flipCtx is what a flip sees: the gateway's live configuration document,
+// which it mutates in place; the document the profile put there, which is
+// what a toggle returns to; and the gateway's management address, the
+// backend a VIP the flip adds forwards to.
+type flipCtx struct {
+	doc      map[string]any
+	baseline map[string]any
+	mgmtIP   string
+}
+
+// flip is one whitelisted configuration change the config-flip action may
+// make to a live gateway.
+type flip struct {
+	name string
+
+	// applicable reports whether the flip means anything on this
+	// gateway's current configuration. An inapplicable flip is a
+	// guardrail skip, not a failure — the engine journals it and moves
+	// on, and the decision stream stays aligned either way.
+	applicable func(c flipCtx) bool
+
+	// apply toggles the option in place, reporting the values it moved
+	// between.
+	apply func(c flipCtx) (from, to string)
+}
+
+func flips() []flip {
+	return []flip{
+		{
+			// What the agent does with a SIGTERM: exit, or hand its
+			// chassis over first. The flip's own restart is the SIGTERM,
+			// so the very next one exercises whichever path it just set.
+			name:       "drain-toggle",
+			applicable: alwaysApplicable,
+			apply: func(c flipCtx) (string, string) {
+				return toggleBool(c.doc, "drain_on_shutdown")
+			},
+		},
+		{
+			// The agent's hairpin SNAT. Traffic from the provider
+			// networks is masqueraded, everything else is not — so an
+			// external probe from client-1 (outside every provider net) is
+			// reachable either way, and what the flip changes is the
+			// nftables ruleset the agent has to program and re-program.
+			name:       "masquerade-toggle",
+			applicable: func(c flipCtx) bool { return apiVIPIn(c.doc) != nil },
+			apply: func(c flipCtx) (string, string) {
+				return toggleBool(apiVIPIn(c.doc), "hairpin_masquerade")
+			},
+		},
+		{
+			// OVN-discovered networks versus a manual filter — the
+			// codepath that has to *exclude* routes rather than add them.
+			// The manual list covers every probed prefix, so it exercises
+			// the filter without blacking a probe out, and the toggle back
+			// is always to what the profile configured: in
+			// port-forward-only mode an empty filter would stop the VIP
+			// being announced at all.
+			name: "cidr-toggle",
+			applicable: func(c flipCtx) bool {
+				return !slices.Equal(stringsOf(c.baseline["network_cidr"]), explicitCIDRs)
+			},
+			apply: func(c flipCtx) (string, string) {
+				from := stringsOf(c.doc["network_cidr"])
+				if slices.Equal(from, explicitCIDRs) {
+					to := stringsOf(c.baseline["network_cidr"])
+					if len(to) == 0 {
+						delete(c.doc, "network_cidr")
+					} else {
+						c.doc["network_cidr"] = anySlice(to)
+					}
+					return cidrLabel(from), cidrLabel(to)
+				}
+				c.doc["network_cidr"] = anySlice(explicitCIDRs)
+				return cidrLabel(from), cidrLabel(explicitCIDRs)
+			},
+		},
+		{
+			// How often the agent re-reconciles — the tuning knob an
+			// operator reaches for first, and the one that decides how
+			// long a missed event stays missed.
+			name:       "cadence-toggle",
+			applicable: alwaysApplicable,
+			apply: func(c flipCtx) (string, string) {
+				from, _ := c.doc["reconcile_interval"].(string)
+				to := slowCadence
+				if from == slowCadence {
+					to = fastCadence
+				}
+				c.doc["reconcile_interval"] = to
+				return from, to
+			},
+		},
+		{
+			// A port-forward rule added and removed under load. It carries
+			// a VIP of its own rather than touching the API VIP's rules:
+			// a rule that exists on one gateway and not on another must
+			// never draw probe traffic to a gateway with no backend.
+			name:       "pf-rule-toggle",
+			applicable: alwaysApplicable,
+			apply: func(c flipCtx) (string, string) {
+				vips := vipsOf(c.doc)
+				for i, vip := range vips {
+					if vipAddrOf(vip) != flipVIPAddr {
+						continue
+					}
+					remaining := append(vips[:i:i], vips[i+1:]...)
+					if len(remaining) == 0 {
+						delete(c.doc, "port_forwards")
+					} else {
+						c.doc["port_forwards"] = remaining
+					}
+					return flipVIPAddr, "absent"
+				}
+				c.doc["port_forwards"] = append(vips, flipVIPBlock(c.mgmtIP))
+				return "absent", flipVIPAddr
+			},
+		},
+	}
+}
+
+// flipName names a drawn flip for the journal, so a decision that was
+// skipped still says which flip it would have been.
+func flipName(idx int) string { return flips()[idx].name }
+
+func alwaysApplicable(flipCtx) bool { return true }
+
+// toggleBool inverts a boolean key, treating an absent key as false —
+// which is what the agent's own config layering does with it.
+func toggleBool(doc map[string]any, key string) (string, string) {
+	from, _ := doc[key].(bool)
+	doc[key] = !from
+	return strconv.FormatBool(from), strconv.FormatBool(!from)
+}
+
+// vipsOf is the document's port_forwards list, as a YAML round-trip
+// leaves it.
+func vipsOf(doc map[string]any) []any {
+	vips, _ := doc["port_forwards"].([]any)
+	return vips
+}
+
+func vipAddrOf(entry any) string {
+	vip, ok := entry.(map[string]any)
+	if !ok {
+		return ""
+	}
+	addr, _ := vip["vip"].(string)
+	return addr
+}
+
+// apiVIPIn is the document's API VIP entry, or nil when it carries none —
+// which is what makes the masquerade flip inapplicable on a gateway whose
+// profile configured no DNAT at all.
+func apiVIPIn(doc map[string]any) map[string]any {
+	for _, entry := range vipsOf(doc) {
+		if vipAddrOf(entry) == apiVIPAddr {
+			vip, _ := entry.(map[string]any)
+			return vip
+		}
+	}
+	return nil
+}
+
+// cidrLabel renders a network filter for the journal. An empty filter is
+// not "nothing": it is the agent discovering the provider networks from
+// OVN itself.
+func cidrLabel(cidrs []string) string {
+	if len(cidrs) == 0 {
+		return "auto"
+	}
+	return strings.Join(cidrs, ",")
+}

--- a/test/e2e/chaos/flips_test.go
+++ b/test/e2e/chaos/flips_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"testing"
+)
+
+// The whitelist order is part of the replay contract — the engine draws a
+// flip by index — so a new one is appended, never inserted.
+func TestFlipWhitelistOrderIsStable(t *testing.T) {
+	want := []string{
+		"drain-toggle", "masquerade-toggle", "cidr-toggle",
+		"cadence-toggle", "pf-rule-toggle",
+	}
+
+	for i, f := range flips() {
+		if i >= len(want) || f.name != want[i] {
+			t.Fatalf("flip %d = %q, want %q", i, f.name, want)
+		}
+		if f.applicable == nil || f.apply == nil {
+			t.Fatalf("flip %s is not fully declared", f.name)
+		}
+		if flipName(i) != want[i] {
+			t.Fatalf("flipName(%d) = %q, want %q", i, flipName(i), want[i])
+		}
+	}
+	if len(flips()) != len(want) {
+		t.Fatalf("whitelist has %d flips, want %d", len(flips()), len(want))
+	}
+}
+
+// Every flip is a toggle: applied twice it puts the gateway back on the
+// configuration the profile gave it. Without that, a long run would drift
+// away from its profile one flip at a time and the run would no longer be
+// testing the configuration it says it is.
+func TestEveryFlipRoundTripsBackToTheProfilesConfig(t *testing.T) {
+	for i, f := range flips() {
+		t.Run(f.name, func(t *testing.T) {
+			// flat-dnat carries the API VIP, so every flip is applicable
+			// on it — including the masquerade one.
+			c := flipContext(t, "flat-dnat", "gateway-1")
+			if !f.applicable(c) {
+				t.Fatalf("%s is not applicable on a gateway with the API VIP", f.name)
+			}
+			before := marshal(t, c.doc)
+
+			from, to := f.apply(c)
+			if from == to {
+				t.Fatalf("%s reported a move from %q to %q — it changed nothing", f.name, from, to)
+			}
+			if marshal(t, c.doc) == before {
+				t.Fatalf("%s reported %s -> %s but rewrote nothing", f.name, from, to)
+			}
+
+			back, forth := flips()[i].apply(c)
+			if back != to || forth != from {
+				t.Fatalf("%s toggled back from %q to %q, want %q -> %q", f.name, back, forth, to, from)
+			}
+			if got := marshal(t, c.doc); got != before {
+				t.Fatalf("%s did not round-trip:\n%s\nwant\n%s", f.name, got, before)
+			}
+		})
+	}
+}
+
+// The CIDR flip toggles between OVN-discovered networks and a manual
+// filter — but the way back is always to what the *profile* configured.
+// In port-forward-only mode the filter is the only reason the VIP is
+// announced at all: toggling it away to nothing would black the run's one
+// probe out for good.
+func TestCIDRFlipNeverEmptiesAFilterTheProfileNeeds(t *testing.T) {
+	c := flipContext(t, "pf-only", "gateway-1")
+
+	from, to := flipNamed(t, "cidr-toggle").apply(c)
+	if from != "192.0.2.0/24" || to != cidrLabel(explicitCIDRs) {
+		t.Fatalf("cidr-toggle moved %q -> %q, want the profile's filter to the manual one", from, to)
+	}
+
+	from, to = flipNamed(t, "cidr-toggle").apply(c)
+	if to != "192.0.2.0/24" {
+		t.Fatalf("cidr-toggle moved %q -> %q, want it back to the filter the profile configured", from, to)
+	}
+	if got := stringsOf(c.doc["network_cidr"]); len(got) == 0 {
+		t.Fatal("the toggle back emptied the filter: nothing would announce the VIP any more")
+	}
+}
+
+// A flip that means nothing on the gateway's current configuration is a
+// guardrail skip, not a rewrite: the masquerade flip has no VIP to flip it
+// on, and the CIDR flip has nowhere to toggle back to when the profile
+// already configured the manual filter.
+func TestInapplicableFlips(t *testing.T) {
+	tests := []struct {
+		flip    string
+		profile string
+		gw      string
+		reason  string
+	}{
+		{
+			flip: "masquerade-toggle", profile: defaultProfileName, gw: "gateway-1",
+			reason: "the gateway has no port-forward VIP at all",
+		},
+		{
+			flip: "masquerade-toggle", profile: "heterogeneous", gw: "gateway-3",
+			reason: "only gateway-2 carries the API VIP under this profile",
+		},
+		{
+			flip: "cidr-toggle", profile: "heterogeneous", gw: "gateway-3",
+			reason: "the profile already put the manual filter on this gateway",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.flip+"/"+tc.profile+"/"+tc.gw, func(t *testing.T) {
+			t.Parallel()
+			if flipNamed(t, tc.flip).applicable(flipContext(t, tc.profile, tc.gw)) {
+				t.Fatalf("%s was applicable even though %s", tc.flip, tc.reason)
+			}
+		})
+	}
+}
+
+// The port-forward flip carries a VIP of its own. Touching the API VIP's
+// rules instead would take the probed data path down on a gateway that is
+// meant to keep serving it.
+func TestPortForwardFlipLeavesTheProbedVIPAlone(t *testing.T) {
+	c := flipContext(t, "flat-dnat", "gateway-2")
+
+	if _, to := flipNamed(t, "pf-rule-toggle").apply(c); to != flipVIPAddr {
+		t.Fatalf("pf-rule-toggle added %q, want the unprobed flip VIP %s", to, flipVIPAddr)
+	}
+	if apiVIPIn(c.doc) == nil {
+		t.Fatalf("the probed API VIP was removed by the flip: %v", c.doc["port_forwards"])
+	}
+	if len(vipsOf(c.doc)) != 2 {
+		t.Fatalf("port_forwards = %v, want the API VIP alongside the flip's own", c.doc["port_forwards"])
+	}
+}
+
+// flipContext renders one gateway's profile configuration and hands back
+// what a flip sees: the live document, the profile's own, and the
+// gateway's management address.
+func flipContext(t *testing.T, profileName, gw string) flipCtx {
+	t.Helper()
+	p := testProfile(t, profileName)
+	raw, err := renderConfig(baseConfig(t), p.gwConfig(gw), "172.20.20.5")
+	if err != nil {
+		t.Fatalf("renderConfig: %v", err)
+	}
+	doc, err := parseConfig(raw)
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	baseline, err := parseConfig(raw)
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	return flipCtx{doc: doc, baseline: baseline, mgmtIP: "172.20.20.5"}
+}
+
+func flipNamed(t *testing.T, name string) flip {
+	t.Helper()
+	for _, f := range flips() {
+		if f.name == name {
+			return f
+		}
+	}
+	t.Fatalf("no flip named %q in the whitelist", name)
+	return flip{}
+}
+
+func marshal(t *testing.T, doc map[string]any) string {
+	t.Helper()
+	raw, err := marshalConfig(doc)
+	if err != nil {
+		t.Fatalf("marshalConfig: %v", err)
+	}
+	return string(raw)
+}

--- a/test/e2e/chaos/journal.go
+++ b/test/e2e/chaos/journal.go
@@ -26,6 +26,7 @@ const (
 const (
 	evRunStart        = "run-start"
 	evProfileApply    = "profile-apply"
+	evConfigFlip      = "config-flip"
 	evStateApplied    = "state-applied"
 	evDecision        = "decision"
 	evInject          = "inject"
@@ -53,6 +54,10 @@ type event struct {
 	HoldMS     int64            `json:"hold_ms,omitempty"`
 	Executed   *bool            `json:"executed,omitempty"`
 	SkipReason string           `json:"skip_reason,omitempty"`
+	Flip       string           `json:"flip,omitempty"`
+	From       string           `json:"from,omitempty"`
+	To         string           `json:"to,omitempty"`
+	Rejected   *bool            `json:"rejected,omitempty"`
 	Probe      string           `json:"probe,omitempty"`
 	Up         *bool            `json:"up,omitempty"`
 	State      string           `json:"state,omitempty"`

--- a/test/e2e/chaos/journal.go
+++ b/test/e2e/chaos/journal.go
@@ -25,6 +25,7 @@ const (
 // Journal event names.
 const (
 	evRunStart        = "run-start"
+	evProfileApply    = "profile-apply"
 	evStateApplied    = "state-applied"
 	evDecision        = "decision"
 	evInject          = "inject"
@@ -66,8 +67,13 @@ type event struct {
 // runInputs is the reproducibility contract: identical inputs replay the
 // identical decision sequence. It is echoed into the `run-start` event
 // and into the run record.
+//
+// The profile is one of them: it decides both the topology the run drives
+// and the configuration every agent in it runs, so a seed without a
+// profile does not identify a run.
 type runInputs struct {
 	Seed       int64          `json:"seed"`
+	Profile    string         `json:"profile"`
 	DurationMS int64          `json:"duration_ms"`
 	TickMinMS  int64          `json:"tick_min_ms"`
 	TickMaxMS  int64          `json:"tick_max_ms"`

--- a/test/e2e/chaos/journal_test.go
+++ b/test/e2e/chaos/journal_test.go
@@ -158,3 +158,36 @@ func TestProberReportsRedTargets(t *testing.T) {
 		t.Fatalf("redTargets = %v, want [fip-vm1]", red)
 	}
 }
+
+// The flip fields describe a configuration change, and nothing else: on
+// every other event they must stay out of the line entirely, or a journal
+// reader cannot tell a decision that flipped a config from one that did
+// not.
+func TestFlipFieldsAreJournaledOnlyWhereTheyBelong(t *testing.T) {
+	var buf bytes.Buffer
+	j := newJournal(&buf, newFakeClock().now)
+
+	j.emit(event{
+		Event: evConfigFlip, Target: "gateway-2", Flip: "drain-toggle",
+		From: "false", To: "true", Rejected: boolPtr(false),
+	})
+	j.emit(event{Event: evInject, Tick: 3, Action: "gateway-kill", Target: "gateway-1"})
+
+	lines := eventsIn(t, buf.String())
+	flip := lines[0]
+	if flip.Flip != "drain-toggle" || flip.From != "false" || flip.To != "true" {
+		t.Fatalf("the config-flip event lost its values: %+v", flip)
+	}
+	if flip.Rejected == nil || *flip.Rejected {
+		t.Fatalf("an applied flip was journaled as rejected: %+v", flip)
+	}
+	raw := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if !strings.Contains(raw[0], `"rejected":false`) {
+		t.Fatalf("an applied flip does not say so explicitly: %s", raw[0])
+	}
+	for _, field := range []string{"flip", "from", "to", "rejected"} {
+		if strings.Contains(raw[1], `"`+field+`"`) {
+			t.Fatalf("the %s field leaked into an event that never flipped anything: %s", field, raw[1])
+		}
+	}
+}

--- a/test/e2e/chaos/lab.go
+++ b/test/e2e/chaos/lab.go
@@ -101,6 +101,15 @@ const (
 	workloadHost = "gateway-3"
 	crPort       = "cr-lr0-public"
 
+	// The agent as the gwnode image ships it: the binary, the config file
+	// the entrypoint execs it with, and the two paths the chaos runner
+	// owns next to it — the staged config it validates before swapping,
+	// and the marker that tells the entrypoint a profile owns the file.
+	agentBinary         = "/usr/local/bin/ovn-network-agent"
+	agentConfigPath     = "/etc/ovn-network-agent/config.yaml"
+	agentConfigNextPath = "/etc/ovn-network-agent/config.next.yaml"
+	profileMarkerPath   = "/etc/ovn-network-agent/chaos-profile"
+
 	// The port-forward VIP from pf-external.sh. The agent does not
 	// propagate Load_Balancer VIPs into the underlay, so the runner
 	// keeps the two routes pointed at the current master itself — see
@@ -269,7 +278,7 @@ func (l *lab) containerHealth(ctx context.Context, gw string) string {
 // runner into an agent-down violation and fail the run over a lab that
 // was fine, so they are returned as an error.
 func (l *lab) agentAlive(ctx context.Context, gw string) (bool, error) {
-	out, err := l.exec(ctx, gw, "pgrep", "-f", "/usr/local/bin/ovn-network-agent")
+	out, err := l.exec(ctx, gw, "pgrep", "-f", agentBinary)
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
@@ -278,6 +287,74 @@ func (l *lab) agentAlive(ctx context.Context, gw string) (bool, error) {
 		return false, err
 	}
 	return strings.TrimSpace(out) != "", nil
+}
+
+// writeFile writes content to a path inside a container. The content is a
+// rendered agent config, so it goes through the same argv-level quoting
+// configureGatewayBGP already uses for its vtysh block.
+func (l *lab) writeFile(ctx context.Context, node, path, content string) error {
+	if _, err := l.sh(ctx, node, "printf '%s' "+shellQuote(content)+" > "+path); err != nil {
+		return fmt.Errorf("write %s on %s: %w", path, node, err)
+	}
+	return nil
+}
+
+func (l *lab) readFile(ctx context.Context, node, path string) (string, error) {
+	out, err := l.exec(ctx, node, "cat", path)
+	if err != nil {
+		return "", fmt.Errorf("read %s on %s: %w", path, node, err)
+	}
+	return out, nil
+}
+
+func (l *lab) moveFile(ctx context.Context, node, from, to string) error {
+	if _, err := l.exec(ctx, node, "mv", from, to); err != nil {
+		return fmt.Errorf("move %s to %s on %s: %w", from, to, node, err)
+	}
+	return nil
+}
+
+func (l *lab) removeFile(ctx context.Context, node, path string) error {
+	if _, err := l.exec(ctx, node, "rm", "-f", path); err != nil {
+		return fmt.Errorf("remove %s on %s: %w", path, node, err)
+	}
+	return nil
+}
+
+// mgmtIP is the gateway's address on the containerlab management network,
+// derived exactly the way the gwnode entrypoint derives its geneve encap
+// IP. It is where the API VIP's DNAT backend listens.
+func (l *lab) mgmtIP(ctx context.Context, gw string) (string, error) {
+	out, err := l.sh(ctx, gw, "ip -o -4 addr show eth0 | awk '{print $4}' | cut -d/ -f1")
+	if err != nil {
+		return "", fmt.Errorf("read the management address of %s: %w", gw, err)
+	}
+	ip := strings.TrimSpace(out)
+	if ip == "" {
+		return "", fmt.Errorf("%s has no address on the management network", gw)
+	}
+	return ip, nil
+}
+
+// checkConfig hands a staged config file to the agent's own validator.
+//
+// Exit 1 is the answer the gate is asking for — the config is invalid —
+// and comes back as (false, why, nil). Every other failure means the
+// question could not be asked at all: a docker daemon under load, a
+// container that is gone, the 30s cmdTimeout expiring. Folding those into
+// "invalid" would be the milder mistake; folding them into "valid" would
+// swap a live agent config on the strength of a check that never ran, so
+// they are returned as an error — the same split agentAlive makes.
+func (l *lab) checkConfig(ctx context.Context, gw, path string) (bool, string, error) {
+	out, err := l.exec(ctx, gw, agentBinary, "--check-config", "--config", path)
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return false, err.Error(), nil
+		}
+		return false, "", fmt.Errorf("validate %s on %s: %w", path, gw, err)
+	}
+	return true, strings.TrimSpace(out), nil
 }
 
 // chassisInSB reports whether gw still has (or has re-registered) its

--- a/test/e2e/chaos/lab_test.go
+++ b/test/e2e/chaos/lab_test.go
@@ -434,3 +434,62 @@ func TestWaitReadyGivesUpOnADeadContext(t *testing.T) {
 		t.Fatalf("waitReady probed the node on a dead context: %v", cmd.lines())
 	}
 }
+
+// The config the runner writes is a YAML document with quotes, hashes and
+// newlines in it. It reaches the container through `sh -euc`, so it has to
+// survive the shell in one piece — an unquoted `#` or `'` would truncate
+// the file or break the command outright.
+func TestWriteFileSurvivesTheShell(t *testing.T) {
+	cmd := &fakeCommander{}
+	l := newTestLab(cmd, newFakeClock())
+	content := "log_level: 'info' # a $comment\nnetwork_cidr:\n  - 192.0.2.0/24\n"
+
+	if err := l.writeFile(context.Background(), "gateway-1", agentConfigNextPath, content); err != nil {
+		t.Fatalf("writeFile: %v", err)
+	}
+
+	want := "printf '%s' 'log_level: '\\''info'\\'' # a $comment\nnetwork_cidr:\n  - 192.0.2.0/24\n' > " +
+		agentConfigNextPath
+	got := cmd.lines()[0]
+	if !strings.HasSuffix(got, want) {
+		t.Fatalf("wrote\n\t%q\nwant it to end in\n\t%q", got, want)
+	}
+}
+
+// The agent exits 1 on a config it rejects — that is the answer the gate
+// is asking for. Every other failure means the question could not be asked
+// at all, and reading it as "valid" would swap a live config on the
+// strength of a check that never ran.
+func TestCheckConfigSeparatesARejectionFromAnUnaskedQuestion(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantValid bool
+		wantErr   bool
+	}{
+		{name: "the agent accepts the config", err: nil, wantValid: true},
+		{name: "the agent rejects the config", err: errExit(t, 1), wantValid: false},
+		{name: "the check could not run at all", err: errBoom, wantValid: false, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := &fakeCommander{respond: func([]string) (string, error) {
+				return "configuration OK\n", tc.err
+			}}
+			l := newTestLab(cmd, newFakeClock())
+
+			valid, _, err := l.checkConfig(context.Background(), "gateway-1", agentConfigNextPath)
+
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("checkConfig error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if valid != tc.wantValid {
+				t.Fatalf("checkConfig valid = %v, want %v", valid, tc.wantValid)
+			}
+			if !cmd.called("--check-config --config " + agentConfigNextPath) {
+				t.Fatalf("the staged config was not the one validated: %v", cmd.lines())
+			}
+		})
+	}
+}

--- a/test/e2e/chaos/main.go
+++ b/test/e2e/chaos/main.go
@@ -2,22 +2,25 @@
 // #176). It drives an already-deployed lab through a randomized fault
 // sequence for a bounded duration and reports what it did.
 //
-// One run: layer the existing scenarios' setups (hairpin, multi-VLAN,
-// port-forward) on top of the bootstrap baseline, start a continuous
-// reachability probe from client-1, then tick until the duration
-// expires — wait a randomized interval, pick a weighted action, check
-// its guardrails, execute it, wait for the node to converge, record it.
+// One run: apply the named configuration profile (issue #177) — the
+// agent configuration every gateway runs, validated and rolled out
+// without an image rebuild — layer the profile's scenario setups on top
+// of the bootstrap baseline, start a continuous reachability probe from
+// client-1, then tick until the duration expires: wait a randomized
+// interval, pick a weighted action, check its guardrails, execute it,
+// wait for the node to converge, record it.
 //
-// Reproducibility is the contract: the seed, the duration, the tick
-// bounds and the action weights are the only inputs, and every decision
-// the engine makes is drawn from a PCG stream seeded by -seed alone. Two
-// runs with identical inputs replay the identical decision sequence —
-// diff the `decision` lines of their journals to see it.
+// Reproducibility is the contract: the profile, the seed, the duration,
+// the tick bounds and the action weights are the only inputs, and every
+// decision the engine makes is drawn from a PCG stream seeded by -seed
+// alone. Two runs with identical inputs replay the identical decision
+// sequence — diff the `decision` lines of their journals to see it.
 //
 // Usage (against a lab that is already up — `make e2e-up`):
 //
 //	go run ./test/e2e/chaos [flags]
 //	make e2e-chaos CHAOS_FLAGS="-duration 3m -seed 7"
+//	make e2e-chaos CHAOS_FLAGS="-profile pf-only"
 //
 // Exit codes: 0 the run passed, 1 the run recorded a violation, 2 the
 // runner could not set the run up. On a non-zero exit the lab's existing
@@ -59,19 +62,23 @@ const collectTimeout = 2 * time.Minute
 
 // config is one run's inputs, as parsed from the flags.
 type config struct {
-	seed       int64
-	duration   time.Duration
-	tickMin    time.Duration
-	tickMax    time.Duration
-	weightSpec string
-	labName    string
-	outDir     string
-	collect    string
+	seed         int64
+	profile      string
+	duration     time.Duration
+	tickMin      time.Duration
+	tickMax      time.Duration
+	weightSpec   string
+	labName      string
+	outDir       string
+	collect      string
+	gwnodeConfig string
 }
 
 func main() {
 	var cfg config
 	flag.Int64Var(&cfg.seed, "seed", 42, "seed for every decision the engine makes")
+	flag.StringVar(&cfg.profile, "profile", defaultProfileName,
+		"configuration profile: the start topology and the agent configuration each gateway runs")
 	flag.DurationVar(&cfg.duration, "duration", 10*time.Minute, "how long to keep injecting faults")
 	flag.DurationVar(&cfg.tickMin, "tick-min", 10*time.Second, "lower bound of the interval between decisions")
 	flag.DurationVar(&cfg.tickMax, "tick-max", 30*time.Second, "upper bound of the interval between decisions")
@@ -80,6 +87,8 @@ func main() {
 	flag.StringVar(&cfg.outDir, "out", "chaos-artifacts", "directory for the journal, the run record and the lab-state dump")
 	flag.StringVar(&cfg.collect, "collect", "test/e2e/scenarios/collect-artifacts.sh",
 		"lab-state collector, run into <out>/lab-state when the run does not pass")
+	flag.StringVar(&cfg.gwnodeConfig, "gwnode-config", "test/e2e/gwnode-config.yaml",
+		"the baked gateway agent config a profile's overlays are layered over")
 	flag.Parse()
 
 	code, err := run(cfg)
@@ -100,7 +109,20 @@ func run(cfg config) (int, error) {
 		return exitFatal, fmt.Errorf("-duration %s is below the %s floor", cfg.duration, minDuration)
 	}
 
-	actions := starterActions()
+	// The profile and the config it is layered over are resolved before a
+	// single artifact is created: an unknown profile, like a bad weight,
+	// is a contradiction in the inputs, and a run built on one cannot be
+	// replayed and is not worth a lab.
+	p, err := profileByName(cfg.profile)
+	if err != nil {
+		return exitFatal, err
+	}
+	base, err := os.ReadFile(cfg.gwnodeConfig)
+	if err != nil {
+		return exitFatal, fmt.Errorf("read the baked gateway config: %w", err)
+	}
+
+	actions := starterActions(p)
 	weights, err := parseWeights(cfg.weightSpec, actions)
 	if err != nil {
 		return exitFatal, err
@@ -139,6 +161,7 @@ func run(cfg config) (int, error) {
 	rec := &runRecord{
 		Inputs: runInputs{
 			Seed:       cfg.seed,
+			Profile:    p.name,
 			DurationMS: cfg.duration.Milliseconds(),
 			TickMinMS:  cfg.tickMin.Milliseconds(),
 			TickMaxMS:  cfg.tickMax.Milliseconds(),
@@ -150,7 +173,7 @@ func run(cfg config) (int, error) {
 	}
 	jrnl.emit(event{Event: evRunStart, Inputs: &rec.Inputs})
 
-	code := drive(ctx, l, actions, jrnl, rec)
+	code := drive(ctx, l, newApplier(l, p, base), actions, jrnl, rec)
 
 	// The run is over and the engine has undone whatever it injected, so
 	// the signals go back to their default disposition: everything below
@@ -178,22 +201,23 @@ func run(cfg config) (int, error) {
 	return code, nil
 }
 
-// drive builds the start state, starts the prober and the baseline
-// checks, and runs the engine to completion. It returns the exit code
-// for a failure the run record cannot express (a start state that never
-// came up green).
-func drive(ctx context.Context, l *lab, actions []*action, jrnl *journal, rec *runRecord) int {
-	if err := applyStartState(ctx, l); err != nil {
-		rec.Violations = append(rec.Violations, violationRecord{
-			TS:     time.Now().UTC().Format(time.RFC3339Nano),
-			Kind:   violationStartState,
-			Detail: err.Error(),
-		})
-		jrnl.emit(event{Event: evViolation, Kind: violationStartState, Detail: err.Error()})
-		fmt.Fprintf(os.Stderr, "[chaos] start state: %v\n", err)
-		return exitFatal
+// drive puts the profile's configuration on the gateways, builds the
+// start state, starts the prober and the baseline checks, and runs the
+// engine to completion. It returns the exit code for a failure the run
+// record cannot express (a configuration the agent rejected, a start
+// state that never came up green).
+func drive(ctx context.Context, l *lab, ap *applier, actions []*action, jrnl *journal, rec *runRecord) int {
+	p := ap.profile
+	if err := ap.discover(ctx); err != nil {
+		return abandon(jrnl, rec, violationProfileApply, err)
 	}
-	jrnl.emit(event{Event: evStateApplied, Detail: "hairpin + multi-vlan + port-forward layered on the bootstrap baseline"})
+	if err := ap.applyProfile(ctx, jrnl); err != nil {
+		return abandon(jrnl, rec, violationProfileApply, err)
+	}
+	if err := applyStartState(ctx, l, p); err != nil {
+		return abandon(jrnl, rec, violationStartState, err)
+	}
+	jrnl.emit(event{Event: evStateApplied, Detail: p.layers()})
 
 	// The prober and the baseline checks run for the whole run, alongside
 	// the engine. Both are cancelled and then *waited for* before the run
@@ -202,10 +226,10 @@ func drive(ctx context.Context, l *lab, actions []*action, jrnl *journal, rec *r
 	sideCtx, stopSide := context.WithCancel(ctx)
 	defer stopSide()
 
-	probes := newProber(l, defaultProbes, jrnl, time.Now)
+	probes := newProber(l, p.probes, jrnl, time.Now)
 	probes.start(sideCtx)
 
-	e := newEngine(l, actions, probes, jrnl, rec)
+	e := newEngine(l, p, actions, probes, jrnl, rec)
 	e.followMaster(ctx)
 
 	checks := &baselineChecks{lab: l, engine: e}
@@ -223,6 +247,22 @@ func drive(ctx context.Context, l *lab, actions []*action, jrnl *journal, rec *r
 	checks.finalize()
 	rec.Probes = probes.summary()
 	return exitPass
+}
+
+// abandon gives up on a run that could not be set up: the lab never
+// reached the state the run measures against, so every fault after it
+// would report a violation the lab did not cause. The failure is recorded
+// and journaled like any other, so the summary of an abandoned run still
+// says what went wrong.
+func abandon(jrnl *journal, rec *runRecord, kind string, err error) int {
+	rec.Violations = append(rec.Violations, violationRecord{
+		TS:     time.Now().UTC().Format(time.RFC3339Nano),
+		Kind:   kind,
+		Detail: err.Error(),
+	})
+	jrnl.emit(event{Event: evViolation, Kind: kind, Detail: err.Error()})
+	fmt.Fprintf(os.Stderr, "[chaos] %s: %v\n", kind, err)
+	return exitFatal
 }
 
 func writeRecord(rec *runRecord, path string) error {

--- a/test/e2e/chaos/main.go
+++ b/test/e2e/chaos/main.go
@@ -122,7 +122,14 @@ func run(cfg config) (int, error) {
 		return exitFatal, fmt.Errorf("read the baked gateway config: %w", err)
 	}
 
-	actions := starterActions(p)
+	// The lab and the applier the config-flip action binds to are plain
+	// values — nothing is touched, and no artifact created, until the run
+	// is under way. So the registry is built here, which keeps the
+	// -weights check — and its "a rejected run leaves no artifacts"
+	// contract — ahead of everything that creates one.
+	l := newLab(cfg.labName, execCommander{})
+	ap := newApplier(l, p, base)
+	actions := allActions(p, ap)
 	weights, err := parseWeights(cfg.weightSpec, actions)
 	if err != nil {
 		return exitFatal, err
@@ -157,7 +164,7 @@ func run(cfg config) (int, error) {
 
 	started := time.Now()
 	jrnl := newJournal(jf, time.Now)
-	l := newLab(cfg.labName, execCommander{})
+	ap.jrnl = jrnl
 	rec := &runRecord{
 		Inputs: runInputs{
 			Seed:       cfg.seed,
@@ -173,7 +180,7 @@ func run(cfg config) (int, error) {
 	}
 	jrnl.emit(event{Event: evRunStart, Inputs: &rec.Inputs})
 
-	code := drive(ctx, l, newApplier(l, p, base), actions, jrnl, rec)
+	code := drive(ctx, l, ap, actions, jrnl, rec)
 
 	// The run is over and the engine has undone whatever it injected, so
 	// the signals go back to their default disposition: everything below
@@ -211,7 +218,7 @@ func drive(ctx context.Context, l *lab, ap *applier, actions []*action, jrnl *jo
 	if err := ap.discover(ctx); err != nil {
 		return abandon(jrnl, rec, violationProfileApply, err)
 	}
-	if err := ap.applyProfile(ctx, jrnl); err != nil {
+	if err := ap.applyProfile(ctx); err != nil {
 		return abandon(jrnl, rec, violationProfileApply, err)
 	}
 	if err := applyStartState(ctx, l, p); err != nil {

--- a/test/e2e/chaos/main.go
+++ b/test/e2e/chaos/main.go
@@ -202,7 +202,7 @@ func drive(ctx context.Context, l *lab, actions []*action, jrnl *journal, rec *r
 	sideCtx, stopSide := context.WithCancel(ctx)
 	defer stopSide()
 
-	probes := newProber(l, probeTargets, jrnl, time.Now)
+	probes := newProber(l, defaultProbes, jrnl, time.Now)
 	probes.start(sideCtx)
 
 	e := newEngine(l, actions, probes, jrnl, rec)

--- a/test/e2e/chaos/main_test.go
+++ b/test/e2e/chaos/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -14,6 +16,7 @@ import (
 func TestRunRejectsInvalidInputs(t *testing.T) {
 	tests := []struct {
 		name     string
+		profile  string
 		duration time.Duration
 		tickMin  time.Duration
 		tickMax  time.Duration
@@ -61,21 +64,38 @@ func TestRunRejectsInvalidInputs(t *testing.T) {
 			weights:  "gateway-melt=1",
 			wantErr:  "unknown action",
 		},
+		// The profile decides the topology the run drives and the
+		// configuration every agent in it runs — a run that cannot name
+		// one cannot be replayed either.
+		{
+			name:     "unknown profile",
+			profile:  "everything-off",
+			duration: time.Minute,
+			tickMin:  10 * time.Second,
+			tickMax:  30 * time.Second,
+			wantErr:  "unknown profile",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			out := t.TempDir()
 
+			profile := tc.profile
+			if profile == "" {
+				profile = defaultProfileName
+			}
 			code, err := run(config{
-				seed:       42,
-				duration:   tc.duration,
-				tickMin:    tc.tickMin,
-				tickMax:    tc.tickMax,
-				weightSpec: tc.weights,
-				labName:    "ovn-e2e",
-				outDir:     out,
-				collect:    "/nonexistent",
+				seed:         42,
+				profile:      profile,
+				duration:     tc.duration,
+				tickMin:      tc.tickMin,
+				tickMax:      tc.tickMax,
+				weightSpec:   tc.weights,
+				labName:      "ovn-e2e",
+				outDir:       out,
+				collect:      "/nonexistent",
+				gwnodeConfig: "../gwnode-config.yaml",
 			})
 
 			if code != exitFatal {
@@ -92,10 +112,72 @@ func TestRunRejectsInvalidInputs(t *testing.T) {
 	}
 }
 
+// A run whose profile never lands is abandoned: the lab never reached the
+// state the run measures against, so every fault after it would report a
+// violation the lab did not cause. The abandoned run still has to say what
+// went wrong — in its exit code, in its summary and in its journal —
+// rather than report a "pass" over a lab it never configured.
+func TestDriveAbandonsARunWhoseProfileNeverLands(t *testing.T) {
+	tests := []struct {
+		name    string
+		respond func(argv []string) (string, error)
+	}{
+		// Every gateway's config carries that gateway's own management
+		// address, so a run that cannot read one cannot render a config at
+		// all.
+		{
+			name: "the management address the config needs cannot be read",
+			respond: func(argv []string) (string, error) {
+				if strings.Contains(strings.Join(argv, " "), "ip -o -4 addr show eth0") {
+					return "", errBoom
+				}
+				return labWithConfig("stale config\n")(argv)
+			},
+		},
+		{
+			name: "the agent rejects the profile's configuration",
+			respond: func(argv []string) (string, error) {
+				if strings.Contains(strings.Join(argv, " "), "--check-config") {
+					return "", errExit(t, 1)
+				}
+				return labWithConfig("stale config\n")(argv)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := newFakeClock()
+			l := newTestLab(&fakeCommander{respond: tc.respond}, clock)
+			p := testProfile(t, "pf-only")
+			ap := newApplier(l, p, baseConfig(t))
+			var buf bytes.Buffer
+			ap.jrnl = newJournal(&buf, clock.now)
+			rec := &runRecord{ActionsByName: map[string]int{}}
+
+			code := drive(context.Background(), l, ap, allActions(p, ap), ap.jrnl, rec)
+
+			if code != exitFatal {
+				t.Fatalf("exit code = %d, want %d", code, exitFatal)
+			}
+			rec.finalize(clock.now())
+			if rec.Result != resultFail || len(rec.Violations) != 1 ||
+				rec.Violations[0].Kind != violationProfileApply {
+				t.Fatalf("the summary of an abandoned run does not say what went wrong: %+v", rec)
+			}
+			if ev := lastEventOf(t, buf.String(), evViolation); ev.Kind != violationProfileApply {
+				t.Fatalf("journaled %+v, want the violation the run was abandoned on", ev)
+			}
+		})
+	}
+}
+
 func TestWriteRecordProducesTheRunSummary(t *testing.T) {
 	path := filepath.Join(t.TempDir(), summaryFile)
 	rec := &runRecord{
-		Inputs:     runInputs{Seed: 42, Lab: "ovn-e2e", Weights: map[string]int{"gateway-kill": 1}},
+		Inputs: runInputs{
+			Seed: 42, Profile: "pf-only", Lab: "ovn-e2e",
+			Weights: map[string]int{"gateway-kill": 1},
+		},
 		Violations: []violationRecord{{Kind: violationRecoveryTimeout, Target: "gateway-2", Detail: "budget"}},
 	}
 	rec.finalize(time.Now())
@@ -118,7 +200,10 @@ func TestWriteRecordProducesTheRunSummary(t *testing.T) {
 	if decoded.Result != resultFail {
 		t.Fatalf("result = %q, want %q — the run recorded a violation", decoded.Result, resultFail)
 	}
-	if decoded.Inputs.Seed != 42 || decoded.Inputs.Weights["gateway-kill"] != 1 {
+	// The profile is part of the reproducibility contract: a seed alone
+	// does not identify a run, so the record has to carry both.
+	if decoded.Inputs.Seed != 42 || decoded.Inputs.Profile != "pf-only" ||
+		decoded.Inputs.Weights["gateway-kill"] != 1 {
 		t.Fatalf("the record did not echo its inputs: %+v", decoded.Inputs)
 	}
 }

--- a/test/e2e/chaos/probe_test.go
+++ b/test/e2e/chaos/probe_test.go
@@ -14,9 +14,9 @@ import (
 func TestProbesAreSourcedFromTheClient(t *testing.T) {
 	cmd := &fakeCommander{}
 	l := newTestLab(cmd, newFakeClock())
-	p := newProber(l, probeTargets, newJournal(&bytes.Buffer{}, newFakeClock().now), newFakeClock().now)
+	p := newProber(l, defaultProbes, newJournal(&bytes.Buffer{}, newFakeClock().now), newFakeClock().now)
 
-	for _, target := range probeTargets {
+	for _, target := range defaultProbes {
 		p.sample(context.Background(), target)
 	}
 
@@ -106,7 +106,7 @@ func TestSampleIgnoresACancelledProbe(t *testing.T) {
 func TestProberStopsWithItsContext(t *testing.T) {
 	cmd := &fakeCommander{}
 	clock := newFakeClock()
-	p := newProber(newTestLab(cmd, clock), probeTargets,
+	p := newProber(newTestLab(cmd, clock), defaultProbes,
 		newJournal(&bytes.Buffer{}, clock.now), clock.now)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -125,7 +125,7 @@ func TestProberStopsWithItsContext(t *testing.T) {
 	}
 
 	// Every target was sampled at least once before the shutdown.
-	for _, target := range probeTargets {
+	for _, target := range defaultProbes {
 		if !cmd.called(target.addr) && !cmd.called(strings.TrimPrefix(target.addr, "http://")) {
 			t.Fatalf("target %s was never probed: %v", target.name, cmd.lines())
 		}

--- a/test/e2e/chaos/profiles.go
+++ b/test/e2e/chaos/profiles.go
@@ -1,0 +1,384 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// A chaos run used to exercise exactly one agent configuration — the one
+// the gwnode image bakes in. A profile (issue #177) makes the
+// configuration an input instead: it names both the start topology the
+// run layers onto the bootstrap baseline and the agent configuration each
+// gateway runs, as an overlay on test/e2e/gwnode-config.yaml. Profile and
+// seed together determine a run, so the profile is part of the
+// reproducibility contract and is journaled alongside the seed.
+//
+// The set below is curated rather than combinatorial: six configurations
+// that each change what the agent actually has to do — no VLAN provider
+// networks, DNAT on an API VIP, no OVN connection at all, gateways
+// running different configurations mid-rollout — instead of every product
+// of the agent's behaviour-changing options.
+
+const (
+	// defaultProfileName keeps today's chaos run: every topology layer
+	// on, every gateway on the baked lab config.
+	defaultProfileName = "everything-on"
+
+	// The API VIP is the agent's *own* DNAT path (port_forwards), as
+	// opposed to the OVN Load_Balancer VIP the port-forward layer puts
+	// up. It sits inside the always-present provider network because the
+	// agent reconciles the FRR prefix-list to exactly the effective
+	// networks — a VIP outside every covered prefix is never announced,
+	// and would be dark for the whole run. Its backend is the gateway's
+	// own management address, where startAPIBackend runs a responder.
+	apiVIPAddr = "192.0.2.80"
+	apiVIPPort = 8080
+	apiVIPURL  = "http://192.0.2.80:8080/"
+
+	// flipVIPAddr is the VIP the pf-rule-toggle flip adds and removes.
+	// It is deliberately neither the API VIP nor probed: a rule that
+	// exists on one gateway and not on another must never draw probe
+	// traffic to a gateway that has no backend behind it.
+	flipVIPAddr = "192.0.2.99"
+	flipVIPPort = 8081
+)
+
+// explicitCIDRs is the manual network filter the profiles and the
+// cidr-toggle flip switch a gateway to. It covers every provider network
+// the lab probes — the bootstrap public net plus the two VLAN nets — and
+// both VIPs, so swapping OVN-discovered networks for a manual filter
+// exercises the filter codepath without darkening a probe.
+var explicitCIDRs = []string{"192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24"}
+
+// The probe targets the start-state layers put up. Which of them a run
+// measures is the profile's call: a layer that is off has no responder
+// behind its target, so probing it would be red for the whole run.
+var (
+	probeVM1     = probeTarget{"fip-vm1", probePing, "192.0.2.10"}
+	probeVM2     = probeTarget{"fip-vm2", probePing, "192.0.2.12"}
+	probeVLAN101 = probeTarget{"fip-vlan101", probePing, "198.51.100.10"}
+	probeVLAN102 = probeTarget{"fip-vlan102", probePing, "203.0.113.10"}
+	probeLBVIP   = probeTarget{"pf-vip", probeHTTP, vipURL}
+	probeAPIVIP  = probeTarget{"api-vip", probeHTTP, apiVIPURL}
+)
+
+// defaultProbes is what a full-topology run measures: the four FIPs and
+// the OVN Load_Balancer VIP.
+//
+// The baseline lab's second FIP, 192.0.2.11, is deliberately absent:
+// bootstrap.sh seeds its NAT row but nothing answers behind
+// 192.168.10.11, so probing it would be red for the whole run.
+var defaultProbes = []probeTarget{probeVM1, probeVM2, probeVLAN101, probeVLAN102, probeLBVIP}
+
+// gwConfig is a profile's agent-configuration overlay for one gateway,
+// layered key by key over the baked lab config. The zero value changes
+// nothing — which is what keeps a fresh lab's everything-on run free of
+// restarts: renderConfig hands the baked bytes back unchanged and the
+// applier finds nothing to swap.
+type gwConfig struct {
+	// apiVIP adds the API VIP's port_forwards block, together with the
+	// port_forward_l3mdev_accept the same-host backend needs: the
+	// backend socket sits in the default VRF while the VIP traffic
+	// ingresses vrf-provider.
+	apiVIP bool
+
+	// portForwardOnly unsets both OVN remotes, which is what puts the
+	// agent into port-forward-only mode (validateMode) — it then skips
+	// every OVN-dependent codepath and runs as a standalone VIP service.
+	// It only makes sense together with apiVIP: without port_forwards
+	// there would be nothing left to do, and the agent refuses to start.
+	portForwardOnly bool
+
+	drainOnShutdown   bool
+	cleanupOnShutdown bool
+	networkCIDRs      []string
+	reconcileInterval string
+}
+
+// empty reports whether the overlay changes anything at all.
+func (c gwConfig) empty() bool {
+	return !c.apiVIP && !c.portForwardOnly && !c.drainOnShutdown && !c.cleanupOnShutdown &&
+		len(c.networkCIDRs) == 0 && c.reconcileInterval == ""
+}
+
+// profile is one named chaos configuration: the topology layers the start
+// state puts up, the agent configuration each gateway runs, and what the
+// run measures.
+type profile struct {
+	name        string
+	description string
+
+	// The start-state layers. Everything the bootstrap baseline itself
+	// seeds (the HA router, FIP 192.0.2.10, the vm1 workload) is always
+	// there — a profile only decides what is layered on top.
+	hairpin bool // hairpin.sh's second FIP and its vm2 responder
+	vlans   bool // multi-vlan.sh's two VLAN provider networks
+	ovnLB   bool // pf-external.sh's OVN Load_Balancer VIP
+
+	// gateways carries the per-gateway agent-config overlay. A gateway
+	// absent from the map runs the baked lab config unchanged.
+	gateways map[string]gwConfig
+
+	probes []probeTarget
+}
+
+// gwConfig returns the overlay for one gateway — the zero value when the
+// profile leaves it on the baked config.
+func (p *profile) gwConfig(gw string) gwConfig { return p.gateways[gw] }
+
+// apiVIPGateways names the gateways whose configuration carries the API
+// VIP. They are the ones that need a responder behind it (startAPIBackend)
+// and the only ones the masquerade flip means anything on.
+func (p *profile) apiVIPGateways() []string {
+	var gws []string
+	for _, gw := range gatewayNames() {
+		if p.gateways[gw].apiVIP {
+			gws = append(gws, gw)
+		}
+	}
+	return gws
+}
+
+// layers renders the profile's start topology for the journal.
+func (p *profile) layers() string {
+	on := []string{"bootstrap baseline"}
+	if p.hairpin {
+		on = append(on, "hairpin")
+	}
+	if p.vlans {
+		on = append(on, "multi-vlan")
+	}
+	if p.ovnLB {
+		on = append(on, "port-forward")
+	}
+	return strings.Join(on, " + ")
+}
+
+// everyGateway is the common case: one overlay, applied to all three
+// gateways.
+func everyGateway(c gwConfig) map[string]gwConfig {
+	all := make(map[string]gwConfig, len(gatewayNames()))
+	for _, gw := range gatewayNames() {
+		all[gw] = c
+	}
+	return all
+}
+
+// profiles is the profile registry, in the order `-profile` lists it.
+// Unlike the action registry, the order is not part of the replay
+// contract — the profile is picked by name, not drawn — but the curated
+// set is: adding one is a deliberate act, not a combinatorial sweep.
+func profiles() []*profile {
+	return []*profile{
+		{
+			name:        defaultProfileName,
+			description: "every topology layer, every gateway on the baked lab config",
+			hairpin:     true,
+			vlans:       true,
+			ovnLB:       true,
+			probes:      defaultProbes,
+		},
+		{
+			name:        "flat-minimal",
+			description: "no VLAN, no DNAT, cleanup on shutdown",
+			gateways:    everyGateway(gwConfig{cleanupOnShutdown: true}),
+			probes:      []probeTarget{probeVM1},
+		},
+		{
+			name:        "flat-dnat",
+			description: "no VLAN; the agent's own DNAT on an API VIP, alongside the OVN Load_Balancer VIP",
+			hairpin:     true,
+			ovnLB:       true,
+			gateways:    everyGateway(gwConfig{apiVIP: true}),
+			probes:      []probeTarget{probeVM1, probeVM2, probeLBVIP, probeAPIVIP},
+		},
+		{
+			name:        "vlan-no-dnat",
+			description: "VLAN provider networks, no DNAT of any kind",
+			hairpin:     true,
+			vlans:       true,
+			probes:      []probeTarget{probeVM1, probeVM2, probeVLAN101, probeVLAN102},
+		},
+		{
+			// No OVN remotes at all: the agent skips every OVN codepath,
+			// so no topology layer is worth putting up and the API VIP is
+			// the only thing left to measure. network_cidr is mandatory
+			// here — without OVN the provider CIDRs cannot be discovered,
+			// so nothing would announce the VIP (and the masquerade flip
+			// would be rejected outright).
+			name:        "pf-only",
+			description: "no OVN connection: the agent runs as a standalone VIP service",
+			gateways: everyGateway(gwConfig{
+				apiVIP:          true,
+				portForwardOnly: true,
+				networkCIDRs:    []string{"192.0.2.0/24"},
+			}),
+			probes: []probeTarget{probeAPIVIP},
+		},
+		{
+			// What a rollout looks like from the inside: the gateways run
+			// different configurations at the same time. The API VIP is
+			// announced by gateway-2 alone, so it is legitimately dark
+			// while gateway-2 is held down — the same pinned-resource
+			// semantics the VLAN FIPs already have on gateway-1.
+			name:        "heterogeneous",
+			description: "each gateway on a different configuration, as mid-rollout",
+			hairpin:     true,
+			vlans:       true,
+			ovnLB:       true,
+			gateways: map[string]gwConfig{
+				"gateway-2": {apiVIP: true, drainOnShutdown: true},
+				"gateway-3": {
+					networkCIDRs:      explicitCIDRs,
+					reconcileInterval: "15s",
+					cleanupOnShutdown: true,
+				},
+			},
+			probes: append(append([]probeTarget{}, defaultProbes...), probeAPIVIP),
+		},
+	}
+}
+
+// profileByName resolves the -profile flag.
+func profileByName(name string) (*profile, error) {
+	known := make([]string, 0, len(profiles()))
+	for _, p := range profiles() {
+		if p.name == name {
+			return p, nil
+		}
+		known = append(known, p.name)
+	}
+	return nil, fmt.Errorf("unknown profile %q (known: %s)", name, strings.Join(known, ", "))
+}
+
+// renderConfig layers one gateway's overlay over the baked lab config.
+//
+// An empty overlay returns the base bytes verbatim, and that byte
+// identity is load-bearing: the applier compares what it rendered against
+// the file already on the gateway to decide whether it has to swap the
+// config and restart the node at all.
+func renderConfig(base []byte, c gwConfig, mgmtIP string) ([]byte, error) {
+	if c.empty() {
+		return base, nil
+	}
+	doc, err := parseConfig(base)
+	if err != nil {
+		return nil, err
+	}
+	applyOverlay(doc, c, mgmtIP)
+	return marshalConfig(doc)
+}
+
+// applyOverlay writes the overlay's keys into a parsed config document,
+// in place. Every write is key-level rather than an append, because
+// yaml.v3 — which the agent itself parses the file with — rejects a
+// document that carries the same mapping key twice.
+func applyOverlay(doc map[string]any, c gwConfig, mgmtIP string) {
+	if c.portForwardOnly {
+		delete(doc, "ovn_sb_remote")
+		delete(doc, "ovn_nb_remote")
+	}
+	if c.drainOnShutdown {
+		doc["drain_on_shutdown"] = true
+	}
+	if c.cleanupOnShutdown {
+		doc["cleanup_on_shutdown"] = true
+	}
+	if len(c.networkCIDRs) > 0 {
+		doc["network_cidr"] = anySlice(c.networkCIDRs)
+	}
+	if c.reconcileInterval != "" {
+		doc["reconcile_interval"] = c.reconcileInterval
+	}
+	if c.apiVIP {
+		doc["port_forward_l3mdev_accept"] = true
+		doc["port_forwards"] = []any{apiVIPBlock(mgmtIP)}
+	}
+}
+
+// apiVIPBlock is the API VIP's port_forwards entry: the agent owns the
+// VIP address, and one TCP rule forwards it to the responder on the
+// gateway's own management address.
+//
+// masquerade is off on purpose: the backend runs on the same host, and
+// SNAT-ing traffic to a same-host backend breaks the reply path (the
+// OUTPUT chains handle the replies, see docs/explanation/port-forwarding.md).
+func apiVIPBlock(mgmtIP string) map[string]any {
+	return map[string]any{
+		"vip":        apiVIPAddr,
+		"manage_vip": true,
+		"masquerade": false,
+		"rules": []any{map[string]any{
+			"proto":     "tcp",
+			"port":      apiVIPPort,
+			"dest_addr": mgmtIP,
+			"dest_port": apiVIPPort,
+		}},
+	}
+}
+
+// flipVIPBlock is the VIP the pf-rule-toggle flip adds. It points at the
+// same responder as the API VIP but on a port of its own, so a gateway
+// that carries it without an API backend behind it is a dead DNAT rule —
+// which is exactly the churn the flip is there to produce, and why
+// nothing probes it.
+func flipVIPBlock(mgmtIP string) map[string]any {
+	return map[string]any{
+		"vip":        flipVIPAddr,
+		"manage_vip": true,
+		"masquerade": false,
+		"rules": []any{map[string]any{
+			"proto":     "tcp",
+			"port":      flipVIPPort,
+			"dest_addr": mgmtIP,
+			"dest_port": apiVIPPort,
+		}},
+	}
+}
+
+func parseConfig(raw []byte) (map[string]any, error) {
+	doc := map[string]any{}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("parse agent config: %w", err)
+	}
+	return doc, nil
+}
+
+func marshalConfig(doc map[string]any) ([]byte, error) {
+	raw, err := yaml.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("render agent config: %w", err)
+	}
+	return raw, nil
+}
+
+// anySlice widens a string list into what a YAML round-trip produces, so
+// a rendered document and a re-parsed one carry the same Go types — the
+// flips read and rewrite these values.
+func anySlice(values []string) []any {
+	out := make([]any, 0, len(values))
+	for _, v := range values {
+		out = append(out, v)
+	}
+	return out
+}
+
+// stringsOf narrows a YAML list (or a scalar) back to a string slice.
+func stringsOf(value any) []string {
+	switch v := value.(type) {
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	case string:
+		return []string{v}
+	default:
+		return nil
+	}
+}

--- a/test/e2e/chaos/profiles.go
+++ b/test/e2e/chaos/profiles.go
@@ -305,11 +305,15 @@ func applyOverlay(doc map[string]any, c gwConfig, mgmtIP string) {
 // masquerade is off on purpose: the backend runs on the same host, and
 // SNAT-ing traffic to a same-host backend breaks the reply path (the
 // OUTPUT chains handle the replies, see docs/explanation/port-forwarding.md).
+// hairpin_masquerade is spelled out rather than left to its default
+// because the masquerade flip toggles it: with the key present, toggling
+// it twice puts the gateway back on exactly the profile's configuration.
 func apiVIPBlock(mgmtIP string) map[string]any {
 	return map[string]any{
-		"vip":        apiVIPAddr,
-		"manage_vip": true,
-		"masquerade": false,
+		"vip":                apiVIPAddr,
+		"manage_vip":         true,
+		"masquerade":         false,
+		"hairpin_masquerade": false,
 		"rules": []any{map[string]any{
 			"proto":     "tcp",
 			"port":      apiVIPPort,

--- a/test/e2e/chaos/profiles_test.go
+++ b/test/e2e/chaos/profiles_test.go
@@ -1,0 +1,273 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// baseConfig is the config the gwnode image bakes into every gateway —
+// the document every overlay is layered over. The tests read the real
+// file so a change to it that a profile depends on (the OVN remotes, the
+// reconcile cadence) shows up here rather than in a lab.
+func baseConfig(t *testing.T) []byte {
+	t.Helper()
+	raw, err := os.ReadFile("../gwnode-config.yaml")
+	if err != nil {
+		t.Fatalf("read the baked gwnode config: %v", err)
+	}
+	return raw
+}
+
+// render is renderConfig plus the round-trip back through yaml.v3 — which
+// is how the agent itself reads the file. A document with a duplicate
+// mapping key parses here exactly as it would fail there.
+func render(t *testing.T, c gwConfig, mgmtIP string) map[string]any {
+	t.Helper()
+	raw, err := renderConfig(baseConfig(t), c, mgmtIP)
+	if err != nil {
+		t.Fatalf("renderConfig: %v", err)
+	}
+	doc := map[string]any{}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("the rendered config is not valid YAML: %v\n%s", err, raw)
+	}
+	return doc
+}
+
+func TestProfileRegistryNamesTheCuratedSet(t *testing.T) {
+	want := []string{
+		"everything-on", "flat-minimal", "flat-dnat",
+		"vlan-no-dnat", "pf-only", "heterogeneous",
+	}
+
+	var got []string
+	for _, p := range profiles() {
+		got = append(got, p.name)
+		if p.description == "" {
+			t.Fatalf("profile %s ships without a description", p.name)
+		}
+		if len(p.probes) == 0 {
+			t.Fatalf("profile %s measures nothing", p.name)
+		}
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("registry = %v, want %v", got, want)
+	}
+
+	def, err := profileByName(defaultProfileName)
+	if err != nil {
+		t.Fatalf("the default profile does not resolve: %v", err)
+	}
+	if !def.hairpin || !def.vlans || !def.ovnLB || len(def.gateways) != 0 {
+		t.Fatalf("the default profile changed today's run: %+v", def)
+	}
+}
+
+// An unknown -profile must fail before the run touches a lab, and say
+// what it could have picked instead.
+func TestProfileByNameRejectsAnUnknownProfile(t *testing.T) {
+	_, err := profileByName("everything-off")
+	if err == nil {
+		t.Fatal("an unknown profile resolved")
+	}
+	if !strings.Contains(err.Error(), "everything-off") || !strings.Contains(err.Error(), defaultProfileName) {
+		t.Fatalf("error %q neither names the unknown profile nor lists the known ones", err)
+	}
+}
+
+// Byte identity for the empty overlay is what lets the applier skip a
+// gateway: a fresh lab's everything-on run must not restart a single one.
+func TestEmptyOverlayRendersTheBaseBytesVerbatim(t *testing.T) {
+	base := baseConfig(t)
+
+	got, err := renderConfig(base, gwConfig{}, "172.20.20.4")
+	if err != nil {
+		t.Fatalf("renderConfig: %v", err)
+	}
+	if !bytes.Equal(got, base) {
+		t.Fatalf("an empty overlay rewrote the baked config:\n%s", got)
+	}
+}
+
+// An overlay owns the keys it names and leaves every other key of the
+// baked config alone — the lab's bridge, VRF and chassis settings are not
+// a profile's business.
+func TestOverlayLayersOverTheBaseAndKeepsTheRest(t *testing.T) {
+	doc := render(t, gwConfig{
+		drainOnShutdown:   true,
+		cleanupOnShutdown: true,
+		reconcileInterval: "15s",
+	}, "172.20.20.4")
+
+	for key, want := range map[string]any{
+		"drain_on_shutdown":   true,
+		"cleanup_on_shutdown": true,
+		"reconcile_interval":  "15s",
+		// Untouched by the overlay, and load-bearing for the lab.
+		"ovn_sb_remote": "tcp:central:6642",
+		"bridge_dev":    "br-ex",
+		"vrf_name":      "vrf-provider",
+	} {
+		if doc[key] != want {
+			t.Fatalf("%s = %v, want %v", key, doc[key], want)
+		}
+	}
+}
+
+// Port-forward-only mode is the absence of both remotes (validateMode) —
+// an empty string would do, but removing the keys is what a gateway
+// deployed without OVN would actually look like.
+func TestPortForwardOnlyOverlayUnsetsBothOVNRemotes(t *testing.T) {
+	doc := render(t, profileGateway(t, "pf-only", "gateway-1"), "172.20.20.5")
+
+	for _, key := range []string{"ovn_sb_remote", "ovn_nb_remote"} {
+		if _, present := doc[key]; present {
+			t.Fatalf("%s survived the port-forward-only overlay: %v", key, doc[key])
+		}
+	}
+	if got := stringsOf(doc["network_cidr"]); len(got) != 1 || got[0] != "192.0.2.0/24" {
+		t.Fatalf("network_cidr = %v, want the provider net — without OVN nothing else announces the VIP", got)
+	}
+	if len(vipsIn(t, doc)) != 1 {
+		t.Fatalf("port-forward-only without a port_forwards block leaves the agent nothing to do: %v", doc)
+	}
+}
+
+// The API VIP's backend is the responder on the gateway's *own*
+// management address, so the rendered rule must carry the address the
+// applier discovered for that gateway — not another gateway's.
+func TestAPIVIPBlockPointsAtTheGatewaysOwnBackend(t *testing.T) {
+	doc := render(t, gwConfig{apiVIP: true}, "172.20.20.7")
+
+	if doc["port_forward_l3mdev_accept"] != true {
+		t.Fatal("the same-host backend in the default VRF needs port_forward_l3mdev_accept")
+	}
+	vip := vipsIn(t, doc)[apiVIPAddr]
+	if vip == nil {
+		t.Fatalf("the API VIP is not in the rendered config: %v", doc["port_forwards"])
+	}
+	if vip["masquerade"] != false {
+		t.Fatal("a same-host backend must not be masqueraded — the OUTPUT chains handle the replies")
+	}
+	rules, ok := vip["rules"].([]any)
+	if !ok || len(rules) != 1 {
+		t.Fatalf("rules = %v, want exactly the one TCP rule", vip["rules"])
+	}
+	rule, _ := rules[0].(map[string]any)
+	if rule["dest_addr"] != "172.20.20.7" || rule["port"] != apiVIPPort {
+		t.Fatalf("rule = %v, want tcp/%d to the gateway's own management address", rule, apiVIPPort)
+	}
+}
+
+// The heterogeneous profile is the point of the per-gateway overlay: the
+// three gateways run three different configurations at once.
+func TestHeterogeneousProfileRendersOneConfigPerGateway(t *testing.T) {
+	p, err := profileByName("heterogeneous")
+	if err != nil {
+		t.Fatalf("profileByName: %v", err)
+	}
+
+	base := baseConfig(t)
+	first, err := renderConfig(base, p.gwConfig("gateway-1"), "172.20.20.4")
+	if err != nil {
+		t.Fatalf("render gateway-1: %v", err)
+	}
+	if !bytes.Equal(first, base) {
+		t.Fatalf("gateway-1 was meant to stay on the baked config:\n%s", first)
+	}
+
+	second := render(t, p.gwConfig("gateway-2"), "172.20.20.5")
+	if second["drain_on_shutdown"] != true || vipsIn(t, second)[apiVIPAddr] == nil {
+		t.Fatalf("gateway-2 = %v, want the drain and the API VIP", second)
+	}
+
+	third := render(t, p.gwConfig("gateway-3"), "172.20.20.6")
+	if got := stringsOf(third["network_cidr"]); len(got) != len(explicitCIDRs) {
+		t.Fatalf("gateway-3 network_cidr = %v, want the manual filter %v", got, explicitCIDRs)
+	}
+	if third["reconcile_interval"] != "15s" || third["cleanup_on_shutdown"] != true {
+		t.Fatalf("gateway-3 = %v, want the slow cadence and the cleanup", third)
+	}
+	if _, present := third["port_forwards"]; present {
+		t.Fatalf("gateway-3 was handed a DNAT config it never asked for: %v", third["port_forwards"])
+	}
+
+	if got := p.apiVIPGateways(); len(got) != 1 || got[0] != "gateway-2" {
+		t.Fatalf("apiVIPGateways = %v, want only the gateway whose config carries the VIP", got)
+	}
+}
+
+// A profile must only probe what its own layers put up — a target behind
+// a layer that is off has no responder and would be red for the whole
+// run, timing out every recovery gate.
+func TestProfileProbesOnlyWhatItsLayersPutUp(t *testing.T) {
+	for _, p := range profiles() {
+		for _, target := range p.probes {
+			switch target.name {
+			case probeVM2.name:
+				if !p.hairpin {
+					t.Fatalf("%s probes the hairpin FIP without the hairpin layer", p.name)
+				}
+			case probeVLAN101.name, probeVLAN102.name:
+				if !p.vlans {
+					t.Fatalf("%s probes a VLAN FIP without the VLAN layers", p.name)
+				}
+			case probeLBVIP.name:
+				if !p.ovnLB {
+					t.Fatalf("%s probes the Load_Balancer VIP without the port-forward layer", p.name)
+				}
+			case probeAPIVIP.name:
+				if len(p.apiVIPGateways()) == 0 {
+					t.Fatalf("%s probes the API VIP but no gateway is configured with it", p.name)
+				}
+			}
+		}
+		// The reverse: a configured API VIP nobody measures would leave the
+		// profile's whole point untested.
+		if len(p.apiVIPGateways()) > 0 && !hasProbe(p.probes, probeAPIVIP.name) {
+			t.Fatalf("%s configures the API VIP but never probes it", p.name)
+		}
+	}
+}
+
+// profileGateway resolves one gateway's overlay out of a named profile.
+func profileGateway(t *testing.T, name, gw string) gwConfig {
+	t.Helper()
+	p, err := profileByName(name)
+	if err != nil {
+		t.Fatalf("profileByName(%q): %v", name, err)
+	}
+	return p.gwConfig(gw)
+}
+
+// vipsIn indexes a rendered document's port_forwards block by VIP.
+func vipsIn(t *testing.T, doc map[string]any) map[string]map[string]any {
+	t.Helper()
+	out := map[string]map[string]any{}
+	entries, ok := doc["port_forwards"].([]any)
+	if !ok {
+		return out
+	}
+	for _, entry := range entries {
+		vip, ok := entry.(map[string]any)
+		if !ok {
+			t.Fatalf("port_forwards entry is not a mapping: %v", entry)
+		}
+		addr, _ := vip["vip"].(string)
+		out[addr] = vip
+	}
+	return out
+}
+
+func hasProbe(targets []probeTarget, name string) bool {
+	for _, t := range targets {
+		if t.name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/chaos/state.go
+++ b/test/e2e/chaos/state.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os/exec"
 	"strings"
 	"time"
 )
@@ -231,9 +233,8 @@ func applyPortForwardLayer(ctx context.Context, l *lab) error {
 // pf-external.sh. Any previous instance is killed first, so this doubles
 // as the restore path after gateway-3 has been recycled.
 func startPFBackend(ctx context.Context, l *lab) error {
-	if _, err := l.sh(ctx, workloadHost,
-		"pkill -f "+pfBackendLog+" || true; : >"+pfBackendLog); err != nil {
-		return fmt.Errorf("reset pf-backend on %s: %w", workloadHost, err)
+	if err := resetResponder(ctx, l, workloadHost, pfBackendLog); err != nil {
+		return err
 	}
 	if _, err := l.docker(ctx, "exec", "-d", l.node(workloadHost),
 		"ip", "netns", "exec", "vm1", "/usr/local/bin/pf-backend",
@@ -255,9 +256,8 @@ func startPFBackend(ctx context.Context, l *lab) error {
 // while the VIP traffic ingresses vrf-provider.
 func startAPIBackend(ctx context.Context, l *lab, gw string) error {
 	addr := fmt.Sprintf(":%d", apiVIPPort)
-	if _, err := l.sh(ctx, gw,
-		"pkill -f "+apiBackendLog+" || true; : >"+apiBackendLog); err != nil {
-		return fmt.Errorf("reset the API backend on %s: %w", gw, err)
+	if err := resetResponder(ctx, l, gw, apiBackendLog); err != nil {
+		return err
 	}
 	if _, err := l.docker(ctx, "exec", "-d", l.node(gw),
 		"/usr/local/bin/pf-backend", "-addr", addr, "-log", apiBackendLog); err != nil {
@@ -266,6 +266,28 @@ func startAPIBackend(ctx context.Context, l *lab, gw string) error {
 	if err := waitListening(ctx, l, gw,
 		fmt.Sprintf("ss -ltn 'sport = %s' | grep -q LISTEN", addr)); err != nil {
 		return fmt.Errorf("the API backend on %s: %w", gw, err)
+	}
+	return nil
+}
+
+// resetResponder stops the responder logging to logPath and truncates its
+// log, so a (re)start never races a previous instance for the port.
+//
+// pkill runs as its own `docker exec`, the way pf-external.sh runs it, and
+// not inside `sh -c`: `pkill -f` matches every process whose command line
+// carries the pattern — including the shell that is running the pkill,
+// whose argv carries it too — and that shell would die before it got to
+// the rest of the line. Exit 1 means nothing matched, which is the normal
+// case on a first start.
+func resetResponder(ctx context.Context, l *lab, node, logPath string) error {
+	if _, err := l.exec(ctx, node, "pkill", "-f", logPath); err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+			return fmt.Errorf("stop the responder logging to %s on %s: %w", logPath, node, err)
+		}
+	}
+	if _, err := l.sh(ctx, node, ": >"+logPath); err != nil {
+		return fmt.Errorf("truncate %s on %s: %w", logPath, node, err)
 	}
 	return nil
 }

--- a/test/e2e/chaos/state.go
+++ b/test/e2e/chaos/state.go
@@ -7,9 +7,9 @@ import (
 	"time"
 )
 
-// The combined start state layers the setups of three existing scenarios
-// on top of the bootstrap baseline, so one chaos run exercises all of
-// them at once:
+// The start state layers the setups of three existing scenarios on top of
+// the bootstrap baseline, so one chaos run can exercise all of them at
+// once:
 //
 //   - hairpin.sh      — a second FIP (192.0.2.12) with a vm2 responder,
 //     so the master carries two FIPs and the hairpin flow is live.
@@ -17,6 +17,11 @@ import (
 //     with a router pinned to gateway-1 and a FIP behind a responder.
 //   - pf-external.sh  — a Load_Balancer VIP (192.0.2.50:80) in front of
 //     the vm1 backend, plus the two routes the agent does not manage.
+//
+// Which of them a run puts up is the profile's call (profiles.go): a
+// profile that configures its gateways without OVN has no use for a
+// Load_Balancer VIP, and one that measures the agent's own DNAT path
+// brings its own backend instead.
 //
 // The bootstrap baseline itself (HA router, FIP 192.0.2.10, the vm1
 // workload) is assumed — the runner drives a lab that `make e2e-up`
@@ -31,6 +36,20 @@ import (
 // before the run is abandoned — a start state that never went green
 // would report every later fault as a false violation.
 const startStateTimeout = 120 * time.Second
+
+// backendBindTimeout is how long an HTTP responder gets to bind its
+// listener before the layering gives up on it. A backend that never bound
+// would leave its VIP probe red for the whole run.
+const backendBindTimeout = 10 * time.Second
+
+// The two responders' log files. They are the same binary, and on the
+// workload host both run in the same PID namespace, so the log path is
+// what a `pkill -f` pattern keys on: `pkill -f /usr/local/bin/pf-backend`
+// would take the other one down with it.
+const (
+	pfBackendLog  = "/tmp/pf-backend.log"
+	apiBackendLog = "/tmp/api-backend.log"
+)
 
 // vlanNetwork is one row of multi-vlan.sh's NETWORKS table.
 type vlanNetwork struct {
@@ -56,48 +75,61 @@ type netns struct {
 	gw   string
 }
 
-// responders is every netns the start state needs on gateway-3 — the
-// bootstrap vm1 plus the ones the three layers add. reprovisionNode
-// re-creates all of them after gateway-3 has been through a container
-// lifecycle event, which destroys its network namespace.
-func responders() []netns {
-	all := []netns{
-		// bootstrap.sh:ensure_workload_netns
-		{"vm1", "ls0-vm1", "02:00:00:00:0a:0a", "192.168.10.10/24", "192.168.10.1"},
+// responders is every netns the profile's start state needs on gateway-3
+// — the bootstrap vm1 plus the ones the layers it puts up add.
+// reprovisionNode re-creates all of them after gateway-3 has been through
+// a container lifecycle event, which destroys its network namespace.
+func responders(p *profile) []netns {
+	// bootstrap.sh:ensure_workload_netns
+	all := []netns{{"vm1", "ls0-vm1", "02:00:00:00:0a:0a", "192.168.10.10/24", "192.168.10.1"}}
+	if p.hairpin {
 		// hairpin.sh:ensure_fip_b_responder
-		{"vm2", "ls0-vm2", "02:00:00:00:0a:0b", "192.168.10.12/24", "192.168.10.1"},
+		all = append(all, netns{"vm2", "ls0-vm2", "02:00:00:00:0a:0b", "192.168.10.12/24", "192.168.10.1"})
 	}
-	// multi-vlan.sh:ensure_responder
-	for _, n := range vlanNetworks {
-		all = append(all, netns{
-			name: "vm" + n.tag,
-			lsp:  "vm" + n.tag,
-			mac:  "02:00:00:" + n.hex + ":0a:0a",
-			cidr: n.tenant + ".10/24",
-			gw:   n.tenant + ".1",
-		})
+	if p.vlans {
+		// multi-vlan.sh:ensure_responder
+		for _, n := range vlanNetworks {
+			all = append(all, netns{
+				name: "vm" + n.tag,
+				lsp:  "vm" + n.tag,
+				mac:  "02:00:00:" + n.hex + ":0a:0a",
+				cidr: n.tenant + ".10/24",
+				gw:   n.tenant + ".1",
+			})
+		}
 	}
 	return all
 }
 
-// applyStartState layers the three scenario setups onto the baseline and
-// waits for every probe target to answer.
-func applyStartState(ctx context.Context, l *lab) error {
-	if err := applyHairpinLayer(ctx, l); err != nil {
-		return err
-	}
-	for _, n := range vlanNetworks {
-		if err := applyVLANLayer(ctx, l, n); err != nil {
+// applyStartState layers the profile's scenario setups onto the baseline
+// and waits for every probe target the profile measures to answer.
+func applyStartState(ctx context.Context, l *lab, p *profile) error {
+	if p.hairpin {
+		if err := applyHairpinLayer(ctx, l); err != nil {
 			return err
 		}
 	}
-	if err := ensureResponders(ctx, l); err != nil {
+	if p.vlans {
+		for _, n := range vlanNetworks {
+			if err := applyVLANLayer(ctx, l, n); err != nil {
+				return err
+			}
+		}
+	}
+	if err := ensureResponders(ctx, l, p); err != nil {
 		return err
 	}
-	if err := applyPortForwardLayer(ctx, l); err != nil {
-		return err
+	if p.ovnLB {
+		if err := applyPortForwardLayer(ctx, l); err != nil {
+			return err
+		}
 	}
-	return waitStartStateGreen(ctx, l)
+	for _, gw := range p.apiVIPGateways() {
+		if err := startAPIBackend(ctx, l, gw); err != nil {
+			return err
+		}
+	}
+	return waitStartStateGreen(ctx, l, p)
 }
 
 // applyHairpinLayer mirrors ensure_fip_b_lsp / ensure_fip_b_nat in
@@ -194,36 +226,69 @@ func applyPortForwardLayer(ctx context.Context, l *lab) error {
 	return nil
 }
 
-// startPFBackend (re)starts the HTTP responder behind the VIP in the vm1
-// netns and waits for it to bind — start_backend in pf-external.sh. Any
-// previous instance is killed first, so this doubles as the restore path
-// after gateway-3 has been recycled.
+// startPFBackend (re)starts the HTTP responder behind the Load_Balancer
+// VIP in the vm1 netns and waits for it to bind — start_backend in
+// pf-external.sh. Any previous instance is killed first, so this doubles
+// as the restore path after gateway-3 has been recycled.
 func startPFBackend(ctx context.Context, l *lab) error {
 	if _, err := l.sh(ctx, workloadHost,
-		"pkill -f /usr/local/bin/pf-backend || true; : >/tmp/pf-backend.log"); err != nil {
+		"pkill -f "+pfBackendLog+" || true; : >"+pfBackendLog); err != nil {
 		return fmt.Errorf("reset pf-backend on %s: %w", workloadHost, err)
 	}
 	if _, err := l.docker(ctx, "exec", "-d", l.node(workloadHost),
 		"ip", "netns", "exec", "vm1", "/usr/local/bin/pf-backend",
-		"-addr", ":8080", "-log", "/tmp/pf-backend.log"); err != nil {
+		"-addr", ":8080", "-log", pfBackendLog); err != nil {
 		return fmt.Errorf("start pf-backend on %s: %w", workloadHost, err)
 	}
-	deadline := l.now().Add(10 * time.Second)
+	if err := waitListening(ctx, l, workloadHost,
+		"ip netns exec vm1 ss -ltn 'sport = :8080' | grep -q LISTEN"); err != nil {
+		return fmt.Errorf("pf-backend on %s: %w", workloadHost, err)
+	}
+	return nil
+}
+
+// startAPIBackend (re)starts the responder behind the API VIP. Unlike the
+// Load_Balancer VIP's backend it runs in the gateway's *default* network
+// namespace, because that is where the VIP's port_forwards rule DNATs to:
+// the gateway's own management address. It is the reason those gateways
+// need port_forward_l3mdev_accept — the socket is in the default VRF
+// while the VIP traffic ingresses vrf-provider.
+func startAPIBackend(ctx context.Context, l *lab, gw string) error {
+	addr := fmt.Sprintf(":%d", apiVIPPort)
+	if _, err := l.sh(ctx, gw,
+		"pkill -f "+apiBackendLog+" || true; : >"+apiBackendLog); err != nil {
+		return fmt.Errorf("reset the API backend on %s: %w", gw, err)
+	}
+	if _, err := l.docker(ctx, "exec", "-d", l.node(gw),
+		"/usr/local/bin/pf-backend", "-addr", addr, "-log", apiBackendLog); err != nil {
+		return fmt.Errorf("start the API backend on %s: %w", gw, err)
+	}
+	if err := waitListening(ctx, l, gw,
+		fmt.Sprintf("ss -ltn 'sport = %s' | grep -q LISTEN", addr)); err != nil {
+		return fmt.Errorf("the API backend on %s: %w", gw, err)
+	}
+	return nil
+}
+
+// waitListening polls a responder's listener until it is up. A backend
+// that never bound must fail the layering rather than leave its VIP probe
+// red — and every recovery gate behind it timing out — for the whole run.
+func waitListening(ctx context.Context, l *lab, node, probe string) error {
+	deadline := l.now().Add(backendBindTimeout)
 	for l.now().Before(deadline) {
-		if _, err := l.sh(ctx, workloadHost,
-			"ip netns exec vm1 ss -ltn 'sport = :8080' | grep -q LISTEN"); err == nil {
+		if _, err := l.sh(ctx, node, probe); err == nil {
 			return nil
 		}
 		l.sleep(time.Second)
 	}
-	return fmt.Errorf("pf-backend did not bind on :8080 within 10s")
+	return fmt.Errorf("did not bind within %s", backendBindTimeout)
 }
 
 // ensureResponders (re)creates every kernel-side responder on the
 // workload host. Idempotent, and the shape is lifted verbatim from
 // ensure_workload_netns in bootstrap.sh.
-func ensureResponders(ctx context.Context, l *lab) error {
-	for _, n := range responders() {
+func ensureResponders(ctx context.Context, l *lab, p *profile) error {
+	for _, n := range responders(p) {
 		hostVeth := n.name + "-host"
 		nsVeth := n.name + "-eth0"
 		script := strings.Join([]string{
@@ -260,51 +325,60 @@ func ensureResponders(ctx context.Context, l *lab) error {
 // container up or recycle the whole lab. A chaos run has to put the node
 // back, because the guardrails only re-target a node that has returned
 // and converged.
-func restoreNode(ctx context.Context, l *lab, gw string) error {
+func restoreNode(ctx context.Context, l *lab, p *profile, gw string) error {
 	if err := l.rewireUnderlay(ctx, gw); err != nil {
 		return err
 	}
-	return reprovisionNode(ctx, l, gw)
+	return reprovisionNode(ctx, l, p, gw)
 }
 
 // reprovisionNode re-creates the node-local state a container restart
-// wiped. Only the workload host carries any — the VIP's scope-link route
-// is re-applied by ensureVIPRouting during convergence, wherever the
-// master happens to be by then.
-func reprovisionNode(ctx context.Context, l *lab, gw string) error {
-	if gw != workloadHost {
+// wiped: the workload host's netns responders and the Load_Balancer VIP's
+// backend, and — on any gateway whose profile configures the API VIP —
+// the responder that VIP forwards to. The Load_Balancer VIP's scope-link
+// route is not re-applied here: ensureVIPRouting does it during
+// convergence, wherever the master happens to be by then.
+func reprovisionNode(ctx context.Context, l *lab, p *profile, gw string) error {
+	if gw == workloadHost {
+		if err := l.waitReady(ctx, gw, "ovs-vsctl br-exists br-int"); err != nil {
+			return fmt.Errorf("wait for br-int on %s: %w", gw, err)
+		}
+		if err := ensureResponders(ctx, l, p); err != nil {
+			return err
+		}
+		if p.ovnLB {
+			if err := startPFBackend(ctx, l); err != nil {
+				return err
+			}
+		}
+	}
+	if !p.gwConfig(gw).apiVIP {
 		return nil
 	}
-	if err := l.waitReady(ctx, gw, "ovs-vsctl br-exists br-int"); err != nil {
-		return fmt.Errorf("wait for br-int on %s: %w", gw, err)
-	}
-	if err := ensureResponders(ctx, l); err != nil {
-		return err
-	}
-	return startPFBackend(ctx, l)
+	return startAPIBackend(ctx, l, gw)
 }
 
 // waitStartStateGreen holds the run until every probe target answers, so
 // a fault is never injected into a lab that was not green to begin with.
-func waitStartStateGreen(ctx context.Context, l *lab) error {
+func waitStartStateGreen(ctx context.Context, l *lab, p *profile) error {
 	deadline := l.now().Add(startStateTimeout)
 	for l.now().Before(deadline) {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		red := redStartTargets(ctx, l)
+		red := redStartTargets(ctx, l, p)
 		if len(red) == 0 {
 			return nil
 		}
 		l.sleep(2 * time.Second)
 	}
 	return fmt.Errorf("start state not green within %s: %s",
-		startStateTimeout, strings.Join(redStartTargets(ctx, l), ", "))
+		startStateTimeout, strings.Join(redStartTargets(ctx, l, p), ", "))
 }
 
-func redStartTargets(ctx context.Context, l *lab) []string {
+func redStartTargets(ctx context.Context, l *lab, p *profile) []string {
 	var red []string
-	for _, t := range defaultProbes {
+	for _, t := range p.probes {
 		var err error
 		switch t.kind {
 		case probeHTTP:

--- a/test/e2e/chaos/state.go
+++ b/test/e2e/chaos/state.go
@@ -32,19 +32,6 @@ import (
 // would report every later fault as a false violation.
 const startStateTimeout = 120 * time.Second
 
-// probeTargets is what the run measures continuously from client-1.
-//
-// The baseline lab's second FIP, 192.0.2.11, is deliberately absent:
-// bootstrap.sh seeds its NAT row but nothing answers behind
-// 192.168.10.11, so probing it would be red for the whole run.
-var probeTargets = []probeTarget{
-	{"fip-vm1", probePing, "192.0.2.10"},
-	{"fip-vm2", probePing, "192.0.2.12"},
-	{"fip-vlan101", probePing, "198.51.100.10"},
-	{"fip-vlan102", probePing, "203.0.113.10"},
-	{"pf-vip", probeHTTP, vipURL},
-}
-
 // vlanNetwork is one row of multi-vlan.sh's NETWORKS table.
 type vlanNetwork struct {
 	tag    string
@@ -317,7 +304,7 @@ func waitStartStateGreen(ctx context.Context, l *lab) error {
 
 func redStartTargets(ctx context.Context, l *lab) []string {
 	var red []string
-	for _, t := range probeTargets {
+	for _, t := range defaultProbes {
 		var err error
 		switch t.kind {
 		case probeHTTP:

--- a/test/e2e/chaos/state_test.go
+++ b/test/e2e/chaos/state_test.go
@@ -240,3 +240,38 @@ func TestStartAPIBackendFailsWhenTheListenerNeverBinds(t *testing.T) {
 		t.Fatalf("error %q does not say the listener never came up", err)
 	}
 }
+
+// pkill exits 1 when nothing matched, which is the normal case the first
+// time a responder is started. Reading that as a failure would abort the
+// run before it began.
+func TestStartingAResponderWithNothingToKillIsNotAFailure(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "pkill") {
+			return "", errExit(t, 1)
+		}
+		return healthyLabResponses(argv)
+	}}
+
+	if err := startAPIBackend(context.Background(), newTestLab(cmd, newFakeClock()), "gateway-2"); err != nil {
+		t.Fatalf("a first start with no previous instance failed: %v", err)
+	}
+	if !cmd.called("exec -d clab-ovn-e2e-gateway-2 /usr/local/bin/pf-backend") {
+		t.Fatalf("the backend was never started: %v", cmd.lines())
+	}
+
+	// A pkill that could not run at all is a different matter: the old
+	// instance may still hold the port, and the new one would never bind.
+	broken := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "pkill") {
+			return "", errBoom
+		}
+		return healthyLabResponses(argv)
+	}}
+	err := startAPIBackend(context.Background(), newTestLab(broken, newFakeClock()), "gateway-2")
+	if err == nil {
+		t.Fatal("a reset that could not run was reported as a clean start")
+	}
+	if broken.called("exec -d clab-ovn-e2e-gateway-2 /usr/local/bin/pf-backend") {
+		t.Fatalf("a second backend was started alongside one that may still be running: %v", broken.lines())
+	}
+}

--- a/test/e2e/chaos/state_test.go
+++ b/test/e2e/chaos/state_test.go
@@ -13,7 +13,7 @@ func TestApplyStartStateLayersEveryScenarioSetup(t *testing.T) {
 	cmd := &fakeCommander{respond: healthyLabResponses}
 	l := newTestLab(cmd, newFakeClock())
 
-	if err := applyStartState(context.Background(), l); err != nil {
+	if err := applyStartState(context.Background(), l, defaultTestProfile(t)); err != nil {
 		t.Fatalf("applyStartState: %v", err)
 	}
 
@@ -54,7 +54,7 @@ func TestApplyStartStateFailsWhenTheLabNeverGoesGreen(t *testing.T) {
 	}}
 	l := newTestLab(cmd, newFakeClock())
 
-	err := applyStartState(context.Background(), l)
+	err := applyStartState(context.Background(), l, defaultTestProfile(t))
 	if err == nil {
 		t.Fatal("a start state with a dead FIP was accepted")
 	}
@@ -90,7 +90,7 @@ func TestRestoreNodeRewiresBeforeReprovisioning(t *testing.T) {
 	cmd := &fakeCommander{respond: healthyLabResponses}
 	l := newTestLab(cmd, newFakeClock())
 
-	if err := restoreNode(context.Background(), l, workloadHost); err != nil {
+	if err := restoreNode(context.Background(), l, defaultTestProfile(t), workloadHost); err != nil {
 		t.Fatalf("restoreNode: %v", err)
 	}
 
@@ -113,7 +113,7 @@ func TestRestoreNodeReportsAFailedRewire(t *testing.T) {
 	}}
 	l := newTestLab(cmd, newFakeClock())
 
-	err := restoreNode(context.Background(), l, "gateway-2")
+	err := restoreNode(context.Background(), l, defaultTestProfile(t), "gateway-2")
 	if err == nil {
 		t.Fatal("a failed veth re-create was reported as a successful restore")
 	}
@@ -127,12 +127,116 @@ func TestRestoreNodeReportsAFailedRewire(t *testing.T) {
 // stay red after its host is recycled and fail the next recovery gate.
 func TestEveryProbedFIPHasARestoredResponder(t *testing.T) {
 	lsps := map[string]bool{}
-	for _, n := range responders() {
+	for _, n := range responders(defaultTestProfile(t)) {
 		lsps[n.lsp] = true
 	}
 	for _, want := range []string{"ls0-vm1", "ls0-vm2", "vm101", "vm102"} {
 		if !lsps[want] {
 			t.Fatalf("responder for %s is not rebuilt after its host is recycled", want)
 		}
+	}
+}
+
+// A profile that puts up no VLAN networks must not layer them anyway: the
+// point of flat-minimal is a lab whose agents have less to reconcile, and
+// a stray VLAN network would leave residue no probe measures.
+func TestApplyStartStateOnlyLayersTheProfilesOwnScenarios(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := applyStartState(context.Background(), l, testProfile(t, "flat-minimal")); err != nil {
+		t.Fatalf("applyStartState: %v", err)
+	}
+
+	for _, unwanted := range []string{
+		"ln-vlan101", // multi-vlan.sh
+		"lr-nat-add lr0 dnat_and_snat 192.0.2.12", // hairpin.sh
+		"lb-add pf-external",                      // pf-external.sh
+		"external_ids:iface-id=ls0-vm2",
+		"/usr/local/bin/pf-backend",
+	} {
+		if cmd.called(unwanted) {
+			t.Fatalf("flat-minimal layered %q, which none of its probes measure: %v", unwanted, cmd.lines())
+		}
+	}
+	// The bootstrap responder behind the one FIP it does probe is still
+	// ensured — it is the restore path too.
+	if !cmd.called("external_ids:iface-id=ls0-vm1") {
+		t.Fatalf("the workload behind the probed FIP was not ensured: %v", cmd.lines())
+	}
+}
+
+// The API VIP's backend runs in the gateway's default namespace, and only
+// on the gateways whose configuration carries the VIP. It is the same
+// binary as the Load_Balancer VIP's backend, so the two kill patterns must
+// not overlap: resetting one on gateway-3 would otherwise take the other
+// one down with it.
+func TestStartStateStartsTheAPIBackendOnlyOnItsGateways(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := applyStartState(context.Background(), l, testProfile(t, "heterogeneous")); err != nil {
+		t.Fatalf("applyStartState: %v", err)
+	}
+
+	if !cmd.called("exec -d clab-ovn-e2e-gateway-2 /usr/local/bin/pf-backend -addr :8080 -log " + apiBackendLog) {
+		t.Fatalf("the API backend was not started on the gateway that announces the VIP: %v", cmd.lines())
+	}
+	if cmd.called("exec -d clab-ovn-e2e-gateway-1 /usr/local/bin/pf-backend") {
+		t.Fatalf("the API backend was started on a gateway whose config has no VIP: %v", cmd.lines())
+	}
+	if cmd.count("pkill -f "+apiBackendLog) != 1 {
+		t.Fatalf("the API backend was reset on more than its own gateway: %v", cmd.lines())
+	}
+	for _, line := range cmd.lines() {
+		if strings.Contains(line, "pkill") && strings.Contains(line, "/usr/local/bin/pf-backend") {
+			t.Fatalf("a kill pattern matches both responders and would take the other one down: %q", line)
+		}
+	}
+}
+
+// A gateway that comes back from a container lifecycle event needs the
+// responder behind its API VIP back too — nothing else restarts it, and
+// the VIP probe would stay red for the rest of the run.
+func TestReprovisionRestartsTheAPIBackendOnItsGateways(t *testing.T) {
+	p := testProfile(t, "heterogeneous")
+	cmd := &fakeCommander{respond: healthyLabResponses}
+
+	if err := reprovisionNode(context.Background(), newTestLab(cmd, newFakeClock()), p, "gateway-2"); err != nil {
+		t.Fatalf("reprovision gateway-2: %v", err)
+	}
+	if !cmd.called("exec -d clab-ovn-e2e-gateway-2 /usr/local/bin/pf-backend") {
+		t.Fatalf("the API backend was not restarted after the lifecycle event: %v", cmd.lines())
+	}
+
+	// A gateway with neither node-local workloads nor an API VIP has
+	// nothing to reprovision.
+	peer := &fakeCommander{respond: healthyLabResponses}
+	if err := reprovisionNode(context.Background(), newTestLab(peer, newFakeClock()), p, "gateway-1"); err != nil {
+		t.Fatalf("reprovision gateway-1: %v", err)
+	}
+	if len(peer.lines()) != 0 {
+		t.Fatalf("reprovision touched a gateway that carries nothing: %v", peer.lines())
+	}
+}
+
+// A backend that never binds must fail the layering rather than leave the
+// API VIP probe red — and every recovery gate behind it timing out — for
+// the whole run.
+func TestStartAPIBackendFailsWhenTheListenerNeverBinds(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "sport = :8080") {
+			return "", errBoom
+		}
+		return "", nil
+	}}
+
+	err := startAPIBackend(context.Background(), newTestLab(cmd, newFakeClock()), "gateway-2")
+
+	if err == nil {
+		t.Fatal("an API backend that never bound was accepted")
+	}
+	if !strings.Contains(err.Error(), "did not bind") {
+		t.Fatalf("error %q does not say the listener never came up", err)
 	}
 }

--- a/test/e2e/gwnode-entrypoint.sh
+++ b/test/e2e/gwnode-entrypoint.sh
@@ -288,6 +288,19 @@ configure_frr() {
     exit 1
 }
 
+# A chaos configuration profile (test/e2e/chaos, issue #177) rewrites the
+# whole agent config file and drops this marker next to it. topology.clab.yml
+# sets OVN_NETWORK_DRAIN_ON_SHUTDOWN on every gateway, and the agent's
+# environment layer beats its config file — so without stepping the override
+# aside, a profile could never turn the drain on. No marker, no change: every
+# existing scenario (drain-hitless included) keeps the deploy-time switch.
+yield_config_to_chaos_profile() {
+    local marker=/etc/ovn-network-agent/chaos-profile
+    [[ -f "${marker}" ]] || return 0
+    log "chaos profile '$(cat "${marker}")' owns the config file: unsetting OVN_NETWORK_DRAIN_ON_SHUTDOWN"
+    unset OVN_NETWORK_DRAIN_ON_SHUTDOWN
+}
+
 main() {
     start_ovs
     resolve_sb_remote
@@ -297,6 +310,7 @@ main() {
     setup_loopback
     start_frr
     configure_frr
+    yield_config_to_chaos_profile
 
     log "exec ovn-network-agent"
     exec /usr/local/bin/ovn-network-agent \


### PR DESCRIPTION
Makes the agent configuration a first-class input to a chaos run. A named profile carries both the start topology and a per-gateway agent-config overlay; applying it to a running lab rewrites each gateway's config, validates it with the agent's own config-check before touching anything, and rolls the gateways one at a time. Configuration change also becomes a chaos action in its own right.

Closes #177

## The change, in commit order

**`99fe195` — define the profiles and their rendering.** Six curated profiles rather than a combinatorial matrix: `everything-on` (the default, today's run), `flat-minimal`, `flat-dnat`, `vlan-no-dnat`, `pf-only` (the agent runs with no OVN connection at all), and `heterogeneous`, where the gateways run different configs as they do mid-rollout. Each carries a start topology and a per-gateway overlay rendered key-level over `test/e2e/gwnode-config.yaml`. An empty overlay renders the baked bytes verbatim — that byte identity is what later lets the applier tell a gateway that must swap and restart from one it can leave alone.

**`83cf6a1` — apply a profile to the running lab.** No image rebuild and no redeploy: the config file is the only thing that changes and the entrypoint execs the agent, so `docker restart` is the reload. Safety comes from the order — render every gateway's config and hand each to `--check-config` *before* a single live file is touched, then roll gateways one at a time, gating each on being back before the next goes down. A gateway already running the rendered config is skipped, so the default profile on a fresh lab restarts nothing. The profile joins the seed in the reproducibility contract (`-profile`, echoed in the run-start event and the run record), gates which scenario layers the start state puts up and which targets get probed, and brings its own responder for the API VIP it configures.

**`be97ece` — the `config-flip` chaos action.** Draws a whitelisted toggle (`drain-toggle`, `masquerade-toggle`, `cidr-toggle`, `cadence-toggle`, `pf-rule-toggle`), rewrites the target's config with it, and restarts the node onto it through the same validate-then-swap path the profile apply uses. A config the agent refuses is journaled and dropped rather than failing the run — that is the answer a rejected rollout gives an operator. Every tick now draws a fifth value, the flip index, whether or not the action it picked reads one, so a guardrail skip cannot shift the random stream.

**`a98c5d4` — docs.** The profiles with their topology, per-gateway config and probe set; how a profile reaches a running lab; the flip whitelist and what a rejected flip means. The replay contract gains the profile: a seed alone no longer identifies a run.

**`535c7a2` — fix the responder reset.** The two pf-backend responders (the Load_Balancer VIP's in the vm1 netns, the API VIP's in the gateway's default namespace) are the same binary in the same PID namespace, so the reset keys on the log path to tell them apart. Running `pkill -f` inside `sh -c` matched the shell's own argv and killed the shell. It now runs as its own `docker exec`, the way `pf-external.sh` already does it.

## Divergences from the issue worth a look

Three things in the diff are not in the issue text, each forced by making the feature actually work on the lab:

- **`test/e2e/gwnode-entrypoint.sh` learns a marker file.** `topology.clab.yml` sets `OVN_NETWORK_DRAIN_ON_SHUTDOWN` on every gateway, and the agent's environment layer beats its config file — so without stepping that override aside, a profile could never turn the drain *on*. A profile drops a marker next to the config file and the entrypoint unsets the env var. No marker, no change: every existing scenario (`drain-hitless` included) keeps the deploy-time switch.
- **`agent-terminate`'s exit budget goes to 120s.** A drain that a profile or a flip turned on holds a SIGTERM'ed agent for up to `drain_timeout` before PID 1 exits. The wait still returns as soon as the container is down.
- **The last commit is a bug fix in existing responder-reset code**, surfaced by the API VIP responder the `flat-dnat` profile needs.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 01245b5 with Claude:claude-opus-4-8_
