### PR TITLE
test/e2e: render a chaos run record as a Markdown report

### DIFF
--- a/.github/workflows/e2e-chaos.yml
+++ b/.github/workflows/e2e-chaos.yml
@@ -215,6 +215,25 @@ jobs:
           CHAOS_PROFILE: ${{ matrix.profile }}
         run: make e2e-chaos CHAOS_FLAGS="-duration ${CHAOS_DURATION} -seed ${CHAOS_SEED} -profile ${CHAOS_PROFILE} -out ${RUNNER_TEMP}/chaos"
 
+      # The report is the run record rendered for a human — verdict,
+      # recovery durations, probe-loss windows attributed to the faults
+      # they overlapped — so a triager reads the job summary instead of
+      # downloading the artifact and querying it by hand. `if: always()`
+      # because a failed run is the one whose report matters most; the
+      # guard covers the runs that died before the runner wrote a record
+      # (a `make e2e-up` failure), where there is nothing to render. A
+      # render error past the guard fails the step on purpose: a green
+      # run with a broken report is a report bug worth surfacing, and the
+      # chaos step above already carries the run's own verdict either way.
+      - name: Render the run report into the job summary
+        if: always()
+        run: |
+          if [ ! -f "${RUNNER_TEMP}/chaos/summary.json" ]; then
+            echo "No chaos run record was produced — the run died before the runner wrote one." >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+          go run ./test/e2e/chaos -report "${RUNNER_TEMP}/chaos" >> "${GITHUB_STEP_SUMMARY}"
+
       # The runner dumps `lab-state/` into the out directory itself on any
       # non-zero exit, but a `make e2e-up` failure dies before the runner
       # ever starts. This guard collects lab state in exactly that case

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION   ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "d
 LDFLAGS   := -s -w -X main.version=$(VERSION)
 GOFLAGS   := -trimpath
 
-.PHONY: all build build-static build-integration clean fmt vet test test-integration install docs-gen docs-gen-check models-gen models-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-hairpin e2e-multi-vlan e2e-pf-external e2e-pf-hairpin e2e-stale-chassis e2e-drain-hitless e2e-chaos
+.PHONY: all build build-static build-integration clean fmt vet test test-integration install docs-gen docs-gen-check models-gen models-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-hairpin e2e-multi-vlan e2e-pf-external e2e-pf-hairpin e2e-stale-chassis e2e-drain-hitless e2e-chaos e2e-chaos-report
 
 # Containerlab E2E harness. See test/e2e/README.md for the topology and
 # acceptance criteria (issue #44).
@@ -305,3 +305,17 @@ e2e-drain-hitless:
 CHAOS_FLAGS ?=
 e2e-chaos:
 	$(E2E_CHAOS) $(CHAOS_FLAGS)
+
+# Render a recorded chaos run as a Markdown report: the verdict, the
+# slowest recoveries against their budgets, and every probe-loss window
+# attributed to the fault it overlapped. CHAOS_RUN is the run directory
+# (or summary.json) a run wrote with -out, or a GitHub Actions run URL —
+# the URL form fetches the artifacts with `gh run download`, so `gh`
+# must be installed and authenticated. The CI workflow renders the same
+# report into each chaos job's summary.
+#
+#   make e2e-chaos-report CHAOS_RUN=/tmp/chaos-a
+#   make e2e-chaos-report CHAOS_RUN=https://github.com/osism/ovn-network-agent/actions/runs/<id>
+CHAOS_RUN ?= chaos-artifacts
+e2e-chaos-report:
+	$(E2E_CHAOS) -report $(CHAOS_RUN)

--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -1425,6 +1425,30 @@ oracle that could not prime against it).
 On any non-zero exit the lab's existing `collect-artifacts.sh` bundle is
 dumped into `<out>/lab-state`.
 
+**Reading a run back.** `-report` renders a recorded run as
+GitHub-flavored Markdown — the verdict, the injected-fault histogram, a
+copy-pasteable replay line, the slowest recoveries against their
+budgets, per-probe loss totals, every loss window attributed to the
+fault whose inject→converged span it overlapped, the settle results,
+and the decisions the guardrails skipped:
+
+```sh
+# A run directory (or its summary.json) written with -out:
+make e2e-chaos-report CHAOS_RUN=/tmp/chaos-a
+
+# An Actions run URL — fetches the artifacts with `gh run download`
+# (so `gh` must be installed and authenticated) and renders every
+# chaos record the run uploaded, e.g. all six nightly profiles:
+make e2e-chaos-report CHAOS_RUN=https://github.com/osism/ovn-network-agent/actions/runs/<id>
+```
+
+The report's spine is `summary.json`; the `journal.jsonl` next to it
+adds what the record alone cannot say — the loss-window attribution and
+the skip reasons. Without a journal the report still renders, falling
+back to the record's 10-second loss buckets. Rendering exits `0` even
+for a run that recorded a failure: the report's exit code says whether
+the report could be produced, not what the run found.
+
 **In CI.** The runner has its own workflow,
 [`e2e-chaos.yml`](https://github.com/osism/ovn-network-agent/blob/main/.github/workflows/e2e-chaos.yml),
 on three triggers. Nightly it fans out as a matrix over all six curated
@@ -1437,7 +1461,10 @@ dispatching it with the seed, profile and duration read back from that
 job's artifacts. A pull request opts into a short smoke (3 minutes,
 seed 42, `everything-on`) by carrying the `chaos-smoke` label, rather
 than chaos running on every PR. Each profile's journal and summary
-upload on every outcome, with the lab-state dump added on failure. It
+upload on every outcome, with the lab-state dump added on failure —
+and each job renders its own `-report` into the Actions job summary,
+so the verdict, the recovery durations and the loss windows are
+readable on the run page without downloading the artifact. It
 is deliberately not part of `e2e.yml`'s PR path: the scenarios there
 each assert one fault and leave the lab baseline-green, while a chaos
 run is a randomized sequence that deliberately leaves the master

