### PR TITLE
test/e2e: background the chaos frr-restart inject

### DIFF
--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -1140,7 +1140,12 @@ announcements return — the probes from `client-1` are only reachable over
 the routes `upstream` re-learns over BGP, so a green probe set is the
 proof. `frr-restart` recycles a gateway's FRR the way the gwnode entrypoint
 does (stop, clear the stale `watchfrr` state, start) and re-asserts the
-session on restore. `upstream-bgp-restart` stops `bgpd` on `upstream` and
+session on restore. The recycle runs backgrounded inside the container and
+touches a completion marker the restore gates on: run synchronously, the
+stop+start can outlive the runner's 30 s command timeout on a loaded CI
+machine — the SIGKILL reaps only the `docker exec` client while FRR
+restarts anyway, and the run records an `action-failed` violation for a
+lab that is healthy seconds later. `upstream-bgp-restart` stops `bgpd` on `upstream` and
 starts it back **in place** — never a `docker restart` and never
 `frrinit.sh restart`, because `watchfrr` is PID 1 on that node and either
 would take the container and its five containerlab veths down (the

--- a/test/e2e/chaos/flaps.go
+++ b/test/e2e/chaos/flaps.go
@@ -20,6 +20,14 @@ import (
 const bgpdReadyProbe = "for _ in $(seq 1 30); do " +
 	"if vtysh -c 'show daemons' 2>/dev/null | grep -qw bgpd; then break; fi; sleep 1; done"
 
+// frrRestartDoneMarker is touched inside a gateway container as the last
+// step of the backgrounded FRR recycle. It is the only signal that tells
+// the restore the new FRR is the one answering vtysh rather than the old
+// instance still shutting down: gated on vtysh alone, the restore would
+// re-assert the session against the doomed instance and the converge
+// gate would race the restart.
+const frrRestartDoneMarker = "/tmp/chaos-frr-restart.done"
+
 // flapActions is the routing-flap fault class. The upstream restart is the
 // run's widest legitimate blast radius — every FIP announcement withdraws
 // until bgpd is back — so it carries the low weight.
@@ -29,15 +37,26 @@ func flapActions() []*action {
 			name:   "frr-restart",
 			weight: 2,
 			scope:  scopeGateway,
-			// No hold: the restart is the fault, and the restore brings FRR
-			// back and re-asserts the session.
+			// No hold: the restart is the fault, and the restore waits out
+			// the recycle and re-asserts the session.
 			recoveryBudget: 120 * time.Second,
 			inject: func(ctx context.Context, l *lab, gw string, _ int) error {
-				// The exit statuses are hints, exactly as the gwnode entrypoint
-				// treats them; readiness is the restore's own probe.
+				// The recycle runs backgrounded inside the container. Run
+				// synchronously, the stop+start can outlive cmdTimeout on a
+				// loaded CI runner — and the SIGKILL that follows reaps only
+				// the docker exec client, so FRR restarted anyway while the
+				// engine recorded an action-failed violation for a lab that
+				// was healthy seconds later. The subshell survives the exec
+				// returning (stdio detached, reparented to the container's
+				// PID 1), and the marker it touches last is the completion
+				// signal restoreGatewayFRR gates on. The frrinit exit
+				// statuses stay hints, exactly as the gwnode entrypoint
+				// treats them.
 				if _, err := l.sh(ctx, gw,
-					"/usr/lib/frr/frrinit.sh stop || true; rm -rf /var/tmp/frr/*; "+
-						"/usr/lib/frr/frrinit.sh start || true"); err != nil {
+					"rm -f "+frrRestartDoneMarker+"; "+
+						"(/usr/lib/frr/frrinit.sh stop || true; rm -rf /var/tmp/frr/*; "+
+						"/usr/lib/frr/frrinit.sh start || true; "+
+						"touch "+frrRestartDoneMarker+") </dev/null >/dev/null 2>&1 &"); err != nil {
 					return fmt.Errorf("restart FRR on %s: %w", gw, err)
 				}
 				return nil
@@ -61,12 +80,17 @@ func flapActions() []*action {
 	}
 }
 
-// restoreGatewayFRR waits for a restarted gateway's vtysh to answer, then
+// restoreGatewayFRR waits out the backgrounded recycle via its completion
+// marker — while the recycle is still in its stop phase, the old FRR
+// answers vtysh happily — then waits for the restarted vtysh and
 // re-asserts the BGP session — idempotent and self-cleaning, ending with
 // `write memory`. The agent re-adds its static routes on the next
 // reconcile, and the converge gate's green probes are the assertion that
 // the announcements returned.
 func restoreGatewayFRR(ctx context.Context, l *lab, gw string) error {
+	if err := l.waitReady(ctx, gw, "test -f "+frrRestartDoneMarker); err != nil {
+		return fmt.Errorf("wait for the FRR recycle on %s: %w", gw, err)
+	}
 	if err := l.waitReady(ctx, gw, "vtysh -c 'show version'"); err != nil {
 		return fmt.Errorf("wait for FRR on %s: %w", gw, err)
 	}

--- a/test/e2e/chaos/flaps_test.go
+++ b/test/e2e/chaos/flaps_test.go
@@ -27,8 +27,12 @@ func lineContaining(f *fakeCommander, substr string) string {
 	return ""
 }
 
-// The gateway FRR restart stops FRR, clears the stale watchfrr state, and
-// starts it again — in that order — then its restore waits for vtysh and
+// The gateway FRR restart backgrounds the recycle inside the container —
+// clear the completion marker, then stop FRR, clear the stale watchfrr
+// state, start it again and touch the marker, in that order — so the
+// docker exec returns immediately instead of riding a slow stop+start
+// into cmdTimeout's SIGKILL. The restore gates on the marker before it
+// waits for vtysh (the old FRR answers vtysh while still stopping) and
 // re-asserts the BGP session so the announcements return.
 func TestFRRRestartRecyclesFRRAndReassertsBGP(t *testing.T) {
 	cmd := &fakeCommander{respond: healthyLabResponses}
@@ -40,21 +44,34 @@ func TestFRRRestartRecyclesFRRAndReassertsBGP(t *testing.T) {
 	}
 
 	line := lineContaining(cmd, "frrinit.sh")
+	unmark := strings.Index(line, "rm -f "+frrRestartDoneMarker)
 	stop := strings.Index(line, "frrinit.sh stop")
 	wipe := strings.Index(line, "rm -rf /var/tmp/frr/*")
 	start := strings.Index(line, "frrinit.sh start")
-	if stop < 0 || wipe < 0 || start < 0 {
-		t.Fatalf("the FRR restart did not stop, clear and start: %q", line)
+	mark := strings.Index(line, "touch "+frrRestartDoneMarker)
+	if unmark < 0 || stop < 0 || wipe < 0 || start < 0 || mark < 0 {
+		t.Fatalf("the FRR restart did not clear the marker, stop, wipe, start and mark: %q", line)
 	}
-	if stop >= wipe || wipe >= start {
+	if unmark >= stop || stop >= wipe || wipe >= start || start >= mark {
 		t.Fatalf("the FRR restart ran its steps out of order: %q", line)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(line), "&") {
+		t.Fatalf("the FRR recycle is not backgrounded — a slow stop+start would ride the exec into cmdTimeout: %q", line)
 	}
 
 	if err := act.restore(context.Background(), l, "gateway-1"); err != nil {
 		t.Fatalf("restore: %v", err)
 	}
-	if !cmd.called("vtysh -c 'show version'") {
+	marker := cmd.indexOf("test -f " + frrRestartDoneMarker)
+	vtysh := cmd.indexOf("vtysh -c 'show version'")
+	if marker < 0 {
+		t.Fatalf("the restore did not gate on the recycle marker: %v", cmd.lines())
+	}
+	if vtysh < 0 {
 		t.Fatalf("the restore did not wait for FRR to come back: %v", cmd.lines())
+	}
+	if marker >= vtysh {
+		t.Fatalf("the restore probed vtysh before the recycle finished — the old FRR answers too: %v", cmd.lines())
 	}
 	if !cmd.called("router bgp 65000 vrf vrf-provider") {
 		t.Fatalf("the restore did not re-assert the BGP session: %v", cmd.lines())


### PR DESCRIPTION
## Problem

The nightly chaos run [29501890572](https://github.com/osism/ovn-network-agent/actions/runs/29501890572) failed with a single `action-failed` violation at tick 5: the `frr-restart` inject on gateway-1 died with `signal: killed`.

The inject ran the full FRR recycle (`frrinit.sh stop` → `rm -rf /var/tmp/frr/*` → `frrinit.sh start`) synchronously inside one `docker exec`, bounded by the global 30 s `cmdTimeout` (`lab.go`). On a loaded CI runner the recycle outlives that bound — and the SIGKILL reaps only the `docker exec` client while the in-container script keeps running, so FRR restarted anyway. The artifact bundle proves it: at collection time, `upstream` showed gateway-1's BGP session re-established (Up/Down `00:00:01`) and every probe was green. The engine recorded a violation and aborted a run whose lab was healthy seconds later.

## Fix

- The inject now backgrounds the recycle **inside the container** (subshell with stdio detached, so the exec returns immediately) and touches a completion marker (`/tmp/chaos-frr-restart.done`) as its last step.
- `restoreGatewayFRR` gates on that marker (via the existing `waitReady`, 60 s budget) **before** probing vtysh. The gate closes a race the backgrounding would otherwise open: while the recycle is still in its stop phase, the *old* FRR answers vtysh happily — a session re-asserted against it would be torn down moments later, with the converge gate racing the restart.
- The frrinit exit statuses stay hints, exactly as the gwnode entrypoint treats them; readiness remains the restore's own probe.

## Verification

- `go vet` and the full chaos package test suite pass; the updated test asserts the marker-clear/stop/wipe/start/mark ordering, the backgrounding itself, and that the restore gates on the marker before vtysh.
- The exec semantics were verified against a real Docker daemon: `docker exec` with the backgrounded, stdio-detached subshell returns in ~74 ms, and the background child survives the client exit and touches the marker — the stdio redirect is what keeps the exec from blocking on the child's open pipes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vq1Lp5zjcuU9Ftn3wT7maA