### PR TITLE
ci: run chaos nightly across the profile matrix

### DIFF
--- a/.github/workflows/e2e-chaos.yml
+++ b/.github/workflows/e2e-chaos.yml
@@ -4,12 +4,25 @@ name: E2E Chaos
 # every job there asserts one fault and leaves the lab baseline-green,
 # while the runner injects a randomized *sequence* and deliberately
 # leaves the master wherever the last election put it, so it is not
-# something to hang off every PR. `workflow_dispatch` gives it a CI
-# path — the one place `execCommander`, the `containerlab tools veth
-# create` re-wire and the collector actually run against a real lab —
-# without adding ~15 min to the PR suite. Dispatch it from the Actions
-# tab when you touch the agent's failover, drain or chassis-cleanup
-# paths.
+# something to hang off every PR. This workflow is its CI path — the one
+# place `execCommander`, the `containerlab tools veth create` re-wire and
+# the collector actually run against a real lab — on three triggers, none
+# of them the default ~15 min PR gate:
+#
+#   - Nightly (`schedule`): accumulating seeded exploration. Each night
+#     sweeps the curated profiles as a matrix, one job per profile at the
+#     runner-default 10 minutes, with the seed set to the run id so
+#     successive nights explore different action sequences. The seed is
+#     echoed to the run log and recorded in the uploaded run record, so a
+#     failing night is replayable from its own artifacts.
+#   - Dispatch (`workflow_dispatch`): the exact replay path. Dispatching
+#     with the seed, profile and duration recorded in a failing nightly
+#     job reruns that job exactly. Also the ad-hoc path: dispatch it from
+#     the Actions tab when you touch the agent's failover, drain or
+#     chassis-cleanup paths.
+#   - PR smoke (`pull_request: labeled`): applying the `chaos-smoke` label
+#     opts a single PR into a 3-minute seed-42 `everything-on` smoke,
+#     rather than adding chaos to every PR in the suite.
 #
 # Unlike the e2e.yml jobs there is no separate baseline gate here: the
 # runner refuses to start against a lab whose combined start state (a
@@ -17,35 +30,158 @@ name: E2E Chaos
 # code 2 — distinct from a real violation (exit 1).
 on:
   workflow_dispatch:
-    # The defaults reproduce the historical CI run (`-seed 42
-    # -duration 3m`): a fixed seed keeps the action sequence
-    # reproducible, and 3 minutes of faults plus the recovery budget of
-    # whatever action was in flight stays inside the same budget as the
-    # drain-hitless job in e2e.yml.
+    # The defaults (`-seed 42 -duration 10m -profile everything-on`)
+    # match a nightly everything-on job's duration and profile, not its
+    # seed — nightly jobs seed from the run id. To replay a specific
+    # nightly job, dispatch with the seed, profile and duration read back
+    # from that job's artifacts; the fixed seed then reproduces its
+    # action sequence exactly.
     inputs:
       seed:
         description: RNG seed for the fault sequence (same seed, same sequence)
         required: false
         default: "42"
       duration:
-        description: Fault-injection duration, Go syntax (bounded by the 25-minute job timeout)
+        description: Fault-injection duration, Go syntax (bounded by the 40-minute job timeout)
         required: false
-        default: "3m"
+        default: "10m"
+      profile:
+        description: Curated chaos profile to replay (profiles listed in registry order)
+        required: false
+        type: choice
+        default: everything-on
+        options:
+          - everything-on
+          - flat-minimal
+          - flat-dnat
+          - vlan-no-dnat
+          - pf-only
+          - heterogeneous
+  # Nightly, off the hour, staggered clear of the Monday 05:00–06:00 UTC
+  # weekly-cron burst (govulncheck/test/codeql/scorecard).
+  schedule:
+    - cron: "17 3 * * *"
+  # Only the `chaos-smoke` label opts a PR in — the gate that acts on it
+  # lives on the `params` job below, so the default PR gate stays at its
+  # current cost. Applying the label needs triage permission, which is
+  # the cost gate.
+  pull_request:
+    types: [labeled]
+    branches: [main]
 
 permissions:
   contents: read
 
 jobs:
