### PR TITLE
test/e2e: wait out the FRR recycle on its own budget

### DIFF
--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -1145,7 +1145,11 @@ touches a completion marker the restore gates on: run synchronously, the
 stop+start can outlive the runner's 30 s command timeout on a loaded CI
 machine — the SIGKILL reaps only the `docker exec` client while FRR
 restarts anyway, and the run records an `action-failed` violation for a
-lab that is healthy seconds later. `upstream-bgp-restart` stops `bgpd` on `upstream` and
+lab that is healthy seconds later. The marker wait runs on its own
+three-minute budget (`frrRecycleTimeout`), not the 60 s daemon-ready
+budget: it carries the whole stop+clear+start, which loaded runners have
+pushed past both shorter bounds while the lab-state dump showed FRR
+healthy again moments after the abort. `upstream-bgp-restart` stops `bgpd` on `upstream` and
 starts it back **in place** — never a `docker restart` and never
 `frrinit.sh restart`, because `watchfrr` is PID 1 on that node and either
 would take the container and its five containerlab veths down (the

--- a/test/e2e/chaos/flaps.go
+++ b/test/e2e/chaos/flaps.go
@@ -28,6 +28,15 @@ const bgpdReadyProbe = "for _ in $(seq 1 30); do " +
 // gate would race the restart.
 const frrRestartDoneMarker = "/tmp/chaos-frr-restart.done"
 
+// frrRecycleTimeout bounds the wait for the recycle's completion marker.
+// The marker carries the whole stop+clear+start, not one daemon coming
+// ready, and on a loaded CI runner the recycle has outlived both the 30s
+// cmdTimeout (run 29501890572) and the 60s daemonReadyTimeout (run
+// 29516365849) — each time with the lab-state dump showing FRR healthy
+// again moments after the abort. Three minutes leaves the vtysh wait and
+// the BGP re-assert comfortable room inside the 5-minute restore backstop.
+const frrRecycleTimeout = 3 * time.Minute
+
 // flapActions is the routing-flap fault class. The upstream restart is the
 // run's widest legitimate blast radius — every FIP announcement withdraws
 // until bgpd is back — so it carries the low weight.
@@ -84,11 +93,12 @@ func flapActions() []*action {
 // marker — while the recycle is still in its stop phase, the old FRR
 // answers vtysh happily — then waits for the restarted vtysh and
 // re-asserts the BGP session — idempotent and self-cleaning, ending with
-// `write memory`. The agent re-adds its static routes on the next
-// reconcile, and the converge gate's green probes are the assertion that
-// the announcements returned.
+// `write memory`. The marker wait runs on frrRecycleTimeout, not the
+// daemon budget: it spans the full stop+clear+start. The agent re-adds
+// its static routes on the next reconcile, and the converge gate's green
+// probes are the assertion that the announcements returned.
 func restoreGatewayFRR(ctx context.Context, l *lab, gw string) error {
-	if err := l.waitReady(ctx, gw, "test -f "+frrRestartDoneMarker); err != nil {
+	if err := l.waitReadyFor(ctx, gw, "test -f "+frrRestartDoneMarker, frrRecycleTimeout); err != nil {
 		return fmt.Errorf("wait for the FRR recycle on %s: %w", gw, err)
 	}
 	if err := l.waitReady(ctx, gw, "vtysh -c 'show version'"); err != nil {

--- a/test/e2e/chaos/flaps_test.go
+++ b/test/e2e/chaos/flaps_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
 func flapActionNamed(t *testing.T, name string) *action {
@@ -75,6 +76,30 @@ func TestFRRRestartRecyclesFRRAndReassertsBGP(t *testing.T) {
 	}
 	if !cmd.called("router bgp 65000 vrf vrf-provider") {
 		t.Fatalf("the restore did not re-assert the BGP session: %v", cmd.lines())
+	}
+}
+
+// The completion marker carries the whole backgrounded recycle — stop,
+// clear, start — not one daemon coming ready, and a loaded CI runner has
+// taken it past the 60s daemon budget (run 29516365849) with the
+// lab-state dump showing FRR healthy moments after the abort. The restore
+// must wait it out on the recycle's own budget instead of parking the
+// node over a restart that is merely slow.
+func TestFRRRestartRestoreOutwaitsARecycleSlowerThanTheDaemonBudget(t *testing.T) {
+	clock := newFakeClock()
+	markerAt := clock.now().Add(daemonReadyTimeout + 30*time.Second)
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		line := strings.Join(argv, " ")
+		if strings.Contains(line, "test -f "+frrRestartDoneMarker) && clock.now().Before(markerAt) {
+			return "", errExit(t, 1)
+		}
+		return healthyLabResponses(argv)
+	}}
+	l := newTestLab(cmd, clock)
+	act := flapActionNamed(t, "frr-restart")
+
+	if err := act.restore(context.Background(), l, "gateway-1"); err != nil {
+		t.Fatalf("restore gave up on a recycle slower than the daemon budget: %v", err)
 	}
 }
 

--- a/test/e2e/chaos/lab.go
+++ b/test/e2e/chaos/lab.go
@@ -585,7 +585,14 @@ func (l *lab) configureGatewayBGP(ctx context.Context, gw string, link underlayL
 // left unwatched, each remaining loop would spin out its 60s against
 // commands the dead context fails instantly.
 func (l *lab) waitReady(ctx context.Context, node, probe string) error {
-	deadline := l.now().Add(daemonReadyTimeout)
+	return l.waitReadyFor(ctx, node, probe, daemonReadyTimeout)
+}
+
+// waitReadyFor is waitReady on the caller's own budget — for the wait
+// that carries more than one daemon coming up, like the backgrounded FRR
+// recycle whose completion marker arrives only after a full stop+start.
+func (l *lab) waitReadyFor(ctx context.Context, node, probe string, timeout time.Duration) error {
+	deadline := l.now().Add(timeout)
 	for l.now().Before(deadline) {
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("waiting for %q on %s: %w", probe, node, err)
@@ -595,7 +602,7 @@ func (l *lab) waitReady(ctx context.Context, node, probe string) error {
 		}
 		l.sleep(2 * time.Second)
 	}
-	return fmt.Errorf("%q on %s did not succeed within %s", probe, node, daemonReadyTimeout)
+	return fmt.Errorf("%q on %s did not succeed within %s", probe, node, timeout)
 }
 
 // ensureVIPRouting points the port-forward VIP's two hand-plumbed routes


### PR DESCRIPTION
## Problem

The chaos run [29516365849](https://github.com/osism/ovn-network-agent/actions/runs/29516365849) (profile `everything-on`, seed 42) failed with a single `action-failed` violation at tick 5: the `frr-restart` restore on gateway-1 gave up with `"test -f /tmp/chaos-frr-restart.done" on gateway-1 did not succeed within 1m0s`, parked the node and aborted the run.

Backgrounding the inject (#193) moved the recycle out from under the 30 s `cmdTimeout` — and onto the next bound. The restore's marker wait ran on `waitReady`'s hardcoded 60 s `daemonReadyTimeout`, a budget sized for one daemon coming ready, not for the full `frrinit.sh` stop+clear+start the marker carries. On a loaded CI runner the recycle outlived that bound too. The artifact bundle proves the recycle itself succeeded: the docker log shows `watchfrr: Terminating on signal` right at inject time, and the lab-state dump — collected moments after the abort — shows gateway-1's FRR fully back with the persisted config (VRF, BGP session, prefix lists). The engine aborted a run whose lab was healthy again seconds later, the same flake as run 29501890572 one timeout further down.

## Fix

- `waitReady` now delegates to a parameterized `waitReadyFor(ctx, node, probe, timeout)`; every existing call keeps the 60 s daemon budget.
- `restoreGatewayFRR` gates on the completion marker with a dedicated `frrRecycleTimeout` of three minutes — it spans the whole backgrounded stop+clear+start, and leaves the vtysh wait and the BGP re-assert comfortable room inside the restore's 5-minute backstop. The vtysh probe after the marker stays on the daemon budget.
- The e2e-tests doc paragraph on the routing flaps now describes the recycle's own budget.

## Verification

- `go vet` and the full chaos package test suite pass (`go test -count=1 ./test/e2e/chaos/`).
- The new regression test `TestFRRRestartRestoreOutwaitsARecycleSlowerThanTheDaemonBudget` drives a recycle whose marker only lands 90 s in — past the daemon budget — and requires the restore to wait it out. It was verified to fail on the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S99BfCpU3aFd1bN3yXjpe3