### PR TITLE
test/e2e: de-flake the lab bring-up

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>osism/renovate-config"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Container image pins in containerlab topology files",
+      "managerFilePatterns": ["/\\.clab\\.ya?ml$/"],
+      "matchStrings": [
+        "image:\\s*(?<depName>[a-z0-9][a-z0-9._\\-/]*):(?<currentValue>[^\\s@]+)@(?<currentDigest>sha256:[a-f0-9]{64})"
+      ],
+      "datasourceTemplate": "docker"
+    }
   ]
 }

--- a/test/e2e/bootstrap.sh
+++ b/test/e2e/bootstrap.sh
@@ -70,6 +70,8 @@
 # start honours:
 #   BGPD_WAIT_SECS=30      # readiness wait per start attempt, seconds
 #   BGPD_START_ATTEMPTS=3  # bounded retries before bring-up is failed
+# and the gateway-entrypoint gate honours:
+#   GWNODE_READY_SECS=120  # wait for the agent process per bring-up
 
 set -euo pipefail
 
@@ -125,6 +127,13 @@ BGP_ROUTER_ID_UPSTREAM="${BGP_ROUTER_ID_UPSTREAM:-100.64.0.1}"
 # full job re-run.
 BGPD_WAIT_SECS="${BGPD_WAIT_SECS:-30}"
 BGPD_START_ATTEMPTS="${BGPD_START_ATTEMPTS:-3}"
+
+# Budget for wait_for_gateway_agents. The gwnode entrypoint's own
+# readiness probes allow up to ~2 minutes of legitimate daemon start
+# time (OVS 30s + br-int 30s + FRR 30s + config push 30s) before it
+# gives up and says why, so the gate must not time out earlier and
+# steal that diagnostic.
+GWNODE_READY_SECS="${GWNODE_READY_SECS:-120}"
 
 CLIENT_NAME="${CLIENT_NAME:-client-1}"
 CLIENT_NODE="clab-${LAB_NAME}-${CLIENT_NAME}"
@@ -225,6 +234,71 @@ wait_for_chassis() {
             tail -n 50 /var/log/ovn/ovn-controller.log >&2 || true
         log "--- ${name}: docker logs ---"
         docker logs --tail 30 "clab-${LAB_NAME}-${name}" >&2 || true
+    done
+    exit 1
+}
+
+# Docker's `restart: always` (containerlab's policy for every node) hides
+# entrypoint crashes: the replacement container comes up healthy and
+# re-registers its chassis in SB, so wait_for_chassis passes — but a
+# restart that landed after containerlab wired the data-plane veths has
+# destroyed them with the old netns, and wire_gateway_underlay /
+# configure_upstream / configure_client then die on `Cannot find device
+# "eth1"` with no visible cause. Surface every restart loudly, with the
+# container's log tail (docker logs spans the previous instance too), so
+# a veth failure that follows is attributable from the job log alone.
+# Warn-only: a restart that landed before the links were wired is
+# harmless, and the wiring steps below still fail hard when it was not.
+report_container_restarts() {
+    local name node restarts
+    for name in "$@"; do
+        node="clab-${LAB_NAME}-${name}"
+        restarts="$(docker inspect --format '{{.RestartCount}}' "${node}" 2>/dev/null || true)"
+        if [ -n "${restarts}" ] && [ "${restarts}" != "0" ]; then
+            log "WARNING: ${node} restarted ${restarts}x since deploy — its entrypoint died at least once; log tail follows"
+            docker logs --tail 40 "${node}" >&2 || true
+        fi
+    done
+}
+
+# SB chassis registration is a MID-entrypoint milestone: ovn-controller
+# registers the chassis as soon as it connects to SB, before the gwnode
+# entrypoint has created vrf-provider (setup_vrf) or brought up FRR. So
+# wait_for_chassis passing does not make the gateways safe to touch —
+# on a fast runner, bootstrap's ~1s of NB provisioning can outrun the
+# entrypoint's remaining steps and wire_gateway_underlay then dies on
+# `ip link set eth1 master vrf-provider: Device does not exist`
+# (observed: registration at t+0.5s, wiring at t+0.9s, setup_vrf at
+# t+1.1s). Gate on the agent process instead: the entrypoint execs
+# ovn-network-agent as its final act, so a running agent implies every
+# prior milestone — VRF, loopback1, FRR started and configured. Same
+# signal as the image healthcheck, but polled at 1s instead of 10s.
+wait_for_gateway_agents() {
+    local pending name node
+    log "waiting for gwnode entrypoints to finish (agent running): $*"
+    for _ in $(seq 1 "${GWNODE_READY_SECS}"); do
+        pending=""
+        for name in "$@"; do
+            node="clab-${LAB_NAME}-${name}"
+            if ! docker exec "${node}" pgrep -f \
+                    /usr/local/bin/ovn-network-agent >/dev/null 2>&1; then
+                pending="${pending} ${name}"
+            fi
+        done
+        if [ -z "${pending}" ]; then
+            log "agent running on all $# gateways"
+            return 0
+        fi
+        sleep 1
+    done
+    echo "gwnode entrypoint did not finish within ${GWNODE_READY_SECS}s;" \
+        "agent still missing on:${pending}" >&2
+    # The entrypoint's ERR trap and readiness probes log why it is stuck
+    # (or died) to the container log — dump it for each straggler.
+    # shellcheck disable=SC2086  # ${pending} is a space-separated name list
+    for name in ${pending}; do
+        log "--- ${name}: docker logs ---"
+        docker logs --tail 60 "clab-${LAB_NAME}-${name}" >&2 || true
     done
     exit 1
 }
