### PR TITLE
test/e2e: reap the gwnode's zombies with tini as PID 1

### DIFF
--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -554,7 +554,7 @@ transit.
 ::: details Why docker restart, not systemctl restart ovn-network-agent
 The gwnode image is not running systemd, so `systemctl restart
 ovn-network-agent` (which the issue body suggests) is unavailable. The
-entrypoint `exec`s the agent so it becomes PID 1; the only way to make
+entrypoint `exec`s the agent as tini's only child; the only way to make
 the agent re-read its config is to restart the whole container. This
 costs ~20 s of OVS / ovn-controller / FRR re-init per phase but stays
 inside the 7-minute CI budget for two reconciles.
@@ -679,9 +679,9 @@ compares the agent's graceful-drain code path
 against the hard-kill case (#105's mechanic, reused here as the
 control arm) and asserts the graceful path stays hitless. The
 graceful arm sends `docker exec … kill -TERM 1` on `gateway-1`
-(the gwnode entrypoint `exec`s the agent at startup, so the agent
-is PID 1 — no `pgrep` needed and the containerlab veth pair is
-not torn down between SIGTERM and the drain completing). The
+(PID 1 is tini, which forwards the signal to the agent the
+entrypoint `exec`s — no `pgrep` needed and the containerlab veth
+pair is not torn down between SIGTERM and the drain completing). The
 hardkill arm uses `docker kill -s KILL clab-${LAB}-gateway-1`.
 Both arms first run `docker update --restart=no` on the gateway
 container so that containerlab's default `restart: always` does