-  chaos:
-    name: Seeded chaos session
+  # Resolve the three run inputs — the profile matrix, the seed and the
+  # duration — once, per trigger, so the chaos job below reads them the
+  # same way on every path. No checkout: the job only writes strings.
+  params:
+    name: Resolve run inputs
     runs-on: ubuntu-latest
-    # Same budget as e2e.yml's drain-hitless job: one bring-up, the
-    # fault window, plus the recovery budget of whatever action was in
-    # flight when the duration expired. A `timeout-minutes` cancellation
-    # is not a failure, so keeping the cap a backstop (rather than the
-    # thing that ends the run) is what lets the runner dump its own
-    # lab-state bundle on the failure path.
-    timeout-minutes: 25
+    timeout-minutes: 5
+    # Unrelated label events skip the whole run; the `chaos` job inherits
+    # the skip through `needs`. This is the PR cost gate — a PR runs
+    # chaos only once someone with triage permission applies the
+    # `chaos-smoke` label.
+    if: github.event_name != 'pull_request' || github.event.label.name == 'chaos-smoke'
+    outputs:
+      profiles: ${{ steps.resolve.outputs.profiles }}
+      seed: ${{ steps.resolve.outputs.seed }}
+      duration: ${{ steps.resolve.outputs.duration }}
+    steps:
+      - name: Resolve inputs per trigger
+        id: resolve
+        # The dispatch inputs travel through env instead of being
+        # interpolated into the script, so a dispatch payload can never
+        # inject shell syntax into it (same rule as the run step below).
+        #
+        # The nightly profile list is duplicated here and in the dispatch
+        # `choice` options above because a `choice` input's options cannot
+        # be computed. `TestChaosWorkflowSweepsEveryProfile` in
+        # test/e2e/chaos/profiles_test.go guards both lists against drift
+        # from the registry in test/e2e/chaos/profiles.go.
+        env:
+          INPUT_SEED: ${{ inputs.seed }}
+          INPUT_DURATION: ${{ inputs.duration }}
+          INPUT_PROFILE: ${{ inputs.profile }}
+        run: |
+          case "${GITHUB_EVENT_NAME}" in
+          schedule)
+            # Nightly: sweep every curated profile, seed = the run id so
+            # each night is a different (recorded, replayable) sequence.
+            profiles='["everything-on","flat-minimal","flat-dnat","vlan-no-dnat","pf-only","heterogeneous"]'
+            seed="${GITHUB_RUN_ID}"
+            duration="10m"
+            ;;
+          workflow_dispatch)
+            # Replay/ad-hoc: a single chosen profile at the dispatched
+            # seed and duration.
+            profiles="[\"${INPUT_PROFILE}\"]"
+            seed="${INPUT_SEED}"
+            duration="${INPUT_DURATION}"
+            ;;
+          pull_request)
+            # PR smoke: one profile, a fixed seed, a short fault window.
+            profiles='["everything-on"]'
+            seed="42"
+            duration="3m"
+            ;;
+          esac
+          # seed and duration are written to GITHUB_OUTPUT below, and on
+          # the dispatch path they are free-form inputs. Passing them
+          # through env blocks shell injection but not GITHUB_OUTPUT
+          # injection: a newline in the value opens a second `key=value`
+          # line. Since profiles= is written before seed=, an injected
+          # `profiles=[...]` line lands after the constrained one, wins as
+          # the last value for the key, and fans the matrix out to
+          # attacker-chosen values. Reject anything but a bare non-negative
+          # integer seed, and forbid a newline in duration. The schedule
+          # and PR paths set literals that pass unchanged.
+          case "${seed}" in
+          ''|*[!0-9]*)
+            echo "seed must be a non-negative integer, got: ${seed}" >&2
+            exit 1
+            ;;
+          esac
+          case "${duration}" in
+          *$'\n'*)
+            echo "duration must not contain a newline" >&2
+            exit 1
+            ;;
+          esac
+          # Echoing to the run log is what records the resolved nightly
+          # seed there; the runner also records it in the uploaded
+          # summary.json and journal.jsonl. Writing the same three values
+          # to GITHUB_OUTPUT is what the matrix and the chaos job read.
+          echo "profiles: ${profiles}"
+          echo "seed: ${seed}"
+          echo "duration: ${duration}"
+          {
+            echo "profiles=${profiles}"
+            echo "seed=${seed}"
+            echo "duration=${duration}"
+          } >> "${GITHUB_OUTPUT}"
+
+  chaos:
+    name: Seeded chaos session (${{ matrix.profile }})
+    runs-on: ubuntu-latest
+    needs: params
+    # fail-fast: false keeps one profile's failure from cancelling the
+    # other five nightly jobs — each profile's run is worth its own
+    # artifact bundle.
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: ${{ fromJSON(needs.params.outputs.profiles) }}
+    # Budget for one bring-up (~10 min incl. image builds), the profile
+    # apply (up to three gateway restarts), the 10-minute wall-clock
+    # fault window, the final settle (≤ the runner's 2m settle timeout
+    # plus confirmation), ≤2 min of lab-state collection and teardown. A
+    # `timeout-minutes` cancellation is not a failure, so keeping the cap
+    # a backstop (rather than the thing that ends the run) is what lets
+    # the runner still dump its own lab-state bundle on the failure path.
+    timeout-minutes: 40
 
     env:
       E2E_TOPOLOGY: test/e2e/topology.clab.yml