@@ -368,9 +442,10 @@ configure_upstream() {
 
 # Dump the upstream container's FRR daemon state to stderr (the job
 # log) so a bgpd bring-up failure can be root-caused after the fact. The
-# upstream image is unpinned (frrouting/frr:latest), so every command is
-# individually best-effort and drawn from an independent source: a
-# future image change degrades one section, not the whole report.
+# upstream image is pinned by digest in topology.clab.yml, but every
+# command stays individually best-effort and drawn from an independent
+# source: a future image bump degrades one section, not the whole
+# report.
 dump_upstream_frr_state() {
     log "dumping ${UPSTREAM_NODE} FRR state for triage"
     log "--- /etc/frr/daemons ---"
@@ -650,6 +725,17 @@ main() {
     ensure_fips
     ensure_workload_lsp
     ensure_upstream_nexthop_mac_binding
+
+    # Before touching the wired interfaces, name any container that has
+    # been auto-restarted since deploy: a restart in the wrong window is
+    # the known cause of a missing eth1 below.
+    report_container_restarts "${chassis_names[@]}" "${UPSTREAM_NAME}" "${CLIENT_NAME}"
+
+    # The chassis gate above passes mid-entrypoint; the wiring and FRR
+    # steps below need the entrypoint's later milestones (vrf-provider,
+    # FRR). Sits here, not next to wait_for_chassis, so the NB
+    # provisioning above overlaps with the entrypoints finishing.
+    wait_for_gateway_agents "${chassis_names[@]}"
 
     # Underlay: each gateway's eth1 moves out of br-ex into vrf-provider
     # with a /30, upstream takes the matching /30s plus a /24 toward the

--- a/test/e2e/gwnode-entrypoint.sh
+++ b/test/e2e/gwnode-entrypoint.sh
@@ -6,9 +6,18 @@
 # ovn-network-agent in the foreground so the container's lifecycle is
 # tied to the agent process.
 
-set -euo pipefail
+set -Eeuo pipefail
 
 log() { printf '[gwnode] %s\n' "$*" >&2; }
+
+# `set -e` kills PID 1 without a word when an unguarded command fails, and
+# Docker's `restart: always` replaces the container so fast that the crash
+# is invisible — the restarted entrypoint's output just continues the log.
+# That silence is what made the eth1-destroying restart race (see the
+# daemon-start block below) cost days to root-cause. The trap cannot stop
+# the exit, but it names the dying command and line in `docker logs`.
+# `set -E` extends the trap into functions.
+trap 'log "FATAL: entrypoint exiting at line ${LINENO}: ${BASH_COMMAND} (exit $?)"' ERR
 
 # Use the chassis name the OVN central bootstrap script seeds. Falls back
 # to the container hostname so the image still works when launched outside
@@ -144,7 +153,15 @@ resolve_sb_remote() {
         return 0 # already numeric, or a form we do not understand — keep
     fi
     for _ in $(seq 1 30); do
-        ip="$(getent hosts "${host}" | awk '{print $1; exit}')"
+        # getent exits non-zero while the name is still unregistered — the
+        # very state this loop exists to wait out. Without the `|| true`,
+        # pipefail turns that into a failed assignment and `set -e` kills
+        # PID 1 on the first iteration, silently; when Docker's restart
+        # then lands after containerlab has wired eth1, the veth dies with
+        # the old netns and the lab is unrecoverable ("Cannot find device
+        # eth1" in bootstrap). That single line caused 7 of 9 lab bring-up
+        # failures between 2026-07-14 and 2026-07-16.
+        ip="$(getent hosts "${host}" | awk '{print $1; exit}' || true)"
         if [ -n "${ip}" ]; then
             log "resolved SB remote ${host} -> ${ip} for ovn-controller"
             OVN_SB_REMOTE="${proto}:${ip}:${port}"

--- a/test/e2e/topology.clab.yml
+++ b/test/e2e/topology.clab.yml
@@ -59,32 +59,64 @@ topology:
       image: ovn-network-agent/gwnode:e2e
       env:
         CHASSIS_NAME: gateway-1
+      # Create the gateways only after `central` is up: the gwnode
+      # entrypoint resolves the SB remote (`central`) by name, and a
+      # gateway created before central could reach that lookup while the
+      # name was still unregistered. The entrypoint retries the lookup
+      # (see resolve_sb_remote in gwnode-entrypoint.sh); this ordering
+      # removes the race entirely instead of merely surviving it.
+      stages:
+        create:
+          wait-for:
+            - node: central
+              stage: create
 
     gateway-2:
       kind: linux
       image: ovn-network-agent/gwnode:e2e
       env:
         CHASSIS_NAME: gateway-2
+      # See gateway-1.
+      stages:
+        create:
+          wait-for:
+            - node: central
+              stage: create
 
     gateway-3:
       kind: linux
       image: ovn-network-agent/gwnode:e2e
       env:
         CHASSIS_NAME: gateway-3
+      # See gateway-1.
+      stages:
+        create:
+          wait-for:
+            - node: central
+              stage: create
 
     upstream:
       kind: linux
-      image: frrouting/frr:latest
+      # Pinned by digest so a registry-side change cannot alter the lab
+      # silently. Docker Hub's frrouting/frr is frozen at FRR 8.4 (last
+      # push 2022) — maintained images live on quay.io/frrouting/frr. The
+      # intermittent `bgpd crashed in startup, signal 11` seen in CI is
+      # inherent to this old build (bootstrap.sh retries the start);
+      # upgrading to a maintained FRR is a separate, behavior-changing
+      # step.
+      image: frrouting/frr:latest@sha256:990e83490108b686fd6df3b1cafa6bdbb2714acb00eedb9a89693946f46f45ce
 
     client-1:
       kind: linux
-      image: nicolaka/netshoot:latest
+      # v0.16 is the exact image `latest` resolved to when the pin
+      # landed — same content, now immutable and Renovate-updatable.
+      image: nicolaka/netshoot:v0.16@sha256:b09d9b21381f47a79b3cbcb30da25266dc17186ea00ae65e99fdc51396f48e70
       # Stay alive without a service — netshoot exits otherwise.
       cmd: "sleep infinity"
 
     client-2:
       kind: linux
-      image: nicolaka/netshoot:latest
+      image: nicolaka/netshoot:v0.16@sha256:b09d9b21381f47a79b3cbcb30da25266dc17186ea00ae65e99fdc51396f48e70
       cmd: "sleep infinity"
 
   links:


### PR DESCRIPTION
## Problem

Since 2026-07-11 only 14 of 33 completed PR E2E runs were green on the first attempt. An analysis of every failed run and its uploaded artifacts found that 7 of 9 "Bring the lab up" failures (2026-07-14 … 2026-07-16), plus 3 drain-hitless failures through the scenario's mid-run lab recycle, share one root cause — including the E2E failure on a pure Renovate PR with no code change.

## Root cause

`resolve_sb_remote()` in `gwnode-entrypoint.sh` resolves `central` in a 30×1s retry loop:

```bash
ip="$(getent hosts "${host}" | awk '{print $1; exit}')"
```

When a gateway is created before `central`, the first `getent` exits 2, `pipefail` turns that into a failed assignment, and `set -e` kills PID 1 **on the first iteration** — silently. Docker's `restart: always` replaces the container; containerlab wires `eth1` ~0.5–1.5 s after container creation, so a restart landing **after** wiring destroys the veth with the old netns (`Cannot find device "eth1"` in bootstrap), and one landing **mid-wiring** fails the deploy itself (`deploy links ... Link not found`). The SB chassis-registration gate passes for the restarted container, masking the cause. Container-creation order in the failure artifacts confirms it: only gateways created before `central` died; the one run where `central` came up first had zero restarts.

The earlier daemon-start hardening (#186) does not cover this path — none of its guard messages appear in the first instance's log.

## Changes

- **`gwnode-entrypoint.sh`**: guard the getent pipeline with `|| true` so the retry loop actually retries; add `set -E` + an ERR trap that names the dying command and line in `docker logs`, so no future `set -e` death is ever silent again.
- **`topology.clab.yml`**: order the gateways after `central` via `stages`/`wait-for` (supported by the pinned containerlab 0.77.0), removing the race instead of merely surviving it.
- **`bootstrap.sh`**: report every container with `RestartCount > 0` (log tail included) right before the underlay wiring — warn-only, since a restart before link wiring is harmless.
- **Image pins**: `frrouting/frr:latest` and `nicolaka/netshoot:latest` are pinned by digest (identical content to today). Note: Docker Hub's `frrouting/frr` is frozen at FRR 8.4 (2022); the intermittent `bgpd crashed in startup, signal 11` seen twice in CI is inherent to that build — upgrading to the maintained quay.io images is left as a separate, behavior-changing step. A Renovate `customManager` keeps the `*.clab.yml` pins updated.

## Verification

- `bash -n` + `shellcheck` clean on both scripts; YAML/JSON parse clean.
- The old form was reproduced in isolation (dies on the first iteration, exactly the CI signature; the new ERR trap names line and command), and the fixed form survives transient failures and resolves.
- A real lab bring-up needs Linux/kernel-OVS — this PR's own E2E run is the end-to-end test, in particular for the `stages` ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)