--- a/test/e2e/chaos/main.go
+++ b/test/e2e/chaos/main.go
@@ -97,6 +97,7 @@ type config struct {
 	outDir        string
 	collect       string
 	gwnodeConfig  string
+	report        string
 }
 
 func main() {
@@ -116,7 +117,21 @@ func main() {
 		"lab-state collector, run into <out>/lab-state when the run does not pass")
 	flag.StringVar(&cfg.gwnodeConfig, "gwnode-config", "test/e2e/gwnode-config.yaml",
 		"the baked gateway agent config a profile's overlays are layered over")
+	flag.StringVar(&cfg.report, "report", "",
+		"render a Markdown report for a recorded run — a run directory, a summary.json, or an Actions run URL — to stdout, then exit")
 	flag.Parse()
+
+	// -report reads a finished run instead of driving a lab, so none of
+	// the run flags apply. It exits 0 even for a run that recorded a
+	// failure: the exit code says whether the report could be produced,
+	// not what the run found — the run itself already reported that.
+	if cfg.report != "" {
+		if err := runReport(cfg.report, os.Stdout, execCommander{timeout: reportDownloadTimeout}); err != nil {
+			fmt.Fprintf(os.Stderr, "[chaos] %v\n", err)
+			os.Exit(exitFatal)
+		}
+		return
+	}
 
 	code, err := run(cfg)
 	if err != nil {

--- a/test/e2e/chaos/report.go
+++ b/test/e2e/chaos/report.go
@@ -1,0 +1,638 @@
+package main
+
+// -report turns a recorded run back into something a human can read.
+// The runner's two artifacts are machine-readable on purpose — the
+// journal replays, the record diffs — but the first question a triager
+// asks ("did it pass, and where did the traffic go?") should not require
+// a jq session. The renderer answers it in GitHub-flavored Markdown, so
+// the same output serves a terminal, a file and the Actions job summary
+// the CI workflow appends it to.
+//
+// It reads what a run left behind and nothing else: summary.json is the
+// report's spine, and journal.jsonl — when it sits next to it — adds
+// what the record alone cannot say, the *when*: which fault a probe's
+// loss window overlapped, and which decisions the guardrails skipped.
+// A record without a journal still renders; the loss table then falls
+// back to the record's 10-second buckets.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// runURLPattern matches the browser URL of one Actions run — the form a
+// triager copies out of the address bar or a workflow notification. The
+// owner, the repository and the run id are all in it, so a URL is the
+// one argument that needs no checkout to resolve.
+var runURLPattern = regexp.MustCompile(`^https://github\.com/([^/]+)/([^/]+)/actions/runs/(\d+)`)
+
+// reportDownloadTimeout bounds the `gh run download`. The chaos record
+// itself is a few kilobytes, but a failed run's artifact carries the
+// lab-state bundle alongside it, and a nightly run has one artifact per
+// profile — so this is minutes, not the commander's 30-second default.
+const reportDownloadTimeout = 5 * time.Minute
+
+// slowestRecoveries caps the recovery table. A 10-minute run executes
+// ~a dozen actions and lists them all; an hours-long soak would bury
+// the verdict under hundreds of sub-second rows nobody scrolls past.
+const slowestRecoveries = 15
+
+// mdWriter is the renderer's pen: it remembers the first write error so
+// the dozens of table-row writes need no per-call checks, and the error
+// still reaches the exit code. After a failure every later write is a
+// no-op — half a report on a full disk should not masquerade as a whole
+// one, and runReport turns the recorded error into its verdict.
+type mdWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (m *mdWriter) printf(format string, args ...any) {
+	if m.err != nil {
+		return
+	}
+	_, m.err = fmt.Fprintf(m.w, format, args...)
+}
+
+// runReport renders every run record the argument names. The argument is
+// either an Actions run URL (the artifacts are fetched with `gh`, and a
+// nightly run yields one record per profile), a directory a run wrote its
+// artifacts into, or a summary.json itself.
+//
+// Rendering a failed run is a successful report: the exit code says
+// whether the report could be produced, not what the run found — the
+// run's own job already carries that verdict.
+func runReport(arg string, w io.Writer, cmdr commander) error {
+	paths, cleanup, err := resolveRecords(arg, cmdr)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		return err
+	}
+	out := &mdWriter{w: w}
+	for i, path := range paths {
+		if i > 0 {
+			out.printf("\n")
+		}
+		rec, events, err := loadRecord(path)
+		if err != nil {
+			return err
+		}
+		// Only a multi-record report labels its sources: the artifact
+		// directory name carries the profile and the run id, which is
+		// what tells six nightly records apart.
+		source := ""
+		if len(paths) > 1 {
+			source = filepath.Base(filepath.Dir(path))
+		}
+		renderReport(out, rec, events, source)
+	}
+	if out.err != nil {
+		return fmt.Errorf("write the report: %w", out.err)
+	}
+	return nil
+}
+
+// resolveRecords turns the -report argument into the summary.json paths
+// to render, plus a cleanup for the temporary download directory when
+// the argument was a URL.
+func resolveRecords(arg string, cmdr commander) ([]string, func(), error) {
+	if m := runURLPattern.FindStringSubmatch(arg); m != nil {
+		return downloadRunRecords(cmdr, m[1], m[2], m[3])
+	}
+	// Any other URL is a mistake worth naming — a job URL or a PR URL
+	// would otherwise fall through to os.Stat and report a baffling
+	// "no such file".
+	if strings.HasPrefix(arg, "http://") || strings.HasPrefix(arg, "https://") {
+		return nil, nil, fmt.Errorf(
+			"%s is not an Actions run URL (want https://github.com/<owner>/<repo>/actions/runs/<id>)", arg)
+	}
+	info, err := os.Stat(arg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read the run record: %w", err)
+	}
+	if !info.IsDir() {
+		return []string{arg}, nil, nil
+	}
+	path := filepath.Join(arg, summaryFile)
+	if _, err := os.Stat(path); err != nil {
+		return nil, nil, fmt.Errorf("%s holds no %s: %w", arg, summaryFile, err)
+	}
+	return []string{path}, nil, nil
+}
+
+// downloadRunRecords fetches a run's artifacts with `gh run download`
+// and returns every summary.json among them, sorted so the nightly
+// matrix renders in a stable profile order.
+func downloadRunRecords(cmdr commander, owner, repo, id string) ([]string, func(), error) {
+	dir, err := os.MkdirTemp("", "chaos-report-")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create a download directory: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+	if _, err := cmdr.run(context.Background(), "gh", "run", "download", id,
+		"-R", owner+"/"+repo, "-D", dir); err != nil {
+		return nil, cleanup, fmt.Errorf(
+			"download the artifacts of run %s (is `gh` installed and authenticated?): %w", id, err)
+	}
+	var paths []string
+	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && d.Name() == summaryFile {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, cleanup, fmt.Errorf("scan the downloaded artifacts: %w", err)
+	}
+	if len(paths) == 0 {
+		return nil, cleanup, fmt.Errorf(
+			"run %s uploaded no %s — not a chaos run, or it died before the runner wrote one", id, summaryFile)
+	}
+	sort.Strings(paths)
+	return paths, cleanup, nil
+}
+
+// loadRecord reads one run record and, best-effort, the journal next to
+// it. The schema gate is deliberate: a summary.json from some other tool
+// would render a report full of zeroes that reads like a clean run.
+func loadRecord(path string) (*runRecord, []event, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read the run record: %w", err)
+	}
+	var rec runRecord
+	if err := json.Unmarshal(raw, &rec); err != nil {
+		return nil, nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if rec.Schema != recordSchema {
+		return nil, nil, fmt.Errorf("%s carries schema %q, want %q", path, rec.Schema, recordSchema)
+	}
+	return &rec, readJournal(filepath.Join(filepath.Dir(path), journalFile)), nil
+}
+
+// readJournal reads the event lines the report enriches itself with.
+// Best-effort by design: a record without a journal renders from the
+// buckets alone, and an interrupted run truncates its last line — a
+// report that refused to render exactly the runs most worth triaging
+// would be useless. Unparsable lines are skipped, not fatal.
+func readJournal(path string) []event {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = f.Close() }()
+	var events []event
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		var ev event
+		if json.Unmarshal(sc.Bytes(), &ev) == nil {
+			events = append(events, ev)
+		}
+	}
+	return events
+}
+
+// renderReport writes one run's Markdown report. events may be nil.
+func renderReport(w *mdWriter, rec *runRecord, events []event, source string) {
+	verdict := "✅ pass"
+	if rec.Result != resultPass {
+		verdict = "❌ " + rec.Result
+	}
+	w.printf("## Chaos run — %s — profile `%s`, seed %d\n\n",
+		verdict, rec.Inputs.Profile, rec.Inputs.Seed)
+	if source != "" {
+		w.printf("Artifact: `%s`\n\n", source)
+	}
+
+	start, startOK := parseTS(rec.StartedAt)
+	end, endOK := parseTS(rec.EndedAt)
+	wall := "unknown"
+	if startOK && endOK {
+		wall = end.Sub(start).Round(time.Second).String()
+	}
+	w.printf("%d ticks — %d executed, %d skipped · %d violations · %d baseline sweeps (%d dual-claim, %d errors) · wall clock %s\n\n",
+		rec.Ticks, rec.Decisions.Executed, rec.Decisions.Skipped, len(rec.Violations),
+		rec.Checks.Sweeps, rec.Checks.DualClaim, rec.Checks.Errors, wall)
+	if line := actionsLine(rec.ActionsByName); line != "" {
+		w.printf("Faults injected: %s\n\n", line)
+	}
+	w.printf("Replay: `make e2e-chaos CHAOS_FLAGS=\"%s\"`\n\n", replayFlags(rec.Inputs))
+
+	renderViolations(w, rec)
+	renderRecoveries(w, rec)
+	renderProbes(w, rec)
+	renderLoss(w, rec, events, start, end)
+	renderSettles(w, rec)
+	renderSkipped(w, events)
+	renderInputs(w, rec)
+}
+
+// actionsLine is the injected-fault histogram as one line, most frequent
+// first — a run's fingerprint at a glance, without a table per action.
+func actionsLine(byName map[string]int) string {
+	names := make([]string, 0, len(byName))
+	for name := range byName {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		if byName[names[i]] != byName[names[j]] {
+			return byName[names[i]] > byName[names[j]]
+		}
+		return names[i] < names[j]
+	})
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		parts = append(parts, fmt.Sprintf("`%s` ×%d", name, byName[name]))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// replayFlags reconstructs the CHAOS_FLAGS that replay this run — the
+// full reproducibility contract except -weights, which the record stores
+// already resolved (defaults folded in), so the overriding spec cannot
+// be read back out of it. The inputs block at the bottom of the report
+// carries the resolved weights for a manual comparison.
+func replayFlags(in runInputs) string {
+	return fmt.Sprintf("-seed %d -profile %s -duration %s -tick-min %s -tick-max %s -settle-every %s -settle-timeout %s",
+		in.Seed, in.Profile, msDuration(in.DurationMS), msDuration(in.TickMinMS), msDuration(in.TickMaxMS),
+		msDuration(in.SettleEveryMS), msDuration(in.SettleTimeoutMS))
+}
+
+func renderViolations(w *mdWriter, rec *runRecord) {
+	if len(rec.Violations) == 0 {
+		return
+	}
+	w.printf("### Violations\n\n")
+	w.printf("| kind | tick | action | target | detail | journal line |\n")
+	w.printf("| --- | --- | --- | --- | --- | --- |\n")
+	for _, v := range rec.Violations {
+		w.printf("| %s | %s | %s | %s | %s | %s |\n",
+			cell(v.Kind), orDash(v.Tick), orDashS(v.Action), orDashS(v.Target),
+			cell(v.Detail), orDash(v.JournalOffset))
+	}
+	w.printf("\n")
+}
+
+func renderRecoveries(w *mdWriter, rec *runRecord) {
+	if len(rec.Recoveries) == 0 {
+		return
+	}
+	rows := make([]recoveryRecord, len(rec.Recoveries))
+	copy(rows, rec.Recoveries)
+	sort.SliceStable(rows, func(i, j int) bool { return rows[i].ConvergedMS > rows[j].ConvergedMS })
+	title := "### Recoveries — slowest first"
+	if len(rows) > slowestRecoveries {
+		title = fmt.Sprintf("### Recoveries — slowest %d of %d", slowestRecoveries, len(rows))
+		rows = rows[:slowestRecoveries]
+	}
+	w.printf("%s\n\n", title)
+	w.printf("| tick | action | target | converged | budget | probe loss after restore |\n")
+	w.printf("| --- | --- | --- | --- | --- | --- |\n")
+	for _, r := range rows {
+		w.printf("| %d | %s | %s | %s | %s | %s |\n",
+			r.Tick, cell(r.Action), cell(r.Target),
+			fmtMS(r.ConvergedMS), fmtMS(r.BudgetMS), probeLoss(r.FromRestoreMS))
+	}
+	w.printf("\n")
+}
+
+// probeLoss names the probes an action actually hurt, measured from the
+// restore — the anchor the recovery budget is enforced against, because
+// resources pinned to the node under fault are legitimately dark while
+// it is held down.
+func probeLoss(fromRestore map[string]int64) string {
+	names := make([]string, 0, len(fromRestore))
+	for name, ms := range fromRestore {
+		if ms > 0 {
+			names = append(names, name)
+		}
+	}
+	if len(names) == 0 {
+		return "none"
+	}
+	sort.Strings(names)
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		parts = append(parts, fmt.Sprintf("%s %s", name, fmtMS(fromRestore[name])))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func renderProbes(w *mdWriter, rec *runRecord) {
+	if len(rec.Probes) == 0 {
+		return
+	}
+	names := make([]string, 0, len(rec.Probes))
+	for name := range rec.Probes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	w.printf("### Probes\n\n")
+	w.printf("| probe | target | sent | lost | loss | transitions |\n")
+	w.printf("| --- | --- | --- | --- | --- | --- |\n")
+	for _, name := range names {
+		p := rec.Probes[name]
+		loss := "—"
+		if p.Sent > 0 {
+			loss = fmt.Sprintf("%.1f%%", float64(p.Lost)*100/float64(p.Sent))
+		}
+		w.printf("| %s | %s | %d | %d | %s | %d |\n",
+			cell(name), cell(p.Target), p.Sent, p.Lost, loss, p.Transitions)
+	}
+	w.printf("\n")
+}
+
+// renderLoss is the report's "where did the traffic go" section. With a
+// journal it renders one row per down window, each attributed to the
+// fault whose inject→converged span it overlapped; without one it falls
+// back to the record's 10-second buckets, which localize the loss in
+// time but cannot name the fault.
+func renderLoss(w *mdWriter, rec *runRecord, events []event, start, end time.Time) {
+	spans := lossSpans(events)
+	if len(spans) > 0 {
+		faults := faultSpans(events, end)
+		w.printf("### Loss windows\n\n")
+		w.printf("| at | probe | down for | during |\n")
+		w.printf("| --- | --- | --- | --- |\n")
+		for _, s := range spans {
+			down := "until run end"
+			if !s.end.IsZero() {
+				down = fmtMS(s.end.Sub(s.start).Milliseconds())
+			}
+			w.printf("| t+%s | %s | %s | %s |\n",
+				offset(start, s.start), cell(s.probe), down, cell(duringFaults(s, faults, end)))
+		}
+		w.printf("\n")
+		return
+	}
+	rows := lossBucketRows(rec)
+	if len(rows) == 0 {
+		w.printf("No probe loss was recorded.\n\n")
+		return
+	}
+	w.printf("### Loss windows — 10 s buckets (no journal next to the record)\n\n")
+	w.printf("| window | probe | lost/sent |\n")
+	w.printf("| --- | --- | --- |\n")
+	for _, r := range rows {
+		w.printf("| t+%s–%s | %s | %d/%d |\n",
+			offsetMS(r.offsetMS), offsetMS(r.offsetMS+10_000), cell(r.probe), r.lost, r.sent)
+	}
+	w.printf("\n")
+}
+
+func renderSettles(w *mdWriter, rec *runRecord) {
+	if len(rec.Settles) == 0 {
+		return
+	}
+	w.printf("### Settle windows\n\n")
+	w.printf("| tick | converged | result | violations |\n")
+	w.printf("| --- | --- | --- | --- |\n")
+	for _, s := range rec.Settles {
+		result := resultPass
+		if !s.Passed {
+			result = resultFail
+		}
+		w.printf("| %d | %s | %s | %d |\n", s.Tick, fmtMS(s.ConvergedMS), result, s.Violations)
+	}
+	w.printf("\n")
+}
+
+// renderSkipped lists the decisions the guardrails vetoed. Only the
+// journal knows why: the record counts skips but does not keep their
+// reasons.
+func renderSkipped(w *mdWriter, events []event) {
+	var rows []event
+	for _, ev := range events {
+		if ev.Event == evDecision && ev.Executed != nil && !*ev.Executed {
+			rows = append(rows, ev)
+		}
+	}
+	if len(rows) == 0 {
+		return
+	}
+	w.printf("### Skipped decisions\n\n")
+	w.printf("| tick | action | target | reason |\n")
+	w.printf("| --- | --- | --- | --- |\n")
+	for _, ev := range rows {
+		w.printf("| %d | %s | %s | %s |\n",
+			ev.Tick, cell(ev.Action), cell(ev.Target), orDashS(ev.SkipReason))
+	}
+	w.printf("\n")
+}
+
+// renderInputs folds the full replay contract — including the resolved
+// weights the replay line cannot carry — behind a details block, so the
+// report stays scannable but the contract stays one click away.
+func renderInputs(w *mdWriter, rec *runRecord) {
+	raw, err := json.MarshalIndent(rec.Inputs, "", "  ")
+	if err != nil {
+		return
+	}
+	w.printf("<details>\n<summary>Run inputs (the replay contract)</summary>\n\n```json\n%s\n```\n\n</details>\n", raw)
+}
+
+// faultSpan is one executed action's inject→converged window, read back
+// out of the journal. A fault the run never saw converge (an aborted or
+// interrupted run) stays open until runEnd.
+type faultSpan struct {
+	tick           int
+	action, target string
+	inject, end    time.Time
+}
+
+func faultSpans(events []event, runEnd time.Time) []faultSpan {
+	var spans []faultSpan
+	byTick := map[int]int{}
+	for _, ev := range events {
+		ts, ok := parseTS(ev.TS)
+		if !ok {
+			continue
+		}
+		switch ev.Event {
+		case evInject:
+			byTick[ev.Tick] = len(spans)
+			spans = append(spans, faultSpan{tick: ev.Tick, action: ev.Action, target: ev.Target, inject: ts})
+		case evConverged:
+			if i, seen := byTick[ev.Tick]; seen {
+				spans[i].end = ts
+			}
+		}
+	}
+	for i := range spans {
+		if spans[i].end.IsZero() {
+			spans[i].end = runEnd
+		}
+	}
+	return spans
+}
+
+// lossSpan is one probe's down window, paired from its transition events.
+// An open span (down at run end) keeps a zero end.
+type lossSpan struct {
+	probe      string
+	start, end time.Time
+}
+
+func lossSpans(events []event) []lossSpan {
+	open := map[string]time.Time{}
+	var spans []lossSpan
+	for _, ev := range events {
+		if ev.Event != evProbeTransition || ev.Up == nil {
+			continue
+		}
+		ts, ok := parseTS(ev.TS)
+		if !ok {
+			continue
+		}
+		if !*ev.Up {
+			if _, already := open[ev.Probe]; !already {
+				open[ev.Probe] = ts
+			}
+		} else if start, down := open[ev.Probe]; down {
+			spans = append(spans, lossSpan{probe: ev.Probe, start: start, end: ts})
+			delete(open, ev.Probe)
+		}
+	}
+	for probe, start := range open {
+		spans = append(spans, lossSpan{probe: probe, start: start})
+	}
+	sort.Slice(spans, func(i, j int) bool {
+		if !spans[i].start.Equal(spans[j].start) {
+			return spans[i].start.Before(spans[j].start)
+		}
+		return spans[i].probe < spans[j].probe
+	})
+	return spans
+}
+
+// duringFaults names the faults a loss window overlapped. A window that
+// overlapped none — loss that surfaced only after the engine declared
+// convergence, like a VIP repoint racing the prober — is attributed to
+// the most recent fault before it, marked "after", rather than dropped:
+// unattributed loss is exactly the kind a triager must not overlook.
+func duringFaults(s lossSpan, faults []faultSpan, runEnd time.Time) string {
+	end := s.end
+	if end.IsZero() {
+		end = runEnd
+	}
+	var hits []string
+	for _, f := range faults {
+		if s.start.Before(f.end) && end.After(f.inject) {
+			hits = append(hits, fmt.Sprintf("tick %d %s → %s", f.tick, f.action, f.target))
+		}
+	}
+	if len(hits) > 0 {
+		return strings.Join(hits, "; ")
+	}
+	last := -1
+	for i, f := range faults {
+		if f.inject.Before(s.start) {
+			last = i
+		}
+	}
+	if last >= 0 {
+		f := faults[last]
+		return fmt.Sprintf("after tick %d %s → %s", f.tick, f.action, f.target)
+	}
+	return "—"
+}
+
+// lossBucketRow is one non-zero bucket of the record's per-probe loss
+// series — the journal-less fallback for the loss table.
+type lossBucketRow struct {
+	offsetMS   int64
+	probe      string
+	lost, sent int
+}
+
+func lossBucketRows(rec *runRecord) []lossBucketRow {
+	var rows []lossBucketRow
+	for name, p := range rec.Probes {
+		for _, b := range p.Buckets {
+			if b.Lost > 0 {
+				rows = append(rows, lossBucketRow{offsetMS: b.OffsetMS, probe: name, lost: b.Lost, sent: b.Sent})
+			}
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].offsetMS != rows[j].offsetMS {
+			return rows[i].offsetMS < rows[j].offsetMS
+		}
+		return rows[i].probe < rows[j].probe
+	})
+	return rows
+}
+
+func parseTS(s string) (time.Time, bool) {
+	t, err := time.Parse(time.RFC3339Nano, s)
+	return t, err == nil
+}
+
+// fmtMS renders a duration the way a reader compares them: milliseconds
+// stay milliseconds, seconds get one decimal, anything longer reads as a
+// Go duration.
+func fmtMS(ms int64) string {
+	switch {
+	case ms < 1000:
+		return fmt.Sprintf("%d ms", ms)
+	case ms < 60_000:
+		return fmt.Sprintf("%.1f s", float64(ms)/1000)
+	default:
+		return (time.Duration(ms) * time.Millisecond).Round(time.Second).String()
+	}
+}
+
+func msDuration(ms int64) time.Duration { return time.Duration(ms) * time.Millisecond }
+
+// offset renders a timestamp as mm:ss from the run start — the same
+// clock the record's buckets use, so the two loss tables line up.
+func offset(start, t time.Time) string {
+	d := t.Sub(start)
+	if d < 0 {
+		d = 0
+	}
+	return offsetMS(d.Milliseconds())
+}
+
+func offsetMS(ms int64) string {
+	total := (ms + 500) / 1000
+	return fmt.Sprintf("%02d:%02d", total/60, total%60)
+}
+
+// cell makes a value safe inside a Markdown table: a pipe or a newline
+// in a violation detail must not shear the row apart.
+func cell(s string) string {
+	s = strings.ReplaceAll(s, "|", "\\|")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return strings.ReplaceAll(s, "\n", " ")
+}
+
+func orDash(n int) string {
+	if n == 0 {
+		return "—"
+	}
+	return fmt.Sprintf("%d", n)
+}
+
+func orDashS(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return cell(s)
+}