@@ -1069,7 +1069,7 @@ part of the replay contract: a new action is appended, never inserted.
 | --- | --- | --- | --- | --- | --- |
 | `controller-restart` | gateway | 3 | 10–30 s | 90 s | `ovn-ctl stop_controller` / `start_controller` ([failover](#failover)) |
 | `gateway-kill` | gateway | 1 | 15–45 s | 180 s | `docker kill -s KILL`, then `docker start` ([stale chassis](#stale-chassis)) |
-| `agent-terminate` | gateway | 2 | 10–30 s | 180 s | `kill -TERM 1` — the agent is PID 1 ([drain-hitless](#drain-hitless)) |
+| `agent-terminate` | gateway | 2 | 10–30 s | 180 s | `kill -TERM 1` — tini forwards to the agent ([drain-hitless](#drain-hitless)) |
 | `gateway-restart` | gateway | 2 | — | 180 s | `docker restart` ([pf-hairpin](#port-forward-hairpin-masquerade)) |
 | `config-flip` | gateway | 2 | — | 180 s | rewrite one gateway's config and restart it onto it — see below |
 | `nb-pause` | central | 2 | 5–90 s | 90 s | SIGSTOP/SIGCONT the NB `ovsdb-server` |
@@ -1141,15 +1141,22 @@ the routes `upstream` re-learns over BGP, so a green probe set is the
 proof. `frr-restart` recycles a gateway's FRR the way the gwnode entrypoint
 does (stop, clear the stale `watchfrr` state, start) and re-asserts the
 session on restore. The recycle runs backgrounded inside the container and
-touches a completion marker the restore gates on: run synchronously, the
-stop+start can outlive the runner's 30 s command timeout on a loaded CI
-machine — the SIGKILL reaps only the `docker exec` client while FRR
-restarts anyway, and the run records an `action-failed` violation for a
-lab that is healthy seconds later. The marker wait runs on its own
-three-minute budget (`frrRecycleTimeout`), not the 60 s daemon-ready
-budget: it carries the whole stop+clear+start, which loaded runners have
-pushed past both shorter bounds while the lab-state dump showed FRR
-healthy again moments after the abort. `upstream-bgp-restart` stops `bgpd` on `upstream` and
+touches a completion marker the restore gates on: run synchronously, a
+slow stop+start rides the exec into the runner's 30 s command timeout —
+the SIGKILL reaps only the `docker exec` client while FRR restarts
+anyway, and the run records an `action-failed` violation for a lab that
+is healthy seconds later. The marker wait runs on its own three-minute
+budget (`frrRecycleTimeout`), not the 60 s daemon-ready budget: it
+carries the whole stop+clear+start. That budget is a backstop — with
+`tini` as the gwnode's PID 1 the recycle completes in seconds. The init
+matters: the FRR daemons daemonize and reparent to PID 1, and while that
+was the agent (a Go binary that never `wait()`s for children it did not
+spawn), every stopped daemon stayed an unreaped zombie that
+`frrinit.sh`'s per-phase 120 s `kill -0` stop loops waited out in full —
+a deterministic ~6-minute stop that three successive runs pushed past
+the 30 s command timeout, the 60 s daemon-ready budget and the
+three-minute marker budget in turn, each abort looking like a loaded
+runner rather than what it was. `upstream-bgp-restart` stops `bgpd` on `upstream` and
 starts it back **in place** — never a `docker restart` and never
 `frrinit.sh restart`, because `watchfrr` is PID 1 on that node and either
 would take the container and its five containerlab veths down (the

--- a/test/e2e/Dockerfile.gwnode
+++ b/test/e2e/Dockerfile.gwnode
@@ -79,6 +79,7 @@ RUN apt-get update \
         iproute2 \
         iputils-ping \
         tcpdump \
+        tini \
  && apt-get purge -y software-properties-common \
  && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
@@ -108,4 +109,17 @@ HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=5 \
         && pgrep -x ovn-controller >/dev/null \
         && pgrep -f /usr/local/bin/ovn-network-agent >/dev/null
 
-ENTRYPOINT ["/usr/local/bin/gwnode-entrypoint.sh"]
+# tini must be PID 1: the daemons the entrypoint starts (watchfrr, zebra,
+# bgpd, staticd, ovsdb-server, ...) daemonize and reparent to PID 1, and the
+# agent the entrypoint execs is a Go binary that never wait()s for children
+# it did not spawn. Without a reaping init every daemon that exits stays a
+# zombie, `kill -0` keeps succeeding on it, and frrinit.sh's daemon_stop
+# waits out its full 120 s kill -0 loop per stop phase — turning one
+# `frrinit.sh stop` into a deterministic ~6 minutes (watchfrr, then
+# bgpd/staticd, then zebra last), which the chaos frr-restart action pushed
+# past three successively larger wait budgets (runs 29501890572,
+# 29516365849, 29525707974) before the zombies were found. tini also
+# forwards signals, so the in-container `kill -TERM 1` handle
+# (drain-hitless.sh, the chaos agent-terminate action) still reaches the
+# agent, and the container still follows the agent down.
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/gwnode-entrypoint.sh"]

--- a/test/e2e/chaos/actions.go
+++ b/test/e2e/chaos/actions.go
@@ -135,8 +135,8 @@ func injectGatewayKill(ctx context.Context, l *lab, gw string, _ int) error {
 	return l.killGateway(ctx, gw)
 }
 
-// injectAgentTerminate signals the agent (PID 1) and waits for the container
-// to follow it down. Whether the agent drains its gateway chassis before
+// injectAgentTerminate signals the agent through PID 1 (tini forwards the
+// SIGTERM) and waits for the container to follow it down. Whether the agent drains its gateway chassis before
 // exiting depends on how the lab was deployed — the fault is the same
 // either way, and the drain only changes how much the run loses.
 func injectAgentTerminate(ctx context.Context, l *lab, gw string, _ int) error {

--- a/test/e2e/chaos/actions_test.go
+++ b/test/e2e/chaos/actions_test.go
@@ -143,8 +143,8 @@ func TestControllerRestartUsesOvnCtlAndTouchesNoContainer(t *testing.T) {
 	}
 }
 
-// The gwnode entrypoint execs the agent, so it is PID 1 — the SIGTERM
-// goes to the container's init, and the container follows it down.
+// The SIGTERM goes to the container's init — tini, which forwards it to
+// the agent it supervises — and the container follows the agent down.
 func TestAgentTerminateSignalsPID1AndWaitsForTheExit(t *testing.T) {
 	cmd := &fakeCommander{respond: healthyLabResponses}
 	l := newTestLab(cmd, newFakeClock())
@@ -154,7 +154,7 @@ func TestAgentTerminateSignalsPID1AndWaitsForTheExit(t *testing.T) {
 	}
 
 	if !cmd.called("docker exec clab-ovn-e2e-gateway-3 kill -TERM 1") {
-		t.Fatalf("the agent was not signalled as PID 1: %v", cmd.lines())
+		t.Fatalf("the agent was not signalled through PID 1: %v", cmd.lines())
 	}
 	if !cmd.called("{{.State.Running}}") {
 		t.Fatalf("the runner did not wait for the container to exit: %v", cmd.lines())

--- a/test/e2e/chaos/flaps.go
+++ b/test/e2e/chaos/flaps.go
@@ -30,11 +30,16 @@ const frrRestartDoneMarker = "/tmp/chaos-frr-restart.done"
 
 // frrRecycleTimeout bounds the wait for the recycle's completion marker.
 // The marker carries the whole stop+clear+start, not one daemon coming
-// ready, and on a loaded CI runner the recycle has outlived both the 30s
-// cmdTimeout (run 29501890572) and the 60s daemonReadyTimeout (run
-// 29516365849) — each time with the lab-state dump showing FRR healthy
-// again moments after the abort. Three minutes leaves the vtysh wait and
-// the BGP re-assert comfortable room inside the 5-minute restore backstop.
+// ready. With tini reaping the gateway's orphans (Dockerfile.gwnode) the
+// recycle completes in seconds, so three minutes is a pure backstop for a
+// genuinely loaded runner. Before tini, every stopped daemon stayed a
+// zombie under the non-reaping agent PID 1, `kill -0` kept succeeding on
+// it, and frrinit.sh's daemon_stop waited out its full 120 s loop per
+// stop phase — a deterministic ~6-minute stop that outlived the 30 s
+// cmdTimeout (run 29501890572), the 60 s daemonReadyTimeout (run
+// 29516365849) and this budget (run 29525707974) in turn, each abort
+// misread as a slow runner because the lab-state dump — taken minutes
+// later — showed FRR healthy again.
 const frrRecycleTimeout = 3 * time.Minute
 
 // flapActions is the routing-flap fault class. The upstream restart is the
@@ -51,13 +56,13 @@ func flapActions() []*action {
 			recoveryBudget: 120 * time.Second,
 			inject: func(ctx context.Context, l *lab, gw string, _ int) error {
 				// The recycle runs backgrounded inside the container. Run
-				// synchronously, the stop+start can outlive cmdTimeout on a
-				// loaded CI runner — and the SIGKILL that follows reaps only
+				// synchronously, a slow stop+start rides the exec into
+				// cmdTimeout — and the SIGKILL that follows reaps only
 				// the docker exec client, so FRR restarted anyway while the
 				// engine recorded an action-failed violation for a lab that
 				// was healthy seconds later. The subshell survives the exec
 				// returning (stdio detached, reparented to the container's
-				// PID 1), and the marker it touches last is the completion
+				// init), and the marker it touches last is the completion
 				// signal restoreGatewayFRR gates on. The frrinit exit
 				// statuses stay hints, exactly as the gwnode entrypoint
 				// treats them.

--- a/test/e2e/chaos/flaps_test.go
+++ b/test/e2e/chaos/flaps_test.go
@@ -80,11 +80,12 @@ func TestFRRRestartRecyclesFRRAndReassertsBGP(t *testing.T) {
 }
 
 // The completion marker carries the whole backgrounded recycle — stop,
-// clear, start — not one daemon coming ready, and a loaded CI runner has
-// taken it past the 60s daemon budget (run 29516365849) with the
-// lab-state dump showing FRR healthy moments after the abort. The restore
-// must wait it out on the recycle's own budget instead of parking the
-// node over a restart that is merely slow.
+// clear, start — not one daemon coming ready. Zombie daemons under the
+// old non-reaping PID 1 took it past the 60s daemon budget (run
+// 29516365849) with the lab-state dump showing FRR healthy moments after
+// the abort, and even with tini reaping, a loaded runner may stretch the
+// recycle. The restore must wait it out on the recycle's own budget
+// instead of parking the node over a restart that is merely slow.
 func TestFRRRestartRestoreOutwaitsARecycleSlowerThanTheDaemonBudget(t *testing.T) {
 	clock := newFakeClock()
 	markerAt := clock.now().Add(daemonReadyTimeout + 30*time.Second)

--- a/test/e2e/chaos/lab.go
+++ b/test/e2e/chaos/lab.go
@@ -200,10 +200,11 @@ func (l *lab) killGateway(ctx context.Context, gw string) error {
 	return nil
 }
 
-// terminateAgent signals the agent with SIGTERM. The gwnode entrypoint
-// execs the agent, so it is PID 1 — the same handle drain-hitless.sh
-// uses. Whether the agent drains before exiting depends on how the lab
-// was deployed (E2E_DRAIN_ON_SHUTDOWN).
+// terminateAgent signals the agent with SIGTERM through PID 1 — tini,
+// which forwards the signal to the agent it supervises and follows it
+// down (the same handle drain-hitless.sh uses). Whether the agent drains
+// before exiting depends on how the lab was deployed
+// (E2E_DRAIN_ON_SHUTDOWN).
 func (l *lab) terminateAgent(ctx context.Context, gw string) error {
 	if _, err := l.exec(ctx, gw, "kill", "-TERM", "1"); err != nil {
 		return fmt.Errorf("terminate agent on %s: %w", gw, err)
@@ -226,7 +227,7 @@ func (l *lab) restartGateway(ctx context.Context, gw string) error {
 }
 
 // containerRunning reports whether the container is up. Used to wait
-// for a SIGTERM'ed agent (PID 1) to actually take the container down. An
+// for a SIGTERM'ed agent to actually take the container down. An
 // inspect docker could not answer is not an exit — the error is handed
 // to the caller rather than folded into the verdict.
 func (l *lab) containerRunning(ctx context.Context, gw string) (bool, error) {

--- a/test/e2e/gwnode-entrypoint.sh
+++ b/test/e2e/gwnode-entrypoint.sh
@@ -3,15 +3,19 @@
 #
 # Starts the supporting daemons in a fixed order — OVS local DB, OVS
 # vswitchd (userspace datapath), ovn-controller, FRR — then execs the
-# ovn-network-agent in the foreground so the container's lifecycle is
-# tied to the agent process.
+# ovn-network-agent in the foreground. tini is PID 1 (see
+# Dockerfile.gwnode) and runs this script as its only child, so the
+# container's lifecycle stays tied to the agent process — and the
+# daemons that daemonize out of this script get reaped when they exit
+# instead of lingering as zombies under the non-reaping agent.
 
 set -Eeuo pipefail
 
 log() { printf '[gwnode] %s\n' "$*" >&2; }
 
-# `set -e` kills PID 1 without a word when an unguarded command fails, and
-# Docker's `restart: always` replaces the container so fast that the crash
+# `set -e` kills this script without a word when an unguarded command fails
+# (tini exits with its child, taking the container down), and Docker's
+# `restart: always` replaces the container so fast that the crash
 # is invisible — the restarted entrypoint's output just continues the log.
 # That silence is what made the eth1-destroying restart race (see the
 # daemon-start block below) cost days to root-cause. The trap cannot stop
@@ -41,9 +45,9 @@ VRF_TABLE_ID="${VRF_TABLE_ID:-100}"
 # Why no daemon start script's exit status may be fatal here
 # ---------------------------------------------------------------------------
 #
-# This script runs under `set -e` AND it is the container's PID 1 (main()
+# This script runs under `set -e` AND it is tini's only child (main()
 # `exec`s the agent at the end). So an unguarded command that returns non-zero
-# does not merely abort a step: it kills PID 1, the container exits, and
+# does not merely abort a step: tini follows it down, the container exits, and
 # Docker's `restart: always` policy — which containerlab applies to every node
 # — restarts it.
 #

--- a/test/e2e/scenarios/drain-hitless.sh
+++ b/test/e2e/scenarios/drain-hitless.sh
@@ -49,10 +49,11 @@
 # this trap). `docker kill -s KILL` is used for the hardkill arm
 # because by then we explicitly DO want the veth gone; the scenario
 # recycles the lab with `make e2e-down && make e2e-up` afterwards.
-# `kill -TERM 1` is correct because the gwnode entrypoint `exec`s the
-# agent at the end of its startup sequence (see
-# `test/e2e/gwnode-entrypoint.sh`), so the agent is PID 1 inside the
-# container — no `pgrep`/`pidof` dance needed.
+# `kill -TERM 1` is correct because PID 1 is tini (see
+# `test/e2e/Dockerfile.gwnode`), which forwards the signal to the agent
+# it supervises — the gwnode entrypoint `exec`s the agent at the end of
+# its startup sequence, so the agent is tini's only child — and exits
+# with it. No `pgrep`/`pidof` dance needed.
 #
 # Why we disable the container's restart policy before each arm:
 # containerlab applies a `restart: always` policy to its containers

--- a/test/e2e/scenarios/pf-hairpin.sh
+++ b/test/e2e/scenarios/pf-hairpin.sh
@@ -392,8 +392,8 @@ restore_agent_config() {
 
 # `docker restart` of the gateway container is the closest equivalent
 # to the issue's `systemctl restart ovn-network-agent`: the gwnode
-# image runs the agent as PID 1 (the entrypoint exec's it), so there
-# is no per-service control. Restart is heavyweight (OVS + ovn-controller
+# image runs the agent as tini's only child (the entrypoint exec's
+# it) with no service manager, so there is no per-service control. Restart is heavyweight (OVS + ovn-controller
 # + FRR re-init) — the scenario's CI budget allows for two such cycles
 # (one per phase).
 restart_master() {


### PR DESCRIPTION
## Problem

The chaos `frr-restart` action has never survived a seeded CI run. The same tick failed three times behind three successively larger wait budgets — 30 s `cmdTimeout` (run 29501890572), 60 s `daemonReadyTimeout` (run 29516365849), 3 m `frrRecycleTimeout` (run [29525707974](https://github.com/osism/ovn-network-agent/actions/runs/29525707974/job/87713519603)) — each abort diagnosed as a loaded runner because the lab-state dump showed FRR healthy again by the time it was taken.

## Root cause

No budget ever had a chance; the wait was a deterministic constant:

- The gwnode entrypoint `exec`s the agent, so PID 1 was a Go binary that never `wait()`s for children it did not spawn. Every FRR daemon daemonizes and reparents to PID 1 — and stays a **zombie** when it exits.
- `kill -0` on a zombie keeps succeeding, and FRR 8.4's `daemon_stop` polls exactly that for up to 1200 × 0.1 s per daemon, never sending SIGKILL.
- One `frrinit.sh stop` therefore burns ~120 s on watchfrr, ~120 s more on bgpd/staticd (stopped in parallel), and ~120 s more on zebra (stopped last, serially): **~6 minutes before the start half of the recycle even begins**.

Run 29525707974 shows the signature exactly: watchfrr logs `Terminating on signal` at inject +0 s, bgpd/staticd die at +123 s (1200 polls at 0.1 s plus fork overhead), and the completion marker is still absent at +180 s while the artifact dump finds bgpd/staticd down and zebra still answering vtysh — the run aborted mid-way through the stop's second zombie wait.

## Fix

Put `tini` in front of the entrypoint (`Dockerfile.gwnode`). Exited daemons are reaped, the `kill -0` loops end as soon as a daemon exits, and the recycle completes in moments. The three-minute `frrRecycleTimeout` stays as a pure backstop, and the comments/docs that blamed runner load now tell the real story. Central is unaffected — its chaos actions only SIGSTOP/SIGCONT, no process there exits.

## Verification (on the built image)

- Before-repro with a non-reaping PID 1: watchfrr in state `Zs` after SIGINT, `kill -0` still succeeding, `frrinit.sh stop` took **246 s** with only two daemons running (the real gateway adds a third 120 s phase), reporting `Failed to stop … still running` for processes long dead.
- With tini: the same stop takes **0.2 s**, the exact chaos-inject script touches its marker, no zombies remain.
- `kill -TERM 1` (drain-hitless.sh, chaos agent-terminate) still works: tini forwards the signal and the container exits 143.
- `go build ./...`, `go vet`, and the chaos package unit tests pass.

To confirm in CI, dispatch the E2E Chaos workflow with seed 42 / `everything-on` — tick 5 should now converge in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)