@@ -74,9 +210,20 @@ jobs:
         # into the run script, so a dispatch payload can never inject
         # shell syntax into the command line.
         env:
-          CHAOS_SEED: ${{ inputs.seed }}
-          CHAOS_DURATION: ${{ inputs.duration }}
-        run: make e2e-chaos CHAOS_FLAGS="-duration ${CHAOS_DURATION} -seed ${CHAOS_SEED} -out ${RUNNER_TEMP}/chaos"
+          CHAOS_SEED: ${{ needs.params.outputs.seed }}
+          CHAOS_DURATION: ${{ needs.params.outputs.duration }}
+          CHAOS_PROFILE: ${{ matrix.profile }}
+        run: make e2e-chaos CHAOS_FLAGS="-duration ${CHAOS_DURATION} -seed ${CHAOS_SEED} -profile ${CHAOS_PROFILE} -out ${RUNNER_TEMP}/chaos"
+
+      # The runner dumps `lab-state/` into the out directory itself on any
+      # non-zero exit, but a `make e2e-up` failure dies before the runner
+      # ever starts. This guard collects lab state in exactly that case
+      # and never double-collects. (The job-level LAB env already serves
+      # collect-artifacts.sh.)
+      - name: Collect failure artifacts
+        if: failure()
+        run: |
+          [ -d "${RUNNER_TEMP}/chaos/lab-state" ] || ./test/e2e/scenarios/collect-artifacts.sh "${RUNNER_TEMP}/chaos/lab-state"
 
       # Uploaded on every outcome, not just failure: the journal and the
       # run summary are the artifact the run exists to produce, and a
