### PR TITLE
test/e2e: verify chaos runs against a config-aware expected-state oracle

### DIFF
--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -231,7 +231,7 @@ Between bring-up and teardown, each scenario is its own `make` target:
 | Scenario | `make` target | What it asserts | Issue |
 | --- | --- | --- | --- |
 | [Baseline](#baseline) | `e2e-baseline` | An external client reaches a FIP once the agent reconciles. | [#45](https://github.com/osism/ovn-network-agent/issues/45) |
-| [Chaos runner](#chaos-runner) | `e2e-chaos` | Under a seeded, randomized fault sequence — in any of six agent [configuration profiles](#configuration-profiles) — the agents stay alive, reachability recovers within budget, and no gateway port is claimed twice. | [#176](https://github.com/osism/ovn-network-agent/issues/176), [#177](https://github.com/osism/ovn-network-agent/issues/177) |
+| [Chaos runner](#chaos-runner) | `e2e-chaos` | Under a seeded, randomized fault sequence — in any of six agent [configuration profiles](#configuration-profiles) — the agents stay alive, reachability recovers within budget, no gateway port is claimed twice, and the lab converges to its config-aware expected state in settle windows. | [#176](https://github.com/osism/ovn-network-agent/issues/176), [#177](https://github.com/osism/ovn-network-agent/issues/177), [#179](https://github.com/osism/ovn-network-agent/issues/179) |
 | [Drain-hitless](#drain-hitless) | `e2e-drain-hitless` | A graceful `SIGTERM` drain loses fewer packets than a hard `docker kill` of the same chassis. | [#113](https://github.com/osism/ovn-network-agent/issues/113) |
 | [Failover](#failover) | `e2e-failover` | `cr-lr0-public` re-elects to a surviving chassis after the master is lost. | [#105](https://github.com/osism/ovn-network-agent/issues/105) |
 | [Hairpin](#hairpin) | `e2e-hairpin` | The `cookie=0x998` hairpin flow reflects FIP-to-FIP traffic on `br-ex`. | [#108](https://github.com/osism/ovn-network-agent/issues/108) |
@@ -888,9 +888,9 @@ structured artifacts. Its unit tests run under `make test` on any
 platform (they drive the real engine against a fake `docker`).
 
 **Inputs — and the replay contract.** The profile, the seed, the
-duration, the tick bounds and the action weights are the *only* inputs,
-and every decision the engine makes is drawn from a PCG stream seeded by
-`-seed` alone:
+duration, the tick bounds, the settle schedule and the action weights
+are the *only* inputs, and every decision the engine makes is drawn from
+a PCG stream seeded by `-seed` alone:
 
 | Flag | Default | Meaning |
 | --- | --- | --- |
@@ -898,11 +898,13 @@ and every decision the engine makes is drawn from a PCG stream seeded by
 | `-profile` | `everything-on` | The [configuration profile](#configuration-profiles): the start topology and the agent configuration each gateway runs. An unknown name is rejected. |
 | `-duration` | `10m` | How long to keep injecting faults. Must be at least `1s`. |
 | `-tick-min` / `-tick-max` | `10s` / `30s` | Bounds of the interval between decisions. `-tick-min` must be at least `100ms`: a tick interval near zero spins the loop and grows the journal without bound, on a run where no fault fits between two ticks. |
+| `-settle-every` | `3m` | How often injection pauses for a settle window that verifies the lab against its config-aware expected state. `0` runs only the final settle after the last fault; a negative value is rejected. |
+| `-settle-timeout` | `2m` | How long a settle window may take to reach full convergence before the divergence becomes violations. Must be at least `35s` — the window has to outlast one slow-cadence reconcile (15 s) plus the 20 s confirmation gap. |
 | `-weights` | registry defaults | `name=n,…`; an unknown action name is rejected. `-weights gateway-kill=0` disables a fault. |
 | `-lab` | `ovn-e2e` | containerlab lab name. |
 | `-out` | `chaos-artifacts` | Where the journal, the run record and the lab-state dump land. |
 | `-collect` | `test/e2e/scenarios/collect-artifacts.sh` | The lab-state collector, run into `<out>/lab-state` when the run does not pass. The default is repo-relative, so run the binary from the repo root (`make e2e-chaos` does). |
-| `-gwnode-config` | `test/e2e/gwnode-config.yaml` | The baked gateway agent config a profile's overlays are layered over. Also repo-relative. |
+| `-gwnode-config` | `test/e2e/gwnode-config.yaml` | The baked gateway agent config a profile's overlays are layered over. Also repo-relative. It now binds `metrics_listen` on loopback so the settle oracle can scrape each agent's own flap-indicator metrics. |
 
 Two runs with identical inputs against identically-behaving labs replay
 the identical action sequence. **Profile and seed together** identify a
@@ -926,7 +928,13 @@ cannot shift the stream: the run that skipped a decision draws the same
 values afterwards as the run that executed it. The flip is drawn on every
 tick even though only `config-flip` reads it, for that same reason. Wall
 clock only bounds *how many* ticks fit in `-duration`, so a slower lab
-truncates the tail of the sequence rather than changing it.
+truncates the tail of the sequence rather than changing it. Settle
+windows draw from that same wall clock and not from the seed: a build
+with settles fits fewer ticks into a given `-duration` than one without,
+so a run recorded before settles existed replays a shorter tail here —
+but for any given tick count the decision stream is exactly the one the
+seed produces. Both settle flags are echoed into `run-start` and
+`summary.json` alongside the seed and profile.
 
 ::: warning Sequences are versioned by the build, not by the seed alone
 A recorded seed replays the sequence it recorded only against the same
@@ -1123,8 +1131,9 @@ MAC-tweak flows exist only where routers are locally active, a
 port-forward-only profile has no FIP routes — rather than record a no-op
 deletion. Removing the MAC-tweak flow darkens external probes and is
 measured; the hairpin flow's restoration is not probe-observable from
-`client-1` (asserting its presence is the config-aware oracle of
-[#179](https://github.com/osism/ovn-network-agent/issues/179)).
+`client-1`, so the config-aware oracle of
+[#179](https://github.com/osism/ovn-network-agent/issues/179) asserts its
+presence in every settle window instead.
 
 **Routing flaps** restart the FRR/BGP daemons and let the run assert the
 announcements return — the probes from `client-1` are only reachable over
@@ -1232,6 +1241,100 @@ evidence that the invariants were evaluated at all: a run whose every
 dual-claim lookup failed asserted nothing, and fails with a
 `checks-never-ran` violation instead of reporting a clean pass.
 
+**The expected-state oracle.** A green probe proves a FIP is
+reachable; it cannot prove the lab is *configured the way it says it
+is*. A route left on a drained gateway, a DNAT rule surviving a config
+change, an announcement for a prefix the filter should exclude — none of
+these darken a probe, and a stale announcement drawing traffic to a dead
+gateway is worse than an outage. Without a config-aware oracle a
+profile-driven run cannot tell "the agent ignored my configuration" from
+"converged fine" (issue
+[#179](https://github.com/osism/ovn-network-agent/issues/179)).
+
+**The settle model.** Periodically (`-settle-every`) and always once
+more after the last fault, injection stops — the settle window runs
+*between* ticks, with every node already restored — and the oracle polls
+the lab every 5 s until every gateway's live data plane matches the
+state its *current* configuration demands. A first all-green evaluation
+is confirmed by a second one 20 s later, with the agent's
+`route_readds_total` steady between the two; only then does the window
+pass. If `-settle-timeout` expires first, the last evaluation's failures
+become violations, and any violation fails the run. Every poll recomputes
+the expectation, so a settle tracks a `config-flip` the instant it lands.
+
+**The seven verified planes.** For each gateway the oracle diffs the
+live data plane against a per-gateway expectation recomputed from the OVN
+NB/SB snapshot and that gateway's own config:
+
+| Plane | What the oracle checks |
+| --- | --- |
+| Kernel routes | proto-44 `/32`s on their device (`br-ex`, or `br-ex.<tag>` for a VLAN segment) |
+| FRR statics | `/32` statics in `vrf-provider` via the veth nexthop |
+| Prefix-list | the `ANNOUNCED-NETWORKS` entries |
+| Hairpin flows | OVS flows under cookie `0x998`, by destination |
+| MAC-tweak flows | the count of cookie `0x999` flows |
+| nftables | DNAT and hairpin-masquerade rules in table `ovn-network-agent` |
+| Managed VIPs | `/32` addresses on `port_forward_dev` |
+
+An eighth check reaches past the gateways to the upstream router: the BGP
+announcements `upstream` actually holds, bounded both ways — nothing
+stale (announced ⊆ desired) and nothing missing (every desired IP the
+mode requires must be announced). They are read from the upstream router
+itself, the ground truth of what the underlay carries, not from any
+gateway's claim about them.
+
+**Config awareness.** The expectation follows the configuration, not a
+fixed target — which is the whole point. With a `network_cidr` filter a
+floating IP outside it must appear in **no** plane; without
+`port_forwards` the agent's nftables table must carry no DNAT chains; in
+port-forward-only mode the agent must not touch OVN at all — its managed
+NB rows stay frozen at their prime content (`ovn-touched-in-pf-only`) and
+only the VIP planes are expected; with the drain disabled a terminating
+agent must not leave a lowered `Gateway_Chassis` priority behind
+(`drain-while-disabled`). Because every poll recomputes from the
+gateway's tracked config, a `cidr-toggle` or a `drain-toggle` moves the
+expectation with it.
+
+**Drain residue is tolerated where a drain explains it.** A
+`Gateway_Chassis` row sitting at priority 0 is a violation only when no
+legitimate drain accounts for it. The oracle tolerates three cases: a row
+already at 0 when the run started; a gateway whose last disruptive action
+ran with the drain *effectively* enabled (the marker / env / config
+resolution mirroring the entrypoint's own precedence); and a gateway
+whose drain question could not be asked at all — an unanswerable question
+tolerates the residue rather than inventing a violation. One blind spot
+is accepted by design: an agent that wrongly drains and then wrongly
+restores its own priority evades the between-ticks check, because the
+window only ever sees the settled state.
+
+**Snapshot invariants.** Three further checks hold across the whole
+snapshot rather than per gateway: the elected owner of every
+multi-candidate `chassisredirect` port must strictly outrank every peer
+(the priority lead HA re-election exists to keep); no managed route may
+name a chassis that has vanished from SB (vanished-chassis hygiene); and
+under port-forward-only the managed NB rows stay frozen at their prime
+content. That frozen-NB check is scoped to rows carrying the agent's own
+`external_ids` markers — an unmarked write would slip past it.
+
+**The metrics flap gate.** The set checks see a converged plane; they
+cannot see a route that is re-added on *every* reconcile and still looks
+right at each poll. So the oracle also scrapes each agent's own
+Prometheus endpoint (`metrics_listen`, loopback-only, over `docker exec`
+and a bash `/dev/tcp` socket) and fails the settle on a non-zero
+`consecutive_readds` or `inactive_routes`, or on any `route_readds_total`
+movement across the 20 s confirmation gap — a flap even when every probe
+stays green.
+
+**Violations and triage.** The oracle adds five violation kinds —
+`expected-state`, `route-flap`, `drain-while-disabled`,
+`ovn-touched-in-pf-only`, and `oracle-setup`. Each settle violation is
+stamped with the tick and the `journal_offset` of the last executed
+action, so a reader jumps from the violation in `summary.json` straight
+to the fault interleaving that preceded it in `journal.jsonl`.
+`oracle-setup` is the one that is fatal: when the oracle cannot prime
+against the green start state the run aborts with exit code 2, like any
+other setup it could not be built on.
+
 ::: details Why the runner re-wires the containerlab veth
 Any container exit destroys the containerlab veth
 `gateway-N:eth1 ↔ upstream:ethN`, and `docker start` does not bring it
@@ -1283,7 +1386,9 @@ flip among them — and either `executed` or a `skip_reason`), `inject` /
 between, and `rejected` when the agent refused it), `ovn-churn` (each
 executed churn, with the `object` it touched and the `from`/`to` values it
 moved between), `node-state`, `probe-transition`, `vip-repoint`,
-`violation` and `run-end`. A `decision`, `inject` or `converged` for a
+`settle-start` / `settle-result` (the latter with the `converged_ms` the
+settle window took to reach its expected state), `violation` and
+`run-end`. A `decision`, `inject` or `converged` for a
 multi-node fault carries the `peer` it also disrupted, and a decision that
 touched a named object (a route, a database server, an nftables table)
 carries it in `object` — so a run mixing all classes is triageable from the
@@ -1291,11 +1396,16 @@ artifacts alone.
 `summary.json` aggregates the run: inputs, tick and decision counts,
 actions by name, how many baseline sweeps ran and how many of them
 evaluated the dual-claim invariant, per-probe sent/lost plus 10-second
-loss buckets, the per-action recovery durations, and every violation.
+loss buckets, the per-action recovery durations, a `settles` section (one
+entry per settle window: its tick, `converged_ms`, whether it passed, and
+how many violations it raised), and every violation — each now stamped
+with the `journal_offset` of the last executed action, so it points back
+into `journal.jsonl`.
 
 **Exit codes:** `0` the run passed, `1` the run recorded a violation,
 `2` the runner could not set the run up (bad flags, an unknown profile, a
-configuration the agent rejected, a start state that never went green).
+configuration the agent rejected, a start state that never went green, an
+oracle that could not prime against it).
 On any non-zero exit the lab's existing `collect-artifacts.sh` bundle is
 dumped into `<out>/lab-state`.
 

--- a/test/e2e/chaos/engine.go
+++ b/test/e2e/chaos/engine.go
@@ -136,6 +136,18 @@ type engine struct {
 	tickMin  time.Duration
 	tickMax  time.Duration
 
+	// oracle verifies each settle window against the config-aware expected
+	// state; settleEvery is how often the tick loop pauses for one (0 disables
+	// the scheduled settles, leaving only the final settle drive runs).
+	// lastActionOffset is the journal offset of the last executed action — the
+	// value a settle violation is stamped with. All three are late-bound in
+	// drive after the oracle has primed against the start state, matching the
+	// ap.jrnl precedent: newEngine's signature is unchanged, and a nil oracle
+	// keeps every existing engine test valid.
+	oracle           *oracle
+	settleEvery      time.Duration
+	lastActionOffset int
+
 	// wait blocks for a duration unless ctx is cancelled first. Every wait
 	// the tick loop makes goes through it, so a Ctrl-C is observed while
 	// the engine is idling out a tick interval or holding a fault instead
@@ -382,7 +394,18 @@ func (e *engine) hasHealthyPeer(d decision) bool {
 // fault is injected; an action already in flight runs to completion.
 func (e *engine) run(ctx context.Context) {
 	deadline := e.now().Add(e.duration)
+	nextSettle := e.now().Add(e.settleEvery)
 	for tick := 1; e.now().Before(deadline); tick++ {
+		// A settle window runs between ticks — after the previous action's
+		// full execute/converge cycle and before the next draw — so it never
+		// lands between an inject and its restore. It draws nothing from the
+		// rng, so the decision stream is untouched; it only consumes
+		// wall-clock, which is why it is scheduled off the clock and not the
+		// tick count.
+		if e.oracle != nil && e.settleEvery > 0 && !e.now().Before(nextSettle) {
+			e.settle(ctx)
+			nextSettle = e.now().Add(e.settleEvery)
+		}
 		d := e.draw(tick)
 		if !e.wait(ctx, d.interval) || !e.now().Before(deadline) {
 			return
@@ -425,6 +448,42 @@ func (e *engine) run(ctx context.Context) {
 	}
 }
 
+// settle runs one settle window against the config-aware oracle: it polls
+// the lab until every gateway's live data plane matches the state its
+// configuration demands or the oracle's settleTimeout expires, records the
+// verdict, and stamps each violation the oracle returns with the current
+// tick and the journal offset of the last executed action — so a reader
+// jumps from a settle violation to the fault that preceded it. drive runs
+// it once more after the last tick; the tick loop runs it on a cadence.
+func (e *engine) settle(ctx context.Context) {
+	e.jrnl.emit(event{Event: evSettleStart, Tick: e.rec.Ticks})
+
+	violations, convergedMS := e.oracle.verify(ctx)
+	for _, v := range violations {
+		v.Tick = e.rec.Ticks
+		v.JournalOffset = e.lastActionOffset
+		e.violate(v)
+	}
+	e.rec.Settles = append(e.rec.Settles, settleRecord{
+		Tick:        e.rec.Ticks,
+		ConvergedMS: convergedMS,
+		Passed:      len(violations) == 0,
+		Violations:  len(violations),
+	})
+
+	result := resultPass
+	if len(violations) > 0 {
+		result = resultFail
+	}
+	ev := event{Event: evSettleResult, Tick: e.rec.Ticks, Result: result}
+	// convergedMS is -1 on a deadline; only a real convergence time is worth
+	// recording (the field is omitempty).
+	if convergedMS >= 0 {
+		ev.ConvergedMS = convergedMS
+	}
+	e.jrnl.emit(ev)
+}
+
 // nodesFor is the set of nodes one decision disrupts: its target, plus the
 // ring-next peer for a gateway-pair fault. It is what execute marks
 // disrupted, what the restore loop puts back, and what convergence gates
@@ -446,6 +505,21 @@ func (e *engine) execute(ctx context.Context, d decision) {
 
 	injectedAt := e.now()
 	e.jrnl.emit(event{Event: evInject, Tick: d.tick, Action: d.action.name, Target: d.target, Peer: d.peer})
+	e.lastActionOffset = e.jrnl.count()
+
+	// Ask the oracle to record what this fault means for the drain
+	// classification before it lands. An error means the question could not
+	// be asked (docker under load, the container gone mid-inject); the oracle
+	// tolerates the residue rather than fabricating a violation, and here it
+	// is journaled — never fatal, mirroring checkError's "could not ask"
+	// philosophy.
+	if e.oracle != nil {
+		if err := e.oracle.observeInject(ctx, d.action.name, d.target); err != nil {
+			e.jrnl.emit(event{Event: evCheckError, Tick: d.tick, Target: d.target,
+				Detail: "oracle drain classification: " + err.Error()})
+		}
+	}
+
 	if err := d.action.inject(ctx, e.lab, d.target, d.flip); err != nil {
 		e.undo(ctx, d, err)
 		return

--- a/test/e2e/chaos/engine.go
+++ b/test/e2e/chaos/engine.go
@@ -54,6 +54,11 @@ const (
 	violationProfileApply    = "profile-not-applied"
 	violationStartState      = "start-state-not-green"
 	violationChecksNeverRan  = "checks-never-ran"
+	violationExpectedState   = "expected-state"
+	violationRouteFlap       = "route-flap"
+	violationDrainDisabled   = "drain-while-disabled"
+	violationOVNTouched      = "ovn-touched-in-pf-only"
+	violationOracleSetup     = "oracle-setup"
 )
 
 // convergePollInterval is how often the engine re-checks a recovering

--- a/test/e2e/chaos/engine_test.go
+++ b/test/e2e/chaos/engine_test.go
@@ -1141,3 +1141,186 @@ func decisionEventsIn(t *testing.T, journal string) []event {
 	}
 	return out
 }
+
+// runEngineOracle drives a full engine run wired to a config-aware oracle over
+// the oracleLab fixture, with settle windows at the given cadence. The engine
+// and the oracle share one fake clock, so a settle consumes the run's
+// wall-clock exactly as it would in production while the whole run still
+// completes in microseconds. It returns the journal and the run record.
+func runEngineOracle(t *testing.T, seed int64, duration, settleEvery time.Duration,
+	actions []*action, fx *oracleLab) (string, *runRecord) {
+	t.Helper()
+
+	clock := newFakeClock()
+	lab := newTestLab(&fakeCommander{respond: fx.respond}, clock)
+	var buf bytes.Buffer
+	jrnl := newJournal(&buf, clock.now)
+
+	rec := &runRecord{
+		Inputs: runInputs{
+			Seed:            seed,
+			DurationMS:      duration.Milliseconds(),
+			TickMinMS:       (10 * time.Second).Milliseconds(),
+			TickMaxMS:       (30 * time.Second).Milliseconds(),
+			SettleEveryMS:   settleEvery.Milliseconds(),
+			SettleTimeoutMS: (90 * time.Second).Milliseconds(),
+			Lab:             "ovn-e2e",
+		},
+		ActionsByName: map[string]int{},
+	}
+	orc := newOracle(lab, oracleApplier(fullModeDocs(t)))
+	orc.settleTimeout = time.Duration(rec.Inputs.SettleTimeoutMS) * time.Millisecond
+	if err := orc.prime(context.Background()); err != nil {
+		t.Fatalf("prime the oracle: %v", err)
+	}
+
+	e := newEngine(lab, defaultTestProfile(t), actions, greenProbes{}, jrnl, rec)
+	e.wait, e.now = clock.wait, clock.now
+	e.oracle = orc
+	e.settleEvery = time.Duration(rec.Inputs.SettleEveryMS) * time.Millisecond
+
+	e.run(context.Background())
+	rec.finalize(clock.now())
+	return buf.String(), rec
+}
+
+// The settle windows run on the configured cadence between ticks — never
+// between an inject and its restore, where the lab is deliberately broken.
+func TestSettleWindowsRunAtTheConfiguredCadenceBetweenTicks(t *testing.T) {
+	fx := newOracleLab(t)
+	journal, rec := runEngineOracle(t, 42, 10*time.Minute, 30*time.Second,
+		noopActions("controller-restart"), fx)
+
+	evs := eventsIn(t, journal)
+	var starts, results int
+	injecting := false
+	settleAfterDecision := false
+	sawDecision := false
+	for _, ev := range evs {
+		switch ev.Event {
+		case evDecision:
+			sawDecision = true
+		case evInject:
+			injecting = true
+		case evRestore:
+			injecting = false
+		case evSettleStart:
+			starts++
+			if injecting {
+				t.Fatal("a settle window opened between an inject and its restore")
+			}
+			if sawDecision {
+				settleAfterDecision = true
+			}
+		case evSettleResult:
+			results++
+			if injecting {
+				t.Fatal("a settle result landed between an inject and its restore")
+			}
+		}
+	}
+
+	if starts == 0 {
+		t.Fatal("no settle window ran at the configured cadence")
+	}
+	if starts != results {
+		t.Fatalf("%d settle-start events but %d settle-result events", starts, results)
+	}
+	if !settleAfterDecision {
+		t.Fatal("every settle ran before the first decision, not between ticks")
+	}
+	if len(rec.Settles) != starts {
+		t.Fatalf("recorded %d settles for %d settle windows", len(rec.Settles), starts)
+	}
+	// Every settle over the green fixture converges cleanly.
+	for _, s := range rec.Settles {
+		if !s.Passed || s.ConvergedMS < 0 {
+			t.Fatalf("a settle over a converged lab did not pass: %+v", s)
+		}
+	}
+	if len(rec.Violations) != 0 {
+		t.Fatalf("a green run recorded violations: %+v", rec.Violations)
+	}
+}
+
+// Settles consume the run's wall-clock but draw nothing from the rng, so the
+// decision stream a replay reproduces is identical whether or not they run.
+func TestSettleDoesNotShiftTheDecisionStream(t *testing.T) {
+	withSettles, settledRec := runEngineOracle(t, 42, 15*time.Minute, 30*time.Second,
+		noopActions("controller-restart", "gateway-kill"), newOracleLab(t))
+	without, _ := runEngineOracle(t, 42, 15*time.Minute, 0,
+		noopActions("controller-restart", "gateway-kill"), newOracleLab(t))
+
+	if len(settledRec.Settles) == 0 {
+		t.Fatal("the settled run ran no settle windows, so it proves nothing")
+	}
+
+	a, b := decisionsIn(t, withSettles), decisionsIn(t, without)
+	if len(a) == 0 {
+		t.Fatal("the settled run made no decisions at all")
+	}
+	// Settles only consume time; they never add ticks, so the settled run
+	// fits no more decisions than the unsettled one.
+	if len(a) > len(b) {
+		t.Fatalf("the settled run fit more decisions (%d) than the unsettled one (%d)", len(a), len(b))
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("decision %d diverged when settles were enabled: %q vs %q", i+1, a[i], b[i])
+		}
+	}
+}
+
+// A settle violation is stamped with the current tick and the journal offset
+// of the last executed action, so a reader jumps straight from the violation
+// in the record to the inject that preceded it in the journal.
+func TestSettleViolationsCarryTheLastActionsJournalOffset(t *testing.T) {
+	fx := newOracleLab(t)
+	fx.dropKernel["gateway-1"] = "192.0.2.10" // a kernel route missing on every poll
+
+	journal, rec := runEngineOracle(t, 42, 10*time.Minute, 30*time.Second,
+		noopActions("controller-restart"), fx)
+
+	var got *violationRecord
+	for i := range rec.Violations {
+		if r := &rec.Violations[i]; r.Kind == violationExpectedState &&
+			r.Target == "gateway-1" && strings.Contains(r.Detail, "kernel") {
+			got = r
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("the settle over the red fixture recorded no kernel violation: %+v", rec.Violations)
+	}
+	if got.Tick == 0 {
+		t.Fatalf("the settle violation was not stamped with a tick: %+v", got)
+	}
+
+	// jrnl.count() right after an emit is that line's 1-based number, so the
+	// stamped offset must be the line of the inject that preceded the first
+	// settle window.
+	evs := eventsIn(t, journal)
+	firstSettle := -1
+	for i, ev := range evs {
+		if ev.Event == evSettleStart {
+			firstSettle = i
+			break
+		}
+	}
+	if firstSettle < 0 {
+		t.Fatal("no settle window ran")
+	}
+	injectLine := -1
+	for i := 0; i < firstSettle; i++ {
+		if evs[i].Event == evInject {
+			injectLine = i + 1
+		}
+	}
+	if injectLine < 0 {
+		t.Fatal("no inject preceded the first settle window")
+	}
+	if got.JournalOffset != injectLine {
+		t.Fatalf("violation journal offset = %d, want the preceding inject's line %d",
+			got.JournalOffset, injectLine)
+	}
+}

--- a/test/e2e/chaos/expect.go
+++ b/test/e2e/chaos/expect.go
@@ -1,0 +1,684 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+)
+
+// =============================================================================
+// Config-aware expected-state oracle
+// =============================================================================
+//
+// computeExpectation recomputes, for one gateway, the exact data-plane state
+// the agent must converge to — from a live OVN NB/SB snapshot and that
+// gateway's own agent configuration. It is a pure function: no lab access, no
+// polling, no side effects. The oracle's observation layer (a later commit)
+// gathers the snapshot and polls the live planes against the verdict this
+// returns.
+//
+// Everything here mirrors an agent code path, so the two derivations cannot
+// drift: the desired-IP fork mirrors desired_state.go (computeDesiredState /
+// DesiredIPs), and the per-mode / per-activity gating mirrors agent.go's
+// reconcile branches (the port-forward-only path, the active branch that owns
+// local routers, and the standby default branch). The rules are documented
+// inline against the file they mirror rather than restated, so a reader can
+// check the oracle against the agent one plane at a time.
+//
+// The oracle is IPv4-only, matching the agent's IPv4-only route/announce planes
+// (desired_state.go:splitIPv4) and the lab, which seeds no IPv6 state.
+
+// natRow is one flattened NB NAT row: only the two columns the oracle reads
+// (the type distinguishes dnat_and_snat / snat, the external IP is what gets a
+// route and an announcement).
+type natRow struct {
+	ExternalIP string
+	Type       string
+}
+
+// lrpRow is a flattened NB Logical_Router_Port: its networks (CIDR strings, the
+// gateway IPs the router owns) and the Gateway_Chassis row-UUID refs that make
+// it a distributed gateway port.
+type lrpRow struct {
+	Networks       []string
+	GatewayChassis []string
+}
+
+// routerRow is a flattened NB Logical_Router: the UUID refs of its member LRPs
+// (resolved to names through ovnSnapshot.LRPNameByUUID) and its NAT rows.
+type routerRow struct {
+	LRPUUIDs []string
+	NATs     []natRow
+}
+
+// gatewayChassisRow is one NB Gateway_Chassis row: the HA candidate a chassis
+// offers for an LRP, at a priority. The oracle's observation layer reads these
+// to reason about which chassis should win an election; computeExpectation
+// takes the winner as already decided by the SB chassisredirect binding.
+type gatewayChassisRow struct {
+	Name        string
+	ChassisName string
+	Priority    int
+}
+
+// staticRouteRow is one managed NB Logical_Router_Static_Route: the observation
+// layer matches it by its external_ids marker. computeExpectation does not read
+// it — it is gathered here so the whole OVN view lives in one snapshot type.
+type staticRouteRow struct {
+	UUID        string
+	IPPrefix    string
+	ExternalIDs map[string]string
+}
+
+// ovnSnapshot is everything the oracle gathers from OVN NB/SB, already
+// flattened to plain maps/slices so the observation layer can populate it from
+// parseOVSDBTable output and the tests can hand-build it. It carries no
+// libovsdb rows and no UUID indirection beyond LRPNameByUUID, which is the one
+// join the router→LRP mapping needs.
+type ovnSnapshot struct {
+	// CRPortChassis maps each chassisredirect Port_Binding's logical port name
+	// (e.g. "cr-lr0-public") to the chassis that currently owns it. An empty
+	// value means the port is unbound (a re-election is in flight).
+	CRPortChassis map[string]string
+
+	// LRPs maps each Logical_Router_Port name to its flattened row.
+	LRPs map[string]lrpRow
+
+	// Routers maps each Logical_Router name to its flattened row.
+	Routers map[string]routerRow
+
+	// LRPNameByUUID resolves a Logical_Router_Port UUID to its name, so a
+	// router's member-port UUID refs (routerRow.LRPUUIDs) connect to LRPs.
+	LRPNameByUUID map[string]string
+
+	// GatewayChassis maps each Gateway_Chassis row UUID to its row.
+	GatewayChassis map[string]gatewayChassisRow
+
+	// StaticRoutes are the managed Logical_Router_Static_Route rows.
+	StaticRoutes []staticRouteRow
+
+	// Chassis is the set of SB Chassis names currently present.
+	Chassis map[string]bool
+
+	// SegmentTagByLRP maps a Logical_Router_Port name to the VLAN tag of the
+	// localnet segment its external network is on: 0 is a flat (untagged)
+	// provider network, a non-zero tag is a VLAN segment. The oracle keys
+	// segments by tag, which the lab's topology makes unambiguous — one flat
+	// provider network at tag 0, each VLAN provider network at its own tag.
+	SegmentTagByLRP map[string]int
+}
+
+// dnatExpectation is one expected nftables DNAT rule: VIP:port on the provider
+// side, backend:destPort on the target side. Single-backend form only — the
+// only shape the lab profiles produce.
+type dnatExpectation struct {
+	VIP      string
+	Proto    string
+	Port     int
+	Backend  string
+	DestPort int
+}
+
+// gatewayExpectation is the per-gateway verdict target: one field (or skip
+// flag) per verified data plane. Each field is what the agent on this gateway
+// must have converged to, given the OVN snapshot and its configuration.
+type gatewayExpectation struct {
+	// Mode is "full" (an OVN gateway) or "pf-only" (a standalone VIP service).
+	Mode string
+
+	// Active reports whether this gateway owns at least one chassisredirect
+	// port — i.e. it is the active chassis for some router. Always false in
+	// pf-only mode, where the agent holds no OVN view.
+	Active bool
+
+	// DesiredIPs is the sorted, deduplicated set of IPv4 addresses that need a
+	// route and an announcement: the locally-active routers' NAT external IPs
+	// (filtered by the effective networks) and LRP gateway IPs, plus the
+	// configured port-forward VIPs. Mirrors desired_state.go DesiredIPs.
+	DesiredIPs []string
+
+	// KernelRouteDev maps each desired IP to the kernel device its proto-44
+	// /32 route must sit on: the provider bridge for a flat segment or a VIP,
+	// <bridge>.<tag> for a VLAN segment. Empty (and SkipKernel set) in pf-only.
+	KernelRouteDev map[string]string
+	SkipKernel     bool
+
+	// FRRStatic is the set of /32 IPs expected as FRR static routes via the
+	// veth nexthop. It equals DesiredIPs in both modes: ensureRoutes manages
+	// FRR for every desired IP, active or standby, full or pf-only.
+	FRRStatic []string
+
+	// PrefixList is the sorted set of CIDR strings the ANNOUNCED-NETWORKS
+	// prefix-list is reconciled to (the effective networks) on a full-mode
+	// active gateway. nil means the list is expected absent — the agent cleans
+	// it on a full-mode standby. SkipPrefixList is set in pf-only, where the
+	// agent never touches the list (the entrypoint placeholder survives).
+	PrefixList     []string
+	SkipPrefixList bool
+
+	// Hairpin is the set of IPs expected to carry a 0x998 hairpin flow: the
+	// IPv4 hairpin targets (NAT external IPs + LRP gateway IPs) when active,
+	// empty when standby. Port-forward VIPs are excluded — their DNAT is
+	// nftables, not a hairpin (buildHairpinTargets). SkipHairpin is set in
+	// pf-only.
+	Hairpin     []string
+	SkipHairpin bool
+
+	// MACTweakFlows is the expected count of 0x999 MAC-tweak flows: two per
+	// distinct locally-active segment when active. -1 means skip the check —
+	// the agent does not clean MAC-tweak flows on standby, so a standby (or a
+	// pf-only) gateway's count is unknowable.
+	MACTweakFlows int
+
+	// DNAT is the expected DNAT rule for each configured port-forward rule.
+	// Empty when no port_forwards are configured (the agent's nftables table
+	// then carries no DNAT chains).
+	DNAT []dnatExpectation
+
+	// HairpinMasquerade is the set of VIPs whose nftables ruleset must carry
+	// the hairpin-masquerade rule (hairpin_masquerade set on the VIP and a
+	// non-empty provider-network set, per buildNftRuleset's writeSNATChain).
+	HairpinMasquerade []string
+
+	// ManagedVIPs is the set of VIP addresses expected as /32 on
+	// PortForwardDev, for VIPs with manage_vip on. Empty otherwise.
+	ManagedVIPs    []string
+	PortForwardDev string
+
+	// MustAnnounce is the presence bound: the IPs the upstream must currently
+	// be announcing. On a full-mode active gateway it is the desired IPs that
+	// fall inside an effective network (the only ones the prefix-list permits);
+	// in pf-only it is the VIPs (the entrypoint placeholder permits all /32s);
+	// on a full-mode standby it is empty.
+	MustAnnounce []string
+
+	// AnnounceBound is the staleness bound: announced ⊆ this set must hold in
+	// every mode and state. It is exactly the desired IPs — the upstream can
+	// never legitimately announce an address the agent does not desire.
+	AnnounceBound []string
+}
+
+// computeExpectation recomputes gw's expected data-plane state from the OVN
+// snapshot and gw's agent configuration doc. mgmtIP is gw's management address
+// (the backend its API VIP forwards to); the DNAT backend itself is read from
+// the already-substituted config, so mgmtIP is threaded through only to keep
+// one signature across the oracle's callers.
+func computeExpectation(snap ovnSnapshot, gw string, doc map[string]any, mgmtIP string) gatewayExpectation {
+	_ = mgmtIP
+
+	// Rule 1 — pf-only iff both OVN remotes are absent (config.go validateMode:
+	// port-forward-only = no remotes + port_forwards set).
+	pfOnly := !docRemoteSet(doc, "ovn_sb_remote") && !docRemoteSet(doc, "ovn_nb_remote")
+	mode := "full"
+	if pfOnly {
+		mode = "pf-only"
+	}
+
+	bridge := docString(doc, "bridge_dev", "br-ex")
+	forwards := docPortForwards(doc)
+	vips := vipAddresses(forwards)
+
+	// In pf-only mode the agent runs with a zero OVNState (a.ovn is nil), so it
+	// sees no local routers regardless of what OVN holds. Everything OVN-derived
+	// below therefore reduces to the VIPs alone.
+	var local []localRouter
+	if !pfOnly {
+		local = snap.localRoutersOn(gw)
+	}
+	active := len(local) > 0
+
+	// Rule 2 — effective networks: the manual network_cidr wins, else the
+	// networks discovered from the locally-active LRPs (config.go
+	// effectiveNetworkFilters).
+	effective := effectiveNetworks(doc, local)
+
+	// Rules 3+4 — NAT external IPs are filtered by the effective networks (a FIP
+	// outside every effective CIDR lands in no plane); LRP gateway IPs are kept
+	// unfiltered. hairpin targets = NAT IPs + LRP gateway IPs; DesiredIPs adds
+	// the VIPs.
+	natIPs, lrpIPs, ipTag := ovnDesired(local, effective)
+	hairpin := sortedUnique(append(append([]string{}, natIPs...), lrpIPs...))
+	desired := sortedUnique(append(append([]string{}, hairpin...), vips...))
+
+	exp := gatewayExpectation{
+		Mode:           mode,
+		Active:         active,
+		DesiredIPs:     desired,
+		FRRStatic:      desired, // rule 6 — FRR static routes are exactly the desired IPs, in both modes.
+		PortForwardDev: docString(doc, "port_forward_dev", "loopback1"),
+		MACTweakFlows:  -1,
+		AnnounceBound:  desired, // rule 12 — announced ⊆ desired always.
+	}
+
+	// Rule 5 — kernel routes: managed only in full mode. Each OVN-derived IP
+	// routes over its segment's device (<bridge>.<tag>, or the bridge for a
+	// flat segment); VIPs default to the bridge. Skipped entirely in pf-only.
+	if pfOnly {
+		exp.SkipKernel = true
+	} else {
+		dev := make(map[string]string, len(desired))
+		for _, ip := range desired {
+			if tag, ok := ipTag[ip]; ok {
+				dev[ip] = kernelDevForTag(bridge, tag)
+			} else {
+				dev[ip] = bridge
+			}
+		}
+		exp.KernelRouteDev = dev
+	}
+
+	// Rule 7 — prefix-list: reconciled to the effective networks on a full-mode
+	// active gateway, cleaned (nil) on a full-mode standby, never touched in
+	// pf-only.
+	switch {
+	case pfOnly:
+		exp.SkipPrefixList = true
+	case active:
+		exp.PrefixList = networkStrings(effective)
+	}
+
+	// Rule 8 — hairpin flows: the hairpin targets when active, removed on
+	// standby, skipped in pf-only.
+	switch {
+	case pfOnly:
+		exp.SkipHairpin = true
+	case active:
+		exp.Hairpin = hairpin
+	}
+
+	// Rule 9 — MAC-tweak flows: two per distinct locally-active segment when
+	// active; left as the -1 skip sentinel on standby and in pf-only.
+	if active {
+		exp.MACTweakFlows = 2 * distinctSegments(local)
+	}
+
+	// Rules 10+11 — nftables. DNAT rules and managed-VIP addresses are managed
+	// independently of OVN state (ReconcilePortForward runs every cycle), so
+	// they follow the config alone.
+	exp.DNAT = dnatExpectations(forwards)
+	exp.HairpinMasquerade = hairpinMasqueradeVIPs(forwards, effective)
+	exp.ManagedVIPs = managedVIPs(forwards)
+
+	// Rule 12 — announced presence bound.
+	switch {
+	case pfOnly:
+		exp.MustAnnounce = desired // = VIPs
+	case active:
+		exp.MustAnnounce = coveredBy(desired, effective)
+	}
+
+	return exp
+}
+
+// localRouter is one router whose chassisredirect port the target gateway owns,
+// with the LRP that redirects to it resolved: its gateway IPs (networks), its
+// segment's VLAN tag, and the router's NAT rows.
+type localRouter struct {
+	router   string
+	lrpName  string
+	networks []string
+	segTag   int
+	nats     []natRow
+}
+
+// localRoutersOn returns the routers gw is the active chassis for: those whose
+// distributed gateway LRP has a chassisredirect port bound to gw. It mirrors
+// the agent's SB→NB join (ovn.go localCRPorts → collectLocalRouters): a CR port
+// owned by gw resolves to its LRP, and the LRP to the router that carries it.
+func (s ovnSnapshot) localRoutersOn(gw string) []localRouter {
+	var out []localRouter
+	for crPort, owner := range s.CRPortChassis {
+		if owner == "" || owner != gw {
+			continue
+		}
+		lrpName := lrpOfCRPort(crPort)
+		router, ok := s.routerForLRP(lrpName)
+		if !ok {
+			continue
+		}
+		out = append(out, localRouter{
+			router:   router,
+			lrpName:  lrpName,
+			networks: s.LRPs[lrpName].Networks,
+			segTag:   s.SegmentTagByLRP[lrpName],
+			nats:     s.Routers[router].NATs,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].router < out[j].router })
+	return out
+}
+
+// routerForLRP returns the name of the Logical_Router that owns the named LRP,
+// resolving each router's member-port UUID refs through LRPNameByUUID.
+func (s ovnSnapshot) routerForLRP(lrpName string) (string, bool) {
+	for router, r := range s.Routers {
+		for _, uuid := range r.LRPUUIDs {
+			if s.LRPNameByUUID[uuid] == lrpName {
+				return router, true
+			}
+		}
+	}
+	return "", false
+}
+
+// lrpOfCRPort resolves the distributed LRP a chassisredirect port redirects for
+// from the ovn-northd "cr-<LRP>" naming convention. That is the agent's own
+// documented fallback (ovn.go crPortLRPName) when a Port_Binding carries no
+// options:distributed-port, and it is the shape the lab's CR ports take
+// (cr-lr0-public ↔ lr0-public). A name that does not fit resolves to no router
+// and is skipped by the caller.
+func lrpOfCRPort(crPort string) string {
+	return strings.TrimPrefix(crPort, "cr-")
+}
+
+// ovnDesired collects the locally-active routers' route/announce-plane inputs:
+// their NAT external IPs filtered by the effective networks (rule 3), their LRP
+// gateway IPs kept unfiltered (rule 4), and the segment tag each IP sits on so
+// the kernel-route device can be derived. All three are IPv4-only, matching the
+// agent's route/announce planes.
+//
+// This mirrors the agent's addNBNATs derivation (ovn.go): NAT external IPs of
+// locally-active routers, validated and filtered by the effective networks. It
+// intentionally omits the agent's second NAT source, addSBGatewayNATAddresses,
+// which folds in the SB gateway port's NatAddresses only for Neutron-managed
+// ports (external_ids:neutron:device_owner == network:router_gateway). The lab
+// seeds no neutron:device_owner metadata, so that path can never contribute and
+// modelling it would add a snapshot column no lab row would ever populate.
+func ovnDesired(local []localRouter, effective []*net.IPNet) (natIPs, lrpIPs []string, ipTag map[string]int) {
+	ipTag = make(map[string]int)
+	for _, lr := range local {
+		for _, nat := range lr.nats {
+			ip := net.ParseIP(nat.ExternalIP)
+			if ip == nil || ip.To4() == nil {
+				continue // invalid or non-IPv4: dropped at ingest, like addNBNATs + splitIPv4.
+			}
+			if len(effective) > 0 && !containedInAny(ip, effective) {
+				continue // outside every effective CIDR — appears in no plane (rule 3).
+			}
+			natIPs = append(natIPs, ip.String())
+			ipTag[ip.String()] = lr.segTag
+		}
+		for _, cidr := range lr.networks {
+			ip, _, err := net.ParseCIDR(cidr)
+			if err != nil || ip.To4() == nil {
+				continue
+			}
+			lrpIPs = append(lrpIPs, ip.String())
+			ipTag[ip.String()] = lr.segTag
+		}
+	}
+	return natIPs, lrpIPs, ipTag
+}
+
+// distinctSegments counts the distinct localnet segments the locally-active
+// routers span, keyed by VLAN tag. Two routers on the same provider segment
+// share a tag and count once (mirrors desired_state.go buildDesiredSegments'
+// dedup, which the lab's one-tag-per-segment topology makes equivalent).
+func distinctSegments(local []localRouter) int {
+	seen := make(map[int]bool, len(local))
+	for _, lr := range local {
+		seen[lr.segTag] = true
+	}
+	return len(seen)
+}
+
+// kernelDevForTag names the kernel device an IP's /32 route belongs on: the
+// provider bridge for a flat (tag 0) segment, "<bridge>.<tag>" for a VLAN
+// segment (mirrors routing_linux.go segmentIfaceName).
+func kernelDevForTag(bridge string, tag int) string {
+	if tag == 0 {
+		return bridge
+	}
+	return fmt.Sprintf("%s.%d", bridge, tag)
+}
+
+// =============================================================================
+// nftables / VIP derivations (config only)
+// =============================================================================
+
+// docPortForwardRule is one flattened port-forward rule from the config doc.
+type docPortForwardRule struct {
+	Proto    string
+	Port     int
+	DestAddr string
+	DestPort int
+}
+
+// docPortForward is one flattened port_forwards entry from the config doc.
+type docPortForward struct {
+	VIP               string
+	ManageVIP         bool
+	HairpinMasquerade bool
+	Rules             []docPortForwardRule
+}
+
+// docPortForwards narrows the doc's port_forwards block into the fields the
+// oracle reads. It reuses vipsOf/vipAddrOf (flips.go) for the block and each
+// entry's VIP, and reads the rules the config doc leaves as nested maps.
+func docPortForwards(doc map[string]any) []docPortForward {
+	var out []docPortForward
+	for _, entry := range vipsOf(doc) {
+		m, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		pf := docPortForward{
+			VIP:               vipAddrOf(entry),
+			ManageVIP:         boolValue(m["manage_vip"]),
+			HairpinMasquerade: boolValue(m["hairpin_masquerade"]),
+		}
+		rules, _ := m["rules"].([]any)
+		for _, r := range rules {
+			rm, ok := r.(map[string]any)
+			if !ok {
+				continue
+			}
+			proto, _ := rm["proto"].(string)
+			addr, _ := rm["dest_addr"].(string)
+			pf.Rules = append(pf.Rules, docPortForwardRule{
+				Proto:    proto,
+				Port:     intValue(rm["port"]),
+				DestAddr: addr,
+				DestPort: intValue(rm["dest_port"]),
+			})
+		}
+		out = append(out, pf)
+	}
+	return out
+}
+
+// dnatExpectations renders one DNAT rule expectation per configured rule. The
+// backend is the rule's dest_addr (the config the agent renders already carries
+// the gateway's own mgmtIP there); the post-DNAT port defaults to the ingress
+// port when the rule does not translate it (mirrors PortForwardRule.destPort).
+func dnatExpectations(forwards []docPortForward) []dnatExpectation {
+	var out []dnatExpectation
+	for _, pf := range forwards {
+		for _, r := range pf.Rules {
+			destPort := r.DestPort
+			if destPort == 0 {
+				destPort = r.Port
+			}
+			out = append(out, dnatExpectation{
+				VIP:      pf.VIP,
+				Proto:    r.Proto,
+				Port:     r.Port,
+				Backend:  r.DestAddr,
+				DestPort: destPort,
+			})
+		}
+	}
+	return out
+}
+
+// hairpinMasqueradeVIPs returns the VIPs whose nftables ruleset carries the
+// hairpin-masquerade rule. buildNftRuleset emits it only when the VIP has
+// hairpin_masquerade set and there is at least one provider network to match a
+// source against, so the effective-network set gates it too.
+func hairpinMasqueradeVIPs(forwards []docPortForward, effective []*net.IPNet) []string {
+	if len(effective) == 0 {
+		return nil
+	}
+	var out []string
+	for _, pf := range forwards {
+		if pf.HairpinMasquerade {
+			out = append(out, pf.VIP)
+		}
+	}
+	return sortedUnique(out)
+}
+
+// managedVIPs returns the VIP addresses the agent adds as /32 on the port
+// forward device, for VIPs with manage_vip on.
+func managedVIPs(forwards []docPortForward) []string {
+	var out []string
+	for _, pf := range forwards {
+		if pf.ManageVIP {
+			out = append(out, pf.VIP)
+		}
+	}
+	return sortedUnique(out)
+}
+
+// vipAddresses returns every configured VIP address.
+func vipAddresses(forwards []docPortForward) []string {
+	out := make([]string, 0, len(forwards))
+	for _, pf := range forwards {
+		out = append(out, pf.VIP)
+	}
+	return out
+}
+
+// =============================================================================
+// Doc helpers
+// =============================================================================
+
+// docRemoteSet reports whether an OVN remote key is present and non-empty,
+// matching validateMode's `cfg.OVNSBRemote != ""` test.
+func docRemoteSet(doc map[string]any, key string) bool {
+	s, _ := doc[key].(string)
+	return s != ""
+}
+
+// docString reads a string key, falling back to def when absent or empty.
+func docString(doc map[string]any, key, def string) string {
+	if s, ok := doc[key].(string); ok && s != "" {
+		return s
+	}
+	return def
+}
+
+// docDrainOnShutdown reports whether the config drains gateways on shutdown,
+// treating an absent key as false — as the agent's config layering does. Used
+// by the oracle's settle loop (a later commit) to decide how a terminated
+// gateway is expected to hand its chassis over.
+func docDrainOnShutdown(doc map[string]any) bool {
+	return boolValue(doc["drain_on_shutdown"])
+}
+
+// =============================================================================
+// Small pure helpers
+// =============================================================================
+
+// effectiveNetworks returns the network filters in effect: the manual
+// network_cidr when set, else the networks discovered from the locally-active
+// LRPs (config.go effectiveNetworkFilters). IPv4-only, matching the agent's
+// computeEffectiveNetworks.
+func effectiveNetworks(doc map[string]any, local []localRouter) []*net.IPNet {
+	if manual := stringsOf(doc["network_cidr"]); len(manual) > 0 {
+		return parseNetworks(manual)
+	}
+	var discovered []string
+	for _, lr := range local {
+		discovered = append(discovered, lr.networks...)
+	}
+	return parseNetworks(discovered)
+}
+
+// parseNetworks parses CIDR strings into their networks, dropping malformed and
+// non-IPv4 entries and deduplicating by network.
+func parseNetworks(cidrs []string) []*net.IPNet {
+	var out []*net.IPNet
+	seen := make(map[string]bool, len(cidrs))
+	for _, s := range cidrs {
+		_, n, err := net.ParseCIDR(s)
+		if err != nil || n.IP.To4() == nil || seen[n.String()] {
+			continue
+		}
+		seen[n.String()] = true
+		out = append(out, n)
+	}
+	return out
+}
+
+// networkStrings renders the networks as sorted CIDR strings — the form the FRR
+// prefix-list carries (net.IPNet.String()).
+func networkStrings(nets []*net.IPNet) []string {
+	out := make([]string, 0, len(nets))
+	for _, n := range nets {
+		out = append(out, n.String())
+	}
+	sort.Strings(out)
+	return out
+}
+
+// containedInAny reports whether ip falls inside any of the networks.
+func containedInAny(ip net.IP, nets []*net.IPNet) bool {
+	for _, n := range nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// coveredBy returns the subset of ips contained in some network, sorted. It is
+// the presence bound on a full-mode active gateway: only desired IPs inside an
+// effective network are permitted by the prefix-list and so must be announced.
+func coveredBy(ips []string, nets []*net.IPNet) []string {
+	var out []string
+	for _, s := range ips {
+		if ip := net.ParseIP(s); ip != nil && containedInAny(ip, nets) {
+			out = append(out, s)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// sortedUnique trims, deduplicates and sorts a list of strings.
+func sortedUnique(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	var out []string
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v != "" && !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// boolValue reads a bool from a config value, treating a missing key as false.
+func boolValue(v any) bool {
+	b, _ := v.(bool)
+	return b
+}
+
+// intValue reads an int from a config value across the numeric types a YAML
+// round-trip (or a hand-built doc) may produce.
+func intValue(v any) int {
+	switch n := v.(type) {
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	default:
+		return 0
+	}
+}

--- a/test/e2e/chaos/expect_test.go
+++ b/test/e2e/chaos/expect_test.go
@@ -1,0 +1,400 @@
+package main
+
+import (
+	"testing"
+)
+
+// The oracle follows the chassisredirect owner: the gateway that owns a
+// router's CR port carries that router's FIP and gateway-IP routes on the right
+// per-segment kernel device, while a standby gateway carries nothing at all.
+func TestExpectationFollowsTheChassisredirectOwner(t *testing.T) {
+	// gateway-1 owns the flat router and a VLAN-101 router; gateway-2 owns
+	// nothing, so it is a standby.
+	snap := ovnSnapshot{
+		CRPortChassis: map[string]string{
+			"cr-lr0-public":        "gateway-1",
+			"cr-lr-vlan101-public": "gateway-1",
+		},
+		LRPs: map[string]lrpRow{
+			"lr0-public":        {Networks: []string{"192.0.2.1/24"}, GatewayChassis: []string{"gc-lr0-1"}},
+			"lr-vlan101-public": {Networks: []string{"198.51.100.1/24"}, GatewayChassis: []string{"gc-v101-1"}},
+		},
+		LRPNameByUUID: map[string]string{
+			"uuid-lr0-public":        "lr0-public",
+			"uuid-lr-vlan101-public": "lr-vlan101-public",
+		},
+		Routers: map[string]routerRow{
+			"lr0": {
+				LRPUUIDs: []string{"uuid-lr0-public"},
+				NATs:     []natRow{{ExternalIP: "192.0.2.10", Type: "dnat_and_snat"}},
+			},
+			"lr-vlan101": {
+				LRPUUIDs: []string{"uuid-lr-vlan101-public"},
+				NATs:     []natRow{{ExternalIP: "198.51.100.10", Type: "dnat_and_snat"}},
+			},
+		},
+		GatewayChassis: map[string]gatewayChassisRow{
+			"gc-lr0-1":  {Name: "lr0-public-gateway-1", ChassisName: "gateway-1", Priority: 30},
+			"gc-v101-1": {Name: "lr-vlan101-public-gateway-1", ChassisName: "gateway-1", Priority: 30},
+		},
+		StaticRoutes: []staticRouteRow{
+			{UUID: "sr-1", IPPrefix: "192.0.2.10/32", ExternalIDs: map[string]string{"ovn-network-agent": "managed"}},
+		},
+		Chassis:         map[string]bool{"gateway-1": true, "gateway-2": true, "gateway-3": true},
+		SegmentTagByLRP: map[string]int{"lr0-public": 0, "lr-vlan101-public": 101},
+	}
+	doc := fullModeDoc(t)
+
+	t.Run("active owner", func(t *testing.T) {
+		exp := computeExpectation(snap, "gateway-1", doc, "172.20.20.4")
+
+		if exp.Mode != "full" || !exp.Active {
+			t.Fatalf("mode=%q active=%v, want a full-mode active gateway", exp.Mode, exp.Active)
+		}
+		wantIPs := []string{"192.0.2.1", "192.0.2.10", "198.51.100.1", "198.51.100.10"}
+		assertSet(t, "DesiredIPs", exp.DesiredIPs, wantIPs)
+		assertSet(t, "FRRStatic", exp.FRRStatic, wantIPs)
+		assertSet(t, "Hairpin", exp.Hairpin, wantIPs)
+		// The flat FIP/gateway IPs route on br-ex; the VLAN-101 ones route on
+		// the segment subinterface br-ex.101.
+		assertDevs(t, exp.KernelRouteDev, map[string]string{
+			"192.0.2.1":     "br-ex",
+			"192.0.2.10":    "br-ex",
+			"198.51.100.1":  "br-ex.101",
+			"198.51.100.10": "br-ex.101",
+		})
+		if exp.SkipKernel {
+			t.Fatal("kernel plane must not be skipped on a full-mode gateway")
+		}
+		assertSet(t, "PrefixList", exp.PrefixList, []string{"192.0.2.0/24", "198.51.100.0/24"})
+		// Two segments (flat + VLAN-101), two MAC-tweak flows each.
+		if exp.MACTweakFlows != 4 {
+			t.Fatalf("MACTweakFlows = %d, want 4 (two per segment, two segments)", exp.MACTweakFlows)
+		}
+		assertSet(t, "MustAnnounce", exp.MustAnnounce, wantIPs)
+		assertSet(t, "AnnounceBound", exp.AnnounceBound, wantIPs)
+	})
+
+	t.Run("standby owner", func(t *testing.T) {
+		exp := computeExpectation(snap, "gateway-2", doc, "172.20.20.5")
+
+		if exp.Active {
+			t.Fatal("gateway-2 owns no CR port, it must not be active")
+		}
+		if len(exp.DesiredIPs) != 0 {
+			t.Fatalf("DesiredIPs = %v, want none on a standby gateway", exp.DesiredIPs)
+		}
+		if len(exp.FRRStatic) != 0 {
+			t.Fatalf("FRRStatic = %v, want no FRR routes on a standby gateway", exp.FRRStatic)
+		}
+		if len(exp.KernelRouteDev) != 0 {
+			t.Fatalf("KernelRouteDev = %v, want no kernel routes on a standby gateway", exp.KernelRouteDev)
+		}
+		// The agent removes the hairpin flows and cleans the prefix-list on a
+		// standby node.
+		if exp.Hairpin != nil {
+			t.Fatalf("Hairpin = %v, want the empty set on a standby gateway", exp.Hairpin)
+		}
+		if exp.SkipHairpin {
+			t.Fatal("the hairpin plane is verified (not skipped) in full mode")
+		}
+		if exp.PrefixList != nil {
+			t.Fatalf("PrefixList = %v, want it absent (nil) on a standby gateway", exp.PrefixList)
+		}
+		// The agent does not clean MAC-tweak flows on standby, so the count is
+		// unknowable and the check is skipped.
+		if exp.MACTweakFlows != -1 {
+			t.Fatalf("MACTweakFlows = %d, want -1 (skip) on a standby gateway", exp.MACTweakFlows)
+		}
+		if len(exp.MustAnnounce) != 0 {
+			t.Fatalf("MustAnnounce = %v, want nothing required on a standby gateway", exp.MustAnnounce)
+		}
+	})
+}
+
+// A NAT IP outside the network_cidr filter must fall out of every plane, while
+// the router's own gateway IPs stay desired regardless of the filter — and the
+// announced presence set drops the desired IPs the filter does not cover.
+func TestExpectationExcludesFIPsOutsideTheNetworkCIDRFilter(t *testing.T) {
+	snap := ovnSnapshot{
+		CRPortChassis: map[string]string{"cr-lr0-public": "gateway-1"},
+		LRPs: map[string]lrpRow{
+			// One gateway IP inside the filter, one outside it.
+			"lr0-public": {Networks: []string{"192.0.2.1/24", "203.0.113.1/24"}},
+		},
+		LRPNameByUUID: map[string]string{"uuid-lr0-public": "lr0-public"},
+		Routers: map[string]routerRow{
+			"lr0": {
+				LRPUUIDs: []string{"uuid-lr0-public"},
+				NATs: []natRow{
+					{ExternalIP: "192.0.2.10", Type: "dnat_and_snat"},   // inside the filter
+					{ExternalIP: "203.0.113.10", Type: "dnat_and_snat"}, // outside the filter
+				},
+			},
+		},
+		SegmentTagByLRP: map[string]int{"lr0-public": 0},
+	}
+	doc := fullModeDoc(t)
+	doc["network_cidr"] = anySlice([]string{"192.0.2.0/24"})
+
+	exp := computeExpectation(snap, "gateway-1", doc, "172.20.20.4")
+
+	// The FIP outside the filter is in no plane.
+	if containsStr(exp.DesiredIPs, "203.0.113.10") {
+		t.Fatalf("DesiredIPs = %v, the out-of-filter FIP must not be desired", exp.DesiredIPs)
+	}
+	// The in-filter FIP and both gateway IPs stay desired (gateway IPs are not
+	// filtered).
+	for _, ip := range []string{"192.0.2.10", "192.0.2.1", "203.0.113.1"} {
+		if !containsStr(exp.DesiredIPs, ip) {
+			t.Fatalf("DesiredIPs = %v, want it to include %s", exp.DesiredIPs, ip)
+		}
+	}
+	// The manual filter is exactly the prefix-list.
+	assertSet(t, "PrefixList", exp.PrefixList, []string{"192.0.2.0/24"})
+	// The presence set keeps only the covered desired IPs.
+	assertSet(t, "MustAnnounce", exp.MustAnnounce, []string{"192.0.2.1", "192.0.2.10"})
+	if containsStr(exp.MustAnnounce, "203.0.113.1") || containsStr(exp.MustAnnounce, "203.0.113.10") {
+		t.Fatalf("MustAnnounce = %v, uncovered IPs must not be required to announce", exp.MustAnnounce)
+	}
+	// The staleness bound is exactly the desired set.
+	assertSet(t, "AnnounceBound", exp.AnnounceBound, exp.DesiredIPs)
+}
+
+// Port-forward-only mode has no OVN view at all: every OVN-driven plane is
+// skipped, the desired set is the VIPs alone, and only the DNAT/FRR/announce
+// planes carry anything.
+func TestExpectationPortForwardOnlySkipsEveryOVNPlane(t *testing.T) {
+	// A snapshot that would make gateway-1 active in full mode — to prove the
+	// pf-only path ignores OVN entirely.
+	snap := ovnSnapshot{
+		CRPortChassis: map[string]string{"cr-lr0-public": "gateway-1"},
+		LRPs:          map[string]lrpRow{"lr0-public": {Networks: []string{"192.0.2.1/24"}}},
+		LRPNameByUUID: map[string]string{"uuid-lr0-public": "lr0-public"},
+		Routers: map[string]routerRow{"lr0": {
+			LRPUUIDs: []string{"uuid-lr0-public"},
+			NATs:     []natRow{{ExternalIP: "192.0.2.10", Type: "dnat_and_snat"}},
+		}},
+		SegmentTagByLRP: map[string]int{"lr0-public": 0},
+	}
+	doc := render(t, profileGateway(t, "pf-only", "gateway-1"), "172.20.20.5")
+
+	exp := computeExpectation(snap, "gateway-1", doc, "172.20.20.5")
+
+	if exp.Mode != "pf-only" {
+		t.Fatalf("mode = %q, want pf-only when both OVN remotes are absent", exp.Mode)
+	}
+	if exp.Active {
+		t.Fatal("a pf-only gateway holds no OVN view and can never be active")
+	}
+	// Desired is the VIP alone — no FIPs, no gateway IPs.
+	assertSet(t, "DesiredIPs", exp.DesiredIPs, []string{apiVIPAddr})
+	assertSet(t, "FRRStatic", exp.FRRStatic, []string{apiVIPAddr})
+	if !exp.SkipKernel || !exp.SkipHairpin || !exp.SkipPrefixList {
+		t.Fatalf("pf-only must skip the kernel/OVS/prefix planes: skipKernel=%v skipHairpin=%v skipPrefix=%v",
+			exp.SkipKernel, exp.SkipHairpin, exp.SkipPrefixList)
+	}
+	if exp.PrefixList != nil {
+		t.Fatalf("PrefixList = %v, want it untouched (nil) in pf-only", exp.PrefixList)
+	}
+	if exp.MACTweakFlows != -1 {
+		t.Fatalf("MACTweakFlows = %d, want -1 (skip) in pf-only", exp.MACTweakFlows)
+	}
+	// The presence bound is the VIP set.
+	if !containsStr(exp.MustAnnounce, apiVIPAddr) {
+		t.Fatalf("MustAnnounce = %v, want it to require the VIP", exp.MustAnnounce)
+	}
+	assertSet(t, "AnnounceBound", exp.AnnounceBound, []string{apiVIPAddr})
+	// The one DNAT rule forwards the API VIP to the gateway's own backend.
+	assertDNAT(t, exp.DNAT, []dnatExpectation{
+		{VIP: apiVIPAddr, Proto: "tcp", Port: apiVIPPort, Backend: "172.20.20.5", DestPort: apiVIPPort},
+	})
+}
+
+// With no port_forwards the agent's nftables table carries no DNAT chains and
+// manages no VIP address; with the API VIP it carries exactly the one DNAT rule
+// to the gateway's mgmtIP, and the hairpin-masquerade set follows the flag.
+func TestExpectationWithoutPortForwardsExpectsNoDNAT(t *testing.T) {
+	// An active gateway, so the effective-network set that gates the hairpin
+	// masquerade rule is non-empty.
+	snap := ovnSnapshot{
+		CRPortChassis:   map[string]string{"cr-lr0-public": "gateway-1"},
+		LRPs:            map[string]lrpRow{"lr0-public": {Networks: []string{"192.0.2.1/24"}}},
+		LRPNameByUUID:   map[string]string{"uuid-lr0-public": "lr0-public"},
+		Routers:         map[string]routerRow{"lr0": {LRPUUIDs: []string{"uuid-lr0-public"}}},
+		SegmentTagByLRP: map[string]int{"lr0-public": 0},
+	}
+
+	t.Run("no port forwards", func(t *testing.T) {
+		exp := computeExpectation(snap, "gateway-1", fullModeDoc(t), "172.20.20.4")
+		if len(exp.DNAT) != 0 {
+			t.Fatalf("DNAT = %v, want no rules without port_forwards", exp.DNAT)
+		}
+		if len(exp.ManagedVIPs) != 0 {
+			t.Fatalf("ManagedVIPs = %v, want none without port_forwards", exp.ManagedVIPs)
+		}
+	})
+
+	t.Run("api vip", func(t *testing.T) {
+		doc := render(t, gwConfig{apiVIP: true}, "172.20.20.4")
+
+		exp := computeExpectation(snap, "gateway-1", doc, "172.20.20.4")
+		assertDNAT(t, exp.DNAT, []dnatExpectation{
+			{VIP: apiVIPAddr, Proto: "tcp", Port: apiVIPPort, Backend: "172.20.20.4", DestPort: apiVIPPort},
+		})
+		assertSet(t, "ManagedVIPs", exp.ManagedVIPs, []string{apiVIPAddr})
+		if exp.PortForwardDev != "loopback1" {
+			t.Fatalf("PortForwardDev = %q, want the loopback1 default", exp.PortForwardDev)
+		}
+		// The profile ships the API VIP with hairpin_masquerade off.
+		if len(exp.HairpinMasquerade) != 0 {
+			t.Fatalf("HairpinMasquerade = %v, want none while the flag is off", exp.HairpinMasquerade)
+		}
+
+		// Turn the flag on and the VIP joins the hairpin-masquerade set.
+		apiVIPIn(doc)["hairpin_masquerade"] = true
+		exp = computeExpectation(snap, "gateway-1", doc, "172.20.20.4")
+		assertSet(t, "HairpinMasquerade", exp.HairpinMasquerade, []string{apiVIPAddr})
+	})
+}
+
+// The announced set is staleness-bounded in every mode: announced ⊆ desired
+// always holds, so a FIP churned out of OVN leaves the expected set and the
+// upstream may no longer announce it.
+func TestExpectationAnnouncedSetIsStalenessBounded(t *testing.T) {
+	base := ovnSnapshot{
+		CRPortChassis:   map[string]string{"cr-lr0-public": "gateway-1"},
+		LRPs:            map[string]lrpRow{"lr0-public": {Networks: []string{"192.0.2.1/24"}}},
+		LRPNameByUUID:   map[string]string{"uuid-lr0-public": "lr0-public"},
+		SegmentTagByLRP: map[string]int{"lr0-public": 0},
+	}
+	withFIP := base
+	withFIP.Routers = map[string]routerRow{"lr0": {
+		LRPUUIDs: []string{"uuid-lr0-public"},
+		NATs:     []natRow{{ExternalIP: "192.0.2.10", Type: "dnat_and_snat"}},
+	}}
+	churned := base
+	churned.Routers = map[string]routerRow{"lr0": {LRPUUIDs: []string{"uuid-lr0-public"}}}
+
+	doc := fullModeDoc(t)
+
+	t.Run("full mode active", func(t *testing.T) {
+		exp := computeExpectation(withFIP, "gateway-1", doc, "172.20.20.4")
+		// The bound is exactly the desired set, and the presence set is within it.
+		assertSet(t, "AnnounceBound", exp.AnnounceBound, exp.DesiredIPs)
+		if !subset(exp.MustAnnounce, exp.AnnounceBound) {
+			t.Fatalf("MustAnnounce %v is not within AnnounceBound %v", exp.MustAnnounce, exp.AnnounceBound)
+		}
+		if !containsStr(exp.AnnounceBound, "192.0.2.10") {
+			t.Fatalf("AnnounceBound = %v, want it to carry the live FIP", exp.AnnounceBound)
+		}
+	})
+
+	t.Run("churned FIP leaves the bound", func(t *testing.T) {
+		exp := computeExpectation(churned, "gateway-1", doc, "172.20.20.4")
+		if containsStr(exp.AnnounceBound, "192.0.2.10") {
+			t.Fatalf("AnnounceBound = %v, the churned-away FIP must have left it", exp.AnnounceBound)
+		}
+		assertSet(t, "AnnounceBound", exp.AnnounceBound, exp.DesiredIPs)
+	})
+
+	t.Run("full mode standby", func(t *testing.T) {
+		exp := computeExpectation(withFIP, "gateway-2", doc, "172.20.20.5")
+		// A standby node desires nothing, so the bound is empty and the subset
+		// relation still holds trivially.
+		assertSet(t, "AnnounceBound", exp.AnnounceBound, exp.DesiredIPs)
+		if !subset(exp.MustAnnounce, exp.AnnounceBound) {
+			t.Fatalf("MustAnnounce %v is not within AnnounceBound %v", exp.MustAnnounce, exp.AnnounceBound)
+		}
+	})
+
+	t.Run("port-forward only", func(t *testing.T) {
+		pfDoc := render(t, profileGateway(t, "pf-only", "gateway-1"), "172.20.20.5")
+		exp := computeExpectation(withFIP, "gateway-1", pfDoc, "172.20.20.5")
+		// The bound is the VIP set, and the presence set matches it.
+		assertSet(t, "AnnounceBound", exp.AnnounceBound, []string{apiVIPAddr})
+		assertSet(t, "AnnounceBound", exp.AnnounceBound, exp.DesiredIPs)
+		if !subset(exp.MustAnnounce, exp.AnnounceBound) {
+			t.Fatalf("MustAnnounce %v is not within AnnounceBound %v", exp.MustAnnounce, exp.AnnounceBound)
+		}
+	})
+}
+
+// fullModeDoc is the baked gwnode config parsed into a doc — both OVN remotes
+// present, no port_forwards, no manual filter — the full-mode starting point
+// the per-test overlays build on.
+func fullModeDoc(t *testing.T) map[string]any {
+	t.Helper()
+	doc, err := parseConfig(baseConfig(t))
+	if err != nil {
+		t.Fatalf("parseConfig(baseConfig): %v", err)
+	}
+	return doc
+}
+
+// assertSet fails unless got equals want as an ordered set (both come sorted
+// out of the oracle / test literals).
+func assertSet(t *testing.T, name string, got, want []string) {
+	t.Helper()
+	if !equalStrings(got, want) {
+		t.Fatalf("%s = %v, want %v", name, got, want)
+	}
+}
+
+func assertDevs(t *testing.T, got, want map[string]string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("KernelRouteDev = %v, want %v", got, want)
+	}
+	for ip, dev := range want {
+		if got[ip] != dev {
+			t.Fatalf("KernelRouteDev[%s] = %q, want %q", ip, got[ip], dev)
+		}
+	}
+}
+
+func assertDNAT(t *testing.T, got, want []dnatExpectation) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("DNAT = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("DNAT[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func subset(sub, super []string) bool {
+	set := make(map[string]bool, len(super))
+	for _, s := range super {
+		set[s] = true
+	}
+	for _, s := range sub {
+		if !set[s] {
+			return false
+		}
+	}
+	return true
+}
+
+func containsStr(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/chaos/fakes_test.go
+++ b/test/e2e/chaos/fakes_test.go
@@ -250,3 +250,363 @@ func eventsIn(t *testing.T, journal string) []event {
 	}
 	return out
 }
+
+// =============================================================================
+// Oracle lab fixture
+// =============================================================================
+//
+// oracleLab is a consistent set of canned answers for every query the oracle
+// makes, modelled on the everything-on profile: one router lr0 whose
+// distributed LRP lr0-public is owned by gateway-1, three Gateway_Chassis
+// candidates, two dnat_and_snat NATs, two managed static routes, and a flat
+// provider segment. It is built so a "green" fixture really evaluates green —
+// the observed data planes match what computeExpectation derives from the OVN
+// tables — and tests mutate one field before running to diverge a single
+// plane. Tests needing time-dependent behaviour (a plane that heals, a metric
+// that climbs) wrap respond with their own counter.
+
+// gwFIPs is the desired IP set the active gateway carries: the LRP gateway IP
+// (192.0.2.1) and the two NAT external IPs, all on the flat br-ex segment.
+var gwFIPs = []string{"192.0.2.1", "192.0.2.10", "192.0.2.12"}
+
+type gcExtra struct {
+	uuid, name, chassis string
+	priority            int
+}
+
+type managedRoute struct {
+	uuid, prefix, chassis, advertised string
+}
+
+type oracleLab struct {
+	t *testing.T
+
+	crOwner  string         // chassis owning cr-lr0-public
+	priority map[string]int // Gateway_Chassis priority per gateway
+	lrpGC    []string       // Gateway_Chassis row UUIDs on lr0-public
+	extraGC  []gcExtra      // Gateway_Chassis rows beyond the three candidates
+	managed  []managedRoute // managed static routes
+	snapErr  bool           // fail the OVN snapshot on every poll
+	marker   map[string]bool
+	drainEnv string // printenv OVN_NETWORK_DRAIN_ON_SHUTDOWN answer
+
+	dropKernel  map[string]string // gw → an IP to omit from proto-44 routes
+	consecutive map[string]int    // gw → ovn_network_agent_consecutive_readds
+	inactive    map[string]int    // gw → ovn_network_agent_inactive_routes
+	readds      map[string]int    // gw → ovn_network_agent_route_readds_total
+}
+
+func newOracleLab(t *testing.T) *oracleLab {
+	return &oracleLab{
+		t:        t,
+		crOwner:  "gateway-1",
+		priority: map[string]int{"gateway-1": 30, "gateway-2": 20, "gateway-3": 10},
+		lrpGC:    []string{"gc-gateway-1", "gc-gateway-2", "gc-gateway-3"},
+		managed: []managedRoute{
+			{uuid: "sr-10", prefix: "192.0.2.10/32", chassis: "gateway-1"},
+			{uuid: "sr-12", prefix: "192.0.2.12/32", chassis: "gateway-1"},
+		},
+		marker:      map[string]bool{},
+		drainEnv:    "false",
+		dropKernel:  map[string]string{},
+		consecutive: map[string]int{},
+		inactive:    map[string]int{},
+		readds:      map[string]int{},
+	}
+}
+
+func (o *oracleLab) respond(argv []string) (string, error) {
+	line := strings.Join(argv, " ")
+	has := func(s string) bool { return strings.Contains(line, s) }
+
+	if o.snapErr && has("list Chassis") {
+		return "", errBoom
+	}
+	switch {
+	case has("find Port_Binding type=chassisredirect"):
+		return o.portBinding(), nil
+	case has("find Logical_Router_Static_Route"):
+		return o.staticRoutes(), nil
+	case has("list Logical_Router_Port"):
+		return o.lrpTable(), nil
+	case has("list Logical_Router"):
+		return o.routerTable(), nil
+	case has("list Logical_Switch_Port"):
+		return o.lspTable(), nil
+	case has("list Logical_Switch"):
+		return o.lsTable(), nil
+	case has("list Gateway_Chassis"):
+		return o.gcTable(), nil
+	case has("list NAT"):
+		return o.natTable(), nil
+	case has("list Chassis"):
+		return o.chassisTable(), nil
+	case has("show bgp ipv4 unicast json"):
+		return o.upstreamBGP(), nil
+	}
+
+	if gw := gatewayOf(line); gw != "" {
+		switch {
+		case has("ip -j route show proto 44"):
+			return o.kernel(gw), nil
+		case has("show ip route vrf vrf-provider static json"):
+			return o.frr(gw), nil
+		case has("show ip prefix-list ANNOUNCED-NETWORKS"):
+			return o.prefixList(gw), nil
+		case has("dump-flows br-ex cookie=0x998"):
+			return o.hairpin(gw), nil
+		case has("dump-flows br-ex cookie=0x999"):
+			return o.macTweak(gw), nil
+		case has("nft list table ip ovn-network-agent"):
+			return "", errExit(o.t, 1) // table absent
+		case has("ip -j addr show dev loopback1"):
+			return "", errExit(o.t, 1) // device absent
+		case has("printenv OVN_NETWORK_DRAIN_ON_SHUTDOWN"):
+			return o.drainEnv + "\n", nil
+		case has("test -f " + profileMarkerPath):
+			if o.marker[gw] {
+				return "", nil
+			}
+			return "", errExit(o.t, 1) // marker absent
+		case has("/metrics"):
+			return o.metrics(gw), nil
+		}
+	}
+	return healthyLabResponses(argv)
+}
+
+// gatewayOf resolves which gateway container an argv targets.
+func gatewayOf(line string) string {
+	for _, gw := range gatewayNames() {
+		if strings.Contains(line, "clab-ovn-e2e-"+gw) {
+			return gw
+		}
+	}
+	return ""
+}
+
+func (o *oracleLab) active(gw string) bool { return gw == o.crOwner }
+
+// ---- OVN snapshot tables ----
+
+func (o *oracleLab) chassisTable() string {
+	rows := [][]any{}
+	for _, gw := range gatewayNames() {
+		rows = append(rows, []any{ovsUUID("ch-" + gw), gw})
+	}
+	return ovsTable([]string{"_uuid", "name"}, rows)
+}
+
+func (o *oracleLab) portBinding() string {
+	chassis := any(ovsSet())
+	if o.crOwner != "" {
+		chassis = ovsUUID("ch-" + o.crOwner)
+	}
+	return ovsTable([]string{"logical_port", "chassis"},
+		[][]any{{"cr-lr0-public", chassis}})
+}
+
+func (o *oracleLab) natTable() string {
+	return ovsTable([]string{"_uuid", "external_ip", "type"}, [][]any{
+		{ovsUUID("nat-10"), "192.0.2.10", "dnat_and_snat"},
+		{ovsUUID("nat-12"), "192.0.2.12", "dnat_and_snat"},
+	})
+}
+
+func (o *oracleLab) lrpTable() string {
+	return ovsTable([]string{"_uuid", "name", "networks", "gateway_chassis"},
+		[][]any{{ovsUUID("lrp-public"), "lr0-public", "192.0.2.1/24", gcRefs(o.lrpGC)}})
+}
+
+func (o *oracleLab) routerTable() string {
+	return ovsTable([]string{"_uuid", "name", "ports", "nat"},
+		[][]any{{ovsUUID("lr0"), "lr0", ovsUUID("lrp-public"),
+			ovsSet(ovsUUID("nat-10"), ovsUUID("nat-12"))}})
+}
+
+func (o *oracleLab) gcTable() string {
+	rows := [][]any{}
+	for _, gw := range gatewayNames() {
+		rows = append(rows, []any{ovsUUID("gc-" + gw), "lr0-public-" + gw, gw, o.priority[gw]})
+	}
+	for _, e := range o.extraGC {
+		rows = append(rows, []any{ovsUUID(e.uuid), e.name, e.chassis, e.priority})
+	}
+	return ovsTable([]string{"_uuid", "name", "chassis_name", "priority"}, rows)
+}
+
+func (o *oracleLab) staticRoutes() string {
+	rows := [][]any{}
+	for _, m := range o.managed {
+		ids := []string{"ovn-network-agent", "managed", "ovn-network-agent-chassis", m.chassis}
+		if m.advertised != "" {
+			ids = append(ids, "ovn-network-agent-advertised", m.advertised)
+		}
+		rows = append(rows, []any{ovsUUID(m.uuid), m.prefix, ovsMap(ids...)})
+	}
+	return ovsTable([]string{"_uuid", "ip_prefix", "external_ids"}, rows)
+}
+
+func (o *oracleLab) lsTable() string {
+	return ovsTable([]string{"_uuid", "name", "ports"},
+		[][]any{{ovsUUID("ls-public"), "public", ovsSet(ovsUUID("lsp-ln"), ovsUUID("lsp-router"))}})
+}
+
+func (o *oracleLab) lspTable() string {
+	return ovsTable([]string{"_uuid", "name", "type", "tag", "options"}, [][]any{
+		{ovsUUID("lsp-ln"), "ln-public", "localnet", ovsSet(), ovsMap("network_name", "physnet1")},
+		{ovsUUID("lsp-router"), "public-lr0", "router", ovsSet(), ovsMap("router-port", "lr0-public")},
+	})
+}
+
+// ---- per-gateway observations ----
+
+func (o *oracleLab) kernel(gw string) string {
+	arr := []map[string]string{}
+	if o.active(gw) {
+		for _, ip := range gwFIPs {
+			if o.dropKernel[gw] == ip {
+				continue
+			}
+			arr = append(arr, map[string]string{"dst": ip, "dev": "br-ex"})
+		}
+	}
+	b, _ := json.Marshal(arr)
+	return string(b)
+}
+
+func (o *oracleLab) frr(gw string) string {
+	doc := map[string][]map[string]any{}
+	if o.active(gw) {
+		for _, ip := range gwFIPs {
+			doc[ip+"/32"] = []map[string]any{{"nexthops": []map[string]string{{"ip": "169.254.0.1"}}}}
+		}
+	}
+	b, _ := json.Marshal(doc)
+	return string(b)
+}
+
+func (o *oracleLab) prefixList(gw string) string {
+	if !o.active(gw) {
+		return "" // the agent cleans the list on a standby gateway
+	}
+	return "ip prefix-list ANNOUNCED-NETWORKS: 1 entries\n" +
+		"   seq 5 permit 192.0.2.0/24 ge 32 le 32\n"
+}
+
+func (o *oracleLab) hairpin(gw string) string {
+	var b strings.Builder
+	b.WriteString("NXST_FLOW reply (xid=0x4):\n")
+	if o.active(gw) {
+		for _, ip := range gwFIPs {
+			fmt.Fprintf(&b, " cookie=0x998, table=0, priority=100,ip,nw_dst=%s actions=NORMAL\n", ip)
+		}
+	}
+	return b.String()
+}
+
+func (o *oracleLab) macTweak(gw string) string {
+	var b strings.Builder
+	b.WriteString("NXST_FLOW reply (xid=0x4):\n")
+	if o.active(gw) {
+		b.WriteString(" cookie=0x999, table=0, priority=100,dl_vlan=0 actions=mod_dl_src\n")
+		b.WriteString(" cookie=0x999, table=0, priority=100,dl_vlan=0 actions=mod_dl_dst\n")
+	}
+	return b.String()
+}
+
+func (o *oracleLab) metrics(gw string) string {
+	return fmt.Sprintf("HTTP/1.0 200 OK\r\nContent-Type: text/plain\r\n\r\n"+
+		"# HELP ovn_network_agent_consecutive_readds ...\n"+
+		"ovn_network_agent_consecutive_readds %d\n"+
+		"ovn_network_agent_inactive_routes %d\n"+
+		"ovn_network_agent_route_readds_total{plane=\"kernel\"} %d\n"+
+		"ovn_network_agent_route_readds_total{plane=\"frr\"} 0\n",
+		o.consecutive[gw], o.inactive[gw], o.readds[gw])
+}
+
+func (o *oracleLab) upstreamBGP() string {
+	routes := map[string][]map[string]any{}
+	if o.crOwner != "" {
+		nexthop := addrOf(mustLink(o.t, o.crOwner).gatewayCIDR)
+		for _, ip := range gwFIPs {
+			routes[ip+"/32"] = []map[string]any{{"nexthops": []map[string]any{{"ip": nexthop}}}}
+		}
+	}
+	b, _ := json.Marshal(map[string]any{"routes": routes})
+	return string(b)
+}
+
+func mustLink(t *testing.T, gw string) underlayLink {
+	t.Helper()
+	link, ok := linkFor(gw)
+	if !ok {
+		t.Fatalf("no underlay link for %s", gw)
+	}
+	return link
+}
+
+// ---- OVSDB JSON builders ----
+
+// ovsTable renders one `ovn-{n,s}bctl --format=json` table. Each cell is a
+// scalar (string/int) or one of the ovs* wrappers below.
+func ovsTable(headings []string, rows [][]any) string {
+	if rows == nil {
+		rows = [][]any{}
+	}
+	b, err := json.Marshal(map[string]any{"headings": headings, "data": rows})
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+func ovsUUID(id string) []any { return []any{"uuid", id} }
+
+func ovsSet(items ...any) []any { return []any{"set", items} }
+
+func ovsMap(kv ...string) []any {
+	pairs := [][]any{}
+	for i := 0; i+1 < len(kv); i += 2 {
+		pairs = append(pairs, []any{kv[i], kv[i+1]})
+	}
+	return []any{"map", pairs}
+}
+
+// gcRefs renders a Gateway_Chassis reference column: a bare UUID for one row,
+// an OVSDB set for several, matching how ovsdb collapses single-element sets.
+func gcRefs(uuids []string) any {
+	if len(uuids) == 1 {
+		return ovsUUID(uuids[0])
+	}
+	items := make([]any, 0, len(uuids))
+	for _, u := range uuids {
+		items = append(items, ovsUUID(u))
+	}
+	return ovsSet(items...)
+}
+
+// oracleApplier builds an applier carrying just the config the oracle reads:
+// each gateway's current document and management address.
+func oracleApplier(docs map[string]map[string]any) *applier {
+	a := &applier{current: docs, mgmtIP: map[string]string{}}
+	for _, gw := range gatewayNames() {
+		a.mgmtIP[gw] = "172.20.20.4"
+	}
+	return a
+}
+
+// fullModeDocs parses the baked gwnode config into an independent document per
+// gateway — the everything-on profile, where every gateway runs full OVN mode.
+func fullModeDocs(t *testing.T) map[string]map[string]any {
+	t.Helper()
+	docs := map[string]map[string]any{}
+	for _, gw := range gatewayNames() {
+		doc, err := parseConfig(baseConfig(t))
+		if err != nil {
+			t.Fatalf("parse baked config: %v", err)
+		}
+		docs[gw] = doc
+	}
+	return docs
+}

--- a/test/e2e/chaos/journal.go
+++ b/test/e2e/chaos/journal.go
@@ -36,6 +36,8 @@ const (
 	evProbeTransition = "probe-transition"
 	evVIPRepoint      = "vip-repoint"
 	evOVNChurn        = "ovn-churn"
+	evSettleStart     = "settle-start"
+	evSettleResult    = "settle-result"
 	evViolation       = "violation"
 	evCheckError      = "check-error"
 	evRunAborted      = "run-aborted"
@@ -46,30 +48,31 @@ const (
 // one flat struct describes the whole event vocabulary and consumers can
 // branch on `event`.
 type event struct {
-	TS         string           `json:"ts"`
-	Event      string           `json:"event"`
-	Tick       int              `json:"tick,omitempty"`
-	Action     string           `json:"action,omitempty"`
-	Target     string           `json:"target,omitempty"`
-	Peer       string           `json:"peer,omitempty"`
-	Object     string           `json:"object,omitempty"`
-	IntervalMS int64            `json:"interval_ms,omitempty"`
-	HoldMS     int64            `json:"hold_ms,omitempty"`
-	Executed   *bool            `json:"executed,omitempty"`
-	SkipReason string           `json:"skip_reason,omitempty"`
-	Flip       string           `json:"flip,omitempty"`
-	From       string           `json:"from,omitempty"`
-	To         string           `json:"to,omitempty"`
-	Rejected   *bool            `json:"rejected,omitempty"`
-	Probe      string           `json:"probe,omitempty"`
-	Up         *bool            `json:"up,omitempty"`
-	State      string           `json:"state,omitempty"`
-	CROwner    string           `json:"cr_owner,omitempty"`
-	RecoveryMS map[string]int64 `json:"recovery_ms,omitempty"`
-	Kind       string           `json:"kind,omitempty"`
-	Detail     string           `json:"detail,omitempty"`
-	Result     string           `json:"result,omitempty"`
-	Inputs     *runInputs       `json:"inputs,omitempty"`
+	TS          string           `json:"ts"`
+	Event       string           `json:"event"`
+	Tick        int              `json:"tick,omitempty"`
+	Action      string           `json:"action,omitempty"`
+	Target      string           `json:"target,omitempty"`
+	Peer        string           `json:"peer,omitempty"`
+	Object      string           `json:"object,omitempty"`
+	IntervalMS  int64            `json:"interval_ms,omitempty"`
+	HoldMS      int64            `json:"hold_ms,omitempty"`
+	Executed    *bool            `json:"executed,omitempty"`
+	SkipReason  string           `json:"skip_reason,omitempty"`
+	Flip        string           `json:"flip,omitempty"`
+	From        string           `json:"from,omitempty"`
+	To          string           `json:"to,omitempty"`
+	Rejected    *bool            `json:"rejected,omitempty"`
+	Probe       string           `json:"probe,omitempty"`
+	Up          *bool            `json:"up,omitempty"`
+	State       string           `json:"state,omitempty"`
+	CROwner     string           `json:"cr_owner,omitempty"`
+	RecoveryMS  map[string]int64 `json:"recovery_ms,omitempty"`
+	Kind        string           `json:"kind,omitempty"`
+	Detail      string           `json:"detail,omitempty"`
+	Result      string           `json:"result,omitempty"`
+	ConvergedMS int64            `json:"converged_ms,omitempty"`
+	Inputs      *runInputs       `json:"inputs,omitempty"`
 }
 
 // runInputs is the reproducibility contract: identical inputs replay the
@@ -80,13 +83,20 @@ type event struct {
 // and the configuration every agent in it runs, so a seed without a
 // profile does not identify a run.
 type runInputs struct {
-	Seed       int64          `json:"seed"`
-	Profile    string         `json:"profile"`
-	DurationMS int64          `json:"duration_ms"`
-	TickMinMS  int64          `json:"tick_min_ms"`
-	TickMaxMS  int64          `json:"tick_max_ms"`
-	Weights    map[string]int `json:"weights"`
-	Lab        string         `json:"lab"`
+	Seed       int64  `json:"seed"`
+	Profile    string `json:"profile"`
+	DurationMS int64  `json:"duration_ms"`
+	TickMinMS  int64  `json:"tick_min_ms"`
+	TickMaxMS  int64  `json:"tick_max_ms"`
+	// SettleEveryMS/SettleTimeoutMS are the settle-window schedule the
+	// expected-state oracle runs on: how often the run pauses to let the
+	// lab converge and how long it waits before calling that a failure.
+	// They belong to the reproducibility contract because they change how
+	// often the oracle is consulted, so a replay must see the same values.
+	SettleEveryMS   int64          `json:"settle_every_ms"`
+	SettleTimeoutMS int64          `json:"settle_timeout_ms"`
+	Weights         map[string]int `json:"weights"`
+	Lab             string         `json:"lab"`
 }
 
 // journal is the append-only JSONL writer. The prober writes transitions
@@ -96,6 +106,10 @@ type journal struct {
 	w   io.Writer
 	now func() time.Time
 	err error
+	// n is the journal offset: the number of lines successfully emitted so
+	// far. A later commit stamps a violation with this value so the oracle
+	// can point at the offset of the last executed action.
+	n int
 }
 
 func newJournal(w io.Writer, now func() time.Time) *journal {
@@ -114,15 +128,30 @@ func (j *journal) emit(e event) {
 		j.err = fmt.Errorf("marshal %s event: %w", e.Event, err)
 		return
 	}
-	if _, err := fmt.Fprintf(j.w, "%s\n", line); err != nil && j.err == nil {
-		j.err = fmt.Errorf("write %s event: %w", e.Event, err)
+	if _, err := fmt.Fprintf(j.w, "%s\n", line); err != nil {
+		if j.err == nil {
+			j.err = fmt.Errorf("write %s event: %w", e.Event, err)
+		}
+		return
 	}
+	// Only a line that both marshalled and reached the writer advances the
+	// journal offset, so count() never claims a line a reader cannot find.
+	j.n++
 }
 
 func (j *journal) Err() error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	return j.err
+}
+
+// count returns the journal offset — the number of lines emitted so far.
+// A violation is stamped with this value to record which action it
+// followed. It is safe to call from any goroutine.
+func (j *journal) count() int {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.n
 }
 
 func boolPtr(b bool) *bool { return &b }
@@ -160,6 +189,18 @@ type recoveryRecord struct {
 	CROwnerAfter  string           `json:"cr_owner_after"`
 }
 
+// settleRecord is the verdict of one settle window: how long the lab took
+// to match the expected-state oracle, whether it matched at all, and how
+// many invariants it broke while it did not. It is the run record's
+// evidence that the lab was checked against its config, not just that no
+// probe went red.
+type settleRecord struct {
+	Tick        int   `json:"tick"`
+	ConvergedMS int64 `json:"converged_ms"`
+	Passed      bool  `json:"passed"`
+	Violations  int   `json:"violations"`
+}
+
 type violationRecord struct {
 	TS     string `json:"ts"`
 	Kind   string `json:"kind"`
@@ -167,6 +208,11 @@ type violationRecord struct {
 	Action string `json:"action,omitempty"`
 	Target string `json:"target,omitempty"`
 	Detail string `json:"detail"`
+	// JournalOffset is the journal line count at the moment the violation
+	// was recorded, i.e. the offset of the last executed action. It lets a
+	// reader jump from a violation in the run record straight to the
+	// decision in journal.jsonl that produced it.
+	JournalOffset int `json:"journal_offset,omitempty"`
 }
 
 type decisionCounts struct {
@@ -199,6 +245,7 @@ type runRecord struct {
 	ActionsByName map[string]int          `json:"actions_by_name"`
 	Probes        map[string]probeSummary `json:"probes"`
 	Recoveries    []recoveryRecord        `json:"recoveries"`
+	Settles       []settleRecord          `json:"settles"`
 	Violations    []violationRecord       `json:"violations"`
 }
 
@@ -223,6 +270,9 @@ func (r *runRecord) finalize(endedAt time.Time) {
 	}
 	if r.Recoveries == nil {
 		r.Recoveries = []recoveryRecord{}
+	}
+	if r.Settles == nil {
+		r.Settles = []settleRecord{}
 	}
 	if r.Violations == nil {
 		r.Violations = []violationRecord{}

--- a/test/e2e/chaos/journal_test.go
+++ b/test/e2e/chaos/journal_test.go
@@ -67,6 +67,34 @@ type failingWriter struct{}
 
 func (failingWriter) Write([]byte) (int, error) { return 0, errBoom }
 
+// count() is the journal offset a violation is stamped with, so it must
+// track exactly the lines a reader can find: zero on a fresh journal, one
+// per successful emit, and left untouched by a write that never landed.
+func TestJournalCountsEmittedLines(t *testing.T) {
+	clock := newFakeClock()
+	var buf bytes.Buffer
+	j := newJournal(&buf, clock.now)
+
+	if got := j.count(); got != 0 {
+		t.Fatalf("a fresh journal counts %d lines, want 0", got)
+	}
+
+	j.emit(event{Event: evRunStart})
+	j.emit(event{Event: evDecision, Tick: 1})
+	j.emit(event{Event: evSettleStart, Tick: 1})
+	if got := j.count(); got != 3 {
+		t.Fatalf("count = %d after three emits, want 3", got)
+	}
+
+	// A write that never reached the writer must not advance the offset,
+	// or a violation would be stamped with a line no reader can find.
+	failing := newJournal(failingWriter{}, clock.now)
+	failing.emit(event{Event: evRunStart})
+	if got := failing.count(); got != 0 {
+		t.Fatalf("a failed write advanced the offset to %d, want 0", got)
+	}
+}
+
 func TestSummaryFailsOnViolation(t *testing.T) {
 	clock := newFakeClock()
 
@@ -74,6 +102,12 @@ func TestSummaryFailsOnViolation(t *testing.T) {
 	clean.finalize(clock.now())
 	if clean.Result != resultPass {
 		t.Fatalf("result = %q, want %q", clean.Result, resultPass)
+	}
+	// The settle list must be an empty slice, never nil, so it serializes
+	// as [] and a reader can tell "no settle windows ran" from "the field
+	// is missing", exactly as the recovery and violation lists do.
+	if clean.Settles == nil {
+		t.Fatal("finalize left Settles nil; the record must carry [] not null")
 	}
 
 	dirty := &runRecord{Violations: []violationRecord{{Kind: violationDualClaim, Detail: "cr-lr0-public"}}}
@@ -95,6 +129,56 @@ func TestSummaryFailsOnViolation(t *testing.T) {
 	}
 	if decoded.Result != resultFail || len(decoded.Violations) != 1 {
 		t.Fatalf("run record lost the violation: %+v", decoded)
+	}
+	if !strings.Contains(buf.String(), `"settles": []`) {
+		t.Fatalf("an empty settle list serialized as null instead of []: %s", buf.String())
+	}
+}
+
+// The journal offset points a violation at the decision line that caused
+// it. A recorded offset must serialize; a zero one is the "no offset
+// recorded" case, which omitempty keeps out of the record.
+func TestViolationRecordSerializesTheJournalOffset(t *testing.T) {
+	stamped, err := json.Marshal(violationRecord{Kind: violationDualClaim, JournalOffset: 7})
+	if err != nil {
+		t.Fatalf("marshal stamped violation: %v", err)
+	}
+	if !strings.Contains(string(stamped), `"journal_offset":7`) {
+		t.Fatalf("the violation dropped its journal offset: %s", stamped)
+	}
+
+	unstamped, err := json.Marshal(violationRecord{Kind: violationDualClaim})
+	if err != nil {
+		t.Fatalf("marshal unstamped violation: %v", err)
+	}
+	if strings.Contains(string(unstamped), "journal_offset") {
+		t.Fatalf("a zero journal offset leaked into the record: %s", unstamped)
+	}
+}
+
+// The settle-window schedule is part of the reproducibility contract, so
+// both keys must reach the run inputs verbatim — and, unlike the omitempty
+// event fields, even at zero, or a replay cannot tell "not set" from "set
+// to the value it computed".
+func TestRunInputsSerializeTheSettleSchedule(t *testing.T) {
+	set, err := json.Marshal(runInputs{SettleEveryMS: 5000, SettleTimeoutMS: 30000})
+	if err != nil {
+		t.Fatalf("marshal run inputs: %v", err)
+	}
+	for _, key := range []string{`"settle_every_ms":5000`, `"settle_timeout_ms":30000`} {
+		if !strings.Contains(string(set), key) {
+			t.Fatalf("the run inputs dropped %s: %s", key, set)
+		}
+	}
+
+	zero, err := json.Marshal(runInputs{})
+	if err != nil {
+		t.Fatalf("marshal zero run inputs: %v", err)
+	}
+	for _, key := range []string{`"settle_every_ms":0`, `"settle_timeout_ms":0`} {
+		if !strings.Contains(string(zero), key) {
+			t.Fatalf("a zero settle schedule was dropped from the contract: %s", zero)
+		}
 	}
 }
 

--- a/test/e2e/chaos/main.go
+++ b/test/e2e/chaos/main.go
@@ -15,6 +15,14 @@
 // outages on the central node, management-path impairment, data-plane
 // drift the agent self-heals, routing flaps, and OVN churn.
 //
+// Between faults the run pauses for a settle window (issue #179): a
+// config-aware expected-state oracle polls every gateway's live data plane
+// until it matches the exact state its configuration demands, or the window
+// times out into a violation. So a run asserts the lab converged to its
+// expected state, not merely that no probe went red. -settle-every sets the
+// cadence (0 runs only a final settle after the last fault) and
+// -settle-timeout how long each window waits for convergence.
+//
 // Reproducibility is the contract: the profile, the seed, the duration,
 // the tick bounds and the action weights are the only inputs, and every
 // decision the engine makes is drawn from a PCG stream seeded by -seed
@@ -65,18 +73,30 @@ const minDuration = time.Second
 // that is already broken, where a `docker exec` can hang for good.
 const collectTimeout = 2 * time.Minute
 
+// minSettleTimeout is the floor under -settle-timeout. The timeout bounds how
+// long a window may take to reach its *first* all-green evaluation — the
+// confirmation that follows one is not deadline-bounded — so the window has to
+// outlast one slow-cadence reconcile (slowCadence = "15s" in flips.go) for a
+// fault to converge at all, plus the confirmation gap (settleConfirmDelay =
+// 20s) a first green that fails its confirmation burns before the loop can try
+// again. Below that a lab that was healing correctly times out into false
+// violations.
+const minSettleTimeout = 35 * time.Second
+
 // config is one run's inputs, as parsed from the flags.
 type config struct {
-	seed         int64
-	profile      string
-	duration     time.Duration
-	tickMin      time.Duration
-	tickMax      time.Duration
-	weightSpec   string
-	labName      string
-	outDir       string
-	collect      string
-	gwnodeConfig string
+	seed          int64
+	profile       string
+	duration      time.Duration
+	tickMin       time.Duration
+	tickMax       time.Duration
+	settleEvery   time.Duration
+	settleTimeout time.Duration
+	weightSpec    string
+	labName       string
+	outDir        string
+	collect       string
+	gwnodeConfig  string
 }
 
 func main() {
@@ -87,6 +107,8 @@ func main() {
 	flag.DurationVar(&cfg.duration, "duration", 10*time.Minute, "how long to keep injecting faults")
 	flag.DurationVar(&cfg.tickMin, "tick-min", 10*time.Second, "lower bound of the interval between decisions")
 	flag.DurationVar(&cfg.tickMax, "tick-max", 30*time.Second, "upper bound of the interval between decisions")
+	flag.DurationVar(&cfg.settleEvery, "settle-every", 3*time.Minute, "how often injection pauses for a settle window; 0 runs only the final settle")
+	flag.DurationVar(&cfg.settleTimeout, "settle-timeout", 2*time.Minute, "how long a settle window waits for full convergence")
 	flag.StringVar(&cfg.weightSpec, "weights", "", "override action weights, e.g. `gateway-kill=0,controller-restart=5`")
 	flag.StringVar(&cfg.labName, "lab", "ovn-e2e", "containerlab lab name")
 	flag.StringVar(&cfg.outDir, "out", "chaos-artifacts", "directory for the journal, the run record and the lab-state dump")
@@ -112,6 +134,12 @@ func run(cfg config) (int, error) {
 	}
 	if cfg.duration < minDuration {
 		return exitFatal, fmt.Errorf("-duration %s is below the %s floor", cfg.duration, minDuration)
+	}
+	if cfg.settleEvery < 0 {
+		return exitFatal, fmt.Errorf("-settle-every %s is negative", cfg.settleEvery)
+	}
+	if cfg.settleTimeout < minSettleTimeout {
+		return exitFatal, fmt.Errorf("-settle-timeout %s is below the %s floor", cfg.settleTimeout, minSettleTimeout)
 	}
 
 	// The profile and the config it is layered over are resolved before a
@@ -174,13 +202,15 @@ func run(cfg config) (int, error) {
 	ch.jrnl = jrnl
 	rec := &runRecord{
 		Inputs: runInputs{
-			Seed:       cfg.seed,
-			Profile:    p.name,
-			DurationMS: cfg.duration.Milliseconds(),
-			TickMinMS:  cfg.tickMin.Milliseconds(),
-			TickMaxMS:  cfg.tickMax.Milliseconds(),
-			Weights:    weights,
-			Lab:        cfg.labName,
+			Seed:            cfg.seed,
+			Profile:         p.name,
+			DurationMS:      cfg.duration.Milliseconds(),
+			TickMinMS:       cfg.tickMin.Milliseconds(),
+			TickMaxMS:       cfg.tickMax.Milliseconds(),
+			SettleEveryMS:   cfg.settleEvery.Milliseconds(),
+			SettleTimeoutMS: cfg.settleTimeout.Milliseconds(),
+			Weights:         weights,
+			Lab:             cfg.labName,
 		},
 		StartedAt:     started.UTC().Format(time.RFC3339Nano),
 		ActionsByName: map[string]int{},
@@ -233,6 +263,18 @@ func drive(ctx context.Context, l *lab, ap *applier, actions []*action, jrnl *jo
 	}
 	jrnl.emit(event{Event: evStateApplied, Detail: p.layers()})
 
+	// The oracle primes against the green start state before the first fault,
+	// so its baseline — the Gateway_Chassis rows already at priority 0, the
+	// managed routes, each gateway's drain environment — reflects a lab that
+	// is where its configuration wants it. A prime that cannot read that
+	// baseline is a setup failure, not a lab fault: the run is abandoned like
+	// any other it could not be built on.
+	orc := newOracle(l, ap)
+	orc.settleTimeout = time.Duration(rec.Inputs.SettleTimeoutMS) * time.Millisecond
+	if err := orc.prime(ctx); err != nil {
+		return abandon(jrnl, rec, violationOracleSetup, err)
+	}
+
 	// The prober and the baseline checks run for the whole run, alongside
 	// the engine. Both are cancelled and then *waited for* before the run
 	// record is read: a sweep still in flight would otherwise be
@@ -244,6 +286,8 @@ func drive(ctx context.Context, l *lab, ap *applier, actions []*action, jrnl *jo
 	probes.start(sideCtx)
 
 	e := newEngine(l, p, actions, probes, jrnl, rec)
+	e.oracle = orc
+	e.settleEvery = time.Duration(rec.Inputs.SettleEveryMS) * time.Millisecond
 	e.followMaster(ctx)
 
 	checks := &baselineChecks{lab: l, engine: e}
@@ -254,6 +298,16 @@ func drive(ctx context.Context, l *lab, ap *applier, actions []*action, jrnl *jo
 	}()
 
 	e.run(ctx)
+
+	// One final settle after the last fault, so the run always ends with the
+	// lab held to its full expected state — even on a -settle-every of 0,
+	// where it is the only settle there is. An aborted run skips it: it has
+	// already failed on the parking violation, and settling a lab with a dark
+	// node would only cascade violations derived from it. A cancelled run
+	// skips it too — the runner is unwinding, not measuring.
+	if !e.abort && ctx.Err() == nil {
+		e.settle(ctx)
+	}
 
 	stopSide()
 	probes.stop()

--- a/test/e2e/chaos/main_test.go
+++ b/test/e2e/chaos/main_test.go
@@ -11,17 +11,37 @@ import (
 	"time"
 )
 
+// The rejection names the floor, so a user who retries with exactly it gets a
+// window that can converge. That makes the floor a promise, and it has to clear
+// the arithmetic it is derived from: one slow-cadence reconcile to reach the
+// first all-green evaluation, plus the confirmation gap a first green that
+// fails its confirmation burns before the loop can try again.
+func TestSettleTimeoutFloorOutlastsAReconcileAndAConfirmation(t *testing.T) {
+	t.Parallel()
+	slow, err := time.ParseDuration(slowCadence)
+	if err != nil {
+		t.Fatalf("parse slowCadence %q: %v", slowCadence, err)
+	}
+	if want := slow + settleConfirmDelay; minSettleTimeout < want {
+		t.Fatalf("minSettleTimeout = %s, want >= %s (a %s reconcile plus the %s confirmation gap): "+
+			"a run taking the advertised floor at face value times out into false violations",
+			minSettleTimeout, want, slow, settleConfirmDelay)
+	}
+}
+
 // Bad inputs must fail before a single fault is injected: a run built on
 // a contradiction cannot be replayed and is not worth a lab.
 func TestRunRejectsInvalidInputs(t *testing.T) {
 	tests := []struct {
-		name     string
-		profile  string
-		duration time.Duration
-		tickMin  time.Duration
-		tickMax  time.Duration
-		weights  string
-		wantErr  string
+		name          string
+		profile       string
+		duration      time.Duration
+		tickMin       time.Duration
+		tickMax       time.Duration
+		settleEvery   time.Duration
+		settleTimeout time.Duration
+		weights       string
+		wantErr       string
 	}{
 		{
 			name:     "tick bounds inverted",
@@ -75,6 +95,27 @@ func TestRunRejectsInvalidInputs(t *testing.T) {
 			tickMax:  30 * time.Second,
 			wantErr:  "unknown profile",
 		},
+		// A negative settle cadence is a contradiction like an inverted tick
+		// bound: the run cannot schedule a settle window at all.
+		{
+			name:        "negative settle cadence",
+			duration:    time.Minute,
+			tickMin:     10 * time.Second,
+			tickMax:     30 * time.Second,
+			settleEvery: -time.Second,
+			wantErr:     "-settle-every",
+		},
+		// A settle window shorter than the floor could not outlast the slow
+		// reconcile a fault needs to converge, so every window would time out
+		// into a false violation.
+		{
+			name:          "settle timeout below the floor",
+			duration:      time.Minute,
+			tickMin:       10 * time.Second,
+			tickMax:       30 * time.Second,
+			settleTimeout: 10 * time.Second,
+			wantErr:       "below the 35s floor",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -85,17 +126,26 @@ func TestRunRejectsInvalidInputs(t *testing.T) {
 			if profile == "" {
 				profile = defaultProfileName
 			}
+			// A zero settle timeout is not the input under test, so it defaults
+			// to a valid one — the cases above reject a specific contradiction,
+			// not the absence of a settle flag.
+			settleTimeout := tc.settleTimeout
+			if settleTimeout == 0 {
+				settleTimeout = 2 * time.Minute
+			}
 			code, err := run(config{
-				seed:         42,
-				profile:      profile,
-				duration:     tc.duration,
-				tickMin:      tc.tickMin,
-				tickMax:      tc.tickMax,
-				weightSpec:   tc.weights,
-				labName:      "ovn-e2e",
-				outDir:       out,
-				collect:      "/nonexistent",
-				gwnodeConfig: "../gwnode-config.yaml",
+				seed:          42,
+				profile:       profile,
+				duration:      tc.duration,
+				tickMin:       tc.tickMin,
+				tickMax:       tc.tickMax,
+				settleEvery:   tc.settleEvery,
+				settleTimeout: settleTimeout,
+				weightSpec:    tc.weights,
+				labName:       "ovn-e2e",
+				outDir:        out,
+				collect:       "/nonexistent",
+				gwnodeConfig:  "../gwnode-config.yaml",
 			})
 
 			if code != exitFatal {
@@ -168,6 +218,166 @@ func TestDriveAbandonsARunWhoseProfileNeverLands(t *testing.T) {
 				t.Fatalf("journaled %+v, want the violation the run was abandoned on", ev)
 			}
 		})
+	}
+}
+
+// driveGreenResponses answers everything a full drive needs against a healthy
+// lab: the oracle's queries (through the oracleLab fixture), the management
+// address the applier discovers, and the live config it reads back — the baked
+// one, so the default profile restarts nothing and the oracle primes and
+// settles green.
+func driveGreenResponses(t *testing.T, fx *oracleLab) func([]string) (string, error) {
+	t.Helper()
+	base := string(baseConfig(t))
+	return func(argv []string) (string, error) {
+		line := strings.Join(argv, " ")
+		switch {
+		case strings.Contains(line, "cat "+agentConfigPath):
+			return base, nil
+		case strings.Contains(line, "ip -o -4 addr show eth0"):
+			return "172.20.20.4\n", nil
+		// currentMaster resolves the cr-lr0-public owner UUID to a name with a
+		// bare `list Chassis <uuid>`; the oracleLab fixture only models the
+		// --format=json form, so answer the bare one with the master itself.
+		case strings.Contains(line, "--bare") && strings.Contains(line, "list Chassis"):
+			return "gateway-1\n", nil
+		}
+		return fx.respond(argv)
+	}
+}
+
+func settleStartsIn(t *testing.T, journal string) int {
+	t.Helper()
+	n := 0
+	for _, ev := range eventsIn(t, journal) {
+		if ev.Event == evSettleStart {
+			n++
+		}
+	}
+	return n
+}
+
+// Every run ends with one final settle over its config-aware expected state —
+// even a -settle-every of 0, where it is the only settle there is. An aborted
+// run is the exception: it has already failed on the parking violation, and
+// settling a lab with a dark node would only cascade.
+func TestDriveRunsTheFinalSettle(t *testing.T) {
+	t.Run("a green run ends with the final settle", func(t *testing.T) {
+		fx := newOracleLab(t)
+		clock := newFakeClock()
+		l := newTestLab(&fakeCommander{respond: driveGreenResponses(t, fx)}, clock)
+		p := defaultTestProfile(t)
+		ap := newApplier(l, p, baseConfig(t))
+		var buf bytes.Buffer
+		ap.jrnl = newJournal(&buf, clock.now)
+		// DurationMS 0 injects no fault, so the run is exactly its green start
+		// state plus the one final settle the feature always runs.
+		rec := &runRecord{
+			Inputs:        runInputs{SettleTimeoutMS: (90 * time.Second).Milliseconds()},
+			ActionsByName: map[string]int{},
+		}
+
+		code := drive(context.Background(), l, ap, nil, ap.jrnl, rec)
+		rec.finalize(clock.now())
+
+		if code != exitPass {
+			t.Fatalf("exit code = %d, want %d: %+v", code, exitPass, rec.Violations)
+		}
+		if len(rec.Settles) != 1 || !rec.Settles[0].Passed {
+			t.Fatalf("settles = %+v, want exactly one passing final settle", rec.Settles)
+		}
+		if ev := lastEventOf(t, buf.String(), evSettleResult); ev.Result != resultPass {
+			t.Fatalf("the final settle-result was not a pass: %+v", ev)
+		}
+		if settleStartsIn(t, buf.String()) != 1 {
+			t.Fatalf("journaled %d settle windows, want the one final settle", settleStartsIn(t, buf.String()))
+		}
+		if rec.Result != resultPass || len(rec.Violations) != 0 {
+			t.Fatalf("a green run did not pass: %+v", rec)
+		}
+	})
+
+	t.Run("an aborted run skips the final settle", func(t *testing.T) {
+		fx := newOracleLab(t)
+		clock := newFakeClock()
+		l := newTestLab(&fakeCommander{respond: driveGreenResponses(t, fx)}, clock)
+		p := defaultTestProfile(t)
+		ap := newApplier(l, p, baseConfig(t))
+		var buf bytes.Buffer
+		ap.jrnl = newJournal(&buf, clock.now)
+		rec := &runRecord{
+			Inputs: runInputs{
+				DurationMS:      time.Second.Milliseconds(),
+				TickMinMS:       (100 * time.Millisecond).Milliseconds(),
+				TickMaxMS:       (100 * time.Millisecond).Milliseconds(),
+				SettleTimeoutMS: (90 * time.Second).Milliseconds(),
+			},
+			ActionsByName: map[string]int{},
+		}
+		// A fault the runner cannot undo parks its node and aborts the run.
+		acts := noopActions("controller-restart")
+		acts[0].holdMin, acts[0].holdMax = 0, 0
+		acts[0].restore = func(context.Context, *lab, string) error { return errBoom }
+
+		code := drive(context.Background(), l, ap, acts, ap.jrnl, rec)
+		rec.finalize(clock.now())
+
+		// drive returns exitPass even for a recorded violation — the fatal
+		// codes are for setups it could not build, not for what a run found.
+		if code != exitPass {
+			t.Fatalf("exit code = %d, want %d", code, exitPass)
+		}
+		if rec.Result != resultFail {
+			t.Fatalf("result = %q, want %q — the run parked a node", rec.Result, resultFail)
+		}
+		if len(rec.Settles) != 0 || settleStartsIn(t, buf.String()) != 0 {
+			t.Fatalf("an aborted run still settled: settles=%+v, journal=%s", rec.Settles, buf.String())
+		}
+	})
+}
+
+// The oracle primes against the green start state before the first fault. A
+// prime it cannot complete is a setup failure the run record cannot express as
+// a lab fault, so the run is abandoned with exit 2 and an oracle-setup
+// violation, like any other it could not be built on.
+func TestDriveAbandonsWhenTheOracleCannotPrime(t *testing.T) {
+	fx := newOracleLab(t)
+	green := driveGreenResponses(t, fx)
+	// The lab comes up green, but the oracle cannot read the Gateway_Chassis
+	// table it primes its baseline from.
+	respond := func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "list Gateway_Chassis") {
+			return "", errBoom
+		}
+		return green(argv)
+	}
+	clock := newFakeClock()
+	l := newTestLab(&fakeCommander{respond: respond}, clock)
+	p := defaultTestProfile(t)
+	ap := newApplier(l, p, baseConfig(t))
+	var buf bytes.Buffer
+	ap.jrnl = newJournal(&buf, clock.now)
+	rec := &runRecord{
+		Inputs:        runInputs{SettleTimeoutMS: (90 * time.Second).Milliseconds()},
+		ActionsByName: map[string]int{},
+	}
+
+	code := drive(context.Background(), l, ap, nil, ap.jrnl, rec)
+
+	if code != exitFatal {
+		t.Fatalf("exit code = %d, want %d when the oracle cannot prime", code, exitFatal)
+	}
+	rec.finalize(clock.now())
+	if rec.Result != resultFail || len(rec.Violations) != 1 ||
+		rec.Violations[0].Kind != violationOracleSetup {
+		t.Fatalf("the summary of a run abandoned at prime does not say so: %+v", rec)
+	}
+	if ev := lastEventOf(t, buf.String(), evViolation); ev.Kind != violationOracleSetup {
+		t.Fatalf("journaled %+v, want the oracle-setup violation the run was abandoned on", ev)
+	}
+	// The final settle never runs on an abandoned setup.
+	if settleStartsIn(t, buf.String()) != 0 {
+		t.Fatalf("a run abandoned at prime still opened a settle window: %s", buf.String())
 	}
 }
 

--- a/test/e2e/chaos/observe.go
+++ b/test/e2e/chaos/observe.go
@@ -1,0 +1,755 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// =============================================================================
+// Oracle observation layer
+// =============================================================================
+//
+// Everything here reads live lab state through the existing commander seam
+// (lab.nbctl / lab.sbctl / lab.exec, and parseOVSDBTable's flattening in
+// lab.go) and hands it back as the plain sets and maps the oracle (oracle.go)
+// diffs against a config-aware expectation (expect.go). It computes nothing —
+// it gathers, mirroring the agent code path each read verifies so the oracle
+// checks one data plane at a time:
+//
+//   - snapshotOVN mirrors the SB→NB join the agent makes (ovn.go);
+//   - observeGateway mirrors the FRR/kernel/OVS/nftables planes the agent
+//     programs (routing.go, routing_linux.go, nftables.go, agent.go);
+//   - observeUpstream reads the announcements the upstream BGP router actually
+//     holds, the ground truth of what the underlay carries.
+//
+// IPv4-only, matching the agent's IPv4-only route/announce planes and the lab.
+
+const (
+	// ovnCtlTimeout bounds every ovn-{n,s}bctl the oracle issues, mirroring
+	// crPortClaims in lab.go: the oracle reads a lab it is actively breaking,
+	// and a wedged database read must fail fast, not hang the settle loop.
+	ovnCtlTimeout = "--timeout=5"
+
+	// vrfProvider is the VRF the agent installs its FRR statics into, and
+	// vethNexthop the link-local next-hop it routes them via — both from the
+	// baked gwnode config (test/e2e/gwnode-config.yaml). Only statics via this
+	// next-hop are the agent's own (routing.go ListFRRRoutes).
+	vrfProvider = "vrf-provider"
+	vethNexthop = "169.254.0.1"
+
+	// announcedPrefixList is the FRR prefix-list the agent reconciles to the
+	// effective networks (config.go FRRPrefixList default).
+	announcedPrefixList = "ANNOUNCED-NETWORKS"
+
+	// bridgeDev is the provider bridge the agent programs its OVS flows on.
+	// All lab gateways run on br-ex (gwnode-config.yaml bridge_dev).
+	bridgeDev = "br-ex"
+
+	// hairpinCookie / macTweakCookie are the OpenFlow cookies the agent stamps
+	// its two flow classes with: 0x998 the hairpin DNAT flows, 0x999 the
+	// MAC-tweak flows.
+	hairpinCookie  = "cookie=0x998/-1"
+	macTweakCookie = "cookie=0x999/-1"
+
+	// agentNftTable is the nftables table the agent renders its port-forward
+	// ruleset into (nftables.go nftTableName). A missing table is a legitimate
+	// observation — the agent removes it when there is nothing to forward.
+	agentNftTable = "ovn-network-agent"
+
+	// The managed-route external_ids markers the agent stamps
+	// (ovn_gateway.go): the managed marker, the owning chassis, and the
+	// takeover-ready marker a takeover node sets before releasing its routes.
+	managedRouteKey    = "ovn-network-agent"
+	routeChassisKey    = "ovn-network-agent-chassis"
+	routeAdvertisedKey = "ovn-network-agent-advertised"
+
+	// metricsScrapeScript reads the agent's loopback-only Prometheus endpoint
+	// (gwnode-config.yaml metrics_listen 127.0.0.1:9273) over a bash /dev/tcp
+	// socket, since the gateway carries no HTTP client.
+	metricsScrapeScript = `exec 3<>/dev/tcp/127.0.0.1/9273; printf "GET /metrics HTTP/1.0\r\n\r\n" >&3; cat <&3`
+)
+
+// =============================================================================
+// OVN snapshot
+// =============================================================================
+
+// snapshotOVN gathers the whole OVN NB/SB view the oracle reasons about into
+// one ovnSnapshot (expect.go). Every query mirrors crPortClaims in lab.go:
+// bounded, --format=json, explicit --columns.
+func snapshotOVN(ctx context.Context, l *lab) (ovnSnapshot, error) {
+	snap := ovnSnapshot{
+		CRPortChassis:   map[string]string{},
+		LRPs:            map[string]lrpRow{},
+		Routers:         map[string]routerRow{},
+		LRPNameByUUID:   map[string]string{},
+		GatewayChassis:  map[string]gatewayChassisRow{},
+		Chassis:         map[string]bool{},
+		SegmentTagByLRP: map[string]int{},
+	}
+
+	// SB Chassis: the present chassis set, and a UUID→name index for the
+	// chassisredirect binding, whose chassis column is a UUID reference.
+	chassisByUUID := map[string]string{}
+	rows, err := sbRows(ctx, l, "Chassis", "", "_uuid", "name")
+	if err != nil {
+		return snap, err
+	}
+	for _, r := range rows {
+		name := cellString(r["name"])
+		if name == "" {
+			continue
+		}
+		chassisByUUID[cellString(r["_uuid"])] = name
+		snap.Chassis[name] = true
+	}
+
+	// SB chassisredirect Port_Binding: which chassis owns each cr port.
+	rows, err = sbRows(ctx, l, "Port_Binding", "type=chassisredirect", "logical_port", "chassis")
+	if err != nil {
+		return snap, err
+	}
+	for _, r := range rows {
+		port := cellString(r["logical_port"])
+		if port == "" {
+			continue
+		}
+		snap.CRPortChassis[port] = chassisByUUID[cellString(r["chassis"])]
+	}
+
+	// NB NAT: external IP and type, indexed by UUID for the router join.
+	natByUUID := map[string]natRow{}
+	rows, err = nbRows(ctx, l, "NAT", "", "_uuid", "external_ip", "type")
+	if err != nil {
+		return snap, err
+	}
+	for _, r := range rows {
+		natByUUID[cellString(r["_uuid"])] = natRow{
+			ExternalIP: cellString(r["external_ip"]),
+			Type:       cellString(r["type"]),
+		}
+	}
+
+	// NB Logical_Router_Port: networks and the Gateway_Chassis refs.
+	rows, err = nbRows(ctx, l, "Logical_Router_Port", "", "_uuid", "name", "networks", "gateway_chassis")
+	if err != nil {
+		return snap, err
+	}
+	for _, r := range rows {
+		name := cellString(r["name"])
+		if name == "" {
+			continue
+		}
+		snap.LRPNameByUUID[cellString(r["_uuid"])] = name
+		snap.LRPs[name] = lrpRow{
+			Networks:       cellStrings(r["networks"]),
+			GatewayChassis: cellStrings(r["gateway_chassis"]),
+		}
+	}
+
+	// NB Logical_Router: member LRP refs and NAT rows (resolved).
+	rows, err = nbRows(ctx, l, "Logical_Router", "", "_uuid", "name", "ports", "nat")
+	if err != nil {
+		return snap, err
+	}
+	for _, r := range rows {
+		name := cellString(r["name"])
+		if name == "" {
+			continue
+		}
+		var nats []natRow
+		for _, u := range cellStrings(r["nat"]) {
+			if n, ok := natByUUID[u]; ok {
+				nats = append(nats, n)
+			}
+		}
+		snap.Routers[name] = routerRow{LRPUUIDs: cellStrings(r["ports"]), NATs: nats}
+	}
+
+	// NB Gateway_Chassis: the HA candidates, keyed by row UUID.
+	rows, err = nbRows(ctx, l, "Gateway_Chassis", "", "_uuid", "name", "chassis_name", "priority")
+	if err != nil {
+		return snap, err
+	}
+	for _, r := range rows {
+		snap.GatewayChassis[cellString(r["_uuid"])] = gatewayChassisRow{
+			Name:        cellString(r["name"]),
+			ChassisName: cellString(r["chassis_name"]),
+			Priority:    cellInt(r["priority"]),
+		}
+	}
+
+	// NB Logical_Router_Static_Route: the agent-managed rows, matched by the
+	// same external_ids marker its consumers use (ovn.go).
+	rows, err = nbRows(ctx, l, "Logical_Router_Static_Route",
+		"external_ids:"+managedRouteKey+"="+"managed", "_uuid", "ip_prefix", "external_ids")
+	if err != nil {
+		return snap, err
+	}
+	for _, r := range rows {
+		snap.StaticRoutes = append(snap.StaticRoutes, staticRouteRow{
+			UUID:        cellString(r["_uuid"]),
+			IPPrefix:    cellString(r["ip_prefix"]),
+			ExternalIDs: ovsdbMap(r["external_ids"]),
+		})
+	}
+
+	if err := snapshotSegments(ctx, l, &snap); err != nil {
+		return snap, err
+	}
+	return snap, nil
+}
+
+// snapshotSegments derives each LRP's provider-segment VLAN tag by joining the
+// logical switches to their localnet and router ports: the localnet port
+// carries the segment tag, the router port names the LRP it patches to.
+func snapshotSegments(ctx context.Context, l *lab, snap *ovnSnapshot) error {
+	type lspInfo struct {
+		typ        string
+		tag        int
+		routerPort string
+	}
+	byUUID := map[string]lspInfo{}
+	rows, err := nbRows(ctx, l, "Logical_Switch_Port", "", "_uuid", "name", "type", "tag", "options")
+	if err != nil {
+		return err
+	}
+	for _, r := range rows {
+		byUUID[cellString(r["_uuid"])] = lspInfo{
+			typ:        cellString(r["type"]),
+			tag:        cellInt(r["tag"]),
+			routerPort: ovsdbMap(r["options"])["router-port"],
+		}
+	}
+
+	rows, err = nbRows(ctx, l, "Logical_Switch", "", "_uuid", "name", "ports")
+	if err != nil {
+		return err
+	}
+	for _, r := range rows {
+		tag := 0
+		var lrps []string
+		for _, u := range cellStrings(r["ports"]) {
+			p := byUUID[u]
+			switch p.typ {
+			case "localnet":
+				tag = p.tag
+			case "router":
+				if p.routerPort != "" {
+					lrps = append(lrps, p.routerPort)
+				}
+			}
+		}
+		for _, lrp := range lrps {
+			snap.SegmentTagByLRP[lrp] = tag
+		}
+	}
+	return nil
+}
+
+// nbRows / sbRows run one `list`/`find` against the NB/SB database and return
+// the rows with each cell kept as raw JSON, so a map column (external_ids,
+// options) can be parsed with ovsdbMap while a scalar/set/uuid column flattens
+// through the shared flattenOVSDBCell.
+func nbRows(ctx context.Context, l *lab, table, cond string, columns ...string) ([]map[string]json.RawMessage, error) {
+	return ovnQuery(ctx, l.nbctl, table, cond, columns)
+}
+
+func sbRows(ctx context.Context, l *lab, table, cond string, columns ...string) ([]map[string]json.RawMessage, error) {
+	return ovnQuery(ctx, l.sbctl, table, cond, columns)
+}
+
+func ovnQuery(ctx context.Context, ctl func(context.Context, ...string) (string, error),
+	table, cond string, columns []string) ([]map[string]json.RawMessage, error) {
+	args := []string{ovnCtlTimeout, "--format=json", "--columns=" + strings.Join(columns, ",")}
+	if cond == "" {
+		args = append(args, "list", table)
+	} else {
+		args = append(args, "find", table, cond)
+	}
+	out, err := ctl(ctx, args...)
+	if err != nil {
+		return nil, fmt.Errorf("read ovsdb table %s: %w", table, err)
+	}
+	rows, err := ovsdbRows(out)
+	if err != nil {
+		return nil, fmt.Errorf("parse ovsdb table %s: %w", table, err)
+	}
+	return rows, nil
+}
+
+// ovsdbRows decodes an ovn-{n,s}bctl --format=json table, keeping each cell as
+// raw JSON. It is the raw-cell counterpart of parseOVSDBTable in lab.go, which
+// flattens every cell to strings and so drops a map column's key/value pairs.
+func ovsdbRows(out string) ([]map[string]json.RawMessage, error) {
+	var table struct {
+		Headings []string            `json:"headings"`
+		Data     [][]json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(out), &table); err != nil {
+		return nil, fmt.Errorf("decode ovsdb json: %w", err)
+	}
+	rows := make([]map[string]json.RawMessage, 0, len(table.Data))
+	for _, data := range table.Data {
+		row := map[string]json.RawMessage{}
+		for i, heading := range table.Headings {
+			if i < len(data) {
+				row[heading] = data[i]
+			}
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+// ovsdbMap parses an OVSDB map cell (`["map",[[k,v],...]]`) into a plain
+// string map. Anything else — a scalar, a set, an empty cell — is an empty
+// map, so external_ids and options read cleanly whether or not they carry
+// values.
+func ovsdbMap(raw json.RawMessage) map[string]string {
+	out := map[string]string{}
+	var tuple []json.RawMessage
+	if err := json.Unmarshal(raw, &tuple); err != nil || len(tuple) != 2 {
+		return out
+	}
+	var kind string
+	if err := json.Unmarshal(tuple[0], &kind); err != nil || kind != "map" {
+		return out
+	}
+	var pairs [][]json.RawMessage
+	if err := json.Unmarshal(tuple[1], &pairs); err != nil {
+		return out
+	}
+	for _, p := range pairs {
+		if len(p) != 2 {
+			continue
+		}
+		var k, v string
+		if json.Unmarshal(p[0], &k) == nil && json.Unmarshal(p[1], &v) == nil {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// cellString / cellStrings flatten a scalar/uuid/set cell through the shared
+// flattenOVSDBCell; cellInt reads an integer column (priority, tag), which
+// flattenOVSDBCell does not model.
+func cellString(raw json.RawMessage) string {
+	if s := flattenOVSDBCell(raw); len(s) > 0 {
+		return s[0]
+	}
+	return ""
+}
+
+func cellStrings(raw json.RawMessage) []string {
+	return flattenOVSDBCell(raw)
+}
+
+func cellInt(raw json.RawMessage) int {
+	var n int
+	if err := json.Unmarshal(raw, &n); err == nil {
+		return n
+	}
+	return 0
+}
+
+// =============================================================================
+// Per-gateway observation
+// =============================================================================
+
+// observedGateway is the live data-plane state gathered from one gateway, in
+// the same shape as gatewayExpectation so the oracle can diff a plane at a
+// time.
+type observedGateway struct {
+	kernelRoutes     map[string]string // desired IP → kernel device
+	frrStatic        map[string]bool   // /32 IPs with an agent FRR static
+	prefixList       map[string]bool   // ANNOUNCED-NETWORKS CIDRs
+	prefixListAbsent bool              // the list does not exist at all
+	hairpin          map[string]bool   // IPs carrying a 0x998 hairpin flow
+	macTweakFlows    int               // count of 0x999 MAC-tweak flows
+	dnat             []observedDNAT    // nftables prerouting_dnat rules
+	masquerade       map[string]bool   // VIPs with a hairpin/router masquerade rule
+	vips             map[string]bool   // /32 addresses on the port-forward device
+	metrics          gatewayMetrics
+}
+
+// observedDNAT is one nftables DNAT rule read back from the live ruleset.
+type observedDNAT struct {
+	vip      string
+	proto    string
+	port     int
+	backend  string
+	destPort int
+}
+
+// gatewayMetrics are the flap-indicator series the oracle gates on.
+type gatewayMetrics struct {
+	consecutiveReAdds int
+	inactiveRoutes    int
+	routeReAddsTotal  int // summed over the plane labels
+}
+
+// observeGateway gathers every data plane the oracle verifies on one gateway.
+// portForwardDev is the device managed VIP addresses land on (loopback1 by
+// default), read from the gateway's expectation.
+func observeGateway(ctx context.Context, l *lab, gw, portForwardDev string) (observedGateway, error) {
+	obs := observedGateway{
+		kernelRoutes: map[string]string{},
+		frrStatic:    map[string]bool{},
+		prefixList:   map[string]bool{},
+		hairpin:      map[string]bool{},
+		masquerade:   map[string]bool{},
+		vips:         map[string]bool{},
+	}
+	if err := observeKernelRoutes(ctx, l, gw, &obs); err != nil {
+		return obs, err
+	}
+	if err := observeFRRStatic(ctx, l, gw, &obs); err != nil {
+		return obs, err
+	}
+	if err := observePrefixList(ctx, l, gw, &obs); err != nil {
+		return obs, err
+	}
+	if err := observeFlows(ctx, l, gw, &obs); err != nil {
+		return obs, err
+	}
+	if err := observeNftables(ctx, l, gw, &obs); err != nil {
+		return obs, err
+	}
+	if err := observeVIPs(ctx, l, gw, portForwardDev, &obs); err != nil {
+		return obs, err
+	}
+	if err := observeMetrics(ctx, l, gw, &obs); err != nil {
+		return obs, err
+	}
+	return obs, nil
+}
+
+// observeKernelRoutes reads the agent's proto-44 /32 routes and the device
+// each sits on (routing_linux.go rtProtoOVNNetworkAgent).
+func observeKernelRoutes(ctx context.Context, l *lab, gw string, obs *observedGateway) error {
+	out, err := l.exec(ctx, gw, "ip", "-j", "route", "show", "proto", "44")
+	if err != nil {
+		return fmt.Errorf("list proto-44 routes on %s: %w", gw, err)
+	}
+	if strings.TrimSpace(out) == "" {
+		return nil
+	}
+	var routes []struct {
+		Dst string `json:"dst"`
+		Dev string `json:"dev"`
+	}
+	if err := json.Unmarshal([]byte(out), &routes); err != nil {
+		return fmt.Errorf("parse proto-44 routes on %s: %w", gw, err)
+	}
+	for _, r := range routes {
+		obs.kernelRoutes[strings.TrimSuffix(r.Dst, "/32")] = r.Dev
+	}
+	return nil
+}
+
+// observeFRRStatic reads the agent's own /32 FRR statics: those via the veth
+// next-hop, mirroring routing.go ListFRRRoutes.
+func observeFRRStatic(ctx context.Context, l *lab, gw string, obs *observedGateway) error {
+	out, err := l.exec(ctx, gw, "vtysh", "-c",
+		fmt.Sprintf("show ip route vrf %s static json", vrfProvider))
+	if err != nil {
+		return fmt.Errorf("list frr statics on %s: %w", gw, err)
+	}
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "" {
+		return nil
+	}
+	var routes map[string][]struct {
+		Nexthops []struct {
+			IP string `json:"ip"`
+		} `json:"nexthops"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &routes); err != nil {
+		return fmt.Errorf("parse frr statics on %s: %w", gw, err)
+	}
+	for prefix, entries := range routes {
+		if !strings.HasSuffix(prefix, "/32") {
+			continue
+		}
+		for _, e := range entries {
+			for _, nh := range e.Nexthops {
+				if nh.IP == vethNexthop {
+					obs.frrStatic[strings.TrimSuffix(prefix, "/32")] = true
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// observePrefixList reads the ANNOUNCED-NETWORKS prefix-list, keeping the CIDR
+// of each `permit <cidr> ge 32 le 32` entry and distinguishing a list that
+// does not exist at all (which the agent cleans on a standby gateway).
+func observePrefixList(ctx context.Context, l *lab, gw string, obs *observedGateway) error {
+	out, err := l.exec(ctx, gw, "vtysh", "-c", "show ip prefix-list "+announcedPrefixList)
+	if err != nil {
+		return fmt.Errorf("read prefix-list on %s: %w", gw, err)
+	}
+	obs.prefixList, obs.prefixListAbsent = parsePrefixList(out)
+	return nil
+}
+
+// parsePrefixList extracts the permitted CIDRs from `show ip prefix-list`
+// text. A body that names no list at all is reported absent.
+func parsePrefixList(out string) (map[string]bool, bool) {
+	cidrs := map[string]bool{}
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		for i := 0; i+1 < len(fields); i++ {
+			if fields[i] == "permit" {
+				cidrs[fields[i+1]] = true
+			}
+		}
+	}
+	absent := len(cidrs) == 0 && !strings.Contains(out, announcedPrefixList)
+	return cidrs, absent
+}
+
+var flowDstRE = regexp.MustCompile(`(?:nw_dst|ip_dst)=([0-9.]+)`)
+
+// observeFlows reads the two OVS flow classes on the provider bridge: the
+// 0x998 hairpin flows (by their IPv4 destination) and the 0x999 MAC-tweak
+// flows (by count).
+func observeFlows(ctx context.Context, l *lab, gw string, obs *observedGateway) error {
+	hairpin, err := l.exec(ctx, gw, "ovs-ofctl", "dump-flows", bridgeDev, hairpinCookie)
+	if err != nil {
+		return fmt.Errorf("dump hairpin flows on %s: %w", gw, err)
+	}
+	for _, m := range flowDstRE.FindAllStringSubmatch(hairpin, -1) {
+		obs.hairpin[m[1]] = true
+	}
+
+	macTweak, err := l.exec(ctx, gw, "ovs-ofctl", "dump-flows", bridgeDev, macTweakCookie)
+	if err != nil {
+		return fmt.Errorf("dump mac-tweak flows on %s: %w", gw, err)
+	}
+	for _, line := range strings.Split(macTweak, "\n") {
+		if strings.Contains(line, "cookie=0x999") {
+			obs.macTweakFlows++
+		}
+	}
+	return nil
+}
+
+var (
+	nftDNATRE = regexp.MustCompile(`ip daddr (\S+) (\S+) dport (\d+) dnat to (\S+):(\d+)`)
+	nftMasqRE = regexp.MustCompile(`ct original (?:ip )?daddr (\S+) ct status dnat masquerade`)
+)
+
+// observeNftables reads the agent's port-forward ruleset. A missing table is a
+// legitimate observation — the agent removes it when there is nothing to
+// forward — and is reported as empty DNAT/masquerade sets, not an error.
+//
+// Only nft's own exit 1 carries that answer: the error errors.As inspects is
+// the docker CLI's, not the remote command's (lab.exec → lab.docker →
+// execCommander.run), so every non-zero docker exit is an *exec.ExitError too.
+// Widening this to any exit code would read a stopped container, an
+// unreachable daemon or an expired cmdTimeout as an empty ruleset — and on a
+// gateway configured with no port forwards the oracle would diff empty against
+// empty and report three data planes converged having never read them. The
+// same exit-1-is-an-answer split agentAlive and checkConfig make.
+func observeNftables(ctx context.Context, l *lab, gw string, obs *observedGateway) error {
+	out, err := l.exec(ctx, gw, "nft", "list", "table", "ip", agentNftTable)
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return nil // the table does not exist — nothing to forward
+		}
+		return fmt.Errorf("read nft table on %s: %w", gw, err)
+	}
+	for _, m := range nftDNATRE.FindAllStringSubmatch(out, -1) {
+		obs.dnat = append(obs.dnat, observedDNAT{
+			vip:      m[1],
+			proto:    m[2],
+			port:     atoi(m[3]),
+			backend:  m[4],
+			destPort: atoi(m[5]),
+		})
+	}
+	for _, m := range nftMasqRE.FindAllStringSubmatch(out, -1) {
+		obs.masquerade[m[1]] = true
+	}
+	return nil
+}
+
+// observeVIPs reads the /32 addresses the agent manages on the port-forward
+// device. An absent device is an empty set, not an error — and, as in
+// observeNftables, only `ip`'s own exit 1 is that answer.
+func observeVIPs(ctx context.Context, l *lab, gw, dev string, obs *observedGateway) error {
+	out, err := l.exec(ctx, gw, "ip", "-j", "addr", "show", "dev", dev)
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return nil // the device does not exist — no managed VIP addresses
+		}
+		return fmt.Errorf("list addresses on %s dev %s: %w", gw, dev, err)
+	}
+	if strings.TrimSpace(out) == "" {
+		return nil
+	}
+	var links []struct {
+		AddrInfo []struct {
+			Local     string `json:"local"`
+			PrefixLen int    `json:"prefixlen"`
+		} `json:"addr_info"`
+	}
+	if err := json.Unmarshal([]byte(out), &links); err != nil {
+		return fmt.Errorf("parse addresses on %s dev %s: %w", gw, dev, err)
+	}
+	for _, link := range links {
+		for _, a := range link.AddrInfo {
+			if a.PrefixLen == 32 {
+				obs.vips[a.Local] = true
+			}
+		}
+	}
+	return nil
+}
+
+// observeMetrics scrapes the agent's loopback Prometheus endpoint for the
+// flap-indicator series.
+func observeMetrics(ctx context.Context, l *lab, gw string, obs *observedGateway) error {
+	out, err := l.exec(ctx, gw, "bash", "-c", metricsScrapeScript)
+	if err != nil {
+		return fmt.Errorf("scrape metrics on %s: %w", gw, err)
+	}
+	obs.metrics = parseMetrics(out)
+	return nil
+}
+
+// parseMetrics reads the three flap-indicator series from a Prometheus text
+// scrape (metrics.go), summing route_readds_total across its plane labels.
+func parseMetrics(body string) gatewayMetrics {
+	var m gatewayMetrics
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		name := fields[0]
+		value := parseMetricValue(fields[len(fields)-1])
+		switch {
+		case name == "ovn_network_agent_consecutive_readds":
+			m.consecutiveReAdds = value
+		case name == "ovn_network_agent_inactive_routes":
+			m.inactiveRoutes = value
+		case strings.HasPrefix(name, "ovn_network_agent_route_readds_total"):
+			m.routeReAddsTotal += value
+		}
+	}
+	return m
+}
+
+func parseMetricValue(s string) int {
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		return int(f)
+	}
+	return 0
+}
+
+func atoi(s string) int {
+	n, _ := strconv.Atoi(s)
+	return n
+}
+
+// =============================================================================
+// Upstream announcements
+// =============================================================================
+
+// upstreamRoutes maps each announced /32 (bare IP) to the set of gateways
+// announcing it, as read from the upstream BGP router.
+type upstreamRoutes map[string]map[string]bool
+
+// announcedBy returns the /32 IPs gw is currently announcing upstream.
+func (u upstreamRoutes) announcedBy(gw string) map[string]bool {
+	out := map[string]bool{}
+	for ip, gws := range u {
+		if gws[gw] {
+			out[ip] = true
+		}
+	}
+	return out
+}
+
+// observeUpstream reads what the upstream BGP router actually holds — the
+// ground truth of what the underlay carries — and attributes each /32 to the
+// gateway that announced it by mapping the path's next-hop through the
+// underlay links (gateway N announces from 100.64.N.2).
+func observeUpstream(ctx context.Context, l *lab) (upstreamRoutes, error) {
+	out, err := l.exec(ctx, upstreamNode, "vtysh", "-c", "show bgp ipv4 unicast json")
+	if err != nil {
+		return nil, fmt.Errorf("read upstream bgp: %w", err)
+	}
+	var doc struct {
+		Routes map[string][]struct {
+			Nexthops []struct {
+				IP string `json:"ip"`
+			} `json:"nexthops"`
+			Peer *struct {
+				PeerID string `json:"peerId"`
+			} `json:"peer"`
+		} `json:"routes"`
+	}
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		return nil, fmt.Errorf("parse upstream bgp: %w", err)
+	}
+
+	byNexthop := map[string]string{}
+	for _, link := range underlayLinks {
+		byNexthop[addrOf(link.gatewayCIDR)] = link.gateway
+	}
+
+	routes := upstreamRoutes{}
+	for prefix, paths := range doc.Routes {
+		if !strings.HasSuffix(prefix, "/32") {
+			continue
+		}
+		ip := strings.TrimSuffix(prefix, "/32")
+		for _, p := range paths {
+			addrs := make([]string, 0, len(p.Nexthops)+1)
+			for _, nh := range p.Nexthops {
+				addrs = append(addrs, nh.IP)
+			}
+			if p.Peer != nil {
+				addrs = append(addrs, p.Peer.PeerID)
+			}
+			for _, addr := range addrs {
+				if gw := byNexthop[addr]; gw != "" {
+					if routes[ip] == nil {
+						routes[ip] = map[string]bool{}
+					}
+					routes[ip][gw] = true
+				}
+			}
+		}
+	}
+	return routes, nil
+}
+
+// sortedKeys returns a map's keys in sorted order, so an iteration over the
+// snapshot's maps yields deterministic violation ordering.
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/test/e2e/chaos/oracle.go
+++ b/test/e2e/chaos/oracle.go
@@ -28,10 +28,6 @@ import (
 // port-forward-only) and a metrics flap gate. Everything it reads comes through
 // observe.go; it draws nothing from the engine's rng and never touches the
 // run's decision stream.
-//
-// The engine wiring — settle scheduling, the observeInject hook, stamping the
-// returned violations with the tick and journal offset — lands in the next
-// commit.
 
 const (
 	// settlePollInterval is how often the settle loop re-observes the lab.
@@ -47,9 +43,8 @@ const (
 
 // oracle verifies one settle window against the config-aware expected state.
 type oracle struct {
-	lab  *lab
-	ap   *applier
-	jrnl *journal
+	lab *lab
+	ap  *applier
 
 	settleTimeout time.Duration
 
@@ -126,6 +121,12 @@ func (o *oracle) observeInject(ctx context.Context, action, target string) error
 
 	drain, err := o.effectiveDrain(ctx, target)
 	if err != nil {
+		// The drain question could not be asked (docker under load, the
+		// container gone mid-inject). An unanswerable question tolerates any
+		// priority-0 residue the target leaves rather than inventing a
+		// drain-while-disabled violation — the same "could not ask" split
+		// agentAlive and checkError make.
+		o.drainedLegit[target] = true
 		return err
 	}
 	o.drainedLegit[target] = drain

--- a/test/e2e/chaos/oracle.go
+++ b/test/e2e/chaos/oracle.go
@@ -1,0 +1,641 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+// =============================================================================
+// Config-aware settle oracle
+// =============================================================================
+//
+// The oracle closes the loop the baseline sweep (checks.go) and the recovery
+// gate (engine.go) leave open: those assert the lab is reachable, this asserts
+// it converged to the exact state its configuration demands. Between faults the
+// engine hands it a settle window; the oracle polls until every gateway's live
+// data plane matches computeExpectation (expect.go) or the window expires.
+//
+// It verifies seven per-gateway planes (kernel routes with their device, FRR
+// statics, the ANNOUNCED-NETWORKS prefix-list, hairpin flows, MAC-tweak flow
+// count, nftables DNAT/masquerade, managed VIP addresses) and the upstream
+// announcements, plus four snapshot-wide invariants (chassisredirect priority
+// lead, drain residue, vanished-chassis hygiene, a frozen NB under
+// port-forward-only) and a metrics flap gate. Everything it reads comes through
+// observe.go; it draws nothing from the engine's rng and never touches the
+// run's decision stream.
+//
+// The engine wiring — settle scheduling, the observeInject hook, stamping the
+// returned violations with the tick and journal offset — lands in the next
+// commit.
+
+const (
+	// settlePollInterval is how often the settle loop re-observes the lab.
+	settlePollInterval = 5 * time.Second
+
+	// settleConfirmDelay is the gap between the first all-green evaluation and
+	// its confirmation. It must exceed the slow reconcile cadence
+	// (slowCadence = "15s" in flips.go) so one confirmation gap always spans at
+	// least one reconcile: a lab that only looks converged because the agent
+	// has not reconciled yet is caught when the next reconcile churns a plane.
+	settleConfirmDelay = 20 * time.Second
+)
+
+// oracle verifies one settle window against the config-aware expected state.
+type oracle struct {
+	lab  *lab
+	ap   *applier
+	jrnl *journal
+
+	settleTimeout time.Duration
+
+	tolerated0      map[string]bool   // Gateway_Chassis row UUIDs already at priority 0 at prime
+	drainedLegit    map[string]bool   // gateways whose last disruptive action ran with drain effectively enabled; consumed by the next settle window
+	baselineManaged map[string]string // managed static-route row UUID → rendered content at prime
+	drainEnv        map[string]string // per-gateway OVN_NETWORK_DRAIN_ON_SHUTDOWN container env ("" = unset)
+}
+
+func newOracle(l *lab, ap *applier) *oracle {
+	return &oracle{
+		lab:             l,
+		ap:              ap,
+		tolerated0:      map[string]bool{},
+		drainedLegit:    map[string]bool{},
+		baselineManaged: map[string]string{},
+		drainEnv:        map[string]string{},
+	}
+}
+
+// prime records the baseline the settle loop reasons against, run once after
+// the start state is green: the Gateway_Chassis rows legitimately already at
+// priority 0, the managed static routes as the port-forward-only frozen-NB
+// check will compare against, and each gateway's drain environment.
+func (o *oracle) prime(ctx context.Context) error {
+	snap, err := snapshotOVN(ctx, o.lab)
+	if err != nil {
+		return fmt.Errorf("prime oracle: %w", err)
+	}
+	for uuid, row := range snap.GatewayChassis {
+		if row.Priority == 0 {
+			o.tolerated0[uuid] = true
+		}
+	}
+	for _, r := range snap.StaticRoutes {
+		o.baselineManaged[r.UUID] = renderManagedRoute(r)
+	}
+	for _, gw := range gatewayNames() {
+		env, err := o.drainEnvOf(ctx, gw)
+		if err != nil {
+			return fmt.Errorf("prime oracle: read drain env of %s: %w", gw, err)
+		}
+		o.drainEnv[gw] = env
+	}
+	return nil
+}
+
+// drainEnvOf reads a gateway's OVN_NETWORK_DRAIN_ON_SHUTDOWN container
+// environment. printenv exits 1 when the variable is unset, which is the
+// answer "" — the same exit-1-is-an-answer split agentAlive makes; any other
+// error means the question could not be asked.
+func (o *oracle) drainEnvOf(ctx context.Context, gw string) (string, error) {
+	out, err := o.lab.exec(ctx, gw, "printenv", "OVN_NETWORK_DRAIN_ON_SHUTDOWN")
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// observeInject records, before a disruptive action injects, whether the
+// target could legitimately end at priority 0 — i.e. its drain is effectively
+// enabled. Only the actions that take a chassis down carry that meaning; the
+// rest leave the drain classification untouched.
+func (o *oracle) observeInject(ctx context.Context, action, target string) error {
+	switch action {
+	case "agent-terminate", "gateway-restart", "config-flip", "double-failover":
+	default:
+		return nil
+	}
+
+	drain, err := o.effectiveDrain(ctx, target)
+	if err != nil {
+		return err
+	}
+	o.drainedLegit[target] = drain
+
+	// A double failover SIGTERMs the target (which drains if enabled) and
+	// SIGKILLs the ring-next peer (control.go injectDoubleFailover). A SIGKILL
+	// never drains, so the peer can never legitimately end at priority 0 —
+	// mark it false, resetting any drain a previous action left recorded.
+	if action == "double-failover" {
+		o.drainedLegit[nextGateway(target)] = false
+	}
+	return nil
+}
+
+// effectiveDrain resolves the drain the target actually runs with. When the
+// profile marker is present the entrypoint unsets the deploy-time env override
+// (gwnode-entrypoint.sh yield_config_to_chaos_profile), so the config doc
+// wins; otherwise the env layer beats the file, and only an explicit "true"
+// drains.
+func (o *oracle) effectiveDrain(ctx context.Context, gw string) (bool, error) {
+	marker, err := o.markerPresent(ctx, gw)
+	if err != nil {
+		return false, err
+	}
+	if marker {
+		return docDrainOnShutdown(o.ap.current[gw]), nil
+	}
+	if env := o.drainEnv[gw]; env != "" {
+		return env == "true", nil
+	}
+	return docDrainOnShutdown(o.ap.current[gw]), nil
+}
+
+// markerPresent reports whether the chaos-profile marker file is on the
+// gateway. `test -f` exits 1 when it is absent, which is the answer.
+func (o *oracle) markerPresent(ctx context.Context, gw string) (bool, error) {
+	if _, err := o.lab.exec(ctx, gw, "test", "-f", profileMarkerPath); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// settleFailure is one broken expectation in a single evaluation. The engine
+// stamps the tick and journal offset onto the violations verify returns.
+type settleFailure struct {
+	kind   string
+	target string
+	detail string
+}
+
+// evaluation is the verdict of one poll: the failures it found, and each
+// gateway's summed route_readds_total for the confirmation delta check.
+type evaluation struct {
+	failures []settleFailure
+	readds   map[string]int
+}
+
+// verify polls the lab against its config-aware expected state until two
+// consecutive evaluations are all-green (a pass) or settleTimeout expires (the
+// last evaluation's failures become violations). It is clocked by the lab's
+// now/sleep, so a run replays without wall-clock time.
+//
+// On pass it returns (nil, convergedMS) where convergedMS is the wall-clock
+// from the loop start to the first of the two green evaluations. On deadline it
+// returns the failures as violations and convergedMS = -1 — the lab never
+// converged, so there is no convergence time to report.
+//
+// The window consumes the drain tolerances the faults before it recorded: a
+// tolerance excuses the priority-0 residue of the fault that earned it, and
+// this is the window that fault's residue shows up in. Carrying it further
+// would exempt the gateway for the rest of the run — the agent restores a
+// drained row to priority 1 on startup (RestoreDrainedGateways), so once a
+// window has seen the target restored, a later priority-0 row is residue no
+// drain explains and is exactly what violationDrainDisabled exists to catch.
+func (o *oracle) verify(ctx context.Context) ([]violationRecord, int64) {
+	defer clear(o.drainedLegit)
+
+	start := o.lab.now()
+	deadline := start.Add(o.settleTimeout)
+	var last []settleFailure
+
+	for o.lab.now().Before(deadline) {
+		if ctx.Err() != nil {
+			break
+		}
+
+		first := o.evaluate(ctx)
+		if len(first.failures) > 0 {
+			last = first.failures
+			o.lab.sleep(settlePollInterval)
+			continue
+		}
+
+		// First all-green evaluation: record convergence and confirm it holds
+		// across a reconcile gap, with route_readds_total steady between the
+		// two — a delta means the plane is still churning under the surface.
+		convergedMS := o.lab.now().Sub(start).Milliseconds()
+		o.lab.sleep(settleConfirmDelay)
+		second := o.evaluate(ctx)
+		flaps := readdFlaps(first.readds, second.readds)
+		switch {
+		case len(second.failures) > 0:
+			last = second.failures
+		case len(flaps) > 0:
+			last = flaps
+		default:
+			return nil, convergedMS
+		}
+		o.lab.sleep(settlePollInterval)
+	}
+
+	return toViolations(last), -1
+}
+
+// evaluate takes one snapshot and checks every plane and invariant against it.
+// A query it cannot answer is a single oracle-setup failure for that poll, not
+// an aborted loop: the deadline turns the last poll's failures into violations,
+// mirroring checks.go's checkError philosophy.
+func (o *oracle) evaluate(ctx context.Context) evaluation {
+	snap, err := snapshotOVN(ctx, o.lab)
+	if err != nil {
+		return evaluation{failures: []settleFailure{{kind: violationOracleSetup, detail: err.Error()}}}
+	}
+	upstream, err := observeUpstream(ctx, o.lab)
+	if err != nil {
+		return evaluation{failures: []settleFailure{{kind: violationOracleSetup, detail: err.Error()}}}
+	}
+
+	ev := evaluation{readds: map[string]int{}}
+	for _, gw := range gatewayNames() {
+		exp := computeExpectation(snap, gw, o.ap.current[gw], o.ap.mgmtIP[gw])
+		obs, err := observeGateway(ctx, o.lab, gw, exp.PortForwardDev)
+		if err != nil {
+			ev.failures = append(ev.failures, settleFailure{kind: violationOracleSetup, target: gw, detail: err.Error()})
+			continue
+		}
+		ev.readds[gw] = obs.metrics.routeReAddsTotal
+		ev.failures = append(ev.failures, comparePlanes(gw, exp, obs, upstream)...)
+		ev.failures = append(ev.failures, metricsGate(gw, obs)...)
+	}
+	ev.failures = append(ev.failures, o.priorityLeadFailures(snap)...)
+	ev.failures = append(ev.failures, o.drainResidueFailures(snap)...)
+	ev.failures = append(ev.failures, o.vanishedChassisFailures(snap)...)
+	ev.failures = append(ev.failures, o.pfOnlyFrozenFailures(snap)...)
+	return ev
+}
+
+// comparePlanes diffs each per-gateway data plane against its expectation,
+// honouring the expectation's skip flags. Every mismatch is an expected-state
+// failure whose detail names the plane and the sorted missing/unexpected sets.
+func comparePlanes(gw string, exp gatewayExpectation, obs observedGateway, upstream upstreamRoutes) []settleFailure {
+	var fs []settleFailure
+	add := func(plane string, missing, unexpected []string) {
+		if len(missing) == 0 && len(unexpected) == 0 {
+			return
+		}
+		fs = append(fs, settleFailure{
+			kind:   violationExpectedState,
+			target: gw,
+			detail: fmt.Sprintf("%s: missing %v, unexpected %v", plane, missing, unexpected),
+		})
+	}
+
+	if !exp.SkipKernel {
+		m, u := diffSet(kernelStrings(exp.KernelRouteDev), setOf(kernelStrings(obs.kernelRoutes)))
+		add("kernel", m, u)
+	}
+
+	m, u := diffSet(exp.FRRStatic, obs.frrStatic)
+	add("frr", m, u)
+
+	if !exp.SkipPrefixList {
+		if exp.PrefixList == nil {
+			// A list expected gone but still present is the failure, whether or
+			// not it still holds permit entries — a standby that emptied the
+			// list without removing it left the object behind. add() would drop
+			// that case: with no entries both its sets are empty and it records
+			// nothing.
+			if !obs.prefixListAbsent {
+				fs = append(fs, settleFailure{
+					kind:   violationExpectedState,
+					target: gw,
+					detail: fmt.Sprintf("prefix-list: want %s absent, have %v",
+						announcedPrefixList, keysOf(obs.prefixList)),
+				})
+			}
+		} else {
+			m, u := diffSet(exp.PrefixList, obs.prefixList)
+			add("prefix-list", m, u)
+		}
+	}
+
+	if !exp.SkipHairpin {
+		m, u := diffSet(exp.Hairpin, obs.hairpin)
+		add("hairpin", m, u)
+	}
+
+	if exp.MACTweakFlows != -1 && obs.macTweakFlows != exp.MACTweakFlows {
+		fs = append(fs, settleFailure{
+			kind:   violationExpectedState,
+			target: gw,
+			detail: fmt.Sprintf("mac-tweak: want %d flows, have %d", exp.MACTweakFlows, obs.macTweakFlows),
+		})
+	}
+
+	m, u = diffSet(dnatStrings(exp.DNAT), setOf(observedDNATStrings(obs.dnat)))
+	add("dnat", m, u)
+
+	m, u = diffSet(exp.HairpinMasquerade, obs.masquerade)
+	add("hairpin-masquerade", m, u)
+
+	m, u = diffSet(exp.ManagedVIPs, obs.vips)
+	add("managed-vip", m, u)
+
+	// Announcements are a presence-and-staleness bound, not set equality:
+	// MustAnnounce ⊆ announced ⊆ AnnounceBound.
+	announced := upstream.announcedBy(gw)
+	var missing, extra []string
+	for _, ip := range exp.MustAnnounce {
+		if !announced[ip] {
+			missing = append(missing, ip)
+		}
+	}
+	bound := setOf(exp.AnnounceBound)
+	for ip := range announced {
+		if !bound[ip] {
+			extra = append(extra, ip)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+	add("announced", missing, extra)
+
+	return fs
+}
+
+// metricsGate holds each gateway to a settled reconcile: no consecutive
+// re-adds and no inactive routes. A sustained non-zero here is route
+// instability the set checks cannot see.
+func metricsGate(gw string, obs observedGateway) []settleFailure {
+	if obs.metrics.consecutiveReAdds == 0 && obs.metrics.inactiveRoutes == 0 {
+		return nil
+	}
+	return []settleFailure{{
+		kind:   violationRouteFlap,
+		target: gw,
+		detail: fmt.Sprintf("consecutive_readds=%d inactive_routes=%d",
+			obs.metrics.consecutiveReAdds, obs.metrics.inactiveRoutes),
+	}}
+}
+
+// priorityLeadFailures asserts the elected owner of every bound chassisredirect
+// port with at least two Gateway_Chassis candidates strictly outranks every
+// peer — the invariant HA re-election exists to keep. Single-candidate groups
+// (a pinned router) are exempt.
+func (o *oracle) priorityLeadFailures(snap ovnSnapshot) []settleFailure {
+	var fs []settleFailure
+	for _, port := range sortedKeys(snap.CRPortChassis) {
+		owner := snap.CRPortChassis[port]
+		if owner == "" {
+			continue // unbound: a re-election is in flight
+		}
+		gcs := snap.LRPs[lrpOfCRPort(port)].GatewayChassis
+		if len(gcs) < 2 {
+			continue
+		}
+		ownerPrio, ok := ownerPriority(snap, gcs, owner)
+		if !ok {
+			fs = append(fs, settleFailure{
+				kind:   violationExpectedState,
+				target: port,
+				detail: fmt.Sprintf("%s is owned by %s, which holds no Gateway_Chassis row", port, owner),
+			})
+			continue
+		}
+		for _, u := range gcs {
+			row, ok := snap.GatewayChassis[u]
+			if !ok || row.ChassisName == owner {
+				continue
+			}
+			if row.Priority >= ownerPrio {
+				fs = append(fs, settleFailure{
+					kind:   violationExpectedState,
+					target: port,
+					detail: fmt.Sprintf("%s owner %s at priority %d does not outrank %s at priority %d",
+						port, owner, ownerPrio, row.ChassisName, row.Priority),
+				})
+			}
+		}
+	}
+	return fs
+}
+
+func ownerPriority(snap ovnSnapshot, gcs []string, owner string) (int, bool) {
+	for _, u := range gcs {
+		if row, ok := snap.GatewayChassis[u]; ok && row.ChassisName == owner {
+			return row.Priority, true
+		}
+	}
+	return 0, false
+}
+
+// drainResidueFailures flags a Gateway_Chassis row left at priority 0 that no
+// legitimate drain explains: not one already at 0 when the run started
+// (tolerated0), and not owned by a gateway whose last disruptive action
+// drained it (drainedLegit). A stray priority-0 row is a chassis that gave up
+// its mastership without being asked to.
+func (o *oracle) drainResidueFailures(snap ovnSnapshot) []settleFailure {
+	var fs []settleFailure
+	for _, uuid := range sortedKeys(snap.GatewayChassis) {
+		row := snap.GatewayChassis[uuid]
+		if row.Priority != 0 || o.tolerated0[uuid] || o.drainedLegit[row.ChassisName] {
+			continue
+		}
+		fs = append(fs, settleFailure{
+			kind:   violationDrainDisabled,
+			target: row.ChassisName,
+			detail: fmt.Sprintf("Gateway_Chassis row %s for %s sits at priority 0 without a drain-enabled termination",
+				row.Name, row.ChassisName),
+		})
+	}
+	return fs
+}
+
+// vanishedChassisFailures asserts every managed static route names a chassis
+// still present in SB. A route pointing at a chassis that is gone is one the
+// stale-chassis cleanup should have reclaimed.
+func (o *oracle) vanishedChassisFailures(snap ovnSnapshot) []settleFailure {
+	var fs []settleFailure
+	for _, r := range snap.StaticRoutes {
+		chassis := r.ExternalIDs[routeChassisKey]
+		if chassis == "" || snap.Chassis[chassis] {
+			continue
+		}
+		fs = append(fs, settleFailure{
+			kind:   violationExpectedState,
+			target: chassis,
+			detail: fmt.Sprintf("managed route %s names chassis %s, absent from the SB Chassis table",
+				r.IPPrefix, chassis),
+		})
+	}
+	return fs
+}
+
+// pfOnlyFrozenFailures asserts a port-forward-only gateway never touches NB: it
+// runs with no OVN view, so any managed row it appears on — new, content-
+// changed, or carrying a takeover marker — relative to prime is a write it
+// could not legitimately have made.
+func (o *oracle) pfOnlyFrozenFailures(snap ovnSnapshot) []settleFailure {
+	var fs []settleFailure
+	for _, gw := range gatewayNames() {
+		doc := o.ap.current[gw]
+		if docRemoteSet(doc, "ovn_sb_remote") || docRemoteSet(doc, "ovn_nb_remote") {
+			continue // not port-forward-only
+		}
+		for _, r := range snap.StaticRoutes {
+			if r.ExternalIDs[routeChassisKey] != gw && r.ExternalIDs[routeAdvertisedKey] != gw {
+				continue // not attributed to this pf-only gateway
+			}
+			baseline, existed := o.baselineManaged[r.UUID]
+			switch {
+			case !existed:
+				fs = append(fs, settleFailure{
+					kind:   violationOVNTouched,
+					target: gw,
+					detail: fmt.Sprintf("pf-only %s grew managed route %s, absent at prime", gw, r.IPPrefix),
+				})
+			case baseline != renderManagedRoute(r):
+				fs = append(fs, settleFailure{
+					kind:   violationOVNTouched,
+					target: gw,
+					detail: fmt.Sprintf("pf-only %s rewrote managed route %s", gw, r.IPPrefix),
+				})
+			}
+		}
+	}
+	return fs
+}
+
+// readdFlaps reports the gateways whose summed route_readds_total moved between
+// the two confirmation evaluations — a route still being re-added even though
+// every set looks converged.
+func readdFlaps(before, after map[string]int) []settleFailure {
+	var fs []settleFailure
+	for _, gw := range gatewayNames() {
+		if after[gw] != before[gw] {
+			fs = append(fs, settleFailure{
+				kind:   violationRouteFlap,
+				target: gw,
+				detail: fmt.Sprintf("route_readds_total moved from %d to %d across the settle confirmation",
+					before[gw], after[gw]),
+			})
+		}
+	}
+	return fs
+}
+
+// toViolations converts a poll's failures into the run record's violations,
+// sorted for a deterministic record. The tick and journal offset are left for
+// the engine to stamp.
+func toViolations(failures []settleFailure) []violationRecord {
+	if len(failures) == 0 {
+		return nil
+	}
+	sort.Slice(failures, func(i, j int) bool {
+		a, b := failures[i], failures[j]
+		if a.kind != b.kind {
+			return a.kind < b.kind
+		}
+		if a.target != b.target {
+			return a.target < b.target
+		}
+		return a.detail < b.detail
+	})
+	out := make([]violationRecord, 0, len(failures))
+	for _, f := range failures {
+		out = append(out, violationRecord{Kind: f.kind, Target: f.target, Detail: f.detail})
+	}
+	return out
+}
+
+// renderManagedRoute renders a managed static route to a stable string —
+// prefix plus its external_ids in sorted-key order — so the port-forward-only
+// frozen-NB check can compare a live row against its prime baseline.
+func renderManagedRoute(r staticRouteRow) string {
+	keys := make([]string, 0, len(r.ExternalIDs))
+	for k := range r.ExternalIDs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+r.ExternalIDs[k])
+	}
+	return r.IPPrefix + "|" + strings.Join(parts, ",")
+}
+
+// =============================================================================
+// Set helpers
+// =============================================================================
+
+// kernelStrings renders an IP→device map as sorted "ip dev <device>" tokens,
+// so the kernel plane is compared on the route and its device together.
+func kernelStrings(byIP map[string]string) []string {
+	out := make([]string, 0, len(byIP))
+	for ip, dev := range byIP {
+		out = append(out, fmt.Sprintf("%s dev %s", ip, dev))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// dnatStrings / observedDNATStrings render DNAT rules to a canonical token so
+// the expected and observed rulesets compare as sets.
+func dnatStrings(rules []dnatExpectation) []string {
+	out := make([]string, 0, len(rules))
+	for _, r := range rules {
+		out = append(out, dnatToken(r.VIP, r.Proto, r.Port, r.Backend, r.DestPort))
+	}
+	return out
+}
+
+func observedDNATStrings(rules []observedDNAT) []string {
+	out := make([]string, 0, len(rules))
+	for _, r := range rules {
+		out = append(out, dnatToken(r.vip, r.proto, r.port, r.backend, r.destPort))
+	}
+	return out
+}
+
+func dnatToken(vip, proto string, port int, backend string, destPort int) string {
+	return fmt.Sprintf("%s %s dport %d -> %s:%d", vip, proto, port, backend, destPort)
+}
+
+// diffSet returns the expected values missing from observed and the observed
+// values not expected, both sorted, for a deterministic failure detail.
+func diffSet(expected []string, observed map[string]bool) (missing, unexpected []string) {
+	exp := setOf(expected)
+	for _, e := range expected {
+		if !observed[e] {
+			missing = append(missing, e)
+		}
+	}
+	for o := range observed {
+		if !exp[o] {
+			unexpected = append(unexpected, o)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(unexpected)
+	return missing, unexpected
+}
+
+func setOf(values []string) map[string]bool {
+	m := make(map[string]bool, len(values))
+	for _, v := range values {
+		m[v] = true
+	}
+	return m
+}
+
+func keysOf(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/test/e2e/chaos/oracle_test.go
+++ b/test/e2e/chaos/oracle_test.go
@@ -322,6 +322,43 @@ func TestManagedEntryNamingAVanishedChassisIsAViolation(t *testing.T) {
 	}
 }
 
+// A drain question the oracle cannot ask at inject time tolerates the target's
+// priority-0 residue rather than fabricating a drain-while-disabled violation —
+// the same "could not ask" split agentAlive and checkError make.
+func TestObserveInjectToleratesAnUnanswerableDrainQuestion(t *testing.T) {
+	fx := newOracleLab(t)
+	// The marker check on gateway-2 is not exit 1 (marker absent) but a
+	// question that could not be asked at all — a docker daemon under load.
+	respond := func(argv []string) (string, error) {
+		line := strings.Join(argv, " ")
+		if strings.Contains(line, "clab-ovn-e2e-gateway-2") && strings.Contains(line, "test -f "+profileMarkerPath) {
+			return "", errBoom
+		}
+		return fx.respond(argv)
+	}
+	o := oracleFor(t, respond, fullModeDocs(t))
+	ctx := context.Background()
+
+	if err := o.prime(ctx); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+
+	// A fresh priority-0 row appears for gateway-2 — drain residue on its face.
+	fx.extraGC = append(fx.extraGC, gcExtra{uuid: "gc-new", name: "lr0-public-extra", chassis: "gateway-2"})
+
+	err := o.observeInject(ctx, "agent-terminate", "gateway-2")
+	if err == nil {
+		t.Fatal("observeInject swallowed the unanswerable drain question instead of surfacing it")
+	}
+	v, convergedMS := o.verify(ctx)
+	if hasViolation(v, violationDrainDisabled, "gateway-2") {
+		t.Fatalf("an unanswerable drain question fabricated a drain-while-disabled violation: %+v", v)
+	}
+	if convergedMS < 0 {
+		t.Fatalf("convergedMS = %d, want >= 0: the tolerated residue leaves the lab converged", convergedMS)
+	}
+}
+
 // A drain tolerance covers the window that follows the fault that earned it,
 // not the rest of the run: the agent restores a drained row to priority 1 on
 // startup, so once a window has consumed the tolerance the same row still at 0

--- a/test/e2e/chaos/oracle_test.go
+++ b/test/e2e/chaos/oracle_test.go
@@ -1,0 +1,472 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// oracleFor wires an oracle over a canned lab and per-gateway config docs,
+// with a generous settle budget the fakeClock burns through instantly.
+func oracleFor(t *testing.T, respond func([]string) (string, error), docs map[string]map[string]any) *oracle {
+	t.Helper()
+	cmd := &fakeCommander{respond: respond}
+	o := newOracle(newTestLab(cmd, newFakeClock()), oracleApplier(docs))
+	o.settleTimeout = 90 * time.Second
+	return o
+}
+
+func hasViolation(v []violationRecord, kind, target string) bool {
+	for _, r := range v {
+		if r.Kind == kind && r.Target == target {
+			return true
+		}
+	}
+	return false
+}
+
+func hasTarget(v []violationRecord, target string) bool {
+	for _, r := range v {
+		if r.Target == target {
+			return true
+		}
+	}
+	return false
+}
+
+// A lab that already matches its configuration passes the settle on the second
+// (confirmation) evaluation, with no violations and a non-negative convergence
+// time.
+func TestSettlePassesOnAConvergedLab(t *testing.T) {
+	fx := newOracleLab(t)
+	o := oracleFor(t, fx.respond, fullModeDocs(t))
+	ctx := context.Background()
+
+	if err := o.prime(ctx); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	v, convergedMS := o.verify(ctx)
+
+	if len(v) != 0 {
+		t.Fatalf("a converged lab reported violations: %+v", v)
+	}
+	if convergedMS < 0 {
+		t.Fatalf("convergedMS = %d, want >= 0 on a pass", convergedMS)
+	}
+}
+
+// A divergence that never heals becomes a violation once the settle window
+// expires — naming the gateway and the plane that stayed wrong.
+func TestSettleDeadlineConvertsDivergenceIntoViolations(t *testing.T) {
+	fx := newOracleLab(t)
+	fx.dropKernel["gateway-1"] = "192.0.2.10" // one kernel route missing on every poll
+	o := oracleFor(t, fx.respond, fullModeDocs(t))
+	ctx := context.Background()
+
+	if err := o.prime(ctx); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	v, convergedMS := o.verify(ctx)
+
+	if convergedMS != -1 {
+		t.Fatalf("convergedMS = %d, want -1 when the lab never converges", convergedMS)
+	}
+	found := false
+	for _, r := range v {
+		if r.Kind == violationExpectedState && r.Target == "gateway-1" && strings.Contains(r.Detail, "kernel") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no kernel expected-state violation naming gateway-1: %+v", v)
+	}
+}
+
+// A transient divergence that heals within the window is absorbed: the retries
+// see it clear and the settle passes.
+func TestSettleRetriesAbsorbTransientDivergence(t *testing.T) {
+	fx := newOracleLab(t)
+	var kernelCalls int
+	respond := func(argv []string) (string, error) {
+		line := strings.Join(argv, " ")
+		if strings.Contains(line, "clab-ovn-e2e-gateway-1") && strings.Contains(line, "ip -j route show proto 44") {
+			kernelCalls++
+			if kernelCalls <= 2 { // the first two evaluations miss a route, then it heals
+				return `[{"dst":"192.0.2.1","dev":"br-ex"},{"dst":"192.0.2.12","dev":"br-ex"}]`, nil
+			}
+		}
+		return fx.respond(argv)
+	}
+	o := oracleFor(t, respond, fullModeDocs(t))
+	ctx := context.Background()
+
+	if err := o.prime(ctx); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	v, convergedMS := o.verify(ctx)
+
+	if len(v) != 0 {
+		t.Fatalf("a divergence that healed still failed the settle: %+v", v)
+	}
+	if convergedMS < 0 {
+		t.Fatalf("convergedMS = %d, want >= 0 once the lab heals", convergedMS)
+	}
+}
+
+// The flap indicators fail the settle two ways: a sustained consecutive-readds
+// gauge, and a route-readds counter that keeps climbing between the two
+// confirmation evaluations.
+func TestSettleFailsOnFlapIndicators(t *testing.T) {
+	t.Run("consecutive readds gauge", func(t *testing.T) {
+		fx := newOracleLab(t)
+		fx.consecutive["gateway-1"] = 2
+		o := oracleFor(t, fx.respond, fullModeDocs(t))
+		ctx := context.Background()
+
+		if err := o.prime(ctx); err != nil {
+			t.Fatalf("prime: %v", err)
+		}
+		v, convergedMS := o.verify(ctx)
+
+		if convergedMS != -1 {
+			t.Fatalf("convergedMS = %d, want -1 on a persistent flap", convergedMS)
+		}
+		if !hasViolation(v, violationRouteFlap, "gateway-1") {
+			t.Fatalf("no route-flap violation for the flapping gateway: %+v", v)
+		}
+	})
+
+	t.Run("route readds counter climbs across the confirmation", func(t *testing.T) {
+		fx := newOracleLab(t)
+		var scrapes int
+		respond := func(argv []string) (string, error) {
+			line := strings.Join(argv, " ")
+			if strings.Contains(line, "clab-ovn-e2e-gateway-1") && strings.Contains(line, "/metrics") {
+				scrapes++ // green gauges, but the counter never settles
+				return climbingMetrics(scrapes), nil
+			}
+			return fx.respond(argv)
+		}
+		o := oracleFor(t, respond, fullModeDocs(t))
+		ctx := context.Background()
+
+		if err := o.prime(ctx); err != nil {
+			t.Fatalf("prime: %v", err)
+		}
+		v, convergedMS := o.verify(ctx)
+
+		if convergedMS != -1 {
+			t.Fatalf("convergedMS = %d, want -1 when the counter never settles", convergedMS)
+		}
+		found := false
+		for _, r := range v {
+			if r.Kind == violationRouteFlap && r.Target == "gateway-1" && strings.Contains(r.Detail, "route_readds_total") {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("no route-flap violation from the climbing counter: %+v", v)
+		}
+	})
+}
+
+// climbingMetrics is a green metrics scrape whose route_readds_total counter is
+// n — used to prove the confirmation catches a counter that never settles.
+func climbingMetrics(n int) string {
+	return fmt.Sprintf("HTTP/1.0 200 OK\r\nContent-Type: text/plain\r\n\r\n"+
+		"ovn_network_agent_consecutive_readds 0\n"+
+		"ovn_network_agent_inactive_routes 0\n"+
+		"ovn_network_agent_route_readds_total{plane=\"kernel\"} %d\n"+
+		"ovn_network_agent_route_readds_total{plane=\"frr\"} 0\n", n)
+}
+
+// A priority-0 Gateway_Chassis row is drain residue — a violation — unless it
+// was already 0 at prime, or a drain-enabled termination explains it.
+func TestDrainResidueIsAViolationOnlyWithoutADrainEnabledTermination(t *testing.T) {
+	fx := newOracleLab(t)
+	// A row already parked at priority 0 when the run started is tolerated.
+	fx.extraGC = append(fx.extraGC, gcExtra{uuid: "gc-zero", name: "lr0-public-standby", chassis: "gateway-3"})
+	docs := fullModeDocs(t)
+	docs["gateway-2"]["drain_on_shutdown"] = true // gateway-2's config drains
+	o := oracleFor(t, fx.respond, docs)
+	ctx := context.Background()
+
+	if err := o.prime(ctx); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+
+	// A fresh priority-0 row for gateway-2, with no termination to explain it.
+	fx.extraGC = append(fx.extraGC, gcExtra{uuid: "gc-new", name: "lr0-public-extra", chassis: "gateway-2"})
+	v, _ := o.verify(ctx)
+	if !hasViolation(v, violationDrainDisabled, "gateway-2") {
+		t.Fatalf("a new priority-0 row was not flagged as drain residue: %+v", v)
+	}
+	if hasTarget(v, "gateway-3") {
+		t.Fatalf("a row already at priority 0 at prime was flagged: %+v", v)
+	}
+
+	// After a drain-enabled termination of gateway-2 (marker present, so the
+	// config's drain wins), the same row is tolerated and the settle passes.
+	fx.marker["gateway-2"] = true
+	if err := o.observeInject(ctx, "agent-terminate", "gateway-2"); err != nil {
+		t.Fatalf("observeInject: %v", err)
+	}
+	v2, convergedMS := o.verify(ctx)
+	if len(v2) != 0 {
+		t.Fatalf("a drain-enabled termination still flagged the residue: %+v", v2)
+	}
+	if convergedMS < 0 {
+		t.Fatalf("convergedMS = %d, want >= 0 once the residue is explained", convergedMS)
+	}
+}
+
+// A port-forward-only gateway runs with no OVN view, so a managed NB row that
+// appears against it after prime is a write it could not have made.
+func TestPFOnlyGatewayMustNotGrowManagedNBRows(t *testing.T) {
+	fx := newOracleLab(t)
+	docs := fullModeDocs(t)
+	docs["gateway-3"] = map[string]any{"bridge_dev": "br-ex"} // no OVN remotes → pf-only
+	o := oracleFor(t, fx.respond, docs)
+	ctx := context.Background()
+
+	if err := o.prime(ctx); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+
+	// A managed static route attributed to the pf-only gateway appears.
+	fx.managed = append(fx.managed, managedRoute{uuid: "sr-pf", prefix: "203.0.113.5/32", chassis: "gateway-3"})
+	v, convergedMS := o.verify(ctx)
+
+	if convergedMS != -1 {
+		t.Fatalf("convergedMS = %d, want -1 when a pf-only gateway grows an NB row", convergedMS)
+	}
+	if !hasViolation(v, violationOVNTouched, "gateway-3") {
+		t.Fatalf("a pf-only gateway growing a managed NB row was not flagged: %+v", v)
+	}
+}
+
+// The elected owner of a multi-candidate chassisredirect port must strictly
+// outrank every peer; a single-candidate group is exempt.
+func TestPriorityLeadViolationWhenAPeerOutranksTheOwner(t *testing.T) {
+	inverted := map[string]int{"gateway-1": 10, "gateway-2": 30, "gateway-3": 10}
+
+	t.Run("peer outranks the owner", func(t *testing.T) {
+		fx := newOracleLab(t)
+		fx.priority = inverted
+		o := oracleFor(t, fx.respond, fullModeDocs(t))
+		ctx := context.Background()
+
+		if err := o.prime(ctx); err != nil {
+			t.Fatalf("prime: %v", err)
+		}
+		v, _ := o.verify(ctx)
+
+		found := false
+		for _, r := range v {
+			if r.Kind == violationExpectedState && r.Target == "cr-lr0-public" && strings.Contains(r.Detail, "outrank") {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("an owner outranked by a peer was not flagged: %+v", v)
+		}
+	})
+
+	t.Run("single-candidate group is exempt", func(t *testing.T) {
+		fx := newOracleLab(t)
+		fx.priority = inverted
+		fx.lrpGC = []string{"gc-gateway-1"} // only the owner is a candidate
+		o := oracleFor(t, fx.respond, fullModeDocs(t))
+		ctx := context.Background()
+
+		if err := o.prime(ctx); err != nil {
+			t.Fatalf("prime: %v", err)
+		}
+		v, convergedMS := o.verify(ctx)
+
+		if hasTarget(v, "cr-lr0-public") {
+			t.Fatalf("a single-candidate group was flagged for priority lead: %+v", v)
+		}
+		if convergedMS < 0 {
+			t.Fatalf("convergedMS = %d, want >= 0 on an otherwise converged lab", convergedMS)
+		}
+	})
+}
+
+// A managed route naming a chassis that has left SB is a violation — the
+// stale-chassis cleanup should have reclaimed it.
+func TestManagedEntryNamingAVanishedChassisIsAViolation(t *testing.T) {
+	fx := newOracleLab(t)
+	fx.managed = append(fx.managed, managedRoute{uuid: "sr-gone", prefix: "192.0.2.77/32", chassis: "gateway-gone"})
+	o := oracleFor(t, fx.respond, fullModeDocs(t))
+	ctx := context.Background()
+
+	if err := o.prime(ctx); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	v, convergedMS := o.verify(ctx)
+
+	if convergedMS != -1 {
+		t.Fatalf("convergedMS = %d, want -1 with a vanished-chassis route present", convergedMS)
+	}
+	found := false
+	for _, r := range v {
+		if r.Kind == violationExpectedState && r.Target == "gateway-gone" && strings.Contains(r.Detail, "SB Chassis") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("a managed route naming a vanished chassis was not flagged: %+v", v)
+	}
+}
+
+// A drain tolerance covers the window that follows the fault that earned it,
+// not the rest of the run: the agent restores a drained row to priority 1 on
+// startup, so once a window has consumed the tolerance the same row still at 0
+// is residue nothing explains.
+func TestDrainToleranceExpiresWithTheSettleWindowThatConsumesIt(t *testing.T) {
+	fx := newOracleLab(t)
+	docs := fullModeDocs(t)
+	docs["gateway-2"]["drain_on_shutdown"] = true
+	o := oracleFor(t, fx.respond, docs)
+	ctx := context.Background()
+
+	if err := o.prime(ctx); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+
+	// A drain-enabled termination of gateway-2, and the priority-0 row it
+	// legitimately leaves behind.
+	fx.marker["gateway-2"] = true
+	if err := o.observeInject(ctx, "agent-terminate", "gateway-2"); err != nil {
+		t.Fatalf("observeInject: %v", err)
+	}
+	fx.extraGC = append(fx.extraGC, gcExtra{uuid: "gc-new", name: "lr0-public-extra", chassis: "gateway-2"})
+
+	if v, _ := o.verify(ctx); hasViolation(v, violationDrainDisabled, "gateway-2") {
+		t.Fatalf("the window following the drain did not tolerate its residue: %+v", v)
+	}
+
+	// A later window, with no new termination to explain it: the same row is
+	// now a chassis that gave up its mastership without being asked to.
+	v, convergedMS := o.verify(ctx)
+	if !hasViolation(v, violationDrainDisabled, "gateway-2") {
+		t.Fatalf("a consumed drain tolerance still exempted gateway-2: %+v", v)
+	}
+	if convergedMS != -1 {
+		t.Fatalf("convergedMS = %d, want -1 with unexplained drain residue present", convergedMS)
+	}
+}
+
+// A prefix-list expected gone but left behind holding no entries is a partial
+// cleanup, not a pass: the standby emptied the list without removing the object.
+func TestAnEmptyButPresentPrefixListOnAStandbyIsAViolation(t *testing.T) {
+	fx := newOracleLab(t)
+	// gateway-2 is a standby (gateway-1 owns cr-lr0-public), so the agent is
+	// expected to have cleaned the list away entirely. Instead the entries are
+	// gone but the list object survives.
+	respond := func(argv []string) (string, error) {
+		line := strings.Join(argv, " ")
+		if strings.Contains(line, "clab-ovn-e2e-gateway-2") &&
+			strings.Contains(line, "show ip prefix-list "+announcedPrefixList) {
+			return "ip prefix-list " + announcedPrefixList + ": 0 entries\n", nil
+		}
+		return fx.respond(argv)
+	}
+	o := oracleFor(t, respond, fullModeDocs(t))
+	ctx := context.Background()
+
+	if err := o.prime(ctx); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	v, convergedMS := o.verify(ctx)
+
+	if convergedMS != -1 {
+		t.Fatalf("convergedMS = %d, want -1 with a stale prefix-list object present", convergedMS)
+	}
+	found := false
+	for _, r := range v {
+		if r.Kind == violationExpectedState && r.Target == "gateway-2" &&
+			strings.Contains(r.Detail, "prefix-list") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("a standby leaking an emptied prefix-list object was not flagged: %+v", v)
+	}
+}
+
+// The absence checks that read a plane as empty key off the tool's own exit 1.
+// Every other non-zero exit is the docker CLI failing — a stopped container, an
+// unreachable daemon, an expired cmdTimeout — and reading it as "absent" would
+// report a plane converged that was never read at all. The baked config carries
+// no port_forwards, so the DNAT, masquerade and VIP expectations are empty and
+// a swallowed failure diffs empty against empty and passes.
+func TestAnUnreadableDataPlaneIsNotReadAsAbsent(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+	}{
+		{name: "nftables ruleset", cmd: "nft list table ip " + agentNftTable},
+		{name: "managed VIP addresses", cmd: "ip -j addr show dev loopback1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fx := newOracleLab(t)
+			// Exit 125 is docker's own "container is not running" — the command
+			// inside never ran, so it answered nothing.
+			respond := func(argv []string) (string, error) {
+				line := strings.Join(argv, " ")
+				if strings.Contains(line, "clab-ovn-e2e-gateway-1") && strings.Contains(line, tc.cmd) {
+					return "", errExit(t, 125)
+				}
+				return fx.respond(argv)
+			}
+			o := oracleFor(t, respond, fullModeDocs(t))
+			ctx := context.Background()
+
+			if err := o.prime(ctx); err != nil {
+				t.Fatalf("prime: %v", err)
+			}
+			v, convergedMS := o.verify(ctx)
+
+			if convergedMS != -1 {
+				t.Fatalf("convergedMS = %d, want -1: a plane that could not be read is not a converged plane", convergedMS)
+			}
+			if !hasViolation(v, violationOracleSetup, "gateway-1") {
+				t.Fatalf("a plane the oracle could not read was reported converged: %+v", v)
+			}
+		})
+	}
+}
+
+// A query the oracle cannot answer fails the settle loudly: the deadline turns
+// the unanswerable poll into a violation carrying the underlying error.
+func TestAnUnanswerableOracleQueryFailsTheSettleLoudly(t *testing.T) {
+	fx := newOracleLab(t)
+	o := oracleFor(t, fx.respond, fullModeDocs(t))
+	ctx := context.Background()
+
+	if err := o.prime(ctx); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	fx.snapErr = true // the OVN snapshot fails on every poll from here on
+
+	v, convergedMS := o.verify(ctx)
+
+	if convergedMS != -1 {
+		t.Fatalf("convergedMS = %d, want -1 when the oracle cannot observe", convergedMS)
+	}
+	found := false
+	for _, r := range v {
+		if r.Kind == violationOracleSetup && strings.Contains(r.Detail, "boom") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("an unanswerable query did not fail loudly with the error: %+v", v)
+	}
+}

--- a/test/e2e/gwnode-config.yaml
+++ b/test/e2e/gwnode-config.yaml
@@ -50,3 +50,12 @@ reconcile_interval: "5s"
 # issue #111 so a change to the default does not silently affect the
 # scenario's wall-clock budget.
 stale_chassis_grace_period: "30s"
+
+# Expose the Prometheus metrics endpoint so the chaos runner's
+# expected-state oracle (issue #179) can read the agent's own
+# flap-indicator series (ovn_network_agent_consecutive_readds,
+# ovn_network_agent_route_readds_total, ovn_network_agent_inactive_routes)
+# during settle windows. Loopback-only on purpose: the endpoint is
+# scraped via `docker exec` inside the gateway and is never exposed on
+# the lab networks.
+metrics_listen: "127.0.0.1:9273"


### PR DESCRIPTION
Closes #179

The chaos runner already asserted that nothing went red. This adds the other half: a config-aware expected-state oracle that recomputes, from live OVN state plus each gateway's own configuration, the exact data plane the agents must converge to — and pauses the run in settle windows to check it.

## The change, in commit order

**`84995aa` test/e2e: expose the agent metrics endpoint in the gwnode config**
The oracle's flap gate reads the agent's own indicator series (`consecutive_readds`, `route_readds_total`, `inactive_routes`), but the lab never served `/metrics` — `metrics_listen` was unset. Bound to `127.0.0.1:9273`, loopback-only on purpose: later commits scrape it via `docker exec` inside each gateway rather than exposing it on the lab networks.

**`3399592` test/e2e: record settle inputs and journal offsets in the run record**
Groundwork only — the run-record fields and journal events the oracle and the engine's settle scheduling build on. Additive to `chaos-run-record/v1`, so existing readers keep working.

**`d40d3f1` test/e2e: compute per-gateway expected state from OVN and the config**
The pure recompute the oracle polls against, mirroring the agent's `computeDesiredState` and its reconcile branches per-mode, per-activity and config-aware. This is what makes profile-driven chaos meaningful: a CIDR filter means floating IPs outside it must have no routes, no port forwarding means no DNAT chains, port-forward-only means OVN is untouched, drain disabled means a terminating agent must not lower its priority. Expectations follow every config flip the engine performs.

**`cb83767` test/e2e: add the config-aware oracle and its observation layer**
`observe.go` gathers every lab-facing plane through the existing commander seam: an OVN NB/SB snapshot (chassisredirect ownership, routers, LRPs, NAT, `Gateway_Chassis`, managed static routes, per-LRP segment tags), kernel proto-44 routes, FRR statics, the `ANNOUNCED-NETWORKS` prefix-list, hairpin and MAC-tweak OVS flows, nftables DNAT/masquerade, managed VIP addresses, agent metrics, and the upstream BGP announcements. It adds a map-aware OVSDB cell parser for the `external_ids`/`options` columns that `parseOVSDBTable` flattens away.

`oracle.go` diffs each gateway against `computeExpectation` across seven data planes, and holds the snapshot to four invariants — chassisredirect priority lead, drain residue, vanished-chassis hygiene, and a frozen NB under port-forward-only — plus the metrics flap gate. `verify` polls a settle loop clocked by the lab and requires two consecutive all-green evaluations a reconcile gap apart with `route_readds_total` steady between them; on deadline the last poll's failures become violations. `prime` records the baseline and `observeInject` classifies whether a terminated gateway could legitimately end at priority 0.

**`4fb6b53` test/e2e: verify chaos runs in settle windows against the oracle**
Wires it in: a settle window between ticks and one final settle after the last fault, the `observeInject` drain hook, and each violation stamped with the current tick and the last executed action's journal offset. Adds `-settle-every`/`-settle-timeout`, records them in the run record, and gates the run on the oracle priming against the green start state (exit 2 on failure).

**`1c59dbc` docs: document the chaos expected-state oracle and settle windows**
Covers the settle model, the seven verified planes plus the upstream announcement bound, config awareness, drain-residue tolerances, the invariants, the flap gate and the five new violation kinds; adds the flag rows, folds the settle schedule into the replay contract, and documents the journal events, the `journal_offset` stamp and the `summary.json` settles section.

## Notes for the reviewer

- **Reproducibility is preserved.** The oracle draws nothing from the engine's rng. Settle windows consume wall-clock but not the decision stream, so a replay at the same seed reproduces the same faults.
- **`-settle-timeout` has a 35s floor** (`minSettleTimeout`). The timeout bounds only the *first* all-green evaluation; the confirmation that follows is not deadline-bounded. The floor covers one slow-cadence reconcile (15s) plus the 20s confirmation gap a failed first green burns — below it, a lab that is healing correctly would time out into false violations.
- **Defaults**: `-settle-every 3m` (0 runs only the final settle), `-settle-timeout 2m`.
- **One addition beyond the issue text**: the `metrics_listen` config change (`84995aa`). The issue asks for the flap gate but the lab could not serve the metrics it needs, so enabling the endpoint was a prerequisite rather than a scope expansion.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) c4682b7 with Claude:claude-opus-4-8_
