### PR TITLE
test/e2e: extend the chaos action catalog with control-plane, network, and drift faults

### DIFF
--- a/.github/actions/e2e-lab-setup/action.yml
+++ b/.github/actions/e2e-lab-setup/action.yml
@@ -17,20 +17,30 @@ runs:
     # The gwnode image uses kernel OVS so OVN's BFD-driven cr-lrp
     # election over geneve tunnels actually converges, and the entrypoint
     # creates a vrf-provider kernel VRF for the agent's veth-leak design.
-    # The gwnode containers only inherit CAP_NET_ADMIN (no CAP_SYS_MODULE),
-    # so the modules must be loaded on the host before lab-up. The Azure
-    # kernel on `ubuntu-latest` ships `openvswitch` in the base modules
-    # set but `vrf` only in `linux-modules-extra-<uname>` — install it on
+    # The chaos runner's management-path impairment (issue #178) also needs
+    # `sch_netem` for its `tc netem` loss/latency qdiscs. The gwnode
+    # containers only inherit CAP_NET_ADMIN (no CAP_SYS_MODULE), so the
+    # modules must be loaded on the host before lab-up. The Azure kernel on
+    # `ubuntu-latest` ships `openvswitch` in the base modules set but `vrf`
+    # and `sch_netem` only in `linux-modules-extra-<uname>` — install it on
     # demand. Without `vrf`, gwnode-entrypoint.sh crash-loops on
     # `ip link add vrf-provider type vrf table 100` with "Unknown device
-    # type".
+    # type"; without `sch_netem` the impairment actions fail to add their
+    # qdisc.
     - name: Load required kernel modules
       shell: bash
       run: |
         set -euo pipefail
         sudo modprobe openvswitch
-        if ! sudo modprobe vrf 2>/dev/null; then
+        install_extra() {
           sudo apt-get update -qq
           sudo apt-get install -y "linux-modules-extra-$(uname -r)"
+        }
+        if ! sudo modprobe vrf 2>/dev/null; then
+          install_extra
           sudo modprobe vrf
+        fi
+        if ! sudo modprobe sch_netem 2>/dev/null; then
+          install_extra
+          sudo modprobe sch_netem
         fi

--- a/Makefile
+++ b/Makefile
@@ -283,11 +283,13 @@ e2e-drain-hitless:
 # Run a seeded chaos session (issue #176) against a lab that is already
 # up. Layers the hairpin, multi-VLAN and port-forward scenario setups on
 # the bootstrap baseline, then drives the lab through a randomized fault
-# sequence: every tick waits a random interval, picks a weighted action
-# (controller-restart, gateway-kill, agent-terminate, gateway-restart),
+# sequence: every tick waits a random interval, picks a weighted action,
 # checks its guardrails and executes it, while a continuous probe from
-# client-1 measures every FIP and the port-forward VIP. Defaults: seed
-# 42, 10 minutes, 10–30 s between decisions.
+# client-1 measures every FIP and the port-forward VIP. The action catalog
+# (issue #178) spans container-level starter faults and a config change,
+# control-plane outages, management-path impairment, data-plane drift,
+# routing flaps and OVN churn. Defaults: seed 42, 10 minutes, 10–30 s
+# between decisions.
 #
 # Reproducibility is the contract: the seed, the duration, the tick
 # bounds and the action weights are the only inputs, and every decision