--- a/test/e2e/chaos/report_test.go
+++ b/test/e2e/chaos/report_test.go
@@ -1,0 +1,376 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// reportRecord is a small but fully-populated run record: every section
+// the renderer knows appears in the output exactly once, so the tests
+// can assert on presence and order without a golden file that breaks on
+// every wording tweak.
+func reportRecord(t *testing.T) *runRecord {
+	t.Helper()
+	rec := &runRecord{
+		Inputs: runInputs{
+			Seed: 7, Profile: "pf-only",
+			DurationMS:      (3 * time.Minute).Milliseconds(),
+			TickMinMS:       (10 * time.Second).Milliseconds(),
+			TickMaxMS:       (30 * time.Second).Milliseconds(),
+			SettleEveryMS:   (3 * time.Minute).Milliseconds(),
+			SettleTimeoutMS: (2 * time.Minute).Milliseconds(),
+			Weights:         map[string]int{"frr-restart": 2},
+			Lab:             "ovn-e2e",
+		},
+		StartedAt:     "2026-07-16T19:00:00Z",
+		Ticks:         3,
+		Decisions:     decisionCounts{Total: 3, Executed: 2, Skipped: 1},
+		Checks:        checkCounts{Sweeps: 12, DualClaim: 12},
+		ActionsByName: map[string]int{"frr-restart": 1, "mgmt-delay": 1},
+		Probes: map[string]probeSummary{
+			"pf-vip": {Target: "http://192.0.2.50:80/", Sent: 180, Lost: 0,
+				Buckets: []lossBucket{{OffsetMS: 0, Sent: 180, Lost: 0}}},
+			"fip-vm1": {Target: "192.0.2.10", Sent: 180, Lost: 4, Transitions: 2,
+				Buckets: []lossBucket{{OffsetMS: 60_000, Sent: 10, Lost: 4}}},
+		},
+		Recoveries: []recoveryRecord{
+			{Tick: 1, Action: "mgmt-delay", Target: "gateway-1", BudgetMS: 90_000, ConvergedMS: 150,
+				FromRestoreMS: map[string]int64{"fip-vm1": 0, "pf-vip": 0}},
+			{Tick: 2, Action: "frr-restart", Target: "gateway-2", BudgetMS: 120_000, ConvergedMS: 5_200,
+				FromRestoreMS: map[string]int64{"fip-vm1": 3_800, "pf-vip": 0}},
+		},
+		Settles: []settleRecord{{Tick: 2, ConvergedMS: 1_600, Passed: true}},
+	}
+	rec.finalize(time.Date(2026, 7, 16, 19, 3, 30, 0, time.UTC))
+	return rec
+}
+
+// renderToString drives the renderer the way runReport does and fails
+// the test on a write error a bytes.Buffer cannot actually produce.
+func renderToString(t *testing.T, rec *runRecord, events []event) string {
+	t.Helper()
+	var buf bytes.Buffer
+	w := &mdWriter{w: &buf}
+	renderReport(w, rec, events, "")
+	if w.err != nil {
+		t.Fatalf("render: %v", w.err)
+	}
+	return buf.String()
+}
+
+func TestRenderReportCoversTheRecord(t *testing.T) {
+	t.Parallel()
+
+	out := renderToString(t, reportRecord(t), nil)
+
+	for _, want := range []string{
+		"✅ pass", "profile `pf-only`, seed 7",
+		"3 ticks — 2 executed, 1 skipped",
+		"12 baseline sweeps",
+		"wall clock 3m30s",
+		"`frr-restart` ×1, `mgmt-delay` ×1",
+		`CHAOS_FLAGS="-seed 7 -profile pf-only -duration 3m0s -tick-min 10s -tick-max 30s -settle-every 3m0s -settle-timeout 2m0s"`,
+		"| 2 | frr-restart | gateway-2 | 5.2 s | 2m0s | fip-vm1 3.8 s |",
+		"| fip-vm1 | 192.0.2.10 | 180 | 4 | 2.2% | 2 |",
+		"| 2 | 1.6 s | pass | 0 |",
+		`"weights"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("report is missing %q:\n%s", want, out)
+		}
+	}
+	// A passing run renders no violation section at all — an empty table
+	// would read like a check that ran and found nothing to say.
+	if strings.Contains(out, "### Violations") {
+		t.Fatalf("a passing run rendered a violations section:\n%s", out)
+	}
+	// Slowest first: the 5.2 s recovery outranks the 150 ms one.
+	if strings.Index(out, "frr-restart | gateway-2") > strings.Index(out, "mgmt-delay | gateway-1") {
+		t.Fatalf("recoveries are not sorted slowest-first:\n%s", out)
+	}
+}
+
+func TestRenderReportNamesTheViolations(t *testing.T) {
+	t.Parallel()
+	rec := reportRecord(t)
+	rec.Violations = []violationRecord{{
+		Kind: violationRecoveryTimeout, Tick: 2, Action: "frr-restart", Target: "gateway-2",
+		Detail: "pipes | and\nnewlines", JournalOffset: 17,
+	}}
+	rec.finalize(time.Date(2026, 7, 16, 19, 3, 30, 0, time.UTC))
+
+	out := renderToString(t, rec, nil)
+
+	if !strings.Contains(out, "❌ fail") {
+		t.Fatalf("a failed run did not render its verdict:\n%s", out)
+	}
+	// The detail lands in one table cell: the pipe is escaped and the
+	// newline flattened, or the row shears apart in the rendered table.
+	if !strings.Contains(out, `pipes \| and newlines`) {
+		t.Fatalf("the violation detail broke the table row:\n%s", out)
+	}
+	if !strings.Contains(out, "| 17 |") {
+		t.Fatalf("the journal offset a triager jumps by is missing:\n%s", out)
+	}
+}
+
+// journalFor renders events as the JSONL the runner writes, so the tests
+// exercise the same decode path a real journal takes.
+func journalFor(t *testing.T, events []event) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	for _, ev := range events {
+		line, err := json.Marshal(ev)
+		if err != nil {
+			t.Fatalf("marshal event: %v", err)
+		}
+		buf.Write(line)
+		buf.WriteByte('\n')
+	}
+	return buf.Bytes()
+}
+
+func TestRenderReportCorrelatesLossWithFaults(t *testing.T) {
+	t.Parallel()
+	events := []event{
+		{TS: "2026-07-16T19:00:30Z", Event: evInject, Tick: 1, Action: "frr-restart", Target: "gateway-2"},
+		// This window sits inside tick 1's inject→converged span.
+		{TS: "2026-07-16T19:00:32Z", Event: evProbeTransition, Probe: "fip-vm1", Up: boolPtr(false)},
+		{TS: "2026-07-16T19:00:36Z", Event: evProbeTransition, Probe: "fip-vm1", Up: boolPtr(true)},
+		{TS: "2026-07-16T19:00:40Z", Event: evConverged, Tick: 1, Action: "frr-restart", Target: "gateway-2"},
+		// This one starts after the convergence: attributed as "after".
+		{TS: "2026-07-16T19:00:50Z", Event: evProbeTransition, Probe: "pf-vip", Up: boolPtr(false)},
+		{TS: "2026-07-16T19:00:51Z", Event: evProbeTransition, Probe: "pf-vip", Up: boolPtr(true)},
+	}
+
+	out := renderToString(t, reportRecord(t), events)
+
+	if !strings.Contains(out, "| t+00:32 | fip-vm1 | 4.0 s | tick 1 frr-restart → gateway-2 |") {
+		t.Fatalf("a loss window inside a fault span was not attributed to it:\n%s", out)
+	}
+	if !strings.Contains(out, "| t+00:50 | pf-vip | 1.0 s | after tick 1 frr-restart → gateway-2 |") {
+		t.Fatalf("a loss window past the convergence was not marked as after the fault:\n%s", out)
+	}
+}
+
+func TestRenderReportListsTheSkippedDecisions(t *testing.T) {
+	t.Parallel()
+	events := []event{
+		{TS: "2026-07-16T19:00:10Z", Event: evDecision, Tick: 1, Action: "frr-route-drop",
+			Target: "gateway-1", Executed: boolPtr(false), SkipReason: "not-applicable"},
+		{TS: "2026-07-16T19:00:30Z", Event: evDecision, Tick: 2, Action: "frr-restart",
+			Target: "gateway-2", Executed: boolPtr(true)},
+	}
+
+	out := renderToString(t, reportRecord(t), events)
+
+	if !strings.Contains(out, "| 1 | frr-route-drop | gateway-1 | not-applicable |") {
+		t.Fatalf("the skipped decision and its reason are missing:\n%s", out)
+	}
+	// An executed decision carries no skip reason, so a leak would render
+	// as this dashed row. (The bare tick/action/target prefix also occurs
+	// in the recoveries table, so it cannot be asserted on.)
+	if strings.Contains(out, "| 2 | frr-restart | gateway-2 | — |") {
+		t.Fatalf("an executed decision leaked into the skipped table:\n%s", out)
+	}
+}
+
+// Without a journal the loss table falls back to the record's 10-second
+// buckets: coarser, but still localizing the loss in time.
+func TestRenderReportFallsBackToTheLossBuckets(t *testing.T) {
+	t.Parallel()
+
+	out := renderToString(t, reportRecord(t), nil)
+
+	if !strings.Contains(out, "| t+01:00–01:10 | fip-vm1 | 4/10 |") {
+		t.Fatalf("the bucket fallback is missing the non-zero bucket:\n%s", out)
+	}
+	if strings.Contains(out, "| pf-vip | 0/") {
+		t.Fatalf("a zero bucket leaked into the loss table:\n%s", out)
+	}
+}
+
+func TestRenderReportSaysWhenNothingWasLost(t *testing.T) {
+	t.Parallel()
+	rec := reportRecord(t)
+	rec.Probes = map[string]probeSummary{
+		"pf-vip": {Target: "http://192.0.2.50:80/", Sent: 180,
+			Buckets: []lossBucket{{OffsetMS: 0, Sent: 180}}},
+	}
+
+	out := renderToString(t, rec, nil)
+
+	if !strings.Contains(out, "No probe loss was recorded.") {
+		t.Fatalf("a lossless run did not say so:\n%s", out)
+	}
+}
+
+// The renderer's writes are individually unchecked on purpose; the first
+// failure still has to reach the exit code, or half a report on a full
+// disk masquerades as a whole one.
+func TestRunReportSurfacesAWriteError(t *testing.T) {
+	t.Parallel()
+	dir := writeRunDir(t, reportRecord(t), nil)
+
+	err := runReport(dir, failingWriter{}, &fakeCommander{})
+
+	if err == nil || !strings.Contains(err.Error(), "write the report") {
+		t.Fatalf("error = %v, want the write failure surfaced", err)
+	}
+}
+
+// writeRunDir lays a record (and optionally a journal) out on disk the
+// way a finished run leaves them.
+func writeRunDir(t *testing.T, rec *runRecord, journal []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := writeRecord(rec, filepath.Join(dir, summaryFile)); err != nil {
+		t.Fatalf("write the record: %v", err)
+	}
+	if journal != nil {
+		if err := os.WriteFile(filepath.Join(dir, journalFile), journal, 0o644); err != nil {
+			t.Fatalf("write the journal: %v", err)
+		}
+	}
+	return dir
+}
+
+func TestRunReportReadsADirectoryOrARecordFile(t *testing.T) {
+	t.Parallel()
+	events := []event{
+		{TS: "2026-07-16T19:00:10Z", Event: evDecision, Tick: 1, Action: "frr-route-drop",
+			Target: "gateway-1", Executed: boolPtr(false), SkipReason: "not-applicable"},
+	}
+	dir := writeRunDir(t, reportRecord(t), journalFor(t, events))
+
+	for name, arg := range map[string]string{
+		"the run directory": dir,
+		"the record itself": filepath.Join(dir, summaryFile),
+	} {
+		var buf bytes.Buffer
+		if err := runReport(arg, &buf, &fakeCommander{}); err != nil {
+			t.Fatalf("runReport(%s): %v", name, err)
+		}
+		// The journal next to the record is picked up on both paths — the
+		// skipped-decision table only exists when it was read.
+		if !strings.Contains(buf.String(), "not-applicable") {
+			t.Fatalf("runReport(%s) did not read the journal next to the record:\n%s", name, buf.String())
+		}
+	}
+}
+
+// A truncated last line is what an interrupted run leaves behind; the
+// journal's intact prefix still has to enrich the report.
+func TestRunReportSurvivesATruncatedJournal(t *testing.T) {
+	t.Parallel()
+	events := []event{
+		{TS: "2026-07-16T19:00:10Z", Event: evDecision, Tick: 1, Action: "frr-route-drop",
+			Target: "gateway-1", Executed: boolPtr(false), SkipReason: "not-applicable"},
+	}
+	journal := append(journalFor(t, events), []byte(`{"ts":"2026-07-16T19:00:20Z","event":"dec`)...)
+	dir := writeRunDir(t, reportRecord(t), journal)
+	var buf bytes.Buffer
+
+	if err := runReport(dir, &buf, &fakeCommander{}); err != nil {
+		t.Fatalf("runReport: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "not-applicable") {
+		t.Fatalf("the intact journal prefix was thrown away:\n%s", buf.String())
+	}
+}
+
+func TestRunReportRejectsWhatItCannotRender(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a directory without a record", func(t *testing.T) {
+		t.Parallel()
+		err := runReport(t.TempDir(), &bytes.Buffer{}, &fakeCommander{})
+		if err == nil || !strings.Contains(err.Error(), summaryFile) {
+			t.Fatalf("error = %v, want one naming the missing %s", err, summaryFile)
+		}
+	})
+
+	t.Run("a record with a foreign schema", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), summaryFile)
+		if err := os.WriteFile(path, []byte(`{"schema":"something-else/v9"}`), 0o644); err != nil {
+			t.Fatalf("write the record: %v", err)
+		}
+		err := runReport(path, &bytes.Buffer{}, &fakeCommander{})
+		if err == nil || !strings.Contains(err.Error(), recordSchema) {
+			t.Fatalf("error = %v, want one naming the expected schema %s", err, recordSchema)
+		}
+	})
+
+	t.Run("a URL that is not an Actions run", func(t *testing.T) {
+		t.Parallel()
+		err := runReport("https://github.com/osism/ovn-network-agent/pull/5", &bytes.Buffer{}, &fakeCommander{})
+		if err == nil || !strings.Contains(err.Error(), "not an Actions run URL") {
+			t.Fatalf("error = %v, want the URL-shape rejection", err)
+		}
+	})
+}
+
+// The URL path shells out to `gh run download` through the commander
+// seam; the fake plays gh and lays two artifacts out in the -D directory,
+// the way a nightly's per-profile matrix uploads them.
+func TestRunReportDownloadsAnActionsRun(t *testing.T) {
+	t.Parallel()
+	respond := func(argv []string) (string, error) {
+		line := strings.Join(argv, " ")
+		if !strings.HasPrefix(line, "gh run download 12345 -R osism/ovn-network-agent -D ") {
+			t.Errorf("unexpected download argv: %v", argv)
+			return "", errBoom
+		}
+		dest := argv[len(argv)-1]
+		for _, profile := range []string{"everything-on", "pf-only"} {
+			rec := reportRecord(t)
+			rec.Inputs.Profile = profile
+			dir := filepath.Join(dest, "e2e-artifacts-chaos-"+profile+"-12345-1")
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return "", err
+			}
+			if err := writeRecord(rec, filepath.Join(dir, summaryFile)); err != nil {
+				return "", err
+			}
+		}
+		return "", nil
+	}
+	var buf bytes.Buffer
+
+	err := runReport("https://github.com/osism/ovn-network-agent/actions/runs/12345",
+		&buf, &fakeCommander{respond: respond})
+	if err != nil {
+		t.Fatalf("runReport: %v", err)
+	}
+	out := buf.String()
+
+	// One report per artifact, labeled with the artifact directory so the
+	// six nightly records stay tellable-apart, in sorted (stable) order.
+	first := strings.Index(out, "Artifact: `e2e-artifacts-chaos-everything-on-12345-1`")
+	second := strings.Index(out, "Artifact: `e2e-artifacts-chaos-pf-only-12345-1`")
+	if first == -1 || second == -1 || second < first {
+		t.Fatalf("the run's records are missing or out of order:\n%s", out)
+	}
+	if got := strings.Count(out, "## Chaos run — "); got != 2 {
+		t.Fatalf("rendered %d reports, want one per artifact record", got)
+	}
+}
+
+func TestRunReportReportsAnEmptyActionsRun(t *testing.T) {
+	t.Parallel()
+	// gh succeeds but the run carried no chaos record at all — a run of
+	// some other workflow, or one that died before the runner wrote one.
+	err := runReport("https://github.com/osism/ovn-network-agent/actions/runs/99999",
+		&bytes.Buffer{}, &fakeCommander{})
+
+	if err == nil || !strings.Contains(err.Error(), "uploaded no "+summaryFile) {
+		t.Fatalf("error = %v, want one saying the run held no record", err)
+	}
+}