@@ -87,7 +234,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: e2e-artifacts-chaos-${{ github.run_id }}-${{ github.run_attempt }}
+          name: e2e-artifacts-chaos-${{ matrix.profile }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/chaos
           if-no-files-found: warn
           retention-days: 7

--- a/docs/contributing/ci.md
+++ b/docs/contributing/ci.md
@@ -17,7 +17,7 @@ a week even with no PR activity.**
 | Integration | `integration.yml` | PR (skips docs-only) | **`smoke`** |
 | govulncheck | `govulncheck.yml` | PR, push `main`, weekly | no |
 | E2E | `e2e.yml` | PR (skips docs-only), dispatch | no |
-| E2E Chaos | `e2e-chaos.yml` | dispatch | no |
+| E2E Chaos | `e2e-chaos.yml` | nightly, dispatch, PR label | no |
 | Docs | `docs.yml` | PR touching docs | no |
 | Package | `package.yml` | PR | no |
 | CodeQL | `codeql.yml` | PR, push `main`, weekly | no |
@@ -140,6 +140,32 @@ green-main contract needs:
 - **weekly cron** catches runner/kernel drift, toolchain updates, and a
   CVE published against a pinned dependency during a quiet period —
   surfacing it within a week with no PR activity.
+
+The chaos runner (`e2e-chaos.yml`) also runs nightly, on its own
+`17 3 * * *` cron — off the hour and staggered clear of the Monday
+05:00–06:00 UTC burst so the two schedules never contend for runners.
+Each night fans out as a `fail-fast: false` matrix over all six curated
+chaos profiles, one job per profile at 10 minutes, so a fault that only
+shows up under a particular gateway configuration still gets exercised.
+The seed is the run id, so successive nights explore different fault
+sequences rather than replaying one; it is echoed to the run log and
+recorded by the runner in the uploaded `summary.json` and
+`journal.jsonl`, so a failing night is fully replayable — dispatch
+`e2e-chaos.yml` with the seed, profile and duration read back from that
+job's artifacts and the run reproduces exactly.
+
+A pull request opts into a short chaos smoke by carrying the
+`chaos-smoke` label, which keeps chaos off the default PR gate;
+applying the label needs triage permission. The label is not created
+automatically — as a one-time repository-admin action (like applying
+the rulesets above), create it once with:
+
+```bash
+gh label create chaos-smoke \
+  --description "Run the e2e-chaos smoke on this PR"
+```
+
+Until the label exists the smoke trigger is inert.
 
 Scheduled-run failures appear in the Actions tab and notify the
 workflow file's last committer.

--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -1411,16 +1411,22 @@ dumped into `<out>/lab-state`.
 
 **In CI.** The runner has its own workflow,
 [`e2e-chaos.yml`](https://github.com/osism/ovn-network-agent/blob/main/.github/workflows/e2e-chaos.yml),
-which runs on `workflow_dispatch` only and uploads the journal, the
-summary and the lab-state dump on every outcome. The seed and duration
-are dispatch inputs defaulting to `-seed 42 -duration 3m`; the run uses
-the default profile (a profile matrix is
-[#180](https://github.com/osism/ovn-network-agent/issues/180)). It is
-deliberately not part of `e2e.yml`'s PR path: the scenarios there each
-assert one fault and leave the lab baseline-green, while a chaos run is
-a randomized sequence that deliberately leaves the master wherever the
-last election put it. Dispatch it from the Actions tab when you touch
-the agent's failover, drain or chassis-cleanup paths.
+on three triggers. Nightly it fans out as a matrix over all six curated
+profiles, one job per profile at the default 10-minute window, with the
+seed set to the run id so each night is a different — and, because the
+runner records it, replayable — fault sequence. `workflow_dispatch`
+takes `seed`/`duration`/`profile` inputs (defaulting to 42 / 10m /
+`everything-on`), so replaying a failing nightly combination is just
+dispatching it with the seed, profile and duration read back from that
+job's artifacts. A pull request opts into a short smoke (3 minutes,
+seed 42, `everything-on`) by carrying the `chaos-smoke` label, rather
+than chaos running on every PR. Each profile's journal and summary
+upload on every outcome, with the lab-state dump added on failure. It
+is deliberately not part of `e2e.yml`'s PR path: the scenarios there
+each assert one fault and leave the lab baseline-green, while a chaos
+run is a randomized sequence that deliberately leaves the master
+wherever the last election put it. Dispatch it from the Actions tab
+when you touch the agent's failover, drain or chassis-cleanup paths.
 
 ### Manual setup for triage
 
@@ -1478,9 +1484,10 @@ Docs-only changes are skipped with a `paths-ignore` filter (`docs/**`,
 to date, so the merged commit already passed E2E on its PR and
 re-running the ~10 min suite post-merge would only burn runner time.
 The [chaos runner](#chaos-runner) is not part of this workflow — it has
-its own dispatch-only
+its own
 [`e2e-chaos.yml`](https://github.com/osism/ovn-network-agent/blob/main/.github/workflows/e2e-chaos.yml),
-described in the chaos-runner section above.
+running on the nightly profile matrix, manual dispatch and the
+`chaos-smoke` PR label, described in the chaos-runner section above.
 
 One job runs per scenario, each on its own runner so a regression in one
 scenario is reported in isolation. Every job installs containerlab and

--- a/test/e2e/chaos/profiles_test.go
+++ b/test/e2e/chaos/profiles_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -232,6 +234,84 @@ func TestProfileProbesOnlyWhatItsLayersPutUp(t *testing.T) {
 			t.Fatalf("%s configures the API VIP but never probes it", p.name)
 		}
 	}
+}
+
+// A profile added to the registry must also reach the workflow's nightly
+// matrix and its dispatch options — otherwise a night silently stops
+// covering it, or a replay dispatch cannot select it. Both lists are
+// duplicated from the registry by hand (a choice input's options cannot be
+// computed, and the schedule) matrix array lives inside a shell script), so
+// this parses each list and asserts the profile actually appears there —
+// not merely somewhere in the file, where a bare comment mention would
+// satisfy the check.
+func TestChaosWorkflowSweepsEveryProfile(t *testing.T) {
+	workflow, err := os.ReadFile("../../../.github/workflows/e2e-chaos.yml")
+	if err != nil {
+		t.Fatalf("read the chaos workflow: %v", err)
+	}
+
+	nightly := workflowNightlyProfiles(t, workflow)
+	options := workflowDispatchOptions(t, workflow)
+
+	for _, p := range profiles() {
+		if !nightly[p.name] {
+			t.Fatalf("profile %s is in the registry but not in the workflow's nightly matrix array — a night silently stops covering it", p.name)
+		}
+		if !options[p.name] {
+			t.Fatalf("profile %s is in the registry but not in the workflow's dispatch choice options — it cannot be replayed", p.name)
+		}
+	}
+}
+
+// workflowNightlyProfiles returns the profiles the schedule) case fans the
+// nightly matrix out over. The array lives inside the resolve step's shell
+// script (a YAML block scalar), so it is read out of the raw bytes rather
+// than the parsed YAML.
+func workflowNightlyProfiles(t *testing.T, workflow []byte) map[string]bool {
+	t.Helper()
+	m := regexp.MustCompile(`(?s)schedule\).*?profiles='(\[.*?\])'`).FindSubmatch(workflow)
+	if m == nil {
+		t.Fatal("could not locate the nightly profiles array in the schedule) case")
+	}
+	var names []string
+	if err := json.Unmarshal(m[1], &names); err != nil {
+		t.Fatalf("nightly profiles array is not valid JSON: %v", err)
+	}
+	return nameSet(names)
+}
+
+// workflowDispatchOptions returns the profiles the workflow_dispatch
+// `profile` choice offers for replay.
+func workflowDispatchOptions(t *testing.T, workflow []byte) map[string]bool {
+	t.Helper()
+	var doc struct {
+		On struct {
+			WorkflowDispatch struct {
+				Inputs struct {
+					Profile struct {
+						Options []string `yaml:"options"`
+					} `yaml:"profile"`
+				} `yaml:"inputs"`
+			} `yaml:"workflow_dispatch"`
+		} `yaml:"on"`
+	}
+	if err := yaml.Unmarshal(workflow, &doc); err != nil {
+		t.Fatalf("parse the chaos workflow as YAML: %v", err)
+	}
+	opts := doc.On.WorkflowDispatch.Inputs.Profile.Options
+	if len(opts) == 0 {
+		t.Fatal("could not locate the workflow_dispatch profile choice options")
+	}
+	return nameSet(opts)
+}
+
+// nameSet indexes a list of profile names for membership tests.
+func nameSet(names []string) map[string]bool {
+	set := make(map[string]bool, len(names))
+	for _, n := range names {
+		set[n] = true
+	}
+	return set
 }
 
 // profileGateway resolves one gateway's overlay out of a named profile.


### PR DESCRIPTION
Closes #180

## Summary

The chaos runner (`e2e-chaos.yml`) was a `workflow_dispatch`-only workflow that ran a single fixed-seed session against the default profile. This branch turns it into a scheduled, profile-sweeping runner so chaos accumulates seeded coverage across every curated gateway configuration overnight, keeps an exact replay path for a failing night, and gains an opt-in PR smoke — all without adding chaos to the default PR gate.

## Change set (commit order)

### `af45b72` — ci: run chaos nightly across the profile matrix

Reworks `.github/workflows/e2e-chaos.yml` from a single dispatch job into three triggers resolved through a new `params` job:

- **Nightly (`schedule: 17 3 * * *`)** — off the hour and staggered clear of the Monday 05:00–06:00 UTC weekly-cron burst. Fans out as a `fail-fast: false` matrix over all six curated profiles (`everything-on`, `flat-minimal`, `flat-dnat`, `vlan-no-dnat`, `pf-only`, `heterogeneous`), one job per profile at 10 minutes, with the seed set to the run id so successive nights explore different action sequences. The seed is echoed to the run log and recorded in the uploaded run record, so a failing night is replayable from its own artifacts.
- **Dispatch (`workflow_dispatch`)** — the exact replay path plus the ad-hoc path. A new `profile` choice input joins `seed`/`duration`; defaults are `-seed 42 -duration 10m -profile everything-on`. Dispatching with the seed, profile and duration read back from a failing nightly job reruns it exactly.
- **PR smoke (`pull_request: labeled`)** — applying the `chaos-smoke` label opts a single PR into a 3-minute seed-42 `everything-on` smoke. The `params` job's `if` (`github.event.label.name == 'chaos-smoke'`) is the cost gate; the `chaos` job inherits the skip through `needs`, so the default PR gate stays at its current cost.

The `params` job resolves the profile matrix, seed and duration per trigger and passes dispatch inputs through env (never interpolated into the script) to block shell injection. It additionally validates the resolved `seed` (bare non-negative integer) and `duration` (no newline) before writing them to `GITHUB_OUTPUT`, closing a `GITHUB_OUTPUT`-injection path where a crafted dispatch value could otherwise append a second `profiles=` line and fan the matrix out to attacker-chosen values. The job timeout backstop grows 25 → 40 minutes to cover the per-profile budget, and a `Collect failure artifacts` step handles the one failure case the runner cannot — an `e2e-up` bring-up failure that dies before the runner starts — without double-collecting. Artifact upload names now include `${{ matrix.profile }}` so each profile's bundle is distinct.

### `c1f03a8` — test/e2e: pin the chaos workflow to the profile registry

Adds `TestChaosWorkflowSweepsEveryProfile` in `test/e2e/chaos/profiles_test.go`. Because a `choice` input's options cannot be computed and the nightly matrix array lives inside a shell block scalar, both profile lists are duplicated from the registry by hand. The test parses each list (the nightly array via regex out of the raw bytes, the dispatch options via YAML) and asserts every registry profile actually appears in both — so a profile added to the registry but never wired into the workflow is caught here instead of by a silently-narrowed nightly run.

### `1a340c0` — docs: describe the nightly chaos matrix and the smoke label

Updates `docs/contributing/ci.md` and `docs/contributing/e2e-tests.md` to match: the gate map now reads "nightly, dispatch, PR label", the scheduled-runs section documents the `17 3 * * *` cron / matrix / run-id seed / replay flow, and the chaos-runner notes describe all three triggers. It also records the one-time `gh label create chaos-smoke` as a repository-admin action, next to the existing ruleset-apply precedent — until the label exists the smoke trigger is inert.

## Divergence from the issue

The issue (#180) asks for chaos on a schedule with a profile matrix; that is the core of `af45b72`. The branch also delivers two things beyond the literal ask, both to protect the change rather than expand scope:

- an opt-in **`chaos-smoke` PR label** smoke path, added alongside the schedule so the runner has a per-PR entry point without touching the default gate; and
- a **drift-guard test** (`c1f03a8`) pinning the hand-duplicated workflow profile lists to the registry.

The dispatch defaults changed from `-seed 42 -duration 3m` (default profile) to `-seed 42 -duration 10m -profile everything-on` so a manual dispatch matches a nightly `everything-on` job's duration and profile (the seed intentionally stays 42, since nightly jobs seed from the run id and dispatch is the fixed-seed replay path).

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) c4682b7 with Claude:claude-opus-4-8_