--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -44,7 +44,12 @@ test/e2e/
   chaos/                    — seeded chaos runner, `make e2e-chaos` (issue #176)
     main.go                 — flags, wiring, exit codes, artifact collection
     engine.go               — the seeded tick loop: draw, guardrails, execute, converge
-    actions.go              — the fault registry (four starter actions)
+    actions.go              — the fault registry (starter faults + config-flip)
+    control.go              — control-plane outages: NB/SB/northd pause, double failover (#178)
+    impair.go               — management-path packet loss and latency (#178)
+    drift.go                — data-plane drift the agent self-heals (#178)
+    flaps.go                — FRR / upstream BGP restarts (#178)
+    churn.go                — OVN churn: FIP, port-forward, priority, chassis (#178)
     lab.go                  — the single seam to docker / containerlab
     state.go                — the combined start state and the node-restore path
     probe.go                — continuous reachability probe from client-1
@@ -1044,23 +1049,107 @@ the VLAN networks in the NB DB — unprobed, but present. Start each
 profile run from a fresh `make e2e-up` for exact semantics.
 :::
 
-**Actions.** The starter set reuses the fault mechanics the scenarios
-already prove; `config-flip` reconfigures a gateway mid-run. The registry
-order and the weights are part of the replay contract — a new action is
-appended, never inserted.
+**Actions.** The catalog spans five fault classes (issue
+[#178](https://github.com/osism/ovn-network-agent/issues/178)): the
+container-level starter faults and the config change, control-plane
+outages, management-path impairment, data-plane drift, routing flaps, and
+OVN churn. Each action reuses a mechanic an existing scenario — or the
+integration tier — already proves. The registry order and the weights are
+part of the replay contract: a new action is appended, never inserted.
 
-| Action | Weight | Hold | Recovery budget | Mechanic |
-| --- | --- | --- | --- | --- |
-| `controller-restart` | 3 | 10–30 s | 90 s | `ovn-ctl stop_controller` / `start_controller` ([failover](#failover)) |
-| `gateway-kill` | 1 | 15–45 s | 180 s | `docker kill -s KILL`, then `docker start` ([stale chassis](#stale-chassis)) |
-| `agent-terminate` | 2 | 10–30 s | 180 s | `kill -TERM 1` — the agent is PID 1 ([drain-hitless](#drain-hitless)) |
-| `gateway-restart` | 2 | — | 180 s | `docker restart` ([pf-hairpin](#port-forward-hairpin-masquerade)) |
-| `config-flip` | 2 | — | 180 s | rewrite one gateway's config and restart it onto it — see below |
+| Action | Target | Weight | Hold | Budget | Mechanic |
+| --- | --- | --- | --- | --- | --- |
+| `controller-restart` | gateway | 3 | 10–30 s | 90 s | `ovn-ctl stop_controller` / `start_controller` ([failover](#failover)) |
+| `gateway-kill` | gateway | 1 | 15–45 s | 180 s | `docker kill -s KILL`, then `docker start` ([stale chassis](#stale-chassis)) |
+| `agent-terminate` | gateway | 2 | 10–30 s | 180 s | `kill -TERM 1` — the agent is PID 1 ([drain-hitless](#drain-hitless)) |
+| `gateway-restart` | gateway | 2 | — | 180 s | `docker restart` ([pf-hairpin](#port-forward-hairpin-masquerade)) |
+| `config-flip` | gateway | 2 | — | 180 s | rewrite one gateway's config and restart it onto it — see below |
+| `nb-pause` | central | 2 | 5–90 s | 90 s | SIGSTOP/SIGCONT the NB `ovsdb-server` |
+| `sb-pause` | central | 2 | 5–90 s | 120 s | SIGSTOP/SIGCONT the SB `ovsdb-server` |
+| `northd-pause` | central | 1 | 10–60 s | 60 s | SIGSTOP/SIGCONT `ovn-northd` |
+| `double-failover` | gateway pair | 1 | 10–30 s | 240 s | SIGTERM one gateway, SIGKILL its ring-next peer while it drains |
+| `mgmt-loss` | gateway | 2 | 20–60 s | 90 s | `tc netem loss 30%` on the gateway→central path |
+| `mgmt-delay` | gateway | 2 | 20–60 s | 90 s | `tc netem delay 200ms 50ms` on the gateway→central path |
+| `kernel-route-drop` | gateway | 2 | — | 60 s | `ip route del 192.0.2.10/32 dev br-ex` |
+| `frr-route-drop` | gateway | 2 | — | 60 s | `no ip route 192.0.2.10/32 169.254.0.1` in `vrf-provider` |
+| `nft-flush` | gateway | 2 | — | 60 s | `nft flush table ip ovn-network-agent` |
+| `ovs-flow-drop` | gateway | 2 | — | 60 s | `ovs-ofctl del-flows` the hairpin (`0x998`) and MAC-tweak (`0x999`) cookies on `br-ex` |
+| `frr-restart` | gateway | 2 | — | 120 s | `frrinit.sh` stop/clear/start, then re-assert BGP |
+| `upstream-bgp-restart` | upstream | 1 | 5–20 s | 90 s | `pkill -x bgpd` on `upstream`, then start it back in place |
+| `fip-churn` | central | 2 | — | 60 s | add/remove a spare FIP (`192.0.2.60`) on `lr0` |
+| `lb-vip-churn` | central | 2 | — | 60 s | add/remove a `vips` entry (`192.0.2.50:81`) on `pf-external` |
+| `priority-flip` | gateway | 2 | — | 120 s | bump a gateway's `Gateway_Chassis` priority above the group peak |
+| `chassis-delete` | gateway | 1 | — | 90 s | `ovn-sbctl chassis-del` while its `ovn-controller` keeps running |
 
 Every action that kills a container first runs `docker update
 --restart=no`, exactly as `drain-hitless.sh` does — containerlab deploys
 with `restart: always`, so without it docker revives the node before the
 fault is observable at all. The policy is restored on the way back.
+
+**Control-plane outages** target the shared `central` node. The database
+and northd pauses SIGSTOP the `ovn-ctl` process by its pidfile under
+`/var/run/ovn` and SIGCONT it on restore, so the connection stalls — for a
+short hold, or one long enough to force every `ovn-controller` and agent
+to reconnect and resync — without tearing the container down. Convergence
+is `central`'s container health, which the image's HEALTHCHECK ties to both
+databases answering. While the SB is paused the baseline sweep's
+`ovn-sbctl --timeout=5` calls fail and are journaled as `check-error`s, not
+violations. `double-failover` SIGTERMs the drawn gateway (which begins its
+drain) and SIGKILLs the ring-next peer before it has finished — two
+gateways down at once, restored one at a time through the same
+container-lifecycle path the starter kills use.
+
+**Network impairment** degrades the management path from a gateway to
+`central` with `tc netem`, forcing the OVSDB connections to flap without
+killing anything. A `prio` qdisc keeps its default band unimpaired and a
+`u32` filter steers only the traffic bound for `central` into the netem
+band — so the gateway-to-gateway geneve tunnels on the same `eth0` stay
+clean and the data plane is not collaterally darkened. `sch_netem` must be
+loaded on the host: CI does it in
+[`e2e-lab-setup`](https://github.com/osism/ovn-network-agent/blob/main/.github/actions/e2e-lab-setup/action.yml),
+and a local run needs `sudo modprobe sch_netem` first (the container holds
+only `CAP_NET_ADMIN` and cannot load it itself).
+
+**Data-plane drift** is the fat-fingered-operator class: delete a managed
+kernel route, flush the agent's nftables table, remove a hairpin or
+MAC-rewrite OVS flow, remove an FRR static route — the exact deletions
+[`scenario_drift_test.go`](https://github.com/osism/ovn-network-agent/blob/main/test/integration/scenario_drift_test.go)
+proves the agent heals on a single host, driven here against the
+multi-node lab. The deletion is the fault; the agent's next periodic
+reconcile is the undo, so the restore is a no-op and the recovery budget
+is the worst-case cadence (15 s after a `cadence-toggle` flip) plus probe
+slack. Each action skips a gateway that does not carry the object — the
+MAC-tweak flows exist only where routers are locally active, a
+port-forward-only profile has no FIP routes — rather than record a no-op
+deletion. Removing the MAC-tweak flow darkens external probes and is
+measured; the hairpin flow's restoration is not probe-observable from
+`client-1` (asserting its presence is the config-aware oracle of
+[#179](https://github.com/osism/ovn-network-agent/issues/179)).
+
+**Routing flaps** restart the FRR/BGP daemons and let the run assert the
+announcements return — the probes from `client-1` are only reachable over
+the routes `upstream` re-learns over BGP, so a green probe set is the
+proof. `frr-restart` recycles a gateway's FRR the way the gwnode entrypoint
+does (stop, clear the stale `watchfrr` state, start) and re-asserts the
+session on restore. `upstream-bgp-restart` stops `bgpd` on `upstream` and
+starts it back **in place** — never a `docker restart` and never
+`frrinit.sh restart`, because `watchfrr` is PID 1 on that node and either
+would take the container and its five containerlab veths down (the
+exit-137 trap `bootstrap.sh` documents).
+
+**OVN churn** mutates the topology under load the way an operator or an
+orchestrator does: add and remove a floating IP and a port-forward `vips`
+entry, flip a `Gateway_Chassis` priority above the group peak externally
+(the same mechanic `bootstrap.sh` uses to converge the master), and delete
+a chassis. The churn FIP (`192.0.2.60`) and VIP (`192.0.2.50:81`) are
+deliberately **unprobed** — a resource that appears and disappears must
+never draw probe traffic — and each churn is left in place for the next
+draw to toggle back. `chassis-delete` removes the SB `Chassis` row while
+the target's `ovn-controller` keeps running, so it re-registers well inside
+the 30 s `stale_chassis_grace_period`: the surviving agents' stale cleanup
+must **not** fire, and the existing gateway convergence (chassis back in
+SB, green probes) is exactly the "returns within the grace period" gate.
+Every executed churn is journaled as an `ovn-churn` event.
 
 `agent-terminate` exercises the agent's *drain* path whenever the target
 is running a config with `drain_on_shutdown` on — a profile that sets it,
@@ -1100,11 +1189,24 @@ truncated: `docker restart`'s 10 s stop-grace SIGKILLs an agent that is
 still draining. That is legitimate chaos — the run only asserts that the
 node recovers — but it is worth knowing when reading a journal.
 
-**Guardrails** keep a run meaningful. A decision is skipped (and
-journaled with its `skip_reason`) when the target has not returned and
-converged since it was last hit, when it is the last healthy gateway, or
-— for `config-flip` — when the drawn flip means nothing on what the
-target is currently running (`flip-not-applicable`).
+**Guardrails** keep a run meaningful, and every action declares the node
+states it may target through its *scope* — gateway, central, upstream, or
+gateway pair. A decision is skipped (and journaled with its `skip_reason`)
+when the target has not returned and converged since it was last hit
+(`target-not-healthy`), when a gateway fault would leave no other healthy
+gateway to fail over to (`no-healthy-peer`), when a `double-failover`'s
+ring-next peer has not converged (`peer-not-healthy`), when the drawn
+`config-flip` means nothing on the target's current config
+(`flip-not-applicable`), or when a drift or churn action's object is absent
+(`not-applicable`). A central- or upstream-scoped fault needs **no** healthy
+gateway peer — pausing the database or restarting the upstream BGP does not
+depend on how many gateways are up. `central` and `upstream` carry their own
+lifecycle in the same node-state map, so a paused database is re-targeted
+only once it has converged; the agent-alive and dual-claim sweeps still
+iterate the gateways alone. The engine executes actions **serially** —
+inject, hold, restore, converge, inline in the tick loop — so at most one
+fault is in flight at a time, and the "how many instances may be in flight"
+guardrail is one for every action by construction.
 
 **Convergence and recovery budgets.** After each restore the runner polls
 the node back to health: the container healthy, its chassis back in SB,
@@ -1178,8 +1280,14 @@ was restarted onto the profile from one that was already on it),
 `state-applied`, one `decision` per tick (with the drawn values — the
 flip among them — and either `executed` or a `skip_reason`), `inject` /
 `restore` / `converged`, `config-flip` (the flip, the values it moved
-between, and `rejected` when the agent refused it), `node-state`,
-`probe-transition`, `vip-repoint`, `violation` and `run-end`.
+between, and `rejected` when the agent refused it), `ovn-churn` (each
+executed churn, with the `object` it touched and the `from`/`to` values it
+moved between), `node-state`, `probe-transition`, `vip-repoint`,
+`violation` and `run-end`. A `decision`, `inject` or `converged` for a
+multi-node fault carries the `peer` it also disrupted, and a decision that
+touched a named object (a route, a database server, an nftables table)
+carries it in `object` — so a run mixing all classes is triageable from the
+artifacts alone.
 `summary.json` aggregates the run: inputs, tick and decision counts,
 actions by name, how many baseline sweeps ran and how many of them
 evaluated the dual-claim invariant, per-probe sent/lost plus 10-second

--- a/test/e2e/chaos/actions.go
+++ b/test/e2e/chaos/actions.go
@@ -120,6 +120,7 @@ func allActions(p *profile, l *lab, ap *applier) []*action {
 	actions = append(actions, controlPlaneActions(p)...)
 	actions = append(actions, impairActions()...)
 	actions = append(actions, driftActions(l)...)
+	actions = append(actions, flapActions()...)
 	return actions
 }
 

--- a/test/e2e/chaos/actions.go
+++ b/test/e2e/chaos/actions.go
@@ -106,6 +106,7 @@ func allActions(p *profile, ap *applier) []*action {
 		holdMin:        0,
 		holdMax:        0,
 		recoveryBudget: 180 * time.Second,
+		usesFlip:       true,
 		applicable:     ap.applicable,
 		inject: func(ctx context.Context, _ *lab, gw string, flip int) error {
 			return ap.flip(ctx, gw, flip)

--- a/test/e2e/chaos/actions.go
+++ b/test/e2e/chaos/actions.go
@@ -118,6 +118,7 @@ func allActions(p *profile, ap *applier) []*action {
 	// The fault classes of issue #178, each appended — never inserted — so a
 	// recorded seed still replays the sequence it recorded.
 	actions = append(actions, controlPlaneActions(p)...)
+	actions = append(actions, impairActions()...)
 	return actions
 }
 

--- a/test/e2e/chaos/actions.go
+++ b/test/e2e/chaos/actions.go
@@ -100,7 +100,7 @@ func starterActions(p *profile) []*action {
 // fault and its own undo, so like gateway-restart it holds nothing and
 // pays the full container-lifecycle recovery budget.
 func allActions(p *profile, ap *applier) []*action {
-	return append(starterActions(p), &action{
+	actions := append(starterActions(p), &action{
 		name:           "config-flip",
 		weight:         2,
 		holdMin:        0,
@@ -115,6 +115,10 @@ func allActions(p *profile, ap *applier) []*action {
 			return restoreNode(ctx, l, p, gw)
 		},
 	})
+	// The fault classes of issue #178, each appended — never inserted — so a
+	// recorded seed still replays the sequence it recorded.
+	actions = append(actions, controlPlaneActions(p)...)
+	return actions
 }
 
 // injectGatewayKill hard-kills the container. containerlab deploys with

--- a/test/e2e/chaos/actions.go
+++ b/test/e2e/chaos/actions.go
@@ -99,7 +99,7 @@ func starterActions(p *profile) []*action {
 // emergency flag flip actually reaches production. Its restart is the
 // fault and its own undo, so like gateway-restart it holds nothing and
 // pays the full container-lifecycle recovery budget.
-func allActions(p *profile, l *lab, ap *applier) []*action {
+func allActions(p *profile, l *lab, ap *applier, ch *churner) []*action {
 	actions := append(starterActions(p), &action{
 		name:           "config-flip",
 		weight:         2,
@@ -121,6 +121,7 @@ func allActions(p *profile, l *lab, ap *applier) []*action {
 	actions = append(actions, impairActions()...)
 	actions = append(actions, driftActions(l)...)
 	actions = append(actions, flapActions()...)
+	actions = append(actions, churnActions(p, ch)...)
 	return actions
 }
 

--- a/test/e2e/chaos/actions.go
+++ b/test/e2e/chaos/actions.go
@@ -99,7 +99,7 @@ func starterActions(p *profile) []*action {
 // emergency flag flip actually reaches production. Its restart is the
 // fault and its own undo, so like gateway-restart it holds nothing and
 // pays the full container-lifecycle recovery budget.
-func allActions(p *profile, ap *applier) []*action {
+func allActions(p *profile, l *lab, ap *applier) []*action {
 	actions := append(starterActions(p), &action{
 		name:           "config-flip",
 		weight:         2,
@@ -119,6 +119,7 @@ func allActions(p *profile, ap *applier) []*action {
 	// recorded seed still replays the sequence it recorded.
 	actions = append(actions, controlPlaneActions(p)...)
 	actions = append(actions, impairActions()...)
+	actions = append(actions, driftActions(l)...)
 	return actions
 }
 

--- a/test/e2e/chaos/actions_test.go
+++ b/test/e2e/chaos/actions_test.go
@@ -399,7 +399,7 @@ func TestAnApplierWithoutAProfileSkipsEveryFlip(t *testing.T) {
 	ap := newApplier(nil, defaultTestProfile(t), nil)
 
 	for i := range flips() {
-		if ap.applicable("gateway-1", i) {
+		if ap.applicable(context.Background(), "gateway-1", i) {
 			t.Fatalf("flip %s was applicable before the profile was applied", flipName(i))
 		}
 	}

--- a/test/e2e/chaos/actions_test.go
+++ b/test/e2e/chaos/actions_test.go
@@ -376,6 +376,8 @@ func TestActionRegistryOrderIsStable(t *testing.T) {
 		"kernel-route-drop", "frr-route-drop", "nft-flush", "ovs-flow-drop",
 		// routing flaps (issue #178)
 		"frr-restart", "upstream-bgp-restart",
+		// OVN churn (issue #178)
+		"fip-churn", "lb-vip-churn", "priority-flip", "chassis-delete",
 	}
 	got := actionOrder(actions)
 	if len(got) != len(want) {
@@ -415,7 +417,7 @@ func TestActionRegistryOrderIsStable(t *testing.T) {
 func fullRegistry(t *testing.T) []*action {
 	t.Helper()
 	p := defaultTestProfile(t)
-	return allActions(p, nil, newApplier(nil, p, nil))
+	return allActions(p, nil, newApplier(nil, p, nil), newChurner(nil))
 }
 
 func actionOrder(actions []*action) []string {

--- a/test/e2e/chaos/actions_test.go
+++ b/test/e2e/chaos/actions_test.go
@@ -374,6 +374,8 @@ func TestActionRegistryOrderIsStable(t *testing.T) {
 		"mgmt-loss", "mgmt-delay",
 		// data-plane drift (issue #178)
 		"kernel-route-drop", "frr-route-drop", "nft-flush", "ovs-flow-drop",
+		// routing flaps (issue #178)
+		"frr-restart", "upstream-bgp-restart",
 	}
 	got := actionOrder(actions)
 	if len(got) != len(want) {

--- a/test/e2e/chaos/actions_test.go
+++ b/test/e2e/chaos/actions_test.go
@@ -370,6 +370,8 @@ func TestActionRegistryOrderIsStable(t *testing.T) {
 		"gateway-restart", "config-flip",
 		// control-plane outages (issue #178)
 		"nb-pause", "sb-pause", "northd-pause", "double-failover",
+		// network impairment (issue #178)
+		"mgmt-loss", "mgmt-delay",
 	}
 	got := actionOrder(actions)
 	if len(got) != len(want) {

--- a/test/e2e/chaos/actions_test.go
+++ b/test/e2e/chaos/actions_test.go
@@ -357,37 +357,78 @@ func TestProbeTargetsExcludeTheBackendlessFIP(t *testing.T) {
 	}
 }
 
-// config-flip is appended to the starter set, never inserted: the weighted
-// pick walks the registry in order, so an insertion would replay every
-// recorded seed as a different run.
-func TestConfigFlipIsAppendedToTheRegistry(t *testing.T) {
-	p := defaultTestProfile(t)
-	actions := allActions(p, newApplier(nil, p, nil))
+// The registry order and the weights are the replay contract: a new action
+// is appended, never inserted, so a recorded seed still replays the
+// sequence it recorded. This asserts the full ordered set and every
+// action's own invariants.
+func TestActionRegistryOrderIsStable(t *testing.T) {
+	actions := fullRegistry(t)
 
 	want := []string{
+		// starter faults (issue #176) and the config change (issue #177)
 		"controller-restart", "gateway-kill", "agent-terminate",
 		"gateway-restart", "config-flip",
+		// control-plane outages (issue #178)
+		"nb-pause", "sb-pause", "northd-pause", "double-failover",
 	}
-	for i, a := range actions {
-		if i >= len(want) || a.name != want[i] {
-			t.Fatalf("registry = %v, want %v", actionNames(actions), want)
+	got := actionOrder(actions)
+	if len(got) != len(want) {
+		t.Fatalf("registry = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("registry = %v, want %v", got, want)
 		}
 	}
-	if len(actions) != len(want) {
-		t.Fatalf("registry = %v, want %v", actionNames(actions), want)
+	for _, a := range actions {
+		if a.weight <= 0 {
+			t.Fatalf("action %s ships with weight %d — the weighted pick would never draw it", a.name, a.weight)
+		}
+		if a.holdMax < a.holdMin {
+			t.Fatalf("action %s has holdMax %s below holdMin %s", a.name, a.holdMax, a.holdMin)
+		}
+		if a.recoveryBudget <= 0 {
+			t.Fatalf("action %s has no recovery budget", a.name)
+		}
 	}
 
-	flip := actions[len(actions)-1]
-	if flip.weight <= 0 {
-		t.Fatalf("config-flip ships with weight %d — the weighted pick would never draw it", flip.weight)
-	}
-	if flip.applicable == nil {
+	// config-flip is the one action whose behaviour depends on the drawn
+	// flip, and its restart onto the new config is its own undo.
+	flip := actionFromRegistry(t, actions, "config-flip")
+	if !flip.usesFlip || flip.applicable == nil {
 		t.Fatal("config-flip does not read the flip index the engine draws for it")
 	}
 	if flip.holdMin != 0 || flip.holdMax != 0 {
-		t.Fatalf("config-flip holds its fault for %s–%s — the restart onto the new config is its own undo",
-			flip.holdMin, flip.holdMax)
+		t.Fatalf("config-flip holds its fault for %s–%s", flip.holdMin, flip.holdMax)
 	}
+}
+
+// fullRegistry builds the registry the runner drives, with the dependencies
+// the actions bind to. A nil lab is fine: the actions capture it but only
+// touch it at run time, and no test here executes one.
+func fullRegistry(t *testing.T) []*action {
+	t.Helper()
+	p := defaultTestProfile(t)
+	return allActions(p, newApplier(nil, p, nil))
+}
+
+func actionOrder(actions []*action) []string {
+	names := make([]string, 0, len(actions))
+	for _, a := range actions {
+		names = append(names, a.name)
+	}
+	return names
+}
+
+func actionFromRegistry(t *testing.T, actions []*action, name string) *action {
+	t.Helper()
+	for _, a := range actions {
+		if a.name == name {
+			return a
+		}
+	}
+	t.Fatalf("no action named %q in the registry: %v", name, actionOrder(actions))
+	return nil
 }
 
 // The guardrail is consulted before the fault is injected, and an applier

--- a/test/e2e/chaos/actions_test.go
+++ b/test/e2e/chaos/actions_test.go
@@ -372,6 +372,8 @@ func TestActionRegistryOrderIsStable(t *testing.T) {
 		"nb-pause", "sb-pause", "northd-pause", "double-failover",
 		// network impairment (issue #178)
 		"mgmt-loss", "mgmt-delay",
+		// data-plane drift (issue #178)
+		"kernel-route-drop", "frr-route-drop", "nft-flush", "ovs-flow-drop",
 	}
 	got := actionOrder(actions)
 	if len(got) != len(want) {
@@ -411,7 +413,7 @@ func TestActionRegistryOrderIsStable(t *testing.T) {
 func fullRegistry(t *testing.T) []*action {
 	t.Helper()
 	p := defaultTestProfile(t)
-	return allActions(p, newApplier(nil, p, nil))
+	return allActions(p, nil, newApplier(nil, p, nil))
 }
 
 func actionOrder(actions []*action) []string {

--- a/test/e2e/chaos/apply.go
+++ b/test/e2e/chaos/apply.go
@@ -203,8 +203,10 @@ func (a *applier) waitBack(ctx context.Context, gw string) error {
 // current configuration — the masquerade flip needs a VIP to flip it on,
 // the CIDR flip a baseline to toggle back to. The engine's guardrails
 // consult it, so an inapplicable flip is a journaled skip rather than a
-// rewrite and a restart that change nothing.
-func (a *applier) applicable(gw string, idx int) bool {
+// rewrite and a restart that change nothing. The ctx matches the action
+// registry's applicable signature — the flip decision reads no live lab
+// state, so it is unused here.
+func (a *applier) applicable(_ context.Context, gw string, idx int) bool {
 	c, ok := a.flipCtx(gw)
 	return ok && flips()[idx].applicable(c)
 }

--- a/test/e2e/chaos/churn.go
+++ b/test/e2e/chaos/churn.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// The OVN churn class mutates the OVN topology under load, the way an
+// operator or an orchestrator does in production: floating IPs and
+// port-forward entries added and removed, gateway-chassis priorities
+// flipped externally, a chassis deleted and left to return within the
+// stale-cleanup grace period. Each churn is deliberately left in place —
+// the next draw toggles it back — and the change is journaled as an
+// ovn-churn event carrying what it touched and the values it moved between.
+
+const (
+	// churnFIP is the floating IP the fip-churn action adds and removes. It
+	// is deliberately unprobed, like the bootstrap's backendless 192.0.2.11:
+	// a FIP that appears and disappears must never draw probe traffic.
+	churnFIP         = "192.0.2.60"
+	churnFIPInternal = "192.168.10.60"
+
+	// churnLBVIP is a second vips entry the lb-vip-churn action toggles on
+	// the port-forward Load_Balancer, pointing at the same backend on a port
+	// of its own. Also unprobed.
+	churnLBVIP     = "192.0.2.50:81"
+	churnLBBackend = "192.168.10.10:8080"
+)
+
+// churner owns the OVN churn actions' journal. The lab it drives is the
+// runner's; the journal is set once the run has earned an artifact
+// directory, the same late binding the applier uses.
+type churner struct {
+	lab  *lab
+	jrnl *journal
+}
+
+func newChurner(l *lab) *churner {
+	return &churner{lab: l}
+}
+
+// emit records one executed churn: what it touched and the values it moved
+// between, so an add/remove cycle is legible from the journal.
+func (c *churner) emit(target, object, from, to string) {
+	if c.jrnl == nil {
+		return
+	}
+	c.jrnl.emit(event{Event: evOVNChurn, Target: target, Object: object, From: from, To: to})
+}
+
+// churnActions is the OVN churn fault class. Every action holds nothing —
+// the change is instantaneous — and its restore is a no-op, because the
+// churn is meant to persist until the next draw toggles it back (and, for
+// chassis-delete, because the live ovn-controller re-registers its own row
+// well within the grace period).
+func churnActions(p *profile, ch *churner) []*action {
+	return []*action{
+		{
+			name:           "fip-churn",
+			weight:         2,
+			scope:          scopeCentral,
+			object:         "fip " + churnFIP,
+			recoveryBudget: 60 * time.Second,
+			inject:         ch.fipChurn,
+			restore:        churnPersists,
+		},
+		{
+			name:           "lb-vip-churn",
+			weight:         2,
+			scope:          scopeCentral,
+			object:         "lb-vip " + churnLBVIP,
+			recoveryBudget: 60 * time.Second,
+			// The port-forward Load_Balancer only exists in a profile that put
+			// it up.
+			applicable: func(context.Context, string, int) bool { return p.ovnLB },
+			inject:     ch.lbVIPChurn,
+			restore:    churnPersists,
+		},
+		{
+			name:           "priority-flip",
+			weight:         2,
+			scope:          scopeGateway,
+			object:         lrPublicPort,
+			recoveryBudget: 120 * time.Second,
+			inject:         ch.priorityFlip,
+			restore:        churnPersists,
+		},
+		{
+			name:           "chassis-delete",
+			weight:         1,
+			scope:          scopeGateway,
+			object:         "chassis",
+			recoveryBudget: 90 * time.Second,
+			inject:         ch.chassisDelete,
+			restore:        churnPersists,
+		},
+	}
+}
+
+// fipChurn toggles a spare floating IP on lr0: it looks up whether the NAT
+// row exists and adds or removes it accordingly.
+func (c *churner) fipChurn(ctx context.Context, _ *lab, _ string, _ int) error {
+	uuid, err := c.lab.nbctl(ctx, "--bare", "--columns=_uuid", "find", "NAT", "external_ip="+churnFIP)
+	if err != nil {
+		return fmt.Errorf("look up the churn FIP NAT row: %w", err)
+	}
+	from, to := churnFIP, "absent"
+	if strings.TrimSpace(uuid) == "" {
+		from, to = "absent", churnFIP
+		if _, err := c.lab.nbctl(ctx, "lr-nat-add", "lr0", "dnat_and_snat", churnFIP, churnFIPInternal); err != nil {
+			return fmt.Errorf("add the churn FIP: %w", err)
+		}
+	} else if _, err := c.lab.nbctl(ctx, "lr-nat-del", "lr0", "dnat_and_snat", churnFIP); err != nil {
+		return fmt.Errorf("remove the churn FIP: %w", err)
+	}
+	c.emit(centralNode, "fip "+churnFIP, from, to)
+	return nil
+}
+
+// lbVIPChurn toggles a second vips entry on the port-forward Load_Balancer.
+func (c *churner) lbVIPChurn(ctx context.Context, _ *lab, _ string, _ int) error {
+	vips, err := c.lab.nbctl(ctx, "--bare", "--columns=vips", "find", "Load_Balancer", "name=pf-external")
+	if err != nil {
+		return fmt.Errorf("look up the port-forward Load_Balancer vips: %w", err)
+	}
+	from, to := "present", "absent"
+	if strings.Contains(vips, churnLBVIP) {
+		if _, err := c.lab.nbctl(ctx, "remove", "load_balancer", "pf-external", "vips", churnLBVIP); err != nil {
+			return fmt.Errorf("remove the churn VIP entry: %w", err)
+		}
+	} else {
+		from, to = "absent", "present"
+		if _, err := c.lab.nbctl(ctx, "set", "load_balancer", "pf-external",
+			`vips:"`+churnLBVIP+`"="`+churnLBBackend+`"`); err != nil {
+			return fmt.Errorf("add the churn VIP entry: %w", err)
+		}
+	}
+	c.emit(centralNode, "lb-vip "+churnLBVIP, from, to)
+	return nil
+}
+
+// priorityFlip bumps the target's Gateway_Chassis priority above the
+// group's current maximum, exactly as bootstrap.sh:converge_master_chassis
+// promotes the master externally. It forces a migration the agent's
+// EnsureActivePriorityLead then defends; followMaster re-points the
+// port-forward VIP and the converge gate waits on green probes.
+func (c *churner) priorityFlip(ctx context.Context, _ *lab, gw string, _ int) error {
+	out, err := c.lab.nbctl(ctx, "--bare", "--columns=priority", "list", "Gateway_Chassis")
+	if err != nil {
+		return fmt.Errorf("list Gateway_Chassis priorities: %w", err)
+	}
+	peak := 0
+	for _, field := range strings.Fields(out) {
+		if p, err := strconv.Atoi(field); err == nil && p > peak {
+			peak = p
+		}
+	}
+	bumped := peak + 10
+	if _, err := c.lab.nbctl(ctx, "lrp-set-gateway-chassis", lrPublicPort, gw, strconv.Itoa(bumped)); err != nil {
+		return fmt.Errorf("bump the %s Gateway_Chassis priority for %s: %w", lrPublicPort, gw, err)
+	}
+	c.emit(gw, lrPublicPort, strconv.Itoa(peak), strconv.Itoa(bumped))
+	return nil
+}
+
+// chassisDelete removes the target's SB Chassis row while its ovn-controller
+// keeps running, so the controller re-registers the row well inside the 30 s
+// stale_chassis_grace_period — the surviving agents' stale cleanup must not
+// fire. The existing gateway convergence (chassis back in SB, green probes)
+// is exactly the "returns within the grace period" gate.
+func (c *churner) chassisDelete(ctx context.Context, _ *lab, gw string, _ int) error {
+	if _, err := c.lab.sbctl(ctx, "--if-exists", "chassis-del", gw); err != nil {
+		return fmt.Errorf("delete the SB Chassis row for %s: %w", gw, err)
+	}
+	c.emit(gw, "chassis "+gw, "present", "absent")
+	return nil
+}
+
+// churnPersists is the restore for the churn class: the change is left in
+// place on purpose. The next draw toggles the FIP and VIP back, the agent
+// re-defends the priority, and the live ovn-controller re-registers its own
+// Chassis row — so the runner puts nothing back.
+func churnPersists(context.Context, *lab, string) error { return nil }

--- a/test/e2e/chaos/churn_test.go
+++ b/test/e2e/chaos/churn_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+// newTestChurner wires a churner against the fake commander, with a journal
+// pointed at a buffer so a test can read the ovn-churn events it emits.
+func newTestChurner(cmd commander) (*churner, *bytes.Buffer) {
+	clock := newFakeClock()
+	ch := newChurner(newTestLab(cmd, clock))
+	var buf bytes.Buffer
+	ch.jrnl = newJournal(&buf, clock.now)
+	return ch, &buf
+}
+
+func churnActionNamed(t *testing.T, p *profile, ch *churner, name string) *action {
+	t.Helper()
+	for _, a := range churnActions(p, ch) {
+		if a.name == name {
+			return a
+		}
+	}
+	t.Fatalf("no churn action named %q", name)
+	return nil
+}
+
+func churnEventsIn(t *testing.T, journal string) []event {
+	t.Helper()
+	var out []event
+	for _, ev := range eventsIn(t, journal) {
+		if ev.Event == evOVNChurn {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+// fip-churn adds the spare FIP when the NAT row is absent and removes it
+// when present, and journals each move.
+func TestFIPChurnTogglesTheNATRow(t *testing.T) {
+	present := false
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "find NAT external_ip=192.0.2.60") {
+			if present {
+				return "some-nat-uuid\n", nil
+			}
+			return "\n", nil
+		}
+		return healthyLabResponses(argv)
+	}}
+	ch, buf := newTestChurner(cmd)
+	act := churnActionNamed(t, defaultTestProfile(t), ch, "fip-churn")
+
+	if err := act.inject(context.Background(), ch.lab, centralNode, 0); err != nil {
+		t.Fatalf("inject (absent): %v", err)
+	}
+	if !cmd.called("lr-nat-add lr0 dnat_and_snat 192.0.2.60 192.168.10.60") {
+		t.Fatalf("the churn did not add the FIP: %v", cmd.lines())
+	}
+
+	present = true
+	if err := act.inject(context.Background(), ch.lab, centralNode, 0); err != nil {
+		t.Fatalf("inject (present): %v", err)
+	}
+	if !cmd.called("lr-nat-del lr0 dnat_and_snat 192.0.2.60") {
+		t.Fatalf("the churn did not remove the FIP: %v", cmd.lines())
+	}
+
+	churns := churnEventsIn(t, buf.String())
+	if len(churns) != 2 {
+		t.Fatalf("emitted %d ovn-churn events, want 2: %+v", len(churns), churns)
+	}
+	if churns[0].From != "absent" || churns[0].To != churnFIP {
+		t.Fatalf("the add churn did not move absent→%s: %+v", churnFIP, churns[0])
+	}
+	if churns[1].From != churnFIP || churns[1].To != "absent" {
+		t.Fatalf("the remove churn did not move %s→absent: %+v", churnFIP, churns[1])
+	}
+}
+
+// A NAT lookup the runner cannot answer must fail the churn rather than
+// guess which way to toggle.
+func TestFIPChurnReportsANBFailure(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "find NAT external_ip=192.0.2.60") {
+			return "", errBoom
+		}
+		return healthyLabResponses(argv)
+	}}
+	ch, _ := newTestChurner(cmd)
+	act := churnActionNamed(t, defaultTestProfile(t), ch, "fip-churn")
+
+	if err := act.inject(context.Background(), ch.lab, centralNode, 0); err == nil {
+		t.Fatal("a failed NAT lookup was swallowed")
+	}
+}
+
+// lb-vip-churn only means anything on a profile that put up the port-forward
+// Load_Balancer.
+func TestLBVIPChurnAppliesOnlyWithTheLoadBalancer(t *testing.T) {
+	ch, _ := newTestChurner(&fakeCommander{respond: healthyLabResponses})
+
+	withLB := churnActionNamed(t, defaultTestProfile(t), ch, "lb-vip-churn")
+	if !withLB.applicable(context.Background(), centralNode, 0) {
+		t.Fatal("lb-vip-churn is inapplicable on a profile with the Load_Balancer")
+	}
+	withoutLB := churnActionNamed(t, testProfile(t, "pf-only"), ch, "lb-vip-churn")
+	if withoutLB.applicable(context.Background(), centralNode, 0) {
+		t.Fatal("lb-vip-churn is applicable on a profile with no Load_Balancer")
+	}
+}
+
+// lb-vip-churn sets a second vips entry when it is absent and removes it
+// when present.
+func TestLBVIPChurnTogglesTheVIPSEntry(t *testing.T) {
+	hasVIP := false
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "find Load_Balancer name=pf-external") {
+			if hasVIP {
+				return "{192.0.2.50:80=192.168.10.10:8080, 192.0.2.50:81=192.168.10.10:8080}\n", nil
+			}
+			return "{192.0.2.50:80=192.168.10.10:8080}\n", nil
+		}
+		return healthyLabResponses(argv)
+	}}
+	ch, _ := newTestChurner(cmd)
+	act := churnActionNamed(t, defaultTestProfile(t), ch, "lb-vip-churn")
+
+	if err := act.inject(context.Background(), ch.lab, centralNode, 0); err != nil {
+		t.Fatalf("inject (absent): %v", err)
+	}
+	if !cmd.called(`set load_balancer pf-external vips:"192.0.2.50:81"="192.168.10.10:8080"`) {
+		t.Fatalf("the churn did not add the vips entry: %v", cmd.lines())
+	}
+
+	hasVIP = true
+	if err := act.inject(context.Background(), ch.lab, centralNode, 0); err != nil {
+		t.Fatalf("inject (present): %v", err)
+	}
+	if !cmd.called("remove load_balancer pf-external vips 192.0.2.50:81") {
+		t.Fatalf("the churn did not remove the vips entry: %v", cmd.lines())
+	}
+}
+
+// priority-flip reads the current Gateway_Chassis priorities and bumps the
+// target ten above the peak, exactly as the bootstrap master-convergence
+// mechanic does.
+func TestPriorityFlipBumpsAboveThePeak(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "--columns=priority list Gateway_Chassis") {
+			return "30\n20\n10\n", nil
+		}
+		return healthyLabResponses(argv)
+	}}
+	ch, buf := newTestChurner(cmd)
+	act := churnActionNamed(t, defaultTestProfile(t), ch, "priority-flip")
+
+	if err := act.inject(context.Background(), ch.lab, "gateway-2", 0); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if !cmd.called("lrp-set-gateway-chassis lr0-public gateway-2 40") {
+		t.Fatalf("priority-flip did not bump ten above the peak (30): %v", cmd.lines())
+	}
+
+	churns := churnEventsIn(t, buf.String())
+	if len(churns) != 1 || churns[0].From != "30" || churns[0].To != "40" {
+		t.Fatalf("priority-flip did not journal 30→40: %+v", churns)
+	}
+}
+
+// chassis-delete removes the target's SB Chassis row with --if-exists and
+// restores nothing — the live ovn-controller re-registers it within the
+// grace period.
+func TestChassisDeleteRemovesTheRowAndRestoresNothing(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	ch, _ := newTestChurner(cmd)
+	act := churnActionNamed(t, defaultTestProfile(t), ch, "chassis-delete")
+
+	if err := act.inject(context.Background(), ch.lab, "gateway-3", 0); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if !cmd.called("--if-exists chassis-del gateway-3") {
+		t.Fatalf("chassis-delete did not remove the row with --if-exists: %v", cmd.lines())
+	}
+
+	restoreCmd := &fakeCommander{respond: healthyLabResponses}
+	rl := newTestLab(restoreCmd, newFakeClock())
+	if err := act.restore(context.Background(), rl, "gateway-3"); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if len(restoreCmd.lines()) != 0 {
+		t.Fatalf("chassis-delete restore issued commands, want none: %v", restoreCmd.lines())
+	}
+}

--- a/test/e2e/chaos/control.go
+++ b/test/e2e/chaos/control.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// The control-plane class targets the shared central node and, for the
+// double failover, a pair of gateways. Container kills and agent restarts
+// are the visible faults; production incidents are more often the quiet
+// ones — a stalled database connection, a second gateway lost while the
+// first is still draining. These reuse the mechanics the lab already
+// proves: SIGSTOP/SIGCONT against the ovn-ctl pidfiles the central
+// entrypoint writes, and the SIGTERM/SIGKILL the starter faults use.
+
+// The ovn-ctl pidfiles inside the central container. central-entrypoint.sh
+// runs `ovn-ctl start_northd`, which writes these under /var/run/ovn (the
+// standard ovn-ctl run dir the entrypoint creates).
+const (
+	nbDBPidfile   = "/var/run/ovn/ovnnb_db.pid"
+	sbDBPidfile   = "/var/run/ovn/ovnsb_db.pid"
+	northdPidfile = "/var/run/ovn/ovn-northd.pid"
+)
+
+// controlPlaneActions is the control-plane fault class. The database
+// pauses span a short stall — below the OVSDB inactivity probe — and an
+// outage long enough to force every ovn-controller and agent to reconnect
+// and resync, so one action covers both. The budgets differ by blast
+// radius: a paused NB stalls writes, a paused SB stalls every chassis, and
+// a double failover is two container bring-ups' worth of re-convergence.
+func controlPlaneActions(p *profile) []*action {
+	startAndRestore := func(ctx context.Context, l *lab, gw string) error {
+		return startAndRestoreGateway(ctx, l, p, gw)
+	}
+	return []*action{
+		{
+			name:           "nb-pause",
+			weight:         2,
+			scope:          scopeCentral,
+			object:         "ovnnb_db",
+			holdMin:        5 * time.Second,
+			holdMax:        90 * time.Second,
+			recoveryBudget: 90 * time.Second,
+			inject: func(ctx context.Context, l *lab, _ string, _ int) error {
+				return pauseCentralProcess(ctx, l, nbDBPidfile)
+			},
+			restore: func(ctx context.Context, l *lab, _ string) error {
+				return resumeCentralProcess(ctx, l, nbDBPidfile)
+			},
+		},
+		{
+			name:   "sb-pause",
+			weight: 2,
+			scope:  scopeCentral,
+			object: "ovnsb_db",
+			// A paused SB forces every ovn-controller and agent to reconnect
+			// and resync. While it is paused the baseline sweep's
+			// sbctl --timeout=5 calls fail and are journaled as check-errors,
+			// not violations.
+			holdMin:        5 * time.Second,
+			holdMax:        90 * time.Second,
+			recoveryBudget: 120 * time.Second,
+			inject: func(ctx context.Context, l *lab, _ string, _ int) error {
+				return pauseCentralProcess(ctx, l, sbDBPidfile)
+			},
+			restore: func(ctx context.Context, l *lab, _ string) error {
+				return resumeCentralProcess(ctx, l, sbDBPidfile)
+			},
+		},
+		{
+			name:           "northd-pause",
+			weight:         1,
+			scope:          scopeCentral,
+			object:         "ovn-northd",
+			holdMin:        10 * time.Second,
+			holdMax:        60 * time.Second,
+			recoveryBudget: 60 * time.Second,
+			inject: func(ctx context.Context, l *lab, _ string, _ int) error {
+				return pauseCentralProcess(ctx, l, northdPidfile)
+			},
+			restore: func(ctx context.Context, l *lab, _ string) error {
+				return resumeCentralProcess(ctx, l, northdPidfile)
+			},
+		},
+		{
+			name:           "double-failover",
+			weight:         1,
+			scope:          scopeGatewayPair,
+			holdMin:        10 * time.Second,
+			holdMax:        30 * time.Second,
+			recoveryBudget: 240 * time.Second,
+			inject:         injectDoubleFailover,
+			// The engine restores each node of the pair in turn, so the same
+			// container-lifecycle restore the starter kills use puts both the
+			// drained target and the killed peer back.
+			restore: startAndRestore,
+		},
+	}
+}
+
+// pauseCentralProcess SIGSTOPs one of central's ovn-ctl-managed processes,
+// stalling its OVSDB or northd without tearing the container down.
+func pauseCentralProcess(ctx context.Context, l *lab, pidfile string) error {
+	if _, err := l.sh(ctx, centralNode, "kill -STOP $(cat "+pidfile+")"); err != nil {
+		return fmt.Errorf("pause %s on %s: %w", pidfile, centralNode, err)
+	}
+	return nil
+}
+
+// resumeCentralProcess SIGCONTs a process pauseCentralProcess stopped.
+func resumeCentralProcess(ctx context.Context, l *lab, pidfile string) error {
+	if _, err := l.sh(ctx, centralNode, "kill -CONT $(cat "+pidfile+")"); err != nil {
+		return fmt.Errorf("resume %s on %s: %w", pidfile, centralNode, err)
+	}
+	return nil
+}
+
+// injectDoubleFailover kills a gateway while another is still draining: it
+// SIGTERMs the drawn target (which begins its graceful drain, if the
+// profile enables it), then SIGKILLs the ring-next peer before the target
+// has finished. The peer resolves identically to the engine's own
+// nextGateway, so both nodes the engine tracks are the ones that go down.
+// Both containers pin their restart policy off first, exactly as the
+// gateway-kill and agent-terminate faults do.
+func injectDoubleFailover(ctx context.Context, l *lab, target string, _ int) error {
+	peer := nextGateway(target)
+	if err := l.setRestartPolicy(ctx, target, "no"); err != nil {
+		return err
+	}
+	if err := l.terminateAgent(ctx, target); err != nil {
+		return err
+	}
+	if err := l.setRestartPolicy(ctx, peer, "no"); err != nil {
+		return err
+	}
+	if err := l.killGateway(ctx, peer); err != nil {
+		return err
+	}
+	return l.waitContainerExit(ctx, target, agentExitTimeout)
+}

--- a/test/e2e/chaos/control_test.go
+++ b/test/e2e/chaos/control_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func controlActionNamed(t *testing.T, name string) *action {
+	t.Helper()
+	for _, a := range controlPlaneActions(defaultTestProfile(t)) {
+		if a.name == name {
+			return a
+		}
+	}
+	t.Fatalf("no control-plane action named %q", name)
+	return nil
+}
+
+// The database and northd pauses SIGSTOP/SIGCONT the ovn-ctl process by its
+// own pidfile, inside the central container, and touch no other node.
+func TestCentralPausesStopAndContTheRightPidfile(t *testing.T) {
+	tests := []struct {
+		name    string
+		pidfile string
+	}{
+		{"nb-pause", nbDBPidfile},
+		{"sb-pause", sbDBPidfile},
+		{"northd-pause", northdPidfile},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &fakeCommander{respond: healthyLabResponses}
+			l := newTestLab(cmd, newFakeClock())
+			act := controlActionNamed(t, tc.name)
+
+			if err := act.inject(context.Background(), l, centralNode, 0); err != nil {
+				t.Fatalf("inject: %v", err)
+			}
+			if err := act.restore(context.Background(), l, centralNode); err != nil {
+				t.Fatalf("restore: %v", err)
+			}
+
+			want := []string{
+				"clab-ovn-e2e-central sh -euc kill -STOP $(cat " + tc.pidfile + ")",
+				"clab-ovn-e2e-central sh -euc kill -CONT $(cat " + tc.pidfile + ")",
+			}
+			for _, w := range want {
+				if !cmd.called(w) {
+					t.Fatalf("%s did not issue %q: %v", tc.name, w, cmd.lines())
+				}
+			}
+			for _, line := range cmd.lines() {
+				if strings.Contains(line, "gateway") || strings.Contains(line, "upstream") {
+					t.Fatalf("%s touched a node other than central: %q", tc.name, line)
+				}
+			}
+		})
+	}
+}
+
+// A paused database is only paused, never killed: nothing signals a
+// container or flips a restart policy.
+func TestCentralPauseNeverKillsAContainer(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	l := newTestLab(cmd, newFakeClock())
+	act := controlActionNamed(t, "sb-pause")
+
+	if err := act.inject(context.Background(), l, centralNode, 0); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	for _, forbidden := range []string{"docker kill", "docker restart", "--restart=no", "docker start"} {
+		if cmd.called(forbidden) {
+			t.Fatalf("a database pause issued %q: %v", forbidden, cmd.lines())
+		}
+	}
+}
+
+// The double failover kills the ring-next peer while the drawn target is
+// still draining: it disables and SIGTERMs the target first, then disables
+// and SIGKILLs the peer, and waits only for the target's own exit.
+func TestDoubleFailoverKillsThePeerWhileTheTargetDrains(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := controlActionNamed(t, "double-failover").
+		inject(context.Background(), l, "gateway-1", 0); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	// The peer is the ring-next gateway, resolved exactly as the engine does.
+	if peer := nextGateway("gateway-1"); peer != "gateway-2" {
+		t.Fatalf("nextGateway(gateway-1) = %q, want gateway-2", peer)
+	}
+
+	disableTarget := cmd.indexOf("update --restart=no clab-ovn-e2e-gateway-1")
+	termTarget := cmd.indexOf("clab-ovn-e2e-gateway-1 kill -TERM 1")
+	disablePeer := cmd.indexOf("update --restart=no clab-ovn-e2e-gateway-2")
+	killPeer := cmd.indexOf("kill -s KILL clab-ovn-e2e-gateway-2")
+	if disableTarget < 0 || termTarget < 0 || disablePeer < 0 || killPeer < 0 {
+		t.Fatalf("the double failover did not drain the target and kill the peer: %v", cmd.lines())
+	}
+	if disableTarget >= termTarget || termTarget >= disablePeer || disablePeer >= killPeer {
+		t.Fatalf("the peer was not killed while the target was still draining: %v", cmd.lines())
+	}
+
+	// Only the target's exit is waited for — the peer is SIGKILLed and gone.
+	if !cmd.called("inspect -f {{.State.Running}} clab-ovn-e2e-gateway-1") {
+		t.Fatalf("the runner did not wait for the drained target to exit: %v", cmd.lines())
+	}
+	if cmd.called("inspect -f {{.State.Running}} clab-ovn-e2e-gateway-2") {
+		t.Fatalf("the runner waited on the SIGKILLed peer's exit: %v", cmd.lines())
+	}
+}

--- a/test/e2e/chaos/drift.go
+++ b/test/e2e/chaos/drift.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// The data-plane drift class is the fat-fingered-operator fault: a human
+// deletes a rule the agent owns, and the agent must notice and re-install
+// it on its next reconcile. These are the exact deletions
+// test/integration/scenario_drift_test.go proves the agent heals on a
+// single host — driven here against the multi-node lab under fault load.
+//
+// The deletion is the fault; the restore is a deliberate no-op, because the
+// agent's periodic reconcile is the undo. Each action carries a live
+// `applicable` so a gateway that does not carry the object is a journaled
+// skip, not a no-op deletion: the MAC-tweak flows exist only where routers
+// are locally active, and a port-forward-only profile has no FIP routes at
+// all.
+
+const (
+	// driftFIP is the bootstrap FIP, present and probed in every profile that
+	// connects to OVN. Its data-plane state is what these actions delete.
+	driftFIP = "192.0.2.10"
+
+	// driftFRRNexthop is the veth_nexthop the agent's FRR static routes point
+	// at (gwnode-config.yaml). staticd's `no ip route` form needs it.
+	driftFRRNexthop = "169.254.0.1"
+
+	// The OVS flow cookies and the nftables table the agent owns, duplicated
+	// here because the chaos runner is package main and cannot import the
+	// agent's root package. Kept in step with ovs.go and nftables.go.
+	driftHairpinCookie  = "0x998" // ovs.go: ovsCookieHairpin
+	driftMACTweakCookie = "0x999" // ovs.go: ovsCookieMACTweak
+	driftNftTable       = "ovn-network-agent"
+)
+
+// driftActions is the data-plane drift fault class. Every action holds
+// nothing (the deletion is instantaneous) and self-heals on the next
+// reconcile, so the budget is the worst-case cadence — 15 s after a
+// cadence flip — plus probe slack.
+func driftActions(l *lab) []*action {
+	return []*action{
+		{
+			name:           "kernel-route-drop",
+			weight:         2,
+			scope:          scopeGateway,
+			object:         driftFIP + "/32 dev br-ex",
+			recoveryBudget: 60 * time.Second,
+			applicable: func(ctx context.Context, gw string, _ int) bool {
+				out, err := l.sh(ctx, gw, "ip route show "+driftFIP+"/32 dev br-ex")
+				return err == nil && strings.TrimSpace(out) != ""
+			},
+			inject: func(ctx context.Context, l *lab, gw string, _ int) error {
+				if _, err := l.exec(ctx, gw, "ip", "route", "del", driftFIP+"/32", "dev", "br-ex"); err != nil {
+					return fmt.Errorf("drop the kernel route for %s on %s: %w", driftFIP, gw, err)
+				}
+				return nil
+			},
+			restore: driftSelfHeals,
+		},
+		{
+			name:           "frr-route-drop",
+			weight:         2,
+			scope:          scopeGateway,
+			object:         driftFIP + "/32 vrf vrf-provider",
+			recoveryBudget: 60 * time.Second,
+			applicable: func(ctx context.Context, gw string, _ int) bool {
+				_, err := l.sh(ctx, gw, "vtysh -c 'show running-config' | grep -q 'ip route "+
+					driftFIP+"/32 "+driftFRRNexthop+"'")
+				return err == nil
+			},
+			inject: func(ctx context.Context, l *lab, gw string, _ int) error {
+				// staticd requires prefix + nexthop on the `no` form; a bare
+				// `no ip route <prefix>` is rejected as incomplete.
+				if _, err := l.exec(ctx, gw, "vtysh",
+					"-c", "conf t",
+					"-c", "vrf vrf-provider",
+					"-c", "no ip route "+driftFIP+"/32 "+driftFRRNexthop,
+					"-c", "exit-vrf",
+					"-c", "end"); err != nil {
+					return fmt.Errorf("drop the FRR route for %s on %s: %w", driftFIP, gw, err)
+				}
+				return nil
+			},
+			restore: driftSelfHeals,
+		},
+		{
+			name:           "nft-flush",
+			weight:         2,
+			scope:          scopeGateway,
+			object:         "table ip " + driftNftTable,
+			recoveryBudget: 60 * time.Second,
+			applicable: func(ctx context.Context, gw string, _ int) bool {
+				_, err := l.exec(ctx, gw, "nft", "list", "table", "ip", driftNftTable)
+				return err == nil
+			},
+			inject: func(ctx context.Context, l *lab, gw string, _ int) error {
+				if _, err := l.exec(ctx, gw, "nft", "flush", "table", "ip", driftNftTable); err != nil {
+					return fmt.Errorf("flush the agent's nftables table on %s: %w", gw, err)
+				}
+				return nil
+			},
+			restore: driftSelfHeals,
+		},
+		{
+			name:           "ovs-flow-drop",
+			weight:         2,
+			scope:          scopeGateway,
+			object:         "cookies " + driftHairpinCookie + "," + driftMACTweakCookie + " on br-ex",
+			recoveryBudget: 60 * time.Second,
+			// The MAC-tweak flows exist only where the routers are locally
+			// active, so a gateway that carries none is a skip. Removing them
+			// darkens external probes and is measured; the hairpin flow's
+			// restoration is not probe-observable from client-1 — asserting
+			// its presence is the config-aware oracle of issue #179.
+			applicable: func(ctx context.Context, gw string, _ int) bool {
+				_, err := l.sh(ctx, gw, "ovs-ofctl dump-flows br-ex 'cookie="+
+					driftMACTweakCookie+"/-1' | grep -q cookie")
+				return err == nil
+			},
+			inject: func(ctx context.Context, l *lab, gw string, _ int) error {
+				for _, cookie := range []string{driftHairpinCookie, driftMACTweakCookie} {
+					if _, err := l.exec(ctx, gw, "ovs-ofctl", "del-flows", "br-ex",
+						"cookie="+cookie+"/-1"); err != nil {
+						return fmt.Errorf("drop the %s flows on %s: %w", cookie, gw, err)
+					}
+				}
+				return nil
+			},
+			restore: driftSelfHeals,
+		},
+	}
+}
+
+// driftSelfHeals is the restore for the drift class: the deletion is the
+// fault and the agent's next reconcile is the undo — the same self-heal
+// contract scenario_drift_test.go proves on a single host — so the runner
+// puts nothing back.
+func driftSelfHeals(context.Context, *lab, string) error { return nil }

--- a/test/e2e/chaos/drift_test.go
+++ b/test/e2e/chaos/drift_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func driftActionNamed(t *testing.T, l *lab, name string) *action {
+	t.Helper()
+	for _, a := range driftActions(l) {
+		if a.name == name {
+			return a
+		}
+	}
+	t.Fatalf("no drift action named %q", name)
+	return nil
+}
+
+// Each drift action is applicable only when its object is actually present
+// on the gateway — otherwise it would be a no-op deletion, and a journaled
+// skip is the honest record instead.
+func TestDriftAppliesOnlyWhenTheObjectIsPresent(t *testing.T) {
+	tests := []struct {
+		action  string
+		probe   string
+		present func([]string) (string, error)
+		absent  func([]string) (string, error)
+	}{
+		{
+			action:  "kernel-route-drop",
+			probe:   "ip route show 192.0.2.10/32 dev br-ex",
+			present: func([]string) (string, error) { return "192.0.2.10 dev br-ex scope link\n", nil },
+			absent:  func([]string) (string, error) { return "", nil }, // ip route show exits 0 with no output
+		},
+		{
+			action:  "frr-route-drop",
+			probe:   "grep -q 'ip route 192.0.2.10/32 169.254.0.1'",
+			present: func([]string) (string, error) { return "", nil },
+			absent:  func([]string) (string, error) { return "", errExit(t, 1) },
+		},
+		{
+			action:  "nft-flush",
+			probe:   "nft list table ip ovn-network-agent",
+			present: func([]string) (string, error) { return "table ip ovn-network-agent {\n}\n", nil },
+			absent:  func([]string) (string, error) { return "", errExit(t, 1) },
+		},
+		{
+			action:  "ovs-flow-drop",
+			probe:   "cookie=0x999/-1' | grep -q cookie",
+			present: func([]string) (string, error) { return "", nil },
+			absent:  func([]string) (string, error) { return "", errExit(t, 1) },
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.action, func(t *testing.T) {
+			for _, present := range []bool{true, false} {
+				respond := tc.absent
+				if present {
+					respond = tc.present
+				}
+				cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+					if strings.Contains(strings.Join(argv, " "), tc.probe) {
+						return respond(argv)
+					}
+					return healthyLabResponses(argv)
+				}}
+				l := newTestLab(cmd, newFakeClock())
+				act := driftActionNamed(t, l, tc.action)
+
+				if got := act.applicable(context.Background(), "gateway-1", 0); got != present {
+					t.Fatalf("%s applicable = %v with the object present=%v", tc.action, got, present)
+				}
+			}
+		})
+	}
+}
+
+// The inject issues exactly the documented deletion, and the restore issues
+// nothing at all — the agent's next reconcile is the undo.
+func TestDriftInjectsTheDeletionAndRestoresNothing(t *testing.T) {
+	tests := []struct {
+		action string
+		want   []string
+	}{
+		{"kernel-route-drop", []string{"ip route del 192.0.2.10/32 dev br-ex"}},
+		{"frr-route-drop", []string{
+			"vtysh -c conf t -c vrf vrf-provider -c no ip route 192.0.2.10/32 169.254.0.1 -c exit-vrf -c end",
+		}},
+		{"nft-flush", []string{"nft flush table ip ovn-network-agent"}},
+		{"ovs-flow-drop", []string{
+			"ovs-ofctl del-flows br-ex cookie=0x998/-1",
+			"ovs-ofctl del-flows br-ex cookie=0x999/-1",
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.action, func(t *testing.T) {
+			cmd := &fakeCommander{respond: healthyLabResponses}
+			l := newTestLab(cmd, newFakeClock())
+			act := driftActionNamed(t, l, tc.action)
+
+			if err := act.inject(context.Background(), l, "gateway-1", 0); err != nil {
+				t.Fatalf("inject: %v", err)
+			}
+			for _, w := range tc.want {
+				if !cmd.called(w) {
+					t.Fatalf("%s did not issue %q: %v", tc.action, w, cmd.lines())
+				}
+			}
+
+			restoreCmd := &fakeCommander{respond: healthyLabResponses}
+			rl := newTestLab(restoreCmd, newFakeClock())
+			if err := act.restore(context.Background(), rl, "gateway-1"); err != nil {
+				t.Fatalf("restore: %v", err)
+			}
+			if len(restoreCmd.lines()) != 0 {
+				t.Fatalf("%s restore issued commands, want none (the reconcile self-heals): %v",
+					tc.action, restoreCmd.lines())
+			}
+		})
+	}
+}
+
+// The flow drop removes the hairpin cookie before the MAC-tweak cookie —
+// both are the agent's, and the issue asks for a hairpin or MAC-rewrite
+// flow removed.
+func TestOVSFlowDropRemovesBothCookies(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := driftActionNamed(t, l, "ovs-flow-drop").
+		inject(context.Background(), l, "gateway-1", 0); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	hairpin := cmd.indexOf("del-flows br-ex cookie=0x998/-1")
+	macTweak := cmd.indexOf("del-flows br-ex cookie=0x999/-1")
+	if hairpin < 0 || macTweak < 0 {
+		t.Fatalf("the flow drop did not remove both cookies: %v", cmd.lines())
+	}
+	if hairpin > macTweak {
+		t.Fatalf("the cookies were removed out of order: %v", cmd.lines())
+	}
+}

--- a/test/e2e/chaos/engine.go
+++ b/test/e2e/chaos/engine.go
@@ -26,9 +26,23 @@ const (
 // Guardrail skip reasons, journaled on the decision they blocked.
 const (
 	skipTargetNotHealthy  = "target-not-healthy"
+	skipPeerNotHealthy    = "peer-not-healthy"
 	skipNoHealthyPeer     = "no-healthy-peer"
 	skipNoWeightedAction  = "no-weighted-action"
 	skipFlipNotApplicable = "flip-not-applicable"
+	skipNotApplicable     = "not-applicable"
+)
+
+// Target scopes. An action targets a gateway by default (the zero value);
+// the control-plane and routing-flap classes reach the shared central and
+// upstream nodes instead, and the double-failover class hits a pair of
+// gateways at once. The scope is what the engine reads to decide which
+// node states it may target and how many nodes one fault disrupts.
+const (
+	scopeGateway     = 0
+	scopeCentral     = 1
+	scopeUpstream    = 2
+	scopeGatewayPair = 3
 )
 
 // Violation kinds.
@@ -70,13 +84,29 @@ type action struct {
 	inject         func(ctx context.Context, l *lab, target string, flip int) error
 	restore        func(ctx context.Context, l *lab, target string) error
 
-	// applicable binds an action to the flip index every decision draws —
-	// the fifth value taken from the stream, which only config-flip reads.
-	// It is the guardrail that skips a flip meaning nothing on the drawn
-	// target's current configuration, and it is nil on every action whose
-	// behaviour does not depend on the flip — so it is also what tells the
-	// engine whether the drawn flip is worth naming in the journal.
-	applicable func(target string, flip int) bool
+	// scope is one of the scope* constants: which node the fault targets and
+	// how many nodes it disrupts. It is the guardrail declaration the issue
+	// asks every action to carry — the node states it may target — and the
+	// engine reads it when it draws the target, checks the guardrails,
+	// restores the fault and gates on convergence.
+	scope int
+
+	// object annotates the decision journal with what the fault touched — a
+	// route prefix, an nftables table, a database server — so a mixed-class
+	// run can be triaged from the artifacts alone. It is static per action.
+	object string
+
+	// usesFlip is set only by config-flip: it is the one action whose
+	// behaviour depends on the flip index every decision draws, and so the
+	// only one whose journal names the drawn flip.
+	usesFlip bool
+
+	// applicable reports whether the drawn fault means anything on its
+	// target's current state — the config-flip whose toggle changes nothing
+	// on the drawn gateway, the drift action whose object the gateway does
+	// not carry. An inapplicable fault is a journaled skip, not a rewrite or
+	// a no-op deletion. It is nil on every action that always applies.
+	applicable func(ctx context.Context, target string, flip int) bool
 }
 
 // probeSource is the slice of the prober the engine consumes.
@@ -139,6 +169,13 @@ func newEngine(l *lab, p *profile, actions []*action, probes probeSource, jrnl *
 	for _, gw := range gatewayNames() {
 		e.nodes[gw] = nodeHealthy
 	}
+	// The control-plane and routing-flap classes target the shared central
+	// and upstream nodes; they carry their own lifecycle in the same node
+	// map so the guardrails re-target them only once they have converged.
+	// healthyNodes() and the agent-alive baseline check iterate the gateways
+	// alone, so these entries never confuse them.
+	e.nodes[centralNode] = nodeHealthy
+	e.nodes[upstreamNode] = nodeHealthy
 	return e
 }
 
@@ -210,6 +247,7 @@ type decision struct {
 	interval time.Duration
 	action   *action
 	target   string
+	peer     string
 	hold     time.Duration
 	flip     int
 }
@@ -246,7 +284,34 @@ func (e *engine) draw(tick int) decision {
 	d.target = gateways[e.rng.IntN(len(gateways))]
 	d.hold = e.drawDuration(d.action.holdMin, d.action.holdMax)
 	d.flip = e.rng.IntN(len(flips()))
+
+	// The gateway draw is taken on every tick, whatever the scope, so the
+	// stream stays aligned across a registry mixing all the classes. A
+	// central- or upstream-scoped action then discards it and targets the
+	// shared node instead; a pair action keeps it as the primary target and
+	// derives the ring-next gateway as its peer.
+	switch d.action.scope {
+	case scopeCentral:
+		d.target = centralNode
+	case scopeUpstream:
+		d.target = upstreamNode
+	case scopeGatewayPair:
+		d.peer = nextGateway(d.target)
+	}
 	return d
+}
+
+// nextGateway is the ring-next gateway after gw, in gatewayNames() order —
+// the peer a gateway-pair fault kills while its primary target drains. It
+// resolves the peer identically for the engine and the inject.
+func nextGateway(gw string) string {
+	names := gatewayNames()
+	for i, name := range names {
+		if name == gw {
+			return names[(i+1)%len(names)]
+		}
+	}
+	return gw
 }
 
 // drawDuration takes one value from the stream even when the bounds
@@ -260,28 +325,51 @@ func (e *engine) drawDuration(low, high time.Duration) time.Duration {
 }
 
 // guardrails decides whether a drawn decision may execute. They keep a
-// run meaningful: the fault target must have returned and converged
-// since it was last hit, and at least one other gateway must stay
-// healthy so the lab always has somewhere to fail over to.
-func (e *engine) guardrails(d decision) string {
+// run meaningful: the fault target must have returned and converged since
+// it was last hit; a fault meaning nothing on the target's current state
+// is skipped rather than injected; and a gateway fault always leaves the
+// lab somewhere to fail over to. A central- or upstream-scoped fault needs
+// no healthy gateway peer — pausing the database or the upstream BGP does
+// not depend on how many gateways are up.
+func (e *engine) guardrails(ctx context.Context, d decision) string {
 	if d.action == nil {
 		return skipNoWeightedAction
 	}
 	if e.nodeState(d.target) != nodeHealthy {
 		return skipTargetNotHealthy
 	}
-	// A flip that means nothing on what the target is currently running —
-	// a masquerade variant on a gateway with no VIP — would rewrite the
-	// same configuration and restart the node for nothing.
-	if d.action.applicable != nil && !d.action.applicable(d.target, d.flip) {
-		return skipFlipNotApplicable
+	// A fault that changes nothing on what the target is currently running —
+	// a masquerade flip on a gateway with no VIP, a route drop on a gateway
+	// that carries no such route — would rewrite the same state, or delete
+	// nothing, and restart or reconcile the node for it.
+	if d.action.applicable != nil && !d.action.applicable(ctx, d.target, d.flip) {
+		if d.action.usesFlip {
+			return skipFlipNotApplicable
+		}
+		return skipNotApplicable
 	}
-	for _, gw := range e.healthyNodes() {
-		if gw != d.target {
-			return ""
+	if d.action.scope == scopeGatewayPair && e.nodeState(d.peer) != nodeHealthy {
+		return skipPeerNotHealthy
+	}
+	if d.action.scope == scopeGateway || d.action.scope == scopeGatewayPair {
+		if !e.hasHealthyPeer(d) {
+			return skipNoHealthyPeer
 		}
 	}
-	return skipNoHealthyPeer
+	return ""
+}
+
+// hasHealthyPeer reports whether a gateway besides the fault's own targets
+// is healthy, so the lab always has a chassis to fail over to. A pair
+// fault holds two gateways down, so it needs a third.
+func (e *engine) hasHealthyPeer(d decision) bool {
+	for _, gw := range e.healthyNodes() {
+		if gw == d.target || gw == d.peer {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 // run is the tick loop: draw, wait, check the guardrails, execute,
@@ -297,7 +385,7 @@ func (e *engine) run(ctx context.Context) {
 
 		e.rec.Ticks = tick
 		e.rec.Decisions.Total++
-		skip := e.guardrails(d)
+		skip := e.guardrails(ctx, d)
 		ev := event{
 			Event:      evDecision,
 			Tick:       tick,
@@ -308,10 +396,12 @@ func (e *engine) run(ctx context.Context) {
 		if d.action != nil {
 			ev.Action = d.action.name
 			ev.Target = d.target
+			ev.Peer = d.peer
+			ev.Object = d.action.object
 			ev.HoldMS = d.hold.Milliseconds()
 			// A flip-aware action names the drawn flip, so a decision that
 			// was skipped still says which one it would have been.
-			if d.action.applicable != nil {
+			if d.action.usesFlip {
 				ev.Flip = flipName(d.flip)
 			}
 		}
@@ -330,13 +420,27 @@ func (e *engine) run(ctx context.Context) {
 	}
 }
 
-// execute injects the fault, holds it, restores it, then gates on
-// convergence before the node is eligible again.
+// nodesFor is the set of nodes one decision disrupts: its target, plus the
+// ring-next peer for a gateway-pair fault. It is what execute marks
+// disrupted, what the restore loop puts back, and what convergence gates
+// on — so a two-gateway fault is tracked as one unit.
+func (e *engine) nodesFor(d decision) []string {
+	if d.action.scope == scopeGatewayPair {
+		return []string{d.target, d.peer}
+	}
+	return []string{d.target}
+}
+
+// execute injects the fault, holds it, restores each node it disrupted,
+// then gates on convergence before the nodes are eligible again.
 func (e *engine) execute(ctx context.Context, d decision) {
-	e.setNodeState(d.target, nodeDisrupted)
+	nodes := e.nodesFor(d)
+	for _, n := range nodes {
+		e.setNodeState(n, nodeDisrupted)
+	}
 
 	injectedAt := e.now()
-	e.jrnl.emit(event{Event: evInject, Tick: d.tick, Action: d.action.name, Target: d.target})
+	e.jrnl.emit(event{Event: evInject, Tick: d.tick, Action: d.action.name, Target: d.target, Peer: d.peer})
 	if err := d.action.inject(ctx, e.lab, d.target, d.flip); err != nil {
 		e.undo(ctx, d, err)
 		return
@@ -349,27 +453,38 @@ func (e *engine) execute(ctx context.Context, d decision) {
 
 	// An injected fault must be undone even when the run is cancelled, or
 	// the lab is left with a dead gateway whose restart policy is off and
-	// no scenario after it can run. A cancelled ctx would kill every
-	// docker invocation on sight, and the restore is long enough to be
-	// interrupted half-way through — startAndRestoreGateway waits out two
-	// daemon bring-ups and pushes BGP — so it always runs on a context of
-	// its own, detached from the signal and bounded by restoreTimeout.
-	restoreCtx, cancelRestore := context.WithTimeout(
-		context.WithoutCancel(ctx), restoreTimeout)
-	defer cancelRestore()
-
-	e.jrnl.emit(event{Event: evRestore, Tick: d.tick, Action: d.action.name, Target: d.target})
-	if err := d.action.restore(restoreCtx, e.lab, d.target); err != nil {
-		e.failAction(d, "restore", err)
-		return
+	// no scenario after it can run. A cancelled ctx would kill every docker
+	// invocation on sight, and the restore is long enough to be interrupted
+	// half-way through — startAndRestoreGateway waits out two daemon
+	// bring-ups and pushes BGP — so every node's restore runs on a context
+	// of its own, detached from the signal and bounded by restoreTimeout.
+	// The bound is per node, not per action: a double failover restores two
+	// gateways, and one 5-minute budget shared across both would cut the
+	// second bring-up off half-way.
+	for _, n := range nodes {
+		e.jrnl.emit(event{Event: evRestore, Tick: d.tick, Action: d.action.name, Target: n})
+		if err := e.restoreNode(ctx, d, n); err != nil {
+			e.failAction(d, "restore", n, err)
+			return
+		}
 	}
 	if ctx.Err() != nil {
 		return
 	}
 	restoredAt := e.now()
-	e.setNodeState(d.target, nodeConverging)
+	for _, n := range nodes {
+		e.setNodeState(n, nodeConverging)
+	}
 
 	e.converge(ctx, d, injectedAt, restoredAt)
+}
+
+// restoreNode runs one node's restore on its own detached, bounded
+// context.
+func (e *engine) restoreNode(ctx context.Context, d decision, node string) error {
+	restoreCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), restoreTimeout)
+	defer cancel()
+	return d.action.restore(restoreCtx, e.lab, node)
 }
 
 // undo restores a fault whose inject failed half-way, then fails the
@@ -385,30 +500,29 @@ func (e *engine) execute(ctx context.Context, d decision) {
 // the held-fault restore uses, since the inject may well have failed
 // because the run was cancelled underneath it.
 func (e *engine) undo(ctx context.Context, d decision, injectErr error) {
-	restoreCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), restoreTimeout)
-	defer cancel()
-
-	detail := "undo after a failed inject"
-	if err := d.action.restore(restoreCtx, e.lab, d.target); err != nil {
-		detail += ": " + err.Error()
+	for _, n := range e.nodesFor(d) {
+		detail := "undo after a failed inject"
+		if err := e.restoreNode(ctx, d, n); err != nil {
+			detail += ": " + err.Error()
+		}
+		e.jrnl.emit(event{
+			Event: evRestore, Tick: d.tick, Action: d.action.name,
+			Target: n, Detail: detail,
+		})
 	}
-	e.jrnl.emit(event{
-		Event: evRestore, Tick: d.tick, Action: d.action.name,
-		Target: d.target, Detail: detail,
-	})
-	e.failAction(d, "inject", injectErr)
+	e.failAction(d, "inject", d.target, injectErr)
 }
 
-// failAction parks the node: a fault the runner could not inject or undo
-// leaves the lab in a state it cannot reason about, so the node is never
-// targeted again and the run fails.
-func (e *engine) failAction(d decision, phase string, err error) {
+// failAction parks the failing node: a fault the runner could not inject or
+// undo leaves the lab in a state it cannot reason about, so the node is
+// never targeted again and the run fails.
+func (e *engine) failAction(d decision, phase, node string, err error) {
 	e.violate(violationRecord{
 		Kind: violationActionFailed, Tick: d.tick,
-		Action: d.action.name, Target: d.target,
+		Action: d.action.name, Target: node,
 		Detail: fmt.Sprintf("%s: %v", phase, err),
 	})
-	e.park(d.target)
+	e.park(node)
 }
 
 // park takes a node out of the run for good and stops the tick loop.
@@ -437,18 +551,22 @@ func (e *engine) park(gw string) {
 // Budget expiry is the reachability-recovery violation the run asserts
 // against.
 func (e *engine) converge(ctx context.Context, d decision, injectedAt, restoredAt time.Time) {
+	nodes := e.nodesFor(d)
 	deadline := restoredAt.Add(d.action.recoveryBudget)
 	for e.now().Before(deadline) {
 		if ctx.Err() != nil {
 			return
 		}
-		if e.converged(ctx, d.target) {
-			e.setNodeState(d.target, nodeHealthy)
+		if e.converged(ctx, d) {
+			for _, n := range nodes {
+				e.setNodeState(n, nodeHealthy)
+			}
 			fromRestore := e.probes.recoverySince(restoredAt)
 			e.rec.Recoveries = append(e.rec.Recoveries, recoveryRecord{
 				Tick:          d.tick,
 				Action:        d.action.name,
 				Target:        d.target,
+				Peer:          d.peer,
 				BudgetMS:      d.action.recoveryBudget.Milliseconds(),
 				ConvergedMS:   e.now().Sub(restoredAt).Milliseconds(),
 				FromInjectMS:  e.probes.recoverySince(injectedAt),
@@ -457,7 +575,7 @@ func (e *engine) converge(ctx context.Context, d decision, injectedAt, restoredA
 			})
 			e.jrnl.emit(event{
 				Event: evConverged, Tick: d.tick, Action: d.action.name,
-				Target: d.target, CROwner: e.vipOwner, RecoveryMS: fromRestore,
+				Target: d.target, Peer: d.peer, CROwner: e.vipOwner, RecoveryMS: fromRestore,
 			})
 			return
 		}
@@ -472,17 +590,44 @@ func (e *engine) converge(ctx context.Context, d decision, injectedAt, restoredA
 	e.park(d.target)
 }
 
-// converged reports whether the restored node is back in service and the
-// data path is green again.
-func (e *engine) converged(ctx context.Context, gw string) bool {
-	if e.lab.containerHealth(ctx, gw) != "healthy" {
-		return false
-	}
-	if !e.lab.chassisInSB(ctx, gw) {
-		return false
+// converged reports whether every node the decision disrupted is back in
+// service and the data path is green again. Each node is checked by the
+// signal its scope defines — a gateway's container health and chassis, the
+// central databases answering, the upstream BGP daemon back up — and the
+// probes are consulted once, after every node has returned.
+func (e *engine) converged(ctx context.Context, d decision) bool {
+	for _, n := range e.nodesFor(d) {
+		if !e.nodeConverged(ctx, d, n) {
+			return false
+		}
 	}
 	e.followMaster(ctx)
 	return e.probes.allGreen()
+}
+
+// nodeConverged reports whether one node is back in service, by the signal
+// its scope defines.
+func (e *engine) nodeConverged(ctx context.Context, d decision, node string) bool {
+	switch d.action.scope {
+	case scopeCentral:
+		// The central image's HEALTHCHECK is `ovn-nbctl show && ovn-sbctl
+		// show`, so a healthy container is exactly both databases answering.
+		return e.lab.containerHealth(ctx, node) == "healthy"
+	case scopeUpstream:
+		return bgpdAlive(ctx, e.lab)
+	default:
+		return e.lab.containerHealth(ctx, node) == "healthy" && e.lab.chassisInSB(ctx, node)
+	}
+}
+
+// bgpdAlive reports whether the upstream BGP daemon is running — the
+// convergence signal for the routing-flap class, whose faults stop bgpd on
+// the upstream node. pgrep exits 1 when nothing matches, which is the fault
+// still in place; any other failure is a question that could not be asked,
+// and reads here as "not yet back" so convergence keeps polling.
+func bgpdAlive(ctx context.Context, l *lab) bool {
+	out, err := l.exec(ctx, upstreamNode, "pgrep", "-x", "bgpd")
+	return err == nil && strings.TrimSpace(out) != ""
 }
 
 // followMaster keeps the port-forward VIP's hand-plumbed routes pointed

--- a/test/e2e/chaos/engine_test.go
+++ b/test/e2e/chaos/engine_test.go
@@ -151,44 +151,118 @@ func TestZeroWeightRegistryInjectsNothing(t *testing.T) {
 }
 
 func TestGuardrailsBlockUnhealthyTargetAndLastGateway(t *testing.T) {
-	act := noopActions("controller-restart")[0]
+	gatewayAct := noopActions("controller-restart")[0]
+	centralAct := &action{name: "nb-pause", scope: scopeCentral, weight: 1}
+	pairAct := &action{name: "double-failover", scope: scopeGatewayPair, weight: 1}
+	driftAct := &action{name: "kernel-route-drop", scope: scopeGateway, weight: 1,
+		applicable: func(context.Context, string, int) bool { return false }}
 
 	tests := []struct {
-		name  string
-		nodes map[string]string
-		want  string
+		name   string
+		action *action
+		target string
+		peer   string
+		nodes  map[string]string
+		want   string
 	}{
 		{
-			name:  "all nodes healthy",
-			nodes: map[string]string{"gateway-1": nodeHealthy, "gateway-2": nodeHealthy, "gateway-3": nodeHealthy},
-			want:  "",
+			name:   "all nodes healthy",
+			action: gatewayAct,
+			target: "gateway-1",
+			nodes:  map[string]string{"gateway-1": nodeHealthy, "gateway-2": nodeHealthy, "gateway-3": nodeHealthy},
+			want:   "",
 		},
 		{
-			name:  "target still converging from an earlier fault",
-			nodes: map[string]string{"gateway-1": nodeConverging, "gateway-2": nodeHealthy, "gateway-3": nodeHealthy},
-			want:  skipTargetNotHealthy,
+			name:   "target still converging from an earlier fault",
+			action: gatewayAct,
+			target: "gateway-1",
+			nodes:  map[string]string{"gateway-1": nodeConverging, "gateway-2": nodeHealthy, "gateway-3": nodeHealthy},
+			want:   skipTargetNotHealthy,
 		},
 		{
-			name:  "target never came back",
-			nodes: map[string]string{"gateway-1": nodeUnconverged, "gateway-2": nodeHealthy, "gateway-3": nodeHealthy},
-			want:  skipTargetNotHealthy,
+			name:   "target never came back",
+			action: gatewayAct,
+			target: "gateway-1",
+			nodes:  map[string]string{"gateway-1": nodeUnconverged, "gateway-2": nodeHealthy, "gateway-3": nodeHealthy},
+			want:   skipTargetNotHealthy,
 		},
 		{
-			name:  "target is the last healthy gateway",
-			nodes: map[string]string{"gateway-1": nodeHealthy, "gateway-2": nodeUnconverged, "gateway-3": nodeUnconverged},
-			want:  skipNoHealthyPeer,
+			// A drift-style fault whose object the target does not carry is a
+			// journaled skip, not a no-op deletion — even with every gateway
+			// healthy and a peer to fail over to.
+			name:   "drift action skipped when its object is absent",
+			action: driftAct,
+			target: "gateway-1",
+			nodes:  map[string]string{"gateway-1": nodeHealthy, "gateway-2": nodeHealthy, "gateway-3": nodeHealthy},
+			want:   skipNotApplicable,
+		},
+		{
+			name:   "target is the last healthy gateway",
+			action: gatewayAct,
+			target: "gateway-1",
+			nodes:  map[string]string{"gateway-1": nodeHealthy, "gateway-2": nodeUnconverged, "gateway-3": nodeUnconverged},
+			want:   skipNoHealthyPeer,
+		},
+		{
+			// A central-scoped fault does not depend on how many gateways are
+			// up: pausing the database with only one healthy gateway is fine.
+			name:   "central action needs no healthy gateway peer",
+			action: centralAct,
+			target: centralNode,
+			nodes: map[string]string{
+				centralNode: nodeHealthy,
+				"gateway-1": nodeHealthy, "gateway-2": nodeUnconverged, "gateway-3": nodeUnconverged,
+			},
+			want: "",
+		},
+		{
+			name:   "central action skipped when central has not converged",
+			action: centralAct,
+			target: centralNode,
+			nodes: map[string]string{
+				centralNode: nodeConverging,
+				"gateway-1": nodeHealthy, "gateway-2": nodeHealthy, "gateway-3": nodeHealthy,
+			},
+			want: skipTargetNotHealthy,
+		},
+		{
+			name:   "pair action skipped when the ring-next peer is unhealthy",
+			action: pairAct,
+			target: "gateway-1",
+			peer:   "gateway-2",
+			nodes:  map[string]string{"gateway-1": nodeHealthy, "gateway-2": nodeConverging, "gateway-3": nodeHealthy},
+			want:   skipPeerNotHealthy,
+		},
+		{
+			// A pair holds two gateways down, so it needs a third to fail
+			// over to.
+			name:   "pair action skipped when no third gateway is healthy",
+			action: pairAct,
+			target: "gateway-1",
+			peer:   "gateway-2",
+			nodes:  map[string]string{"gateway-1": nodeHealthy, "gateway-2": nodeHealthy, "gateway-3": nodeUnconverged},
+			want:   skipNoHealthyPeer,
+		},
+		{
+			name:   "pair action runs with target, peer and a third gateway healthy",
+			action: pairAct,
+			target: "gateway-1",
+			peer:   "gateway-2",
+			nodes:  map[string]string{"gateway-1": nodeHealthy, "gateway-2": nodeHealthy, "gateway-3": nodeHealthy},
+			want:   "",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			clock := newFakeClock()
-			e := newEngine(newTestLab(&fakeCommander{}, clock), defaultTestProfile(t), []*action{act},
+			e := newEngine(newTestLab(&fakeCommander{}, clock), defaultTestProfile(t), []*action{tc.action},
 				greenProbes{}, newJournal(&bytes.Buffer{}, clock.now),
 				&runRecord{ActionsByName: map[string]int{}})
 			e.nodes = tc.nodes
 
-			got := e.guardrails(decision{action: act, target: "gateway-1"})
+			got := e.guardrails(context.Background(),
+				decision{action: tc.action, target: tc.target, peer: tc.peer})
 			if got != tc.want {
 				t.Fatalf("guardrails = %q, want %q", got, tc.want)
 			}
@@ -824,7 +898,7 @@ func slicesEqual(a, b []string) bool {
 func TestSameSeedReplaysTheSameFlips(t *testing.T) {
 	actions := func() []*action {
 		acts := noopActions("gateway-kill")
-		acts[0].applicable = func(string, int) bool { return true }
+		acts[0].usesFlip = true
 		return acts
 	}
 	first, _ := runEngine(t, 7, 20*time.Minute, actions(), nil)
@@ -855,11 +929,13 @@ func TestSameSeedReplaysTheSameFlips(t *testing.T) {
 // draws the same values afterwards as the run that executed.
 func TestAnInapplicableFlipIsSkippedWithoutShiftingTheStream(t *testing.T) {
 	flippable := noopActions("config-flip")
-	flippable[0].applicable = func(string, int) bool { return true }
+	flippable[0].usesFlip = true
+	flippable[0].applicable = func(context.Context, string, int) bool { return true }
 
 	applied := noopActions("config-flip")
+	applied[0].usesFlip = true
 	// gateway-2's configuration has nothing the drawn flip can change.
-	applied[0].applicable = func(gw string, _ int) bool { return gw != "gateway-2" }
+	applied[0].applicable = func(_ context.Context, gw string, _ int) bool { return gw != "gateway-2" }
 
 	open, _ := runEngine(t, 42, 20*time.Minute, flippable, nil)
 	guarded, rec := runEngine(t, 42, 20*time.Minute, applied, nil)
@@ -907,4 +983,161 @@ func TestFollowMasterDoesNothingWithoutTheLoadBalancerVIP(t *testing.T) {
 	if e.vipOwner != "" {
 		t.Fatalf("vipOwner = %q on a run with no Load_Balancer VIP", e.vipOwner)
 	}
+}
+
+// A central-scoped action targets the shared central node and discards the
+// gateway the tick drew. The draw still happens, so the stream stays
+// aligned: a run of a central action draws the same intervals, holds and
+// flips as a run of the same action scoped to a gateway.
+func TestCentralActionKeepsTheDrawStreamAligned(t *testing.T) {
+	central := noopActions("nb-pause")
+	central[0].scope = scopeCentral
+	gateway := noopActions("nb-pause") // scopeGateway (zero value)
+
+	centralJournal, _ := runEngine(t, 42, 20*time.Minute, central, nil)
+	gatewayJournal, _ := runEngine(t, 42, 20*time.Minute, gateway, nil)
+
+	c := decisionEventsIn(t, centralJournal)
+	g := decisionEventsIn(t, gatewayJournal)
+	if len(c) == 0 || len(c) != len(g) {
+		t.Fatalf("central run drew %d decisions, gateway run %d", len(c), len(g))
+	}
+	for i := range c {
+		if c[i].IntervalMS != g[i].IntervalMS || c[i].HoldMS != g[i].HoldMS || c[i].Flip != g[i].Flip {
+			t.Fatalf("decision %d diverged: the discarded gateway draw shifted the stream", i+1)
+		}
+		if c[i].Target != centralNode {
+			t.Fatalf("central action decision %d targeted %q, want %q", i+1, c[i].Target, centralNode)
+		}
+	}
+}
+
+// A gateway-pair fault disrupts and restores both its target and the
+// ring-next peer, and its recovery record and converged event name the
+// peer so a double failover can be triaged from the artifacts.
+func TestPairActionDisruptsRestoresAndConvergesBothNodes(t *testing.T) {
+	restored := map[string]int{}
+	acts := noopActions("double-failover")
+	acts[0].scope = scopeGatewayPair
+	acts[0].holdMin, acts[0].holdMax = 0, 0
+	acts[0].restore = func(_ context.Context, _ *lab, node string) error {
+		restored[node]++
+		return nil
+	}
+
+	journal, rec := runEngine(t, 42, 5*time.Minute, acts, nil)
+
+	if rec.Decisions.Executed == 0 {
+		t.Fatal("no pair fault executed")
+	}
+	total := 0
+	for _, n := range restored {
+		total += n
+	}
+	if total != 2*rec.Decisions.Executed {
+		t.Fatalf("restored %d nodes for %d executed pair faults, want two per fault", total, rec.Decisions.Executed)
+	}
+	if len(rec.Recoveries) != rec.Decisions.Executed {
+		t.Fatalf("recorded %d recoveries for %d executions", len(rec.Recoveries), rec.Decisions.Executed)
+	}
+	for _, r := range rec.Recoveries {
+		if r.Peer == "" || r.Peer != nextGateway(r.Target) {
+			t.Fatalf("recovery %+v does not name the ring-next peer", r)
+		}
+	}
+	disrupted := map[string]bool{}
+	var peeredConverged int
+	for _, ev := range eventsIn(t, journal) {
+		if ev.Event == evNodeState && ev.State == nodeDisrupted {
+			disrupted[ev.Target] = true
+		}
+		if ev.Event == evConverged && ev.Peer != "" && ev.Peer == nextGateway(ev.Target) {
+			peeredConverged++
+		}
+	}
+	if peeredConverged != rec.Decisions.Executed {
+		t.Fatalf("journaled %d converged events naming a peer, want %d", peeredConverged, rec.Decisions.Executed)
+	}
+	for _, r := range rec.Recoveries {
+		if !disrupted[r.Target] || !disrupted[r.Peer] {
+			t.Fatalf("fault on %s/%s did not mark both nodes disrupted", r.Target, r.Peer)
+		}
+	}
+}
+
+// Convergence is gated by a per-scope signal: a central node's container
+// health (both databases answering), an upstream node's bgpd. A node that
+// never returns by that signal times out and is never wrongly re-targeted.
+func TestConvergenceDispatchesPerNodeKind(t *testing.T) {
+	tests := []struct {
+		name    string
+		scope   int
+		respond func([]string) (string, error)
+	}{
+		{
+			name:  "central action never converges while central is unhealthy",
+			scope: scopeCentral,
+			respond: func(argv []string) (string, error) {
+				if strings.Contains(strings.Join(argv, " "), "{{.State.Health.Status}}") {
+					return "unhealthy\n", nil
+				}
+				return healthyLabResponses(argv)
+			},
+		},
+		{
+			name:  "upstream action never converges while bgpd is down",
+			scope: scopeUpstream,
+			respond: func(argv []string) (string, error) {
+				if strings.Contains(strings.Join(argv, " "), "pgrep -x bgpd") {
+					return "", errExit(t, 1)
+				}
+				return healthyLabResponses(argv)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			acts := noopActions("control-plane")
+			acts[0].scope = tc.scope
+			acts[0].recoveryBudget = 30 * time.Second
+			acts[0].holdMin, acts[0].holdMax = 0, 0
+
+			_, rec := runEngine(t, 42, 2*time.Minute, acts, func(e *engine) {
+				e.lab.cmd = &fakeCommander{respond: tc.respond}
+			})
+
+			if len(rec.Violations) == 0 || rec.Violations[0].Kind != violationRecoveryTimeout {
+				t.Fatalf("violations = %+v, want a %s", rec.Violations, violationRecoveryTimeout)
+			}
+		})
+	}
+}
+
+// The flip is named on a decision only for the one action that reads it —
+// config-flip, which sets usesFlip. A drift-style action reads live state
+// through applicable but never touches the flip, so its decisions must not
+// carry one.
+func TestOnlyFlipAwareActionsJournalTheFlip(t *testing.T) {
+	acts := noopActions("kernel-route-drop")
+	acts[0].applicable = func(context.Context, string, int) bool { return true }
+
+	journal, _ := runEngine(t, 42, 20*time.Minute, acts, nil)
+
+	for _, ev := range eventsIn(t, journal) {
+		if ev.Event == evDecision && ev.Flip != "" {
+			t.Fatalf("a non-flip action named a flip on its decision: %+v", ev)
+		}
+	}
+}
+
+// decisionEventsIn extracts the decision events from a journal, in order.
+func decisionEventsIn(t *testing.T, journal string) []event {
+	t.Helper()
+	var out []event
+	for _, ev := range eventsIn(t, journal) {
+		if ev.Event == evDecision {
+			out = append(out, ev)
+		}
+	}
+	return out
 }

--- a/test/e2e/chaos/fakes_test.go
+++ b/test/e2e/chaos/fakes_test.go
@@ -106,6 +106,8 @@ func healthyLabResponses(argv []string) (string, error) {
 		return "Device \"eth1\" does not exist.", errBoom
 	case strings.Contains(line, "pgrep -f /usr/local/bin/ovn-network-agent"):
 		return "1\n", nil
+	case strings.Contains(line, "pgrep -x bgpd"):
+		return "1\n", nil // a healthy upstream runs bgpd
 	case strings.Contains(line, "find Chassis name="):
 		return strings.TrimPrefix(argv[len(argv)-1], "name=") + "\n", nil
 	case strings.Contains(line, "--columns=chassis find Port_Binding"):

--- a/test/e2e/chaos/flaps.go
+++ b/test/e2e/chaos/flaps.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// The routing-flap class restarts the FRR/BGP daemons — on a gateway and on
+// the upstream — and lets the run assert that the announcements return. The
+// "announcements return" check is the engine's existing converge gate: the
+// probes from client-1 are only reachable over routes the upstream re-learns
+// over BGP, so a green probe set is proof the sessions re-established.
+
+// bgpdReadyProbe polls a restarted bgpd until it has registered with
+// watchfrr, mirroring start_upstream_bgpd in bootstrap.sh.
+const bgpdReadyProbe = "for _ in $(seq 1 30); do " +
+	"if vtysh -c 'show daemons' 2>/dev/null | grep -qw bgpd; then break; fi; sleep 1; done"
+
+// flapActions is the routing-flap fault class. The upstream restart is the
+// run's widest legitimate blast radius — every FIP announcement withdraws
+// until bgpd is back — so it carries the low weight.
+func flapActions() []*action {
+	return []*action{
+		{
+			name:   "frr-restart",
+			weight: 2,
+			scope:  scopeGateway,
+			// No hold: the restart is the fault, and the restore brings FRR
+			// back and re-asserts the session.
+			recoveryBudget: 120 * time.Second,
+			inject: func(ctx context.Context, l *lab, gw string, _ int) error {
+				// The exit statuses are hints, exactly as the gwnode entrypoint
+				// treats them; readiness is the restore's own probe.
+				if _, err := l.sh(ctx, gw,
+					"/usr/lib/frr/frrinit.sh stop || true; rm -rf /var/tmp/frr/*; "+
+						"/usr/lib/frr/frrinit.sh start || true"); err != nil {
+					return fmt.Errorf("restart FRR on %s: %w", gw, err)
+				}
+				return nil
+			},
+			restore: restoreGatewayFRR,
+		},
+		{
+			name:           "upstream-bgp-restart",
+			weight:         1,
+			scope:          scopeUpstream,
+			holdMin:        5 * time.Second,
+			holdMax:        20 * time.Second,
+			recoveryBudget: 90 * time.Second,
+			inject: func(ctx context.Context, l *lab, _ string, _ int) error {
+				return killUpstreamBGPD(ctx, l)
+			},
+			restore: func(ctx context.Context, l *lab, _ string) error {
+				return restoreUpstreamBGPD(ctx, l)
+			},
+		},
+	}
+}
+
+// restoreGatewayFRR waits for a restarted gateway's vtysh to answer, then
+// re-asserts the BGP session — idempotent and self-cleaning, ending with
+// `write memory`. The agent re-adds its static routes on the next
+// reconcile, and the converge gate's green probes are the assertion that
+// the announcements returned.
+func restoreGatewayFRR(ctx context.Context, l *lab, gw string) error {
+	if err := l.waitReady(ctx, gw, "vtysh -c 'show version'"); err != nil {
+		return fmt.Errorf("wait for FRR on %s: %w", gw, err)
+	}
+	link, ok := linkFor(gw)
+	if !ok {
+		return fmt.Errorf("no underlay link known for %s", gw)
+	}
+	return l.configureGatewayBGP(ctx, gw, link)
+}
+
+// killUpstreamBGPD stops bgpd on the upstream node. It never restarts the
+// container: watchfrr is PID 1 there, so `frrinit.sh restart` or a
+// docker restart would take the container and its five containerlab veths
+// down (bootstrap.sh:start_upstream_bgpd documents the exit-137 trap). A
+// pkill that matches nothing means bgpd was already down — which is the
+// fault in place — so its exit 1 is not an error.
+func killUpstreamBGPD(ctx context.Context, l *lab) error {
+	if _, err := l.exec(ctx, upstreamNode, "pkill", "-x", "bgpd"); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return nil
+		}
+		return fmt.Errorf("stop bgpd on %s: %w", upstreamNode, err)
+	}
+	return nil
+}
+
+// restoreUpstreamBGPD starts bgpd in place — never `frrinit.sh restart`,
+// never a docker restart — polls for it to register with watchfrr, then
+// reloads the write-memory'd config with `vtysh -b`, mirroring
+// start_upstream_bgpd in bootstrap.sh.
+func restoreUpstreamBGPD(ctx context.Context, l *lab) error {
+	script := strings.Join([]string{
+		"pgrep -x bgpd >/dev/null 2>&1 || /usr/lib/frr/bgpd -d -A 127.0.0.1 -u frr -g frr",
+		bgpdReadyProbe,
+		"vtysh -b",
+	}, "; ")
+	if _, err := l.sh(ctx, upstreamNode, script); err != nil {
+		return fmt.Errorf("restart bgpd on %s: %w", upstreamNode, err)
+	}
+	return nil
+}

--- a/test/e2e/chaos/flaps_test.go
+++ b/test/e2e/chaos/flaps_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func flapActionNamed(t *testing.T, name string) *action {
+	t.Helper()
+	for _, a := range flapActions() {
+		if a.name == name {
+			return a
+		}
+	}
+	t.Fatalf("no flap action named %q", name)
+	return nil
+}
+
+// lineContaining returns the first recorded call containing substr, or "".
+func lineContaining(f *fakeCommander, substr string) string {
+	for _, line := range f.lines() {
+		if strings.Contains(line, substr) {
+			return line
+		}
+	}
+	return ""
+}
+
+// The gateway FRR restart stops FRR, clears the stale watchfrr state, and
+// starts it again — in that order — then its restore waits for vtysh and
+// re-asserts the BGP session so the announcements return.
+func TestFRRRestartRecyclesFRRAndReassertsBGP(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	l := newTestLab(cmd, newFakeClock())
+	act := flapActionNamed(t, "frr-restart")
+
+	if err := act.inject(context.Background(), l, "gateway-1", 0); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	line := lineContaining(cmd, "frrinit.sh")
+	stop := strings.Index(line, "frrinit.sh stop")
+	wipe := strings.Index(line, "rm -rf /var/tmp/frr/*")
+	start := strings.Index(line, "frrinit.sh start")
+	if stop < 0 || wipe < 0 || start < 0 {
+		t.Fatalf("the FRR restart did not stop, clear and start: %q", line)
+	}
+	if stop >= wipe || wipe >= start {
+		t.Fatalf("the FRR restart ran its steps out of order: %q", line)
+	}
+
+	if err := act.restore(context.Background(), l, "gateway-1"); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if !cmd.called("vtysh -c 'show version'") {
+		t.Fatalf("the restore did not wait for FRR to come back: %v", cmd.lines())
+	}
+	if !cmd.called("router bgp 65000 vrf vrf-provider") {
+		t.Fatalf("the restore did not re-assert the BGP session: %v", cmd.lines())
+	}
+}
+
+// The upstream BGP restart stops bgpd in place and its restore starts it in
+// place and reloads the config — it must never restart or kill the upstream
+// container, whose PID 1 is watchfrr (a docker restart would take the
+// container and its containerlab veths down).
+func TestUpstreamBGPRestartNeverRecyclesTheContainer(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	l := newTestLab(cmd, newFakeClock())
+	act := flapActionNamed(t, "upstream-bgp-restart")
+
+	if err := act.inject(context.Background(), l, upstreamNode, 0); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if !cmd.called("exec clab-ovn-e2e-upstream pkill -x bgpd") {
+		t.Fatalf("the inject did not stop bgpd on the upstream: %v", cmd.lines())
+	}
+
+	if err := act.restore(context.Background(), l, upstreamNode); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	for _, want := range []string{
+		"bgpd -d -A 127.0.0.1 -u frr -g frr",
+		"grep -qw bgpd",
+		"vtysh -b",
+	} {
+		if !cmd.called(want) {
+			t.Fatalf("the restore did not start bgpd in place and reload: missing %q in %v", want, cmd.lines())
+		}
+	}
+
+	for _, line := range cmd.lines() {
+		if strings.Contains(line, "clab-ovn-e2e-upstream") &&
+			(strings.Contains(line, "docker restart") || strings.Contains(line, "docker kill") ||
+				strings.Contains(line, "frrinit.sh restart")) {
+			t.Fatalf("the upstream container was recycled — watchfrr is PID 1: %q", line)
+		}
+	}
+}
+
+// A pkill that matches nothing means bgpd was already down, which is the
+// fault in place — not a failure. Any other pkill failure must surface.
+func TestKillUpstreamBGPDToleratesNoMatchButNotRealFailure(t *testing.T) {
+	noMatch := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "pkill -x bgpd") {
+			return "", errExit(t, 1)
+		}
+		return healthyLabResponses(argv)
+	}}
+	if err := killUpstreamBGPD(context.Background(), newTestLab(noMatch, newFakeClock())); err != nil {
+		t.Fatalf("a no-match pkill (bgpd already down) was treated as an error: %v", err)
+	}
+
+	broken := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "pkill -x bgpd") {
+			return "", errBoom
+		}
+		return healthyLabResponses(argv)
+	}}
+	if err := killUpstreamBGPD(context.Background(), newTestLab(broken, newFakeClock())); err == nil {
+		t.Fatal("a real pkill failure was swallowed")
+	}
+}

--- a/test/e2e/chaos/impair.go
+++ b/test/e2e/chaos/impair.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// The network-impairment class degrades the management path between a
+// gateway and the OVN central node without killing anything: it forces the
+// gateway's OVSDB connections to central to flap while the container stays
+// healthy, which is the quiet failure a lossy or slow management link
+// produces. The impairment is scoped to the gateway→central path with a
+// u32 filter, so the geneve tunnels between gateways — whose encap IP is
+// also eth0 — stay clean and the data plane is not collaterally darkened.
+
+// The fixed netem specs the two impairment actions apply. They are
+// constants, not extra draws, so the impairment does not change the number
+// of values a tick takes from the stream.
+const (
+	mgmtLossSpec  = "loss 30%"
+	mgmtDelaySpec = "delay 200ms 50ms"
+)
+
+// impairActions is the network-impairment fault class. Neither kills
+// anything: the container stays healthy and only the connections to central
+// flap, which is the point.
+func impairActions() []*action {
+	return []*action{
+		{
+			name:           "mgmt-loss",
+			weight:         2,
+			scope:          scopeGateway,
+			object:         "loss 30% → central",
+			holdMin:        20 * time.Second,
+			holdMax:        60 * time.Second,
+			recoveryBudget: 90 * time.Second,
+			inject: func(ctx context.Context, l *lab, gw string, _ int) error {
+				return injectMgmtImpair(ctx, l, gw, mgmtLossSpec)
+			},
+			restore: restoreMgmtImpair,
+		},
+		{
+			name:           "mgmt-delay",
+			weight:         2,
+			scope:          scopeGateway,
+			object:         "delay 200ms → central",
+			holdMin:        20 * time.Second,
+			holdMax:        60 * time.Second,
+			recoveryBudget: 90 * time.Second,
+			inject: func(ctx context.Context, l *lab, gw string, _ int) error {
+				return injectMgmtImpair(ctx, l, gw, mgmtDelaySpec)
+			},
+			restore: restoreMgmtImpair,
+		},
+	}
+}
+
+// injectMgmtImpair applies a netem impairment to only the traffic from gw's
+// eth0 to the central node. It builds a prio qdisc whose default band is
+// unimpaired, hangs the netem discipline off a spare band, and steers just
+// the packets destined for central into it with a u32 filter — so the
+// gateway-to-gateway geneve tunnels on the same interface are untouched.
+//
+// sch_netem cannot be modprobe'd from inside the container (it holds only
+// CAP_NET_ADMIN), so it must be loaded on the host — CI does it in
+// e2e-lab-setup. The in-container modprobe is a best-effort no-op where the
+// module is already loaded; if it is genuinely absent the tc netem command
+// below fails and the engine parks the node, which is visible, not silent.
+func injectMgmtImpair(ctx context.Context, l *lab, gw, netemSpec string) error {
+	central, err := l.mgmtIP(ctx, centralNode)
+	if err != nil {
+		return fmt.Errorf("resolve the central management address: %w", err)
+	}
+	script := strings.Join([]string{
+		"modprobe sch_netem 2>/dev/null || true",
+		"tc qdisc replace dev eth0 root handle 1: prio bands 4 priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+		"tc qdisc replace dev eth0 parent 1:4 handle 40: netem " + netemSpec,
+		"tc filter add dev eth0 parent 1: protocol ip prio 1 u32 match ip dst " + central + "/32 flowid 1:4",
+	}, "; ")
+	if _, err := l.sh(ctx, gw, script); err != nil {
+		return fmt.Errorf("impair the management path on %s: %w", gw, err)
+	}
+	return nil
+}
+
+// restoreMgmtImpair removes the whole prio+netem+filter hierarchy in one
+// step by deleting the root qdisc, reverting eth0 to its default.
+func restoreMgmtImpair(ctx context.Context, l *lab, gw string) error {
+	if _, err := l.sh(ctx, gw, "tc qdisc del dev eth0 root"); err != nil {
+		return fmt.Errorf("remove the management-path impairment on %s: %w", gw, err)
+	}
+	return nil
+}

--- a/test/e2e/chaos/impair_test.go
+++ b/test/e2e/chaos/impair_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func impairActionNamed(t *testing.T, name string) *action {
+	t.Helper()
+	for _, a := range impairActions() {
+		if a.name == name {
+			return a
+		}
+	}
+	t.Fatalf("no impairment action named %q", name)
+	return nil
+}
+
+// The impairment resolves central's management address and steers only the
+// traffic bound for it into the netem band, on the target gateway's eth0 —
+// so the gateway-to-gateway geneve tunnels on the same interface stay
+// clean. The two actions differ only in the netem discipline.
+func TestMgmtImpairScopesNetemToTheCentralPath(t *testing.T) {
+	tests := []struct {
+		name string
+		spec string
+	}{
+		{"mgmt-loss", "netem loss 30%"},
+		{"mgmt-delay", "netem delay 200ms 50ms"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+				line := strings.Join(argv, " ")
+				if strings.Contains(line, "ip -o -4 addr show eth0") {
+					return "172.20.20.2\n", nil
+				}
+				return healthyLabResponses(argv)
+			}}
+			l := newTestLab(cmd, newFakeClock())
+			act := impairActionNamed(t, tc.name)
+
+			if err := act.inject(context.Background(), l, "gateway-1", 0); err != nil {
+				t.Fatalf("inject: %v", err)
+			}
+
+			for _, want := range []string{
+				"clab-ovn-e2e-gateway-1 sh -euc",
+				"tc qdisc replace dev eth0 root handle 1: prio",
+				tc.spec,
+				"u32 match ip dst 172.20.20.2/32 flowid 1:4",
+			} {
+				if !cmd.called(want) {
+					t.Fatalf("%s did not issue %q: %v", tc.name, want, cmd.lines())
+				}
+			}
+			// Central is only read for its address, never impaired: the netem
+			// hierarchy lives entirely on the gateway's own egress qdisc.
+			for _, line := range cmd.lines() {
+				if strings.Contains(line, "clab-ovn-e2e-central") && strings.Contains(line, "tc ") {
+					t.Fatalf("%s applied tc inside central: %q", tc.name, line)
+				}
+			}
+		})
+	}
+}
+
+// The restore deletes the root qdisc, which takes the whole prio+netem+
+// filter hierarchy down in one step.
+func TestMgmtImpairRestoreRemovesTheRootQdisc(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := impairActionNamed(t, "mgmt-loss").restore(context.Background(), l, "gateway-2"); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	if !cmd.called("clab-ovn-e2e-gateway-2 sh -euc tc qdisc del dev eth0 root") {
+		t.Fatalf("the restore did not remove the root qdisc: %v", cmd.lines())
+	}
+}
+
+// A gateway whose management address cannot be resolved must fail the
+// impairment rather than steer traffic at an empty destination.
+func TestMgmtImpairFailsWhenCentralAddressIsUnreadable(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "ip -o -4 addr show eth0") {
+			return "", errBoom
+		}
+		return healthyLabResponses(argv)
+	}}
+	l := newTestLab(cmd, newFakeClock())
+
+	err := impairActionNamed(t, "mgmt-delay").inject(context.Background(), l, "gateway-1", 0)
+	if err == nil {
+		t.Fatal("the impairment was applied without a central address to steer at")
+	}
+	if !strings.Contains(err.Error(), "central management address") {
+		t.Fatalf("error %q does not name the address it could not resolve", err)
+	}
+}

--- a/test/e2e/chaos/journal.go
+++ b/test/e2e/chaos/journal.go
@@ -35,6 +35,7 @@ const (
 	evNodeState       = "node-state"
 	evProbeTransition = "probe-transition"
 	evVIPRepoint      = "vip-repoint"
+	evOVNChurn        = "ovn-churn"
 	evViolation       = "violation"
 	evCheckError      = "check-error"
 	evRunAborted      = "run-aborted"
@@ -50,6 +51,8 @@ type event struct {
 	Tick       int              `json:"tick,omitempty"`
 	Action     string           `json:"action,omitempty"`
 	Target     string           `json:"target,omitempty"`
+	Peer       string           `json:"peer,omitempty"`
+	Object     string           `json:"object,omitempty"`
 	IntervalMS int64            `json:"interval_ms,omitempty"`
 	HoldMS     int64            `json:"hold_ms,omitempty"`
 	Executed   *bool            `json:"executed,omitempty"`
@@ -149,6 +152,7 @@ type recoveryRecord struct {
 	Tick          int              `json:"tick"`
 	Action        string           `json:"action"`
 	Target        string           `json:"target"`
+	Peer          string           `json:"peer,omitempty"`
 	BudgetMS      int64            `json:"budget_ms"`
 	ConvergedMS   int64            `json:"converged_ms"`
 	FromInjectMS  map[string]int64 `json:"from_inject_ms"`

--- a/test/e2e/chaos/journal_test.go
+++ b/test/e2e/chaos/journal_test.go
@@ -191,3 +191,53 @@ func TestFlipFieldsAreJournaledOnlyWhereTheyBelong(t *testing.T) {
 		}
 	}
 }
+
+// peer and object annotate the multi-node and object-touching faults. Like
+// every other optional field they must stay out of the events that do not
+// set them, so a reader can tell a pair fault from a single-node one and a
+// drift fault from a container kill.
+func TestPeerAndObjectAreJournaledOnlyWhereTheyBelong(t *testing.T) {
+	var buf bytes.Buffer
+	j := newJournal(&buf, newFakeClock().now)
+
+	j.emit(event{
+		Event: evDecision, Tick: 1, Action: "double-failover",
+		Target: "gateway-1", Peer: "gateway-2", Executed: boolPtr(true),
+	})
+	j.emit(event{
+		Event: evDecision, Tick: 2, Action: "kernel-route-drop",
+		Target: "gateway-3", Object: "192.0.2.10/32 dev br-ex", Executed: boolPtr(true),
+	})
+	j.emit(event{Event: evInject, Tick: 3, Action: "gateway-kill", Target: "gateway-1"})
+
+	events := eventsIn(t, buf.String())
+	if events[0].Peer != "gateway-2" || events[0].Object != "" {
+		t.Fatalf("the pair decision lost its peer or gained an object: %+v", events[0])
+	}
+	if events[1].Object != "192.0.2.10/32 dev br-ex" || events[1].Peer != "" {
+		t.Fatalf("the drift decision lost its object or gained a peer: %+v", events[1])
+	}
+	raw := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	for _, field := range []string{"peer", "object"} {
+		if strings.Contains(raw[2], `"`+field+`"`) {
+			t.Fatalf("the %s field leaked into an event that touched neither: %s", field, raw[2])
+		}
+	}
+}
+
+// The ovn-churn event carries what a churn touched and the values it moved
+// between, so an add/remove cycle is legible from the journal.
+func TestOVNChurnEventRoundTrips(t *testing.T) {
+	var buf bytes.Buffer
+	j := newJournal(&buf, newFakeClock().now)
+
+	j.emit(event{
+		Event: evOVNChurn, Target: centralNode, Object: "fip 192.0.2.60",
+		From: "absent", To: "192.0.2.60",
+	})
+
+	ev := eventsIn(t, buf.String())[0]
+	if ev.Event != evOVNChurn || ev.Object != "fip 192.0.2.60" || ev.From != "absent" || ev.To != "192.0.2.60" {
+		t.Fatalf("the ovn-churn event did not round-trip: %+v", ev)
+	}
+}

--- a/test/e2e/chaos/lab.go
+++ b/test/e2e/chaos/lab.go
@@ -100,6 +100,7 @@ const (
 	clientNode   = "client-1"
 	workloadHost = "gateway-3"
 	crPort       = "cr-lr0-public"
+	lrPublicPort = "lr0-public"
 
 	// The agent as the gwnode image ships it: the binary, the config file
 	// the entrypoint execs it with, and the two paths the chaos runner

--- a/test/e2e/chaos/main.go
+++ b/test/e2e/chaos/main.go
@@ -129,7 +129,7 @@ func run(cfg config) (int, error) {
 	// contract — ahead of everything that creates one.
 	l := newLab(cfg.labName, execCommander{})
 	ap := newApplier(l, p, base)
-	actions := allActions(p, ap)
+	actions := allActions(p, l, ap)
 	weights, err := parseWeights(cfg.weightSpec, actions)
 	if err != nil {
 		return exitFatal, err

--- a/test/e2e/chaos/main.go
+++ b/test/e2e/chaos/main.go
@@ -10,6 +10,11 @@
 // interval, pick a weighted action, check its guardrails, execute it,
 // wait for the node to converge, record it.
 //
+// The action catalog (issue #178) spans five fault classes: the
+// container-level starter faults and the config change, control-plane
+// outages on the central node, management-path impairment, data-plane
+// drift the agent self-heals, routing flaps, and OVN churn.
+//
 // Reproducibility is the contract: the profile, the seed, the duration,
 // the tick bounds and the action weights are the only inputs, and every
 // decision the engine makes is drawn from a PCG stream seeded by -seed
@@ -129,7 +134,8 @@ func run(cfg config) (int, error) {
 	// contract — ahead of everything that creates one.
 	l := newLab(cfg.labName, execCommander{})
 	ap := newApplier(l, p, base)
-	actions := allActions(p, l, ap)
+	ch := newChurner(l)
+	actions := allActions(p, l, ap, ch)
 	weights, err := parseWeights(cfg.weightSpec, actions)
 	if err != nil {
 		return exitFatal, err
@@ -165,6 +171,7 @@ func run(cfg config) (int, error) {
 	started := time.Now()
 	jrnl := newJournal(jf, time.Now)
 	ap.jrnl = jrnl
+	ch.jrnl = jrnl
 	rec := &runRecord{
 		Inputs: runInputs{
 			Seed:       cfg.seed,

--- a/test/e2e/chaos/main_test.go
+++ b/test/e2e/chaos/main_test.go
@@ -154,7 +154,7 @@ func TestDriveAbandonsARunWhoseProfileNeverLands(t *testing.T) {
 			ap.jrnl = newJournal(&buf, clock.now)
 			rec := &runRecord{ActionsByName: map[string]int{}}
 
-			code := drive(context.Background(), l, ap, allActions(p, l, ap), ap.jrnl, rec)
+			code := drive(context.Background(), l, ap, allActions(p, l, ap, newChurner(l)), ap.jrnl, rec)
 
 			if code != exitFatal {
 				t.Fatalf("exit code = %d, want %d", code, exitFatal)

--- a/test/e2e/chaos/main_test.go
+++ b/test/e2e/chaos/main_test.go
@@ -154,7 +154,7 @@ func TestDriveAbandonsARunWhoseProfileNeverLands(t *testing.T) {
 			ap.jrnl = newJournal(&buf, clock.now)
 			rec := &runRecord{ActionsByName: map[string]int{}}
 
-			code := drive(context.Background(), l, ap, allActions(p, ap), ap.jrnl, rec)
+			code := drive(context.Background(), l, ap, allActions(p, l, ap), ap.jrnl, rec)
 
 			if code != exitFatal {
 				t.Fatalf("exit code = %d, want %d", code, exitFatal)


### PR DESCRIPTION
Closes #178

## What this does

Extends the E2E chaos runner's action catalog beyond the container-level faults it already exercises, adding the five failure classes issue #178 calls for: control-plane outages, management-path impairment, data-plane drift, routing flaps, and OVN churn. Production incidents are more often the quiet ones — a stalled database connection, a lossy management link, a human deleting a rule the agent owns — and the integration tier already proves the agent heals each in isolation on a single host. This makes those classes available to every multi-node chaos run, in combination, under time pressure.

The change lands as one engine-enabling commit, one commit per fault class, and a docs commit. Reading in commit order:

## Change set (commit order)

1. **`0c26f66` — teach the chaos engine central, upstream and pair targets.** Enabling change with no new action registered, so every recorded seed replays unchanged. An action now declares a scope (gateway — the zero value — central, upstream, or gateway-pair), the static object it touches, and whether it reads the drawn flip. The engine seeds central/upstream into the node-state map, still draws the gateway target every tick to keep the stream aligned, then derives the real target and ring-next peer from the scope. Guardrails gate on scope (a pair needs its peer plus a third gateway healthy; central/upstream faults need no gateway peer); restore and convergence run per node (gateway by container + chassis, central by container health, upstream by `bgpd`). The journal gains `peer` and `object` fields and an `ovn-churn` event; `applicable` becomes context-aware.

2. **`0357044` — control-plane pause and double-failover actions.** SIGSTOP/SIGCONT against the OVN NB/SB `ovsdb-server` and `northd` pidfiles on the central node, for holds spanning both a short stall and an outage long enough to force a real reconnect; plus killing a gateway while another drains (double failover). Pauses converge on central's container health (its HEALTHCHECK ties to both databases answering); the double failover restores each gateway of the pair through the same container-lifecycle path the starter kills use. Appended after `config-flip` so recorded seeds keep replaying.

3. **`d7e1d73` — management-path loss and latency actions.** Packet loss and added latency on the management path between a gateway and the OVN central node, forcing OVSDB connections to flap without killing anything. A `prio` qdisc keeps the default band unimpaired and a `u32` filter steers only central-bound traffic into a `netem` band, so gateway-to-gateway geneve tunnels on the same `eth0` stay clean. Because `sch_netem` cannot be modprobe'd from inside the `CAP_NET_ADMIN`-only containers, `e2e-lab-setup` now loads it on the host with the same install-and-retry fallback the `vrf` module already uses.

4. **`12653dd` — data-plane drift actions.** The fat-fingered-operator class: delete a managed kernel route, flush the agent's nftables table, remove a hairpin or MAC-rewrite OVS flow, remove an FRR static route — the exact deletions the integration drift scenarios prove the agent heals, driven here against the multi-node lab under fault load. The deletion is the fault and the agent's next reconcile is the undo, so restore is a deliberate no-op. Each action carries a live `applicable` so a gateway not carrying the object is a journaled skip rather than a no-op deletion; `allActions` now takes the lab to capture it for those checks.

5. **`72edd99` — FRR and upstream BGP restart actions.** `frr-restart` recycles a gateway's FRR the way the gwnode entrypoint does (stop, clear stale watchfrr state, start), then re-asserts the BGP session on restore. `upstream-bgp-restart` stops `bgpd` on the upstream node and starts it back in place — never restarting the container, whose PID 1 is `watchfrr`, since a container restart would take it and its five containerlab veths down. "Announcements return" reuses the engine's existing converge gate: client-1 probes are only reachable over routes the upstream re-learns via BGP.

6. **`5d4959e` — OVN churn actions.** Mutate the topology under load: add/remove a floating IP and a port-forward entry, flip a gateway-chassis priority externally, and delete a chassis that the live `ovn-controller` re-registers within the stale-cleanup grace period. A churner owns the journal so each executed change lands as an `ovn-churn` event. The FIP and VIP are deliberately unprobed (a resource that appears and disappears must never draw probe traffic) and each churn is left in place for the next draw to toggle back. `allActions` now takes the churner, completing the catalog.

7. **`6c15476` — document the extended catalog.** The Actions table gains a Target column and the sixteen new rows, with per-class prose (including the `sch_netem` host-module requirement, the upstream `watchfrr` PID-1 caveat, and the chassis-delete grace-period semantics). The guardrails, journal, and Makefile help text are updated to match.

## Divergence from the issue

None material. The implementation follows the issue's five fault classes as written; the only structural addition beyond what the issue text enumerates is the `0c26f66` engine commit, which is the prerequisite target-scope machinery (central / upstream / gateway-pair) the new actions build on, landed separately so recorded seeds stay stable.

## Scope

Test-tier and CI/docs only — the diff touches `test/e2e/chaos/`, the `e2e-lab-setup` GitHub action, the `Makefile` help text, and `docs/contributing/e2e-tests.md`. No agent or production code changes.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 01245b5 with Claude:claude-opus-4-8_