### PR DESCRIPTION
## What & why

The chaos runner's two artifacts are machine-readable on purpose — the journal replays, the record diffs — but the first question a triager asks ("did it pass, and where did the traffic go?") took an artifact download and a jq session to answer. This PR renders that answer automatically.

**A `-report` mode on the runner.** `go run ./test/e2e/chaos -report <arg>` (or `make e2e-chaos-report CHAOS_RUN=<arg>`) renders a recorded run as GitHub-flavored Markdown: the verdict, the injected-fault histogram, a copy-pasteable replay line, the slowest recoveries against their budgets, per-probe loss totals, the settle results, and the decisions the guardrails skipped. The argument is the run directory (or its `summary.json`) a run wrote with `-out`, or an Actions run URL — the URL form fetches the artifacts with `gh run download` and renders every record the run uploaded, so a nightly yields all six profiles in one report.

**Loss windows attributed to their faults.** The record is the report's spine; the `journal.jsonl` next to it adds the *when*: every probe down-window is paired from its transition events and attributed to the fault whose inject→converged span it overlapped ("tick 5 frr-restart → gateway-1"). Loss that surfaced only after convergence is attributed to the most recent fault before it and marked "after", rather than dropped. A record without a journal still renders (falling back to the record's 10-second buckets), a truncated journal line is skipped rather than fatal, and a `summary.json` with a foreign schema is rejected.

**The report in every chaos job's summary.** The e2e-chaos workflow appends the same report to `GITHUB_STEP_SUMMARY` under `if: always()` — a failed run is the one whose report matters most — guarded for runs that died before the runner wrote a record.

Verified end-to-end against run 29529705065: local directory, `summary.json`, make target and the URL form all render the same report; the CI step was exercised with a simulated `GITHUB_STEP_SUMMARY` including the missing-record guard branch.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
      (they feed the release notes — see [CONTRIBUTING.md](../CONTRIBUTING.md)).
- [x] `make test` passes.
- [ ] `make docs-gen` was run if `config.go`, `metrics.go`, or the config
      surface changed.
- [x] Documentation is updated for any user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
