### PR TITLE
Agent: tighten the failover hot path and add a failover-latency metric

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -86,14 +86,30 @@ jobs:
         run: make e2e-down
 
   failover:
-    name: HA failover (master chassis loss)
+    name: HA failover (${{ matrix.variant }})
     runs-on: ubuntu-latest
     # Runs after the baseline job, but on its own runner so a failover
     # regression is reported in isolation from the baseline path. Same
-    # 15-minute budget — the scenario only adds ~30s of failover wait
-    # on top of the baseline gate.
+    # 15-minute budget — the default leg only adds ~30s of failover
+    # wait on top of the baseline gate, the strict leg the ~40s
+    # ping-flood window of issue #131.
     needs: baseline
     timeout-minutes: 15
+
+    # The strict leg is the same scenario with LOSS_BUDGET set, so it
+    # is a matrix leg rather than a copy of this job. fail-fast is off
+    # so a strict-budget breach still lets the plain re-election leg
+    # report its own result.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: failover
+            variant: "master chassis loss"
+            loss_budget: ""
+          - id: failover-strict
+            variant: "strict ~2s outage budget"
+            loss_budget: "2"
 
     env:
       E2E_TOPOLOGY: test/e2e/topology.clab.yml
@@ -109,6 +125,17 @@ jobs:
         run: make e2e-up
 
       - name: Run failover scenario
+        # LOSS_BUDGET switches failover.sh into the strict variant: a
+        # 0.1s-spaced ping flood from client-1 is captured with tcpdump
+        # across the re-election and the largest reply gap must stay
+        # within the budget (issue #131). Empty selects the default
+        # variant. The pcap is directed into the shared artifact root
+        # so collect-artifacts.sh and the uploader both pick it up.
+        # `runner.temp` is only available at step scope, not the
+        # job-level env block.
+        env:
+          LOSS_BUDGET: ${{ matrix.loss_budget }}
+          ARTIFACTS_DIR: ${{ runner.temp }}/e2e-artifacts/${{ matrix.id }}
         run: ./test/e2e/scenarios/failover.sh
 
       - name: Collect failure artifacts
@@ -120,7 +147,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: e2e-artifacts-failover-${{ github.run_id }}-${{ github.run_attempt }}
+          name: e2e-artifacts-${{ matrix.id }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/e2e-artifacts
           if-no-files-found: warn
           retention-days: 7

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -111,3 +111,10 @@ linters:
       - path: '_test\.go$'
         linters: [revive]
         text: 'context-as-argument'
+      # staticcheck QF1009 (use time.Time.Equal): the monotonic-clock test
+      # compares a Time against its Round(0) form with == on purpose.
+      # Equal compares instants and would be vacuously true; only struct
+      # equality can see whether the monotonic reading is present.
+      - path: '_test\.go$'
+        linters: [staticcheck]
+        text: 'QF1009'

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION   ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "d
 LDFLAGS   := -s -w -X main.version=$(VERSION)
 GOFLAGS   := -trimpath
 
-.PHONY: all build build-static build-integration clean fmt vet test test-integration install docs-gen docs-gen-check models-gen models-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-hairpin e2e-multi-vlan e2e-pf-external e2e-pf-hairpin e2e-stale-chassis e2e-drain-hitless e2e-chaos e2e-chaos-report
+.PHONY: all build build-static build-integration clean fmt vet test test-integration install docs-gen docs-gen-check models-gen models-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-failover-strict e2e-hairpin e2e-multi-vlan e2e-pf-external e2e-pf-hairpin e2e-stale-chassis e2e-drain-hitless e2e-chaos e2e-chaos-report
 
 # Containerlab E2E harness. See test/e2e/README.md for the topology and
 # acceptance criteria (issue #44).
@@ -201,6 +201,15 @@ e2e-baseline:
 # tearing the lab down.
 e2e-failover:
 	$(E2E_FAILOVER)
+
+# Run the HA failover scenario with the strict outage-budget assertion
+# (issue #131): a 0.1s-spaced ping flood from client-1 is captured with
+# tcpdump across the re-election, and the largest reply gap must stay
+# within LOSS_BUDGET seconds (default 2). Mirrors the failover-strict
+# leg of the CI failover job; runs the same failover.sh, only with the
+# strict variant on.
+e2e-failover-strict:
+	LOSS_BUDGET=2 $(E2E_FAILOVER)
 
 # Run the same-chassis hairpin scenario (issue #108) against a lab
 # that is already up. Adds a second FIP backend (ls0-vm2 / 192.0.2.12)

--- a/agent.go
+++ b/agent.go
@@ -49,6 +49,15 @@ type Agent struct {
 // chassis grace period to prevent thundering-herd cleanup across agents.
 const maxStaleCleanupJitter = 30 * time.Second
 
+// Reconcile trigger labels. These are the "trigger" metric label and, for
+// triggerStartup, gate the failover-announce metric — so the call sites and
+// the guard must stay in sync by reference rather than by matching literals.
+const (
+	triggerStartup  = "startup"
+	triggerEvent    = "event"
+	triggerPeriodic = "periodic"
+)
+
 // ovnConnectRetryInterval is how long Run waits between failed OVN connect
 // attempts. The agent is a long-running daemon: when its OVN endpoint is
 // unreachable on cold start, the right behaviour is to keep retrying rather
@@ -163,7 +172,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	}
 
 	// Initial reconciliation
-	a.reconcile(ctx, "startup")
+	a.reconcile(ctx, triggerStartup)
 
 	// Drain any reconcile signals queued during startup — the initial
 	// reconcile already handled the current state.
@@ -230,11 +239,11 @@ func (a *Agent) Run(ctx context.Context) error {
 
 		case <-a.reconcileCh:
 			slog.Debug("event-triggered reconciliation")
-			a.reconcile(ctx, "event")
+			a.reconcile(ctx, triggerEvent)
 
 		case <-ticker.C:
 			slog.Debug("periodic reconciliation")
-			a.reconcile(ctx, "periodic")
+			a.reconcile(ctx, triggerPeriodic)
 		}
 	}
 }
@@ -257,8 +266,16 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 	// OVNState (no local routers, no SNAT IPs, no discovered networks)
 	// drives the rest of the cycle through the port-forward-only path.
 	var state OVNState
+	// failoverObservedAt is the time a chassisredirect change was last seen
+	// in the immediate-refresh path. It is consumed against this cycle's own
+	// snapshot: a cycle whose state predates the change leaves the
+	// observation for the reconcile that actually announces the takeover,
+	// and a cycle that does reflect it consumes it either way, so a stale
+	// observation cannot leak into a later, unrelated announce.
+	var failoverObservedAt time.Time
 	if a.ovn != nil {
 		state = a.ovn.GetState()
+		failoverObservedAt = a.ovn.takeFailoverObservedAt(state.Gen)
 	}
 
 	// Compute effective network filters for this cycle.
@@ -291,6 +308,12 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 		slog.Debug("desired IP list", "ips", desiredIPs)
 	}
 
+	// The reachability-critical OVN/OVS setup runs before the BGP announce
+	// so a failover takeover reconcile starts attracting traffic as early as
+	// possible. The stability steps (priority lead, veth-leak, route
+	// verification, stale-chassis cleanup) are deferred to after the
+	// announce — see issue #131. The prefix-list stays on the critical path:
+	// it is the BGP outbound filter, so the announce is a no-op without it.
 	switch {
 	case a.cfg.PortForwardOnly:
 		// Port-forward-only mode: no OVN state to act on. OVS flows,
@@ -316,6 +339,8 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 		// routers, each pointing at the MAC of its own segment's kernel
 		// interface. When the segment bindings are not (yet) resolved,
 		// fall back to the bridge MAC — the flat single-network value.
+		// Reply traffic needs the NB default route, so this stays on the
+		// reachability-critical path before the announce.
 		macByLRP := make(map[string]string, len(state.LocalRouters))
 		fallbackMAC := ""
 		for _, lr := range state.LocalRouters {
@@ -334,18 +359,13 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 			slog.Error("failed to ensure gateway routing", "error", err)
 		}
 
-		// Ensure the active chassis has a strictly higher priority than
-		// standby peers, preventing reverse failover after drain/restore.
-		if err := a.ovn.EnsureActivePriorityLead(ctx, state.LocalRouters, state.LocalChassisName); err != nil {
-			slog.Error("failed to ensure active priority lead", "error", err)
-		}
-
-		// Reconcile per-network veth leak routes and policy rules.
-		if err := a.routing.ReconcileVethLeakNetworks(a.effectiveFilters); err != nil {
-			slog.Error("failed to reconcile veth leak networks", "error", err)
-		}
-
-		// Reconcile FRR prefix-list entries for discovered networks.
+		// Reconcile FRR prefix-list entries for discovered networks. The
+		// prefix-list is the BGP outbound filter (neighbor ... prefix-list
+		// ... out) and it is what permits the FIP /32s, so the announce
+		// below advertises nothing until it is populated. A standby chassis
+		// empties it via the default: branch, so on a takeover this must run
+		// BEFORE the announce — it is reachability-critical, not a stability
+		// step.
 		if err := a.routing.ReconcileFRRPrefixList(a.effectiveFilters); err != nil {
 			slog.Error("failed to reconcile FRR prefix-list", "error", err)
 		}
@@ -393,26 +413,59 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 		ipDev[ip] = a.routing.SegmentDev(target.Segment)
 	}
 
-	// Ensure routes for all desired IPs (FIPs, SNATs, and port forward VIPs).
-	// When no local routers are present but port forwards are configured,
-	// this still installs VIP routes on br-ex and in FRR.
-	announced := false
+	// The BGP announce. Ensure routes for all desired IPs (FIPs, SNATs, and
+	// port forward VIPs). When no local routers are present but port
+	// forwards are configured, this still installs VIP routes on br-ex and
+	// in FRR.
+	var routeSync routeSyncResult
 	if len(desiredIPs) > 0 || state.HasLocalRouters {
-		announced = a.ensureRoutes(desiredIPs, ipDev, skipKernelRoute)
+		routeSync = a.ensureRoutes(desiredIPs, ipDev, skipKernelRoute)
 	} else {
 		a.removeAllRoutes("no locally active routers and no port forward VIPs")
+	}
+
+	// Failover-latency metric: time from observing the chassisredirect
+	// change to completing the BGP announce of the takeover routes.
+	// Recorded only on a takeover reconcile (FRR routes were added and BGP
+	// refreshed) and never for the startup cycle. Recorded before the NB
+	// writes below so their latency does not inflate the sample.
+	if routeSync.announced && !failoverObservedAt.IsZero() && trigger != triggerStartup {
+		recordFailoverAnnounce(time.Since(failoverObservedAt))
 	}
 
 	// On a node that owns local routers, stamp the takeover readiness marker on
 	// each managed default route once the announce succeeded. A draining peer
 	// polls NB for this marker before it releases its own FIP routes, so it
 	// must only be written when this node can actually forward (ensureRoutes
-	// returns true only after RefreshBGP succeeded). HasLocalRouters is false in
-	// port-forward-only mode (a.ovn is nil), so this is skipped there.
-	if announced && state.HasLocalRouters {
+	// reports ready only when no route add or BGP refresh failed).
+	// HasLocalRouters is false in port-forward-only mode (a.ovn is nil), so
+	// this is skipped there.
+	if routeSync.ready && state.HasLocalRouters {
 		if err := a.ovn.MarkTakeoverReady(ctx, state.LocalRouters); err != nil {
 			slog.Error("failed to write takeover readiness marker", "error", err)
 		}
+	}
+
+	// Stability steps — deferred to after the announce so the FRR/BGP
+	// announce on a failover takeover is not gated behind them.
+	if state.HasLocalRouters {
+		// Ensure the active chassis has a strictly higher priority than
+		// standby peers, preventing reverse failover after drain/restore.
+		if err := a.ovn.EnsureActivePriorityLead(ctx, state.LocalRouters, state.LocalChassisName); err != nil {
+			slog.Error("failed to ensure active priority lead", "error", err)
+		}
+
+		// Reconcile per-network veth leak routes and policy rules.
+		if err := a.routing.ReconcileVethLeakNetworks(a.effectiveFilters); err != nil {
+			slog.Error("failed to reconcile veth leak networks", "error", err)
+		}
+	}
+
+	// Post-change route verification: re-add any desired route that
+	// disappeared during the mutation. Runs after the announce and only
+	// when routes actually changed, matching the pre-#131 trigger.
+	if routeSync.changed {
+		a.verifyRoutes(desiredIPs, ipDev, skipKernelRoute)
 	}
 
 	// Surface desired routes that are configured in FRR but not actually
@@ -540,20 +593,42 @@ func (a *Agent) desiredRouteDev(ip string, ipDev map[string]string) string {
 	return a.cfg.BridgeDev
 }
 
+// routeSyncResult reports what ensureRoutes changed so the caller can run
+// the post-announce route verification, record the failover-latency metric,
+// and decide whether to write the takeover readiness marker.
+type routeSyncResult struct {
+	// changed is true when FRR routes were added or removed — the trigger
+	// for the post-change route verification.
+	changed bool
+	// announced is true when FRR routes were added AND both the route-add
+	// and the BGP outbound soft-refresh succeeded — i.e. this cycle really
+	// did advertise takeover routes. Both operations only log their errors
+	// and continue, so this must reflect their outcome and not merely the
+	// intent to run them: a takeover chassis whose vtysh is unavailable
+	// (a failure correlated with the event that triggered the failover)
+	// advertises nothing, and reporting that as a fast, healthy announce
+	// would leave the latency histogram green while every FIP is unreachable.
+	announced bool
+	// ready is true unless a kernel-route add, an FRR add, or the BGP
+	// soft-refresh failed. Unlike announced it is also true for a
+	// steady-state cycle with nothing to change. The drain takeover
+	// handshake uses it so a node that attracted BGP traffic it cannot yet
+	// deliver never signals readiness to a draining peer, while a marker
+	// missed in one cycle self-heals on the next.
+	ready bool
+}
+
 // ensureRoutes adds routes for all desired IPs and removes stale ones.
 // ipDev names the kernel interface each IP's route belongs on; kernel routes
 // are reconciled as (IP, device) pairs so a route that sits on the wrong
 // segment interface is replaced. IPs in skipKernelRoute keep their existing
 // kernel route untouched — their VLAN segment did not resolve this cycle, so
 // moving the /32 to the bridge fallback would mis-deliver the traffic.
-// ensureRoutes returns whether this node successfully announced the desired
-// routes: true unless a kernel-route add, an FRR add, or the BGP soft-refresh
-// failed. The drain takeover handshake uses it so a node that attracted BGP
-// traffic it cannot yet deliver never signals readiness to a draining peer. A
-// steady-state cycle with nothing to change returns true, so a marker missed
-// in one cycle self-heals on the next.
-func (a *Agent) ensureRoutes(desiredIPs []string, ipDev map[string]string, skipKernelRoute map[string]bool) bool {
-	announced := true
+// It returns what changed so the caller can run the post-announce route
+// verification, record the failover-latency metric, and decide whether to
+// write the takeover readiness marker.
+func (a *Agent) ensureRoutes(desiredIPs []string, ipDev map[string]string, skipKernelRoute map[string]bool) routeSyncResult {
+	kernelOK := true
 	desiredSet := make(map[string]bool, len(desiredIPs))
 	for _, ip := range desiredIPs {
 		desiredSet[ip] = true
@@ -612,7 +687,7 @@ func (a *Agent) ensureRoutes(desiredIPs []string, ipDev map[string]string, skipK
 		if needsKernel {
 			if err := a.routing.AddKernelRoute(ip, dev); err != nil {
 				slog.Error("failed to add kernel route", "ip", ip, "dev", dev, "error", err)
-				announced = false
+				kernelOK = false
 			}
 		}
 		if needsFRR {
@@ -621,10 +696,11 @@ func (a *Agent) ensureRoutes(desiredIPs []string, ipDev map[string]string, skipK
 	}
 
 	// Batch-add all missing FRR routes in one vtysh call.
+	addOK := true
 	if len(addFRR) > 0 {
 		if err := a.routing.AddFRRRoutes(addFRR); err != nil {
 			slog.Error("failed to batch-add FRR routes", "count", len(addFRR), "ips", addFRR, "error", err)
-			announced = false
+			addOK = false
 		}
 	}
 
@@ -680,21 +756,25 @@ func (a *Agent) ensureRoutes(desiredIPs []string, ipDev map[string]string, skipK
 	// only re-evaluates outbound policy and re-sends; it never withdraws
 	// a route, so re-announcing the existing set alongside the new ones
 	// is harmless.
+	//
+	// This MUST stay a separate vtysh invocation from AddFRRRoutes above:
+	// bundling the route-add and the soft-refresh into one vtysh process
+	// makes "clear ... soft out" race the static→zebra→BGP redistribution,
+	// so the freshly added /32s miss the immediate re-advertise and only
+	// go out on FRR's slower redistribution timing.
+	refreshOK := true
 	if len(addFRR) > 0 || len(delFRR) > 0 {
 		if err := a.routing.RefreshBGP(); err != nil {
 			slog.Warn("BGP soft-refresh failed, peers may wait for MRAI timer", "error", err)
-			announced = false
+			refreshOK = false
 		}
 	}
 
-	// Safety net: after any route changes, verify that all desired routes
-	// are still present. A BGP soft-refresh re-evaluates outbound policy
-	// and could (in edge cases) interact with FRR in unexpected ways.
-	if len(addFRR) > 0 || len(delFRR) > 0 {
-		a.verifyRoutes(desiredIPs, ipDev, skipKernelRoute)
+	return routeSyncResult{
+		changed:   len(addFRR) > 0 || len(delFRR) > 0,
+		announced: len(addFRR) > 0 && addOK && refreshOK,
+		ready:     kernelOK && addOK && refreshOK,
 	}
-
-	return announced
 }
 
 // removeAllRoutes removes every agent-owned FIP route. Ownership is scoped by

--- a/agent_test.go
+++ b/agent_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"os/exec"
 	"reflect"
@@ -1417,6 +1418,152 @@ func TestReconcileLeavesFailoverStampForTheAnnouncingCycle(t *testing.T) {
 	// reconcile: a stamp re-taken later would record a near-zero latency.
 	if sum < 0.4 || sum > 2.0 {
 		t.Errorf("failover_announce_seconds sum = %v, want ~0.4 (the observed→announce interval)", sum)
+	}
+}
+
+// TestReconcileAnnouncesBeforeStabilitySteps pins the reconcile ordering
+// introduced by issue #131: on a takeover the BGP announce — the FRR
+// route-add followed by the "clear ip bgp ... soft out" soft-refresh — must
+// run BEFORE the stability steps, and the post-change route verification must
+// run AFTER it. Gating the announce behind the stability steps (priority lead,
+// veth-leak, stale-chassis cleanup) adds seconds of external downtime on a
+// failover, so a regression reverting the reorder must fail here.
+//
+// The prefix-list is deliberately NOT a stability step: it is the BGP
+// outbound filter (neighbor ... prefix-list ... out) and permits the FIP
+// /32s, so an announce that runs before it is populated advertises nothing.
+// A standby chassis empties the list, so on a takeover the repopulation must
+// precede the announce.
+//
+// The pin is expressed as an index ordering over the recorded vtysh calls:
+//
+//	prefix-list  "ip prefix-list fip-out ... permit 198.51.100.0/24 ge 32 le 32"
+//	             (ReconcileFRRPrefixList — the BGP outbound filter)
+//	  <
+//	route-add    "ip route 198.51.100.0/32 ..."              (ensureRoutes)
+//	  <
+//	soft-refresh "clear ip bgp vrf vrf-provider * soft out"  (ensureRoutes)
+//	  <
+//	route re-add "ip route 198.51.100.0/32 ..."              (verifyRoutes)
+//
+// AC1 (the announce is not filtered away) is pinned by prefix-list <
+// route-add < soft-refresh: with the prefix-list repopulation deferred to
+// after ensureRoutes, the soft-refresh runs against an empty outbound filter
+// and the takeover advertises zero prefixes, which inverts the assertion.
+//
+// AC2 (verification still runs, after the announce) is pinned by
+// soft-refresh < route re-add. The vtysh recorder answers every FRR static
+// listing with an empty document, so verifyRoutes finds the freshly announced
+// /32 "missing" and re-adds it — a second route-add call that only
+// verifyRoutes issues and that must land after the announce. The listing
+// itself cannot anchor AC2: ListFRRRoutes and InactiveFRRRoutes share the
+// same memoized "show ip route ... static json" query, so a second listing
+// appears with or without verifyRoutes (checkFRRRouteActivity re-reads too).
+//
+// EnsureActivePriorityLead and the stale-chassis cleanup are NB/SB-side, not
+// vtysh, so they cannot be interleaved with the vtysh stream and are not
+// asserted here.
+func TestReconcileAnnouncesBeforeStabilitySteps(t *testing.T) {
+	rec := newVtyshRecorder()
+	// Non-dry-run RouteManager so the FRR helpers actually reach the vtysh
+	// hook (dry-run would short-circuit them). FRRPrefixList is non-empty so
+	// ReconcileFRRPrefixList populates the outbound filter. The OVS hook is a
+	// no-op recorder so the pre-announce OVS steps (EnsureSegments, hairpin
+	// flows) don't shell out on this host, and the kernel-route listing hook
+	// keeps verifyRoutes from bailing out before its FRR re-read on hosts
+	// where kernel routes are unsupported.
+	rm := &RouteManager{
+		cfg:                  Config{BridgeDev: "br-ex", VRFName: "vrf-provider", VethNexthop: "169.254.0.1", FRRPrefixList: "fip-out"},
+		execVtyshHook:        rec.hook(),
+		execOVSHook:          newOVSRecorder().hook(),
+		listKernelRoutesHook: func() ([]kernelRouteEntry, error) { return nil, nil },
+	}
+
+	// Same OVN rig as takeoverAgent: one locally-active router whose LRP
+	// network 198.51.100.0/24 makes 198.51.100.0 the desired announce IP.
+	_, cidr, _ := net.ParseCIDR("198.51.100.0/24")
+	c, _, _ := newOVNClientWithFakes(t, "host-a")
+	c.state.Replace(OVNState{
+		LocalRouters: []LocalRouterInfo{{
+			RouterName:  "router1",
+			LRPName:     "lrp-abc",
+			LRPMAC:      "aa:aa:aa:aa:aa:aa",
+			LRPNetworks: []string{"198.51.100.0/24"},
+		}},
+		HasLocalRouters:    true,
+		DiscoveredNetworks: []*net.IPNet{cidr},
+	})
+	a := &Agent{
+		cfg:            Config{},
+		ovn:            c,
+		routing:        rm,
+		reconcileCh:    make(chan struct{}, 1),
+		missingChassis: make(map[string]time.Time),
+	}
+
+	// The kernel-route add helpers error out on this host (no br-ex);
+	// reconcile only logs those and proceeds to the FRR/vtysh path, which is
+	// all this test inspects.
+	a.reconcile(context.Background(), "event")
+
+	// firstIdx locates a recorded vtysh call by a substring of its full,
+	// space-joined args; -1 when absent. allIdxs returns every match.
+	firstIdx := func(sub string) int {
+		for i, args := range rec.calls {
+			if strings.Contains(strings.Join(args, " "), sub) {
+				return i
+			}
+		}
+		return -1
+	}
+	allIdxs := func(sub string) []int {
+		var idxs []int
+		for i, args := range rec.calls {
+			if strings.Contains(strings.Join(args, " "), sub) {
+				idxs = append(idxs, i)
+			}
+		}
+		return idxs
+	}
+	dump := func() string {
+		var b strings.Builder
+		for i, args := range rec.calls {
+			fmt.Fprintf(&b, "\n  [%d] %s", i, strings.Join(args, " "))
+		}
+		return b.String()
+	}
+
+	// route-add occurrences: the announce's add of the desired /32
+	// (ensureRoutes), then verifyRoutes' re-add of the same /32.
+	routeAdds := allIdxs("ip route 198.51.100.0/32")
+	softRefresh := firstIdx("clear ip bgp vrf vrf-provider * soft out")
+	// The prefix-list populate: the entry that permits the FIP /32s through
+	// the BGP outbound filter.
+	prefixListAdd := firstIdx("permit 198.51.100.0/24 ge 32 le 32")
+
+	if len(routeAdds) == 0 || softRefresh < 0 || prefixListAdd < 0 {
+		t.Fatalf("missing expected vtysh calls: prefixListAdd=%d routeAdds=%v softRefresh=%d; calls:%s",
+			prefixListAdd, routeAdds, softRefresh, dump())
+	}
+
+	// AC1: the outbound filter is populated before the announce, and the
+	// announce is route-add followed by soft-refresh. Deferring the
+	// prefix-list to after the announce advertises nothing.
+	if prefixListAdd >= routeAdds[0] || routeAdds[0] >= softRefresh {
+		t.Errorf("prefix-list must be populated before the announce: prefixListAdd=%d routeAdd=%d softRefresh=%d; calls:%s",
+			prefixListAdd, routeAdds[0], softRefresh, dump())
+	}
+
+	// AC2: verifyRoutes still runs, after the announce. The recorder reports
+	// an empty FRR document on every listing, so verifyRoutes re-adds the
+	// /32 it just announced — deleting verifyRoutes drops this second add.
+	if len(routeAdds) < 2 {
+		t.Fatalf("want the announce's route-add plus verifyRoutes' re-add, got %v; calls:%s",
+			routeAdds, dump())
+	}
+	if reAdd := routeAdds[1]; reAdd <= softRefresh {
+		t.Errorf("route verification must run after the announce: softRefresh=%d reAdd=%d; calls:%s",
+			softRefresh, reAdd, dump())
 	}
 }
 

--- a/agent_test.go
+++ b/agent_test.go
@@ -638,7 +638,13 @@ func TestEnsureRoutesAddsMissingAndRemovesStale(t *testing.T) {
 	a := &Agent{routing: rm, effectiveFilters: []*net.IPNet{cidr}}
 
 	// Desired: 198.51.100.10 (new) and 198.51.100.20 (already in FRR).
-	a.ensureRoutes([]string{"198.51.100.10", "198.51.100.20"}, nil, nil)
+	res := a.ensureRoutes([]string{"198.51.100.10", "198.51.100.20"}, nil, nil)
+	if !res.changed {
+		t.Error("routeSyncResult.changed = false, want true (routes were added and removed)")
+	}
+	if !res.announced {
+		t.Error("routeSyncResult.announced = false, want true (an FRR route was added)")
+	}
 
 	var sawAdd, sawDel, sawRefresh bool
 	for _, c := range rec.calls {
@@ -666,55 +672,55 @@ func TestEnsureRoutesAddsMissingAndRemovesStale(t *testing.T) {
 	}
 }
 
-// TestEnsureRoutesReturnsAnnounceOutcome pins the announce outcome the drain
-// takeover handshake keys on: ensureRoutes returns true when the FIP routes
-// were announced (or nothing needed changing) and false when the FRR add or
-// the BGP soft-refresh failed. PortForwardOnly skips kernel routes so only the
-// FRR/BGP paths — the ones the outcome depends on — are exercised, keeping the
-// test off the real bridge.
-func TestEnsureRoutesReturnsAnnounceOutcome(t *testing.T) {
+// TestEnsureRoutesReportsReadyOutcome pins the route-sync outcome the drain
+// takeover handshake keys on: ensureRoutes reports ready when the FIP routes
+// were announced (or nothing needed changing) and not ready when the FRR add
+// or the BGP soft-refresh failed. PortForwardOnly skips kernel routes so only
+// the FRR/BGP paths — the ones the outcome depends on — are exercised, keeping
+// the test off the real bridge.
+func TestEnsureRoutesReportsReadyOutcome(t *testing.T) {
 	_, cidr, _ := net.ParseCIDR("198.51.100.0/24")
 	newAgent := func(rec *vtyshRecorder) *Agent {
 		rm := &RouteManager{cfg: Config{BridgeDev: "ovnagent-nonexistent-br", VRFName: "vrf-provider", VethNexthop: "169.254.0.1"}, execVtyshHook: rec.hook()}
 		return &Agent{cfg: Config{PortForwardOnly: true}, routing: rm, effectiveFilters: []*net.IPNet{cidr}}
 	}
 
-	t.Run("clean add announces", func(t *testing.T) {
+	t.Run("clean add is ready", func(t *testing.T) {
 		rec := newVtyshRecorder()
 		// FRR reports no routes, so the desired IP is added and BGP refreshed;
 		// the recorder returns success for both.
-		if !newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, nil, nil) {
-			t.Errorf("clean add cycle: announced = false, want true (calls: %v)", rec.calls)
+		if !newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, nil, nil).ready {
+			t.Errorf("clean add cycle: ready = false, want true (calls: %v)", rec.calls)
 		}
 	})
 
-	t.Run("no-change cycle announces", func(t *testing.T) {
+	t.Run("no-change cycle is ready", func(t *testing.T) {
 		rec := newVtyshRecorder()
 		// FRR already advertises the only desired IP: nothing is added or
-		// removed, so no BGP refresh runs and the cycle still announces.
+		// removed, so no BGP refresh runs and the cycle is still ready.
 		rec.on([]string{"vtysh", "-c", "show ip route vrf vrf-provider static json"},
 			frrStaticRoutesJSON("169.254.0.1", "198.51.100.10"), nil)
-		if !newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, nil, nil) {
-			t.Errorf("no-change cycle: announced = false, want true (calls: %v)", rec.calls)
+		if !newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, nil, nil).ready {
+			t.Errorf("no-change cycle: ready = false, want true (calls: %v)", rec.calls)
 		}
 	})
 
-	t.Run("FRR add failure does not announce", func(t *testing.T) {
+	t.Run("FRR add failure is not ready", func(t *testing.T) {
 		rec := newVtyshRecorder()
 		rec.on([]string{"vtysh", "-c", "conf t", "-c", "vrf vrf-provider",
 			"-c", "ip route 198.51.100.10/32 169.254.0.1", "-c", "exit-vrf", "-c", "end"},
 			"", errors.New("vtysh add failed"))
-		if newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, nil, nil) {
-			t.Errorf("FRR add failure: announced = true, want false")
+		if newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, nil, nil).ready {
+			t.Errorf("FRR add failure: ready = true, want false")
 		}
 	})
 
-	t.Run("BGP refresh failure does not announce", func(t *testing.T) {
+	t.Run("BGP refresh failure is not ready", func(t *testing.T) {
 		rec := newVtyshRecorder()
 		rec.on([]string{"vtysh", "-c", "clear ip bgp vrf vrf-provider * soft out"},
 			"", errors.New("bgp refresh failed"))
-		if newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, nil, nil) {
-			t.Errorf("BGP refresh failure: announced = true, want false")
+		if newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, nil, nil).ready {
+			t.Errorf("BGP refresh failure: ready = true, want false")
 		}
 	})
 }
@@ -807,6 +813,51 @@ func TestCheckFRRRouteActivity(t *testing.T) {
 			t.Errorf("gauge with a healthy route = %v, want 0", got)
 		}
 	})
+}
+
+// TestEnsureRoutesKeepsAnnounceSeparateFromRouteAdd verifies that a takeover
+// reconcile with only additions issues the FRR route-add and the BGP
+// soft-refresh as two separate vtysh invocations. Bundling them into one
+// process makes the soft-refresh race the static→BGP redistribution, so the
+// freshly added /32s miss the immediate re-advertise (issue #131 follow-up).
+func TestEnsureRoutesKeepsAnnounceSeparateFromRouteAdd(t *testing.T) {
+	rec := newVtyshRecorder()
+	// FRR has no static routes yet — every desired route is a pure addition.
+	rec.on(
+		[]string{"vtysh", "-c", "show ip route vrf vrf-provider static json"},
+		"",
+		nil,
+	)
+	rm := &RouteManager{cfg: Config{BridgeDev: "ovnagent-nonexistent-br", VRFName: "vrf-provider", VethNexthop: "169.254.0.1"}, execVtyshHook: rec.hook()}
+	a := &Agent{routing: rm}
+
+	res := a.ensureRoutes([]string{"198.51.100.10", "198.51.100.20"}, nil, nil)
+	if !res.announced || !res.changed {
+		t.Fatalf("routeSyncResult = %+v, want changed+announced", res)
+	}
+
+	var addCall, refreshCall, bundled int
+	for _, c := range rec.calls {
+		joined := strings.Join(c, " ")
+		hasAdd := strings.Contains(joined, "ip route 198.51.100.10/32") &&
+			!strings.Contains(joined, "no ip route")
+		hasRefresh := strings.Contains(joined, "clear ip bgp vrf vrf-provider")
+		if hasAdd {
+			addCall++
+		}
+		if hasRefresh {
+			refreshCall++
+		}
+		if hasAdd && hasRefresh {
+			bundled++
+		}
+	}
+	if addCall != 1 || refreshCall != 1 {
+		t.Errorf("expected one route-add and one BGP refresh call, got add=%d refresh=%d (calls: %v)", addCall, refreshCall, rec.calls)
+	}
+	if bundled != 0 {
+		t.Errorf("route-add and BGP refresh must not share a vtysh call: %v", rec.calls)
+	}
 }
 
 // TestRemoveAllRoutesWithStubbedFRRList exercises the FRR-driven removal
@@ -1214,6 +1265,306 @@ func TestReconcileCompletesPromptlyOnCancelledContext(t *testing.T) {
 	// would leave the agent half-initialised on the next tick.
 	if len(a.effectiveFilters) != 1 || a.effectiveFilters[0].String() != "198.51.100.0/24" {
 		t.Errorf("effectiveFilters = %v, want [198.51.100.0/24]", a.effectiveFilters)
+	}
+}
+
+// takeoverAgent builds an Agent whose OVN state has one locally-active
+// router, so a reconcile cycle takes the HasLocalRouters branch and the
+// announce adds the router's FIP /32 to FRR. The RouteManager is in
+// dry-run, so the FRR/kernel helpers are no-ops.
+func takeoverAgent(t *testing.T) (*Agent, *OVNClient) {
+	t.Helper()
+	_, cidr, _ := net.ParseCIDR("198.51.100.0/24")
+	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex", VRFName: "vrf-provider", VethNexthop: "169.254.0.1", DryRun: true}}
+	c, _, _ := newOVNClientWithFakes(t, "host-a")
+	c.state.Replace(OVNState{
+		LocalRouters: []LocalRouterInfo{{
+			RouterName:  "router1",
+			LRPName:     "lrp-abc",
+			LRPMAC:      "aa:aa:aa:aa:aa:aa",
+			LRPNetworks: []string{"198.51.100.0/24"},
+		}},
+		HasLocalRouters:    true,
+		DiscoveredNetworks: []*net.IPNet{cidr},
+	})
+	a := &Agent{
+		cfg:            Config{},
+		ovn:            c,
+		routing:        rm,
+		reconcileCh:    make(chan struct{}, 1),
+		missingChassis: make(map[string]time.Time),
+	}
+	return a, c
+}
+
+// observeFailoverAt stamps a chassisredirect observation made at `at`, then
+// advances the published state generation the way the immediate refreshState
+// pass that follows the observation does. The reconcile's snapshot therefore
+// reflects the change and is entitled to consume the observation, which is the
+// production sequence: stamp, refresh, announce.
+func observeFailoverAt(t *testing.T, c *OVNClient, at time.Time) {
+	t.Helper()
+	c.failoverObserved.Store(&failoverObservation{at: at, gen: c.refreshSeq.Load()})
+	st := c.state.Snapshot()
+	st.Gen = c.refreshSeq.Add(1)
+	c.state.Replace(st)
+}
+
+// failoverAnnounceSample returns the observation count and the summed
+// observed seconds of the ovn_network_agent_failover_announce_seconds
+// histogram. The sum matters as much as the count: the documented alert reads
+// the observed interval, so a test that only counts samples would pass on a
+// histogram recording the wrong duration.
+func failoverAnnounceSample(t *testing.T, m *metricsRegistry) (uint64, float64) {
+	t.Helper()
+	got, _ := m.registry.Gather()
+	for _, mf := range got {
+		if mf.GetName() == "ovn_network_agent_failover_announce_seconds" {
+			h := mf.GetMetric()[0].GetHistogram()
+			return h.GetSampleCount(), h.GetSampleSum()
+		}
+	}
+	t.Fatal("failover_announce_seconds histogram missing from registry")
+	return 0, 0
+}
+
+// TestReconcileRecordsFailoverAnnounceMetric verifies that a takeover
+// reconcile triggered by a chassisredirect change records the
+// failover-announce latency, and consumes the timestamp exactly once.
+func TestReconcileRecordsFailoverAnnounceMetric(t *testing.T) {
+	m := withTestMetrics(t)
+	a, c := takeoverAgent(t)
+
+	// A chassisredirect change was observed ~400ms ago.
+	observeFailoverAt(t, c, time.Now().Add(-400*time.Millisecond))
+
+	a.reconcile(context.Background(), triggerEvent)
+	count, sum := failoverAnnounceSample(t, m)
+	if count != 1 {
+		t.Fatalf("failover_announce_seconds count after takeover = %d, want 1", count)
+	}
+	// The recorded value must be the observed→announce interval (~0.4s plus
+	// the reconcile itself), not merely a sample: the p95 alert in
+	// docs/guides/metrics.md reads the value, not the count. A guard on the
+	// count alone would pass on a histogram recording 0.
+	if sum < 0.4 || sum > 2.0 {
+		t.Errorf("failover_announce_seconds sum = %v, want ~0.4 (the stamped interval)", sum)
+	}
+
+	// The timestamp is consumed: a follow-up reconcile with no new
+	// observation must not record another sample.
+	a.reconcile(context.Background(), triggerEvent)
+	if count, _ := failoverAnnounceSample(t, m); count != 1 {
+		t.Errorf("failover_announce_seconds count after second reconcile = %d, want 1", count)
+	}
+}
+
+// TestReconcileLeavesFailoverStampForTheAnnouncingCycle covers the reconcile
+// that loses the race to the takeover: a failover produces a storm of OVN
+// changes, most of them not chassisredirect, so a debounce cycle is almost
+// always in flight alongside the immediate path. That cycle refreshes state,
+// arms its reconcile timer, and the chassisredirect change lands inside the
+// window — so its reconcile runs on the pre-failover snapshot, announces
+// nothing, and must leave the observation alone. Consuming it there loses the
+// sample for the takeover reconcile that follows and does announce, so a
+// genuine failover records nothing at all.
+func TestReconcileLeavesFailoverStampForTheAnnouncingCycle(t *testing.T) {
+	m := withTestMetrics(t)
+	a, c := takeoverAgent(t)
+
+	// The debounce cycle published the pre-failover snapshot (no local
+	// routers), then the chassisredirect change was observed ~400ms ago.
+	preFailover := c.state.Snapshot()
+	preFailover.LocalRouters = nil
+	preFailover.HasLocalRouters = false
+	preFailover.Gen = c.refreshSeq.Add(1)
+	c.state.Replace(preFailover)
+	c.failoverObserved.Store(&failoverObservation{
+		at:  time.Now().Add(-400 * time.Millisecond),
+		gen: c.refreshSeq.Load(),
+	})
+
+	// The reconcile armed by the debounce cycle: it still holds the stale
+	// snapshot, so it announces nothing and records nothing.
+	a.reconcile(context.Background(), triggerEvent)
+	if count, _ := failoverAnnounceSample(t, m); count != 0 {
+		t.Fatalf("failover_announce_seconds count after the stale cycle = %d, want 0", count)
+	}
+
+	// The immediate refresh publishes the post-failover snapshot; the
+	// reconcile it triggers is the one that announces the takeover routes and
+	// must find the observation still pending.
+	_, cidr, _ := net.ParseCIDR("198.51.100.0/24")
+	postFailover := c.state.Snapshot()
+	postFailover.LocalRouters = []LocalRouterInfo{{
+		RouterName:  "router1",
+		LRPName:     "lrp-abc",
+		LRPMAC:      "aa:aa:aa:aa:aa:aa",
+		LRPNetworks: []string{"198.51.100.0/24"},
+	}}
+	postFailover.HasLocalRouters = true
+	postFailover.DiscoveredNetworks = []*net.IPNet{cidr}
+	postFailover.Gen = c.refreshSeq.Add(1)
+	c.state.Replace(postFailover)
+
+	a.reconcile(context.Background(), triggerEvent)
+	count, sum := failoverAnnounceSample(t, m)
+	if count != 1 {
+		t.Fatalf("failover_announce_seconds count after the takeover = %d, want 1 — "+
+			"the stale cycle consumed the observation the announcing cycle needed", count)
+	}
+	// The sample must span from the observation, not from the takeover
+	// reconcile: a stamp re-taken later would record a near-zero latency.
+	if sum < 0.4 || sum > 2.0 {
+		t.Errorf("failover_announce_seconds sum = %v, want ~0.4 (the observed→announce interval)", sum)
+	}
+}
+
+// TestReconcileSkipsFailoverMetricOnStartup verifies that the startup
+// reconcile never records a failover-announce sample, even though it adds
+// FRR routes — startup is not a failover.
+func TestReconcileSkipsFailoverMetricOnStartup(t *testing.T) {
+	m := withTestMetrics(t)
+	a, c := takeoverAgent(t)
+	observeFailoverAt(t, c, time.Now())
+
+	a.reconcile(context.Background(), triggerStartup)
+	if count, _ := failoverAnnounceSample(t, m); count != 0 {
+		t.Errorf("failover_announce_seconds count after startup = %d, want 0", count)
+	}
+	// The startup cycle still consumes the timestamp so it cannot leak.
+	if !c.takeFailoverObservedAt(c.GetState().Gen).IsZero() {
+		t.Error("startup reconcile must consume the failover timestamp")
+	}
+}
+
+// TestEnsureRoutesRemovalOnlyIsNotAnnounce verifies that a cycle which only
+// withdraws routes reports changed (so verification still runs) but not
+// announced: withdrawing a /32 attracts no traffic, so it is not a takeover
+// announce and must not feed the failover-latency metric.
+func TestEnsureRoutesRemovalOnlyIsNotAnnounce(t *testing.T) {
+	rec := newVtyshRecorder()
+	// FRR still carries a /32 that is no longer desired.
+	rec.on([]string{"vtysh", "-c", "show ip route vrf vrf-provider static json"},
+		frrStaticRoutesJSON("169.254.0.1", "203.0.113.5"), nil)
+	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex", VRFName: "vrf-provider", VethNexthop: "169.254.0.1"}, execVtyshHook: rec.hook()}
+	a := &Agent{
+		cfg:            Config{},
+		routing:        rm,
+		reconcileCh:    make(chan struct{}, 1),
+		missingChassis: make(map[string]time.Time),
+	}
+
+	// Disjoint desired set: the stale /32 is withdrawn, nothing is added.
+	res := a.ensureRoutes(nil, nil, nil)
+	if !res.changed {
+		t.Errorf("changed = false, want true — the stale /32 was withdrawn")
+	}
+	if res.announced {
+		t.Errorf("announced = true, want false — a withdrawal is not an announce")
+	}
+}
+
+// TestEnsureRoutesAnnounceReportsOutcomeNotIntent verifies that an announce
+// which failed is not reported as one that happened. The FRR route-add and the
+// BGP soft-refresh both only log their error and let the cycle continue, so
+// deriving announced from the intent to run them — the list of routes to add —
+// claims a successful announce whenever either silently failed.
+//
+// The failure is correlated with the event under measurement: the takeover
+// chassis is under stress precisely because of whatever moved the gateway to
+// it, and an unavailable or restarting vtysh fails both calls. The histogram
+// would then record a fast, healthy failover and keep the p95 alert green
+// while zero FIPs are advertised and every FIP on the router is unreachable
+// from outside — the alert is worth less than none at all.
+func TestEnsureRoutesAnnounceReportsOutcomeNotIntent(t *testing.T) {
+	tests := []struct {
+		name   string
+		failOn string // substring of the vtysh args that must fail
+	}{
+		{"route-add fails", "ip route 198.51.100.7/32"},
+		{"soft-refresh fails", "clear ip bgp"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rm := &RouteManager{
+				cfg: Config{BridgeDev: "br-ex", VRFName: "vrf-provider", VethNexthop: "169.254.0.1"},
+				execVtyshHook: func(cmd *exec.Cmd) ([]byte, error) {
+					if strings.Contains(strings.Join(cmd.Args, " "), tc.failOn) {
+						return []byte("vtysh: failed to connect to zebra"), errors.New("exit status 1")
+					}
+					return nil, nil
+				},
+			}
+			// Port-forward-only keeps ensureRoutes off the kernel-route path,
+			// so the cycle under test is exactly the FRR add plus the
+			// soft-refresh on every platform. The empty route listing above
+			// makes the desired /32 missing, so the add is attempted.
+			a := &Agent{
+				cfg:            Config{PortForwardOnly: true},
+				routing:        rm,
+				reconcileCh:    make(chan struct{}, 1),
+				missingChassis: make(map[string]time.Time),
+			}
+
+			res := a.ensureRoutes([]string{"198.51.100.7"}, nil, nil)
+			if !res.changed {
+				t.Error("changed = false, want true — the cycle still touched FRR, so verification must run")
+			}
+			if res.announced {
+				t.Error("announced = true after the announce failed: the failover histogram " +
+					"would record a fast, healthy takeover while nothing is advertised")
+			}
+		})
+	}
+}
+
+// TestReconcileSkipsFailoverMetricWithoutAnnounce verifies that a reconcile
+// which changes routes but announces nothing records no failover sample, even
+// with a chassisredirect observation pending. Only an announce ends a
+// failover, so timing a withdrawal-only cycle would report a bogus latency.
+func TestReconcileSkipsFailoverMetricWithoutAnnounce(t *testing.T) {
+	m := withTestMetrics(t)
+
+	rec := newVtyshRecorder()
+	// The desired /32 (198.51.100.0, from the router's LRP network) is
+	// already in FRR, so nothing is added and the cycle cannot announce.
+	// 198.51.100.77 falls inside the discovered /24 — it is managed, no
+	// longer desired, and therefore withdrawn: changed, but not announced.
+	rec.on([]string{"vtysh", "-c", "show ip route vrf vrf-provider static json"},
+		frrStaticRoutesJSON("169.254.0.1", "198.51.100.0", "198.51.100.77"), nil)
+	rm := &RouteManager{
+		cfg:           Config{BridgeDev: "br-ex", VRFName: "vrf-provider", VethNexthop: "169.254.0.1"},
+		execVtyshHook: rec.hook(),
+		execOVSHook:   newOVSRecorder().hook(),
+	}
+
+	_, cidr, _ := net.ParseCIDR("198.51.100.0/24")
+	c, _, _ := newOVNClientWithFakes(t, "host-a")
+	c.state.Replace(OVNState{
+		LocalRouters: []LocalRouterInfo{{
+			RouterName:  "router1",
+			LRPName:     "lrp-abc",
+			LRPMAC:      "aa:aa:aa:aa:aa:aa",
+			LRPNetworks: []string{"198.51.100.0/24"},
+		}},
+		HasLocalRouters:    true,
+		DiscoveredNetworks: []*net.IPNet{cidr},
+	})
+	a := &Agent{
+		cfg:            Config{},
+		ovn:            c,
+		routing:        rm,
+		reconcileCh:    make(chan struct{}, 1),
+		missingChassis: make(map[string]time.Time),
+	}
+
+	observeFailoverAt(t, c, time.Now().Add(-400*time.Millisecond))
+
+	a.reconcile(context.Background(), triggerEvent)
+	if count, _ := failoverAnnounceSample(t, m); count != 0 {
+		t.Errorf("failover_announce_seconds count after a withdrawal-only cycle = %d, want 0", count)
 	}
 }
 

--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -234,6 +234,7 @@ Between bring-up and teardown, each scenario is its own `make` target:
 | [Chaos runner](#chaos-runner) | `e2e-chaos` | Under a seeded, randomized fault sequence — in any of six agent [configuration profiles](#configuration-profiles) — the agents stay alive, reachability recovers within budget, no gateway port is claimed twice, and the lab converges to its config-aware expected state in settle windows. | [#176](https://github.com/osism/ovn-network-agent/issues/176), [#177](https://github.com/osism/ovn-network-agent/issues/177), [#179](https://github.com/osism/ovn-network-agent/issues/179) |
 | [Drain-hitless](#drain-hitless) | `e2e-drain-hitless` | A graceful `SIGTERM` drain loses fewer packets than a hard `docker kill` of the same chassis. | [#113](https://github.com/osism/ovn-network-agent/issues/113) |
 | [Failover](#failover) | `e2e-failover` | `cr-lr0-public` re-elects to a surviving chassis after the master is lost. | [#105](https://github.com/osism/ovn-network-agent/issues/105) |
+| [Failover (strict)](#failover) | `e2e-failover-strict` | The data-plane outage across the re-election stays within a ~2s budget. | [#131](https://github.com/osism/ovn-network-agent/issues/131) |
 | [Hairpin](#hairpin) | `e2e-hairpin` | The `cookie=0x998` hairpin flow reflects FIP-to-FIP traffic on `br-ex`. | [#108](https://github.com/osism/ovn-network-agent/issues/108) |
 | [Multi-VLAN](#multi-vlan) | `e2e-multi-vlan` | Two VLAN provider networks on one node get per-segment kernel interfaces, flows, and BGP-announced FIPs. | [#147](https://github.com/osism/ovn-network-agent/issues/147) |
 | [Port-forward (external client)](#port-forward-external-client) | `e2e-pf-external` | Inbound DNAT preserves the external client's source IP. | [#109](https://github.com/osism/ovn-network-agent/issues/109) |
@@ -303,8 +304,21 @@ mechanism under test — re-election of `cr-lr0-public` after the
 priority-30 chassis's claim goes away — is the same either way.
 :::
 
+`make e2e-failover-strict` invokes the same
+[`failover.sh`](https://github.com/osism/ovn-network-agent/blob/main/test/e2e/scenarios/failover.sh)
+with `LOSS_BUDGET=2`, which switches on the strict variant from
+[#131](https://github.com/osism/ovn-network-agent/issues/131). On top
+of the control-plane migration check, it measures the data-plane
+outage: a `ping -i 0.1` flood from `client-1` is captured with
+`tcpdump` on its `eth1` across the re-election, and the largest gap
+between consecutive ICMP echo replies must stay within `LOSS_BUDGET`
+seconds. The pcap is written to `ARTIFACTS_DIR` for triage. With
+`LOSS_BUDGET` unset the script behaves exactly as the plain failover
+scenario.
+
 **Overrides for triage:** `MASTER`, `FIP`, `FAILOVER_TIMEOUT`,
-`FAILBACK_TIMEOUT`, `SANITY_GATE`.
+`FAILBACK_TIMEOUT`, `SANITY_GATE`; the strict variant adds
+`LOSS_BUDGET` and `PROBE_INTERVAL`.
 
 ### Hairpin
 
@@ -1543,8 +1557,17 @@ composite action:
   on failure (`e2e-artifacts-<run id>-<attempt>`), and always tears the
   lab down.
 - **`failover`** (`needs: baseline`) — same shape as baseline, but
-  executes `test/e2e/scenarios/failover.sh`. On failure the artifact
-  bundle is uploaded as `e2e-artifacts-failover-<run id>-<attempt>`.
+  executes `test/e2e/scenarios/failover.sh`. It runs as a two-leg
+  matrix (`fail-fast: false`, so a breach on one leg still lets the
+  other report):
+  - `failover` — the default variant. On failure the artifact bundle
+    is uploaded as `e2e-artifacts-failover-<run id>-<attempt>`.
+  - `failover-strict` — the same scenario with `LOSS_BUDGET=2`, so it
+    fails on an outage above ~2s. The leg points the scenario's
+    `ARTIFACTS_DIR` at the same artifact root so the
+    `failover-strict/...` pcap is bundled with the lab-state dump. On
+    failure the artifact bundle is uploaded as
+    `e2e-artifacts-failover-strict-<run id>-<attempt>`.
 - **`hairpin`** (`needs: baseline`, runs in parallel with `failover`)
   — same shape, but executes `test/e2e/scenarios/hairpin.sh`. The
   job points the scenario's `ARTIFACTS_DIR` at the same artifact
@@ -1600,8 +1623,9 @@ the budgets in issues
 [#45](https://github.com/osism/ovn-network-agent/issues/45),
 [#105](https://github.com/osism/ovn-network-agent/issues/105),
 [#108](https://github.com/osism/ovn-network-agent/issues/108),
-[#109](https://github.com/osism/ovn-network-agent/issues/109), and
-[#111](https://github.com/osism/ovn-network-agent/issues/111).
+[#109](https://github.com/osism/ovn-network-agent/issues/109),
+[#111](https://github.com/osism/ovn-network-agent/issues/111), and
+[#131](https://github.com/osism/ovn-network-agent/issues/131).
 [`drain-hitless`](https://github.com/osism/ovn-network-agent/issues/113)
 is capped at 25: it deploys the lab twice and runs `baseline.sh` twice
 (sanity gate, then the gate on the recycled lab), so its green path is
@@ -1636,6 +1660,7 @@ writes:
   kernel/<gateway>-ip-route.txt    — `ip route show table all`
   agent/<gateway>.log              — copy of the gateway container's stdout
   ovn-controller/<gateway>.log     — gateway `ovn-controller` log (chassis-registration daemon)
+  failover-strict/failover-strict.pcap — client-1 ICMP capture across the re-election (failover-strict only)
   hairpin/hairpin-flows-before.txt — `cookie=0x998` flows on master:br-ex before adding FIP_B (hairpin only)
   hairpin/hairpin-flows-after.txt  — `cookie=0x998` flows on master:br-ex after adding FIP_B (hairpin only)
   pf-external/pf-backend.log       — per-connection source-IP log from the workload-side HTTP responder (pf-external only)

--- a/docs/explanation/how-it-works.md
+++ b/docs/explanation/how-it-works.md
@@ -23,9 +23,6 @@ provider bridge).
      requests for FIP addresses.
 4. **Reacts** instantly to changes — for each router whose gateway is active
    on this chassis:
-   - Ensures a **default route** (`0.0.0.0/0 via <virtual-gw>`) and **static
-     MAC binding** in OVN NB so reply traffic exits the logical router
-     correctly (see [Gatewayless provider networks](gatewayless-networks)).
    - Installs **OVS MAC-tweak flows** on the provider bridge so the kernel
      accepts packets from OVN (rewrites destination MAC to `br-ex` MAC).
    - Installs **OVS hairpin flows** (per FIP, priority 910) that reflect
@@ -33,14 +30,14 @@ provider bridge).
      rewriting both source MAC (`br-ex` MAC) and destination MAC (owning
      router port MAC) — see
      [Hairpin OVS flows](gatewayless-networks#hairpin-ovs-flows-on-br-ex).
-   - Applies the **active priority lead boost** to its `Gateway_Chassis`
-     entries: when this chassis is active, its priority is raised to
-     `max(max peer + 1, 2)` so a peer returning from drain (restored to 1)
-     cannot trigger reverse failover — see
-     [Priority semantics](gateway-drain#priority-semantics).
-   - Reconciles **per-network veth-leak routes and policy rules** in the
-     veth leak table (default 200) so SNAT reply traffic on the provider
-     subnet crosses into `vrf-provider` for BGP delivery.
+   - Ensures a **default route** (`0.0.0.0/0 via <virtual-gw>`) and **static
+     MAC binding** in OVN NB so reply traffic exits the logical router
+     correctly (see [Gatewayless provider networks](gatewayless-networks)).
+   - If configured, reconciles the **FRR prefix-list** with
+     `permit <network> ge 32 le 32` entries for each discovered provider
+     network. This is the BGP outbound filter, and a standby chassis empties
+     it, so it is repopulated *before* the announce below — otherwise the
+     takeover would advertise nothing.
    - Ensures `/32` **kernel routes** (with IP rules when using a dedicated
      routing table) and **FRR static routes** in the VRF for each FIP, SNAT
      IP, router LRP gateway IP, and (independent of router locality)
@@ -49,7 +46,10 @@ provider bridge).
      full IPv6 support ([#85](https://github.com/osism/ovn-network-agent/issues/85),
      [#70](https://github.com/osism/ovn-network-agent/issues/70)) lands. A
      single malformed OVN row (an invalid `external_ip`) degrades only its own
-     FIP — it never fails the whole batch.
+     FIP — it never fails the whole batch. The stability steps below
+     deliberately run after this kernel/FRR route installation and BGP
+     announce so a failover takeover announce is never gated behind them
+     (issue #131).
    - **Route ownership** is explicit: every agent-created kernel route is
      tagged with the agent's route protocol (`proto 44`) and every FRR static
      route uses the agent's veth next-hop. Reconciliation — including standby
@@ -59,9 +59,14 @@ provider bridge).
      still-desired routes are re-tagged automatically on the next reconcile;
      any stale pre-upgrade leftovers are indistinguishable from operator
      routes and must be cleaned up once by hand.
-   - If configured, reconciles the **FRR prefix-list** with
-     `permit <network> ge 32 le 32` entries for each discovered provider
-     network.
+   - Applies the **active priority lead boost** to its `Gateway_Chassis`
+     entries: when this chassis is active, its priority is raised to
+     `max(max peer + 1, 2)` so a peer returning from drain (restored to 1)
+     cannot trigger reverse failover — see
+     [Priority semantics](gateway-drain#priority-semantics).
+   - Reconciles **per-network veth-leak routes and policy rules** in the
+     veth leak table (default 200) so SNAT reply traffic on the provider
+     subnet crosses into `vrf-provider` for BGP delivery.
    - If no routers are locally active: removes all managed routes (port
      forward VIPs still get kernel/FRR routes if any are configured).
 5. **Port forwarding (DNAT)** — optionally forwards traffic from anycast VIP

--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -31,5 +31,7 @@ All metrics are prefixed with `ovn_network_agent_`.
 - `ovn_connection_state{database="nb"} == 0` for >2m — NB DB unreachable;
   agent cannot write OVN state.
 - `rate(route_readds_total[10m]) > 0` — flapping routes.
+- `histogram_quantile(0.95, rate(failover_announce_seconds_bucket[1h])) > 2`
+  — failover announces slower than the ~2s failover budget.
 - `histogram_quantile(0.95, rate(reconcile_duration_seconds_bucket[5m])) > 5`
   — slow reconciles.

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -35,6 +35,7 @@ regenerate it with `go generate ./...`.
 | `ovn_network_agent_route_readds_total` | counter (vec) | `plane`={`kernel`,`frr`} | Total routes re-added by post-change verification, labelled by route plane. |
 | `ovn_network_agent_consecutive_readds` | gauge | — | Number of consecutive reconcile cycles that required route re-adds. Sustained non-zero indicates persistent route instability. |
 | `ovn_network_agent_inactive_routes` | gauge | — | Number of desired FIP/VIP routes that exist as FRR static routes but are not selected/installed — i.e. not advertised via BGP. Non-zero means those FIPs are unreachable from outside. |
+| `ovn_network_agent_failover_announce_seconds` | histogram | — | Time from observing a chassisredirect change to completing the BGP announce of the takeover FIP routes, in seconds. Measured on the takeover reconcile. |
 | `ovn_network_agent_ovn_connection_state` | gauge (vec) | `database`={`nb`,`sb`} | 1 when the named OVN database client is connected, 0 otherwise. |
 | `ovn_network_agent_drain_duration_seconds` | histogram | — | Duration of a gateway drain operation in seconds. |
 | `ovn_network_agent_drain_total` | counter (vec) | `outcome`={`completed`,`timeout`,`error`,`noop`} | Total drain operations, labelled by outcome (completed, timeout, error, noop). |

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -52,5 +52,7 @@ regenerate it with `go generate ./...`.
 - `inactive_routes > 0` for >2m — FIP `/32`s configured in FRR but not
   advertised via BGP (e.g. an unresolvable next-hop); those FIPs are
   unreachable from outside.
+- `histogram_quantile(0.95, rate(failover_announce_seconds_bucket[1h])) > 2`
+  — failover announces slower than the ~2s failover budget.
 - `histogram_quantile(0.95, rate(reconcile_duration_seconds_bucket[5m])) > 5`
   — slow reconciles.

--- a/metrics.go
+++ b/metrics.go
@@ -37,6 +37,9 @@ type metricsRegistry struct {
 	consecutiveReAdds prometheus.Gauge
 	inactiveRoutes    prometheus.Gauge
 
+	// Failover metrics
+	failoverAnnounceDuration prometheus.Histogram
+
 	// OVN connection state
 	ovnConnectionState *prometheus.GaugeVec
 
@@ -131,6 +134,13 @@ func newMetricsRegistry() *metricsRegistry {
 			Help:      "Number of desired FIP/VIP routes that exist as FRR static routes but are not selected/installed — i.e. not advertised via BGP. Non-zero means those FIPs are unreachable from outside.",
 		}),
 
+		failoverAnnounceDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "failover_announce_seconds",
+			Help:      "Time from observing a chassisredirect change to completing the BGP announce of the takeover FIP routes, in seconds. Measured on the takeover reconcile.",
+			Buckets:   []float64{0.1, 0.25, 0.5, 1, 1.5, 2, 3, 5, 10},
+		}),
+
 		ovnConnectionState: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
 			Name:      "ovn_connection_state",
@@ -174,6 +184,7 @@ func newMetricsRegistry() *metricsRegistry {
 		m.routeReAddsTotal,
 		m.consecutiveReAdds,
 		m.inactiveRoutes,
+		m.failoverAnnounceDuration,
 		m.ovnConnectionState,
 		m.drainDuration,
 		m.drainTotal,
@@ -311,6 +322,15 @@ func setInactiveRoutes(n int) {
 		return
 	}
 	metrics.inactiveRoutes.Set(float64(n))
+}
+
+// recordFailoverAnnounce records the time from observing a chassisredirect
+// change to completing the BGP announce of the takeover FIP routes.
+func recordFailoverAnnounce(d time.Duration) {
+	if metrics == nil {
+		return
+	}
+	metrics.failoverAnnounceDuration.Observe(d.Seconds())
 }
 
 func setOVNConnectionState(database string, connected bool) {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -35,6 +35,8 @@ func TestRecordingHelpersAreNilSafe(t *testing.T) {
 	setLocalnetSegments(2)
 	recordRouteReAdds(1, 2)
 	setConsecutiveReAdds(4)
+	setInactiveRoutes(0)
+	recordFailoverAnnounce(750 * time.Millisecond)
 	setOVNConnectionState("nb", true)
 	recordDrain("completed", time.Second)
 	recordStaleChassisCleanup("success", 2)
@@ -59,6 +61,7 @@ func TestNewMetricsRegistryRegistersAllCollectors(t *testing.T) {
 		"ovn_network_agent_route_readds_total",
 		"ovn_network_agent_consecutive_readds",
 		"ovn_network_agent_inactive_routes",
+		"ovn_network_agent_failover_announce_seconds",
 		"ovn_network_agent_ovn_connection_state",
 		"ovn_network_agent_drain_duration_seconds",
 		"ovn_network_agent_drain_total",
@@ -332,6 +335,31 @@ func TestSetInactiveRoutesSetsGauge(t *testing.T) {
 		if v := mf.GetMetric()[0].GetGauge().GetValue(); v != 3 {
 			t.Errorf("inactive_routes = %v, want 3", v)
 		}
+	}
+}
+
+func TestRecordFailoverAnnounceObservesHistogram(t *testing.T) {
+	m := withTestMetrics(t)
+	recordFailoverAnnounce(900 * time.Millisecond)
+	recordFailoverAnnounce(1500 * time.Millisecond)
+
+	got, _ := m.registry.Gather()
+	var found bool
+	for _, mf := range got {
+		if mf.GetName() != "ovn_network_agent_failover_announce_seconds" {
+			continue
+		}
+		found = true
+		h := mf.GetMetric()[0].GetHistogram()
+		if c := h.GetSampleCount(); c != 2 {
+			t.Errorf("failover_announce_seconds sample count = %d, want 2", c)
+		}
+		if sum := h.GetSampleSum(); sum < 2.39 || sum > 2.41 {
+			t.Errorf("failover_announce_seconds sample sum = %v, want ~2.4", sum)
+		}
+	}
+	if !found {
+		t.Error("failover_announce_seconds histogram missing from registry")
 	}
 }
 

--- a/ovn.go
+++ b/ovn.go
@@ -149,6 +149,12 @@ type OVNState struct {
 	// AllChassisNames is the set of chassis hostnames currently present in
 	// the SB Chassis table. Used for stale chassis cleanup.
 	AllChassisNames map[string]bool
+
+	// Gen is the refreshState pass that published this state. It orders a
+	// snapshot against a pending failover observation, so that a reconcile
+	// only consumes an observation its own snapshot already reflects — see
+	// takeFailoverObservedAt.
+	Gen uint64
 }
 
 // clone returns a deep copy of s in which every reference-typed field is
@@ -255,6 +261,36 @@ type OVNClient struct {
 	// loopDone is closed when refreshLoop exits. Set by Connect() before
 	// starting the loop; nil before Connect() succeeds.
 	loopDone chan struct{}
+
+	// failoverObserved holds the first chassisredirect change observed in the
+	// immediate-refresh path, or nil when no observation is pending. The
+	// takeover reconcile consumes it via takeFailoverObservedAt to record the
+	// failover-announce latency metric. Atomic because it is stamped from
+	// cache event-handler goroutines and consumed by the reconcile loop.
+	failoverObserved atomic.Pointer[failoverObservation]
+
+	// refreshSeq numbers the refreshState passes. It is incremented at the
+	// start of a pass and published as OVNState.Gen once that pass completes,
+	// which is what orders a snapshot against a failover observation.
+	refreshSeq atomic.Uint64
+}
+
+// failoverObservation is a chassisredirect change seen on the immediate-refresh
+// path, awaiting the reconcile that announces the takeover routes.
+type failoverObservation struct {
+	// at is when the change was observed. It stays a time.Time rather than a
+	// Unix nanosecond count so that it keeps its monotonic clock reading:
+	// time.Since then subtracts on the monotonic clock, so an NTP step
+	// between the observation and the announce — likely, since a gateway
+	// reboot both triggers a takeover and steps the clock on startup —
+	// cannot yield a negative or a wildly inflated sample.
+	at time.Time
+
+	// gen is the state generation current when the change was observed. Only
+	// a refreshState pass that started afterwards reads the change out of the
+	// cache, so only a snapshot with a higher Gen reflects it — and only that
+	// snapshot's reconcile may consume the observation.
+	gen uint64
 }
 
 func NewOVNClient(cfg Config, onChange func()) *OVNClient {
@@ -830,6 +866,12 @@ func (nc *natCollection) addSBGatewayNATAddresses(
 // ovn_cache.go). The per-step joins themselves are the pure helpers above; this
 // function only sequences them and publishes the result.
 func (o *OVNClient) refreshState(ctx context.Context) {
+	// Number this pass before the first cache read. An observation stamped
+	// while the reads below are already in flight must not be consumed by the
+	// state this pass publishes: those reads may have passed the changed row
+	// already, so the resulting snapshot need not reflect the change.
+	seq := o.refreshSeq.Add(1)
+
 	// Step 1: chassisredirect port bindings and chassis hostnames.
 	portBindings, err := cachedList(ctx, o.sbClient, "Port_Binding",
 		pbCheckColumns, keyOfSBPortBinding, decodeSBPortBinding)
@@ -898,6 +940,7 @@ func (o *OVNClient) refreshState(ctx context.Context) {
 		NATIPToSegment:     nc.IPToSegment,
 		DiscoveredNetworks: discoveredNets,
 		AllChassisNames:    allChassisNames,
+		Gen:                seq,
 	})
 
 	slog.Info("state updated",
@@ -1008,6 +1051,16 @@ func (o *OVNClient) immediateStateRefresh() {
 	if !o.ready.Load() {
 		return // not fully connected yet
 	}
+	// Stamp the first chassisredirect observation of this failover window so
+	// the takeover reconcile can measure the announce latency. The cache has
+	// already applied the change by the time the event handler runs, so any
+	// refreshState pass numbered above refreshSeq reads it. CompareAndSwap
+	// keeps the earliest observation; takeFailoverObservedAt clears the slot
+	// once a reconcile that reflects the change has consumed it.
+	o.failoverObserved.CompareAndSwap(nil, &failoverObservation{
+		at:  time.Now(),
+		gen: o.refreshSeq.Load(),
+	})
 	select {
 	case o.immediateCh <- struct{}{}:
 	default:
@@ -1032,6 +1085,37 @@ func (o *OVNClient) signalDrainWatch() {
 	}
 }
 
+// takeFailoverObservedAt consumes the chassisredirect observation stamped by
+// immediateStateRefresh and returns when the change was seen, or the zero Time
+// when nothing is pending.
+//
+// snapGen is OVNState.Gen of the caller's own snapshot. An observation is only
+// consumed by a snapshot that already reflects it (snapGen > gen). Without that
+// check the observation would go to whichever reconcile ran first, which is not
+// necessarily the one that announces: a debounce cycle refreshes state, arms its
+// reconcile timer, and a chassisredirect change landing inside that window is
+// then consumed — and discarded — by a reconcile still holding the pre-failover
+// snapshot, leaving the genuine takeover reconcile that follows with nothing to
+// measure.
+//
+// A snapshot that does reflect the change consumes the observation whether or
+// not it goes on to announce. That keeps the lifetime bounded to one failover
+// window: the event handler stamps on every chassis, not just the takeover
+// target, so an observation left pending on a standby would otherwise attach
+// itself to some unrelated announce minutes later.
+//
+// Only the reconcile loop consumes, and it is serial, so clearing the slot
+// cannot drop a competing observation — immediateStateRefresh only ever stamps
+// into an empty one.
+func (o *OVNClient) takeFailoverObservedAt(snapGen uint64) time.Time {
+	obs := o.failoverObserved.Load()
+	if obs == nil || snapGen <= obs.gen {
+		return time.Time{}
+	}
+	o.failoverObserved.Store(nil)
+	return obs.at
+}
+
 // =============================================================================
 // SB event handler (implements cache.EventHandler)
 // =============================================================================
@@ -1051,8 +1135,8 @@ func (h *sbEventHandler) OnAdd(table string, m model.Model) {
 }
 
 func (h *sbEventHandler) OnUpdate(table string, old, updated model.Model) {
-	if h.isChassisRedirect(table, updated) {
-		slog.Debug("chassisredirect port updated, immediate refresh")
+	if h.isChassisRedirect(table, updated) && h.chassisRebound(old, updated) {
+		slog.Debug("chassisredirect port rebound, immediate refresh")
 		h.ovn.signalDrainWatch()
 		h.ovn.immediateStateRefresh()
 		return
@@ -1076,6 +1160,41 @@ func (h *sbEventHandler) isChassisRedirect(table string, m model.Model) bool {
 	}
 	pb, ok := m.(*SBPortBinding)
 	return ok && pb.Type == "chassisredirect"
+}
+
+// chassisRebound reports whether a Port_Binding update moved the row to a
+// different chassis, which is what a gateway re-election looks like on the
+// wire.
+//
+// The SB monitor selects whole tables, so OnUpdate fires for every column of a
+// chassisredirect row, not just chassis. refreshState reads only Type and
+// Chassis from such a row, so an update that leaves Chassis alone — northd
+// rewriting nat_addresses because an operator added a FIP, say — changes
+// nothing this agent derives and is not a failover. Those updates take the
+// debounced path: routing them through the immediate path would stamp a
+// failover observation, and the sub-second announce that follows (no
+// re-election to wait for) would land in failover_announce_seconds. FIP churn
+// outnumbers failovers by orders of magnitude, so the histogram would sit in
+// the fast buckets and a p95 alert would stay quiet through a slow takeover.
+//
+// A pair that is not two Port_Binding rows cannot be compared; treat it as a
+// rebinding rather than risk missing a real failover.
+func (h *sbEventHandler) chassisRebound(old, updated model.Model) bool {
+	oldPB, oldOK := old.(*SBPortBinding)
+	newPB, newOK := updated.(*SBPortBinding)
+	if !oldOK || !newOK {
+		return true
+	}
+	return chassisRef(oldPB) != chassisRef(newPB)
+}
+
+// chassisRef returns a Port_Binding's chassis reference, collapsing the unset
+// pointer and the empty string — both mean "bound nowhere" to refreshState.
+func chassisRef(pb *SBPortBinding) string {
+	if pb.Chassis == nil {
+		return ""
+	}
+	return *pb.Chassis
 }
 
 func (h *sbEventHandler) handleChange(table string) {

--- a/ovn_test.go
+++ b/ovn_test.go
@@ -146,6 +146,7 @@ func TestOVNStateCloneReallocatesEveryReferenceField(t *testing.T) {
 		NATIPToSegment:     map[string]string{"198.51.100.1": "physnet1"},
 		DiscoveredNetworks: []*net.IPNet{cidr},
 		AllChassisNames:    map[string]bool{"node1": true},
+		Gen:                1,
 	}
 
 	// Every field must be non-zero, or the re-allocation check below would
@@ -857,10 +858,10 @@ func TestSBEventHandlerOnUpdateAndOnDelete(t *testing.T) {
 	c.ready.Store(true)
 	h := &sbEventHandler{ovn: c}
 
-	// chassisredirect update → immediate.
+	// chassisredirect rebinding → immediate.
 	h.OnUpdate("Port_Binding",
-		&SBPortBinding{Type: "chassisredirect"},
-		&SBPortBinding{Type: "chassisredirect"})
+		&SBPortBinding{Type: "chassisredirect", Chassis: strPtr("ch-a")},
+		&SBPortBinding{Type: "chassisredirect", Chassis: strPtr("ch-b")})
 	if got := len(c.immediateCh); got != 1 {
 		t.Errorf("OnUpdate(chassisredirect) immediateCh len = %d, want 1", got)
 	}
@@ -884,6 +885,91 @@ func TestSBEventHandlerOnUpdateAndOnDelete(t *testing.T) {
 	h.OnDelete("Chassis", &SBChassis{Name: "ch-a"})
 	if got := len(c.debounceCh); got != 1 {
 		t.Errorf("OnDelete(Chassis) debounceCh len = %d, want 1", got)
+	}
+}
+
+// TestSBEventHandlerOnUpdateIgnoresNonChassisChurn pins the failover-announce
+// histogram against routine chassisredirect churn. The SB monitor selects whole
+// tables, so OnUpdate fires for every column of a cr-port row — northd rewrites
+// nat_addresses whenever an operator adds a FIP to the router. Such an update
+// is not a re-election, and the announce that follows it is sub-second because
+// there is nothing to wait for. FIP churn outnumbers failovers by orders of
+// magnitude, so stamping these would pull the histogram into the fast buckets
+// and leave a p95 alert quiet through a genuinely slow takeover.
+func TestSBEventHandlerOnUpdateIgnoresNonChassisChurn(t *testing.T) {
+	tests := []struct {
+		name          string
+		oldPB, newPB  *SBPortBinding
+		wantImmediate bool
+	}{
+		{
+			name:          "nat_addresses churn on a bound cr-port is not a failover",
+			oldPB:         &SBPortBinding{Type: "chassisredirect", Chassis: strPtr("ch-a")},
+			newPB:         &SBPortBinding{Type: "chassisredirect", Chassis: strPtr("ch-a"), NatAddresses: []string{"fa:16:3e:11:22:33 198.51.100.60"}},
+			wantImmediate: false,
+		},
+		{
+			name:          "an unbound cr-port staying unbound is not a failover",
+			oldPB:         &SBPortBinding{Type: "chassisredirect"},
+			newPB:         &SBPortBinding{Type: "chassisredirect", NatAddresses: []string{"fa:16:3e:11:22:33 198.51.100.60"}},
+			wantImmediate: false,
+		},
+		{
+			name:          "nil and empty chassis both mean bound nowhere",
+			oldPB:         &SBPortBinding{Type: "chassisredirect"},
+			newPB:         &SBPortBinding{Type: "chassisredirect", Chassis: strPtr("")},
+			wantImmediate: false,
+		},
+		{
+			name:          "a re-election onto this chassis is a failover",
+			oldPB:         &SBPortBinding{Type: "chassisredirect", Chassis: strPtr("ch-a")},
+			newPB:         &SBPortBinding{Type: "chassisredirect", Chassis: strPtr("ch-b")},
+			wantImmediate: true,
+		},
+		{
+			name:          "a cr-port gaining a chassis is a failover",
+			oldPB:         &SBPortBinding{Type: "chassisredirect"},
+			newPB:         &SBPortBinding{Type: "chassisredirect", Chassis: strPtr("ch-b")},
+			wantImmediate: true,
+		},
+		{
+			name:          "a cr-port losing its chassis is a failover",
+			oldPB:         &SBPortBinding{Type: "chassisredirect", Chassis: strPtr("ch-a")},
+			newPB:         &SBPortBinding{Type: "chassisredirect"},
+			wantImmediate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _, _ := newOVNClientWithFakes(t, "host-a")
+			c.ready.Store(true)
+			h := &sbEventHandler{ovn: c}
+
+			h.OnUpdate("Port_Binding", tt.oldPB, tt.newPB)
+
+			if tt.wantImmediate {
+				if got := len(c.immediateCh); got != 1 {
+					t.Errorf("immediateCh len = %d, want 1", got)
+				}
+				if c.failoverObserved.Load() == nil {
+					t.Error("a chassis rebinding must stamp a failover observation")
+				}
+				return
+			}
+
+			if got := len(c.immediateCh); got != 0 {
+				t.Errorf("immediateCh len = %d, want 0: routine churn must not take the failover path", got)
+			}
+			if obs := c.failoverObserved.Load(); obs != nil {
+				t.Errorf("routine churn stamped a failover observation (%v); the "+
+					"sub-second announce that follows would be recorded as failover latency", obs.at)
+			}
+			// The change still reaches the refresh loop, just debounced.
+			if got := len(c.debounceCh); got != 1 {
+				t.Errorf("debounceCh len = %d, want 1: the update must still refresh state", got)
+			}
+		})
 	}
 }
 
@@ -1376,6 +1462,113 @@ func TestImmediateStateRefreshIgnoresNotReady(t *testing.T) {
 	c.immediateStateRefresh()
 	if got := len(c.immediateCh); got != 0 {
 		t.Errorf("immediateCh should remain empty when not ready, got len = %d", got)
+	}
+	if !c.takeFailoverObservedAt(c.refreshSeq.Load() + 1).IsZero() {
+		t.Error("a not-ready immediateStateRefresh must not stamp a failover timestamp")
+	}
+}
+
+// TestImmediateStateRefreshStampsFailoverObservedAt verifies that the
+// immediate-refresh path records the chassisredirect-observed timestamp and
+// that repeated observations keep the earliest one until it is consumed.
+func TestImmediateStateRefreshStampsFailoverObservedAt(t *testing.T) {
+	c, _, _ := newOVNClientWithFakes(t, "host-a")
+	c.ready.Store(true)
+
+	before := time.Now()
+	c.immediateStateRefresh()
+	first := c.failoverObserved.Load().at
+	if first.Before(before) || first.After(time.Now()) {
+		t.Errorf("failoverObserved.at = %v, want within the call window", first)
+	}
+
+	// A second observation before the first is consumed keeps the earliest.
+	c.immediateStateRefresh()
+	if got := c.failoverObserved.Load().at; !got.Equal(first) {
+		t.Errorf("second observation changed the timestamp: %v != %v", got, first)
+	}
+
+	// A snapshot published after the observation consumes and clears it.
+	snapGen := c.refreshSeq.Add(1)
+	if got := c.takeFailoverObservedAt(snapGen); !got.Equal(first) {
+		t.Errorf("takeFailoverObservedAt = %v, want %v", got, first)
+	}
+	if !c.takeFailoverObservedAt(snapGen).IsZero() {
+		t.Error("takeFailoverObservedAt must return the zero Time once consumed")
+	}
+}
+
+// TestTakeFailoverObservedAtKeepsMonotonicReading pins the clock source of the
+// failover-announce metric. time.Since only subtracts on the monotonic clock
+// when its operand carries a monotonic reading; a timestamp round-tripped
+// through an integer (time.Unix(0, ns)) carries none, so time.Since falls back
+// to the wall clock. A gateway reboot is exactly when a takeover happens and
+// also when chronyd steps the clock, and a backward step would then hand
+// Observe a negative sample — which Prometheus accepts, decreasing the
+// histogram _sum and making rate() see a counter reset.
+func TestTakeFailoverObservedAtKeepsMonotonicReading(t *testing.T) {
+	c, _, _ := newOVNClientWithFakes(t, "host-a")
+	c.ready.Store(true)
+
+	c.immediateStateRefresh()
+	got := c.takeFailoverObservedAt(c.refreshSeq.Add(1))
+	if got.IsZero() {
+		t.Fatal("takeFailoverObservedAt returned the zero Time, want the stamped observation")
+	}
+	// Round(0) strips the monotonic reading, so a value that still differs
+	// from its stripped form carries one.
+	if got == got.Round(0) {
+		t.Error("takeFailoverObservedAt returned a Time with no monotonic reading: " +
+			"time.Since would fall back to the wall clock and an NTP step would corrupt the sample")
+	}
+}
+
+// TestTakeFailoverObservedAtIgnoresStaleSnapshot covers the reconcile that runs
+// with a snapshot predating the chassisredirect change. The observation must
+// survive it: a debounce cycle refreshes state and arms its reconcile timer,
+// and a chassisredirect change landing inside that 100ms window is otherwise
+// consumed — and discarded — by that older cycle, which announces nothing.
+// The takeover reconcile that follows the immediate refresh would then find the
+// slot empty and record no sample at all for a genuine failover.
+func TestTakeFailoverObservedAtIgnoresStaleSnapshot(t *testing.T) {
+	c, _, _ := newOVNClientWithFakes(t, "host-a")
+	c.ready.Store(true)
+
+	// A debounce cycle already published state (gen 1), then the
+	// chassisredirect change is observed.
+	staleGen := c.refreshSeq.Add(1)
+	c.immediateStateRefresh()
+
+	// The reconcile armed by that debounce cycle still holds the
+	// pre-failover snapshot, so it must not consume the observation.
+	if got := c.takeFailoverObservedAt(staleGen); !got.IsZero() {
+		t.Errorf("a snapshot predating the change consumed the observation (%v); "+
+			"the takeover reconcile that announces would have nothing to measure", got)
+	}
+
+	// The immediate refresh publishes a snapshot that does reflect the
+	// change; its reconcile is the one that announces, and it consumes.
+	if c.takeFailoverObservedAt(c.refreshSeq.Add(1)).IsZero() {
+		t.Error("the snapshot reflecting the change must consume the observation")
+	}
+}
+
+// TestTakeFailoverObservedAtConsumesWithoutAnnounce pins the bound on an
+// observation's lifetime. The SB event handler stamps on every chassis, not
+// just the takeover target, so a standby that reflects the change must still
+// consume it even though it announces nothing. Holding the observation until
+// some cycle announces would attach it to an unrelated announce minutes later
+// and report that interval as failover latency.
+func TestTakeFailoverObservedAtConsumesWithoutAnnounce(t *testing.T) {
+	c, _, _ := newOVNClientWithFakes(t, "host-a")
+	c.ready.Store(true)
+
+	c.immediateStateRefresh()
+	if c.takeFailoverObservedAt(c.refreshSeq.Add(1)).IsZero() {
+		t.Fatal("the snapshot reflecting the change must consume the observation")
+	}
+	if got := c.failoverObserved.Load(); got != nil {
+		t.Errorf("observation still pending after a non-announcing cycle consumed it: %v", got.at)
 	}
 }
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -15,6 +15,7 @@ make e2e-install-tools   # one-time, installs containerlab on Linux
 make e2e-up              # build images, deploy topology, seed OVN NB
 make e2e-baseline        # run the baseline reachability scenario
 make e2e-failover        # run the HA failover scenario (master chassis loss)
+make e2e-failover-strict # run the failover scenario with the strict ~2s outage budget
 make e2e-chaos           # run a seeded 10-minute chaos session
 make e2e-down            # destroy the lab
 ```

--- a/test/e2e/scenarios/failover.sh
+++ b/test/e2e/scenarios/failover.sh
@@ -33,6 +33,16 @@
 # shutdown via the SIGTERM handler, so re-election needs the process
 # to actually exit.
 #
+# Strict variant (issue #131): when LOSS_BUDGET is set, the scenario
+# additionally measures the data-plane outage. A 0.1s-spaced `ping`
+# flood from CLIENT is captured with `tcpdump` on its eth1 across the
+# re-election; the failover outage is the largest gap between
+# consecutive ICMP echo replies and must stay within LOSS_BUDGET
+# seconds. The pcap is written to ARTIFACTS_DIR for triage. The
+# loss-measurement pattern follows issue #113 (`ping -i 0.1` +
+# `tcpdump`). With LOSS_BUDGET unset the scenario behaves exactly as
+# before.
+#
 # Pre-condition: the lab is up. When SANITY_GATE=1 (default) this
 # scenario runs `baseline.sh` first so a broken green path is reported
 # as a baseline regression instead of being attributed to failover.
@@ -57,6 +67,11 @@
 #   PING_COUNT         packets for the final reachability check (default 5)
 #   PING_TIMEOUT       per-packet wait, passed to ping -W (default 2)
 #   SANITY_GATE        run baseline.sh first when 1 (default 1)
+#   LOSS_BUDGET        when set, run the strict variant and fail if the
+#                      failover outage exceeds this many seconds
+#                      (issue #131; default unset = strict variant off)
+#   PROBE_INTERVAL     ping spacing for the strict-variant flood (default 0.1)
+#   ARTIFACTS_DIR      when set, the strict-variant pcap is saved here
 
 set -euo pipefail
 
@@ -73,6 +88,9 @@ FAILBACK_TIMEOUT="${FAILBACK_TIMEOUT:-60}"
 PING_COUNT="${PING_COUNT:-5}"
 PING_TIMEOUT="${PING_TIMEOUT:-2}"
 SANITY_GATE="${SANITY_GATE:-1}"
+LOSS_BUDGET="${LOSS_BUDGET:-}"
+PROBE_INTERVAL="${PROBE_INTERVAL:-0.1}"
+ARTIFACTS_DIR="${ARTIFACTS_DIR:-}"
 
 SCENARIOS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BASELINE="${BASELINE:-${SCENARIOS_DIR}/baseline.sh}"
@@ -201,6 +219,84 @@ probe() {
     docker exec "${CLIENT}" ping -c "${PING_COUNT}" -W "${PING_TIMEOUT}" "${FIP}"
 }
 
+# Strict variant: drive the failover while a fine-grained ping flood
+# from CLIENT is captured with tcpdump on its eth1. The failover outage
+# is the largest gap between consecutive ICMP echo replies; the variant
+# fails when that exceeds LOSS_BUDGET seconds. tcpdump runs with -U so
+# the pcap is consistent on disk even if the capture is not stopped
+# cleanly. Returns non-zero on a budget breach so main() can fail the
+# scenario after still confirming the control-plane migration.
+measured_failover() {
+    local pcap="/tmp/failover-strict.pcap"
+    local window=$(( FAILOVER_TIMEOUT + 10 ))
+    # Seconds of flood before the re-election and after recovery. The
+    # capture must cover both, so min_span below is derived from them.
+    local baseline_secs=2 post_secs=3
+
+    log "strict mode: capturing ICMP on ${CLIENT}:eth1, loss budget ${LOSS_BUDGET}s"
+    docker exec -d "${CLIENT}" \
+        timeout "$(( window + 5 ))" tcpdump -i eth1 -n -U -w "${pcap}" icmp
+    sleep 1  # let tcpdump open the capture before traffic starts
+
+    # Steady ping flood spanning the whole failover window: one packet every
+    # PROBE_INTERVAL for `window` seconds. -c bounds it so it self-terminates
+    # even if the pkill below is missed. Derive the count from
+    # PROBE_INTERVAL rather than hardcoding its default reciprocal, so
+    # overriding the knob during triage still bounds the flood to the window
+    # instead of letting the ping outlive the capture.
+    local count
+    count=$(awk -v w="${window}" -v i="${PROBE_INTERVAL}" 'BEGIN { printf "%d", w / i }')
+    docker exec -d "${CLIENT}" \
+        ping -n -i "${PROBE_INTERVAL}" -c "${count}" "${FIP}"
+    sleep "${baseline_secs}"  # baseline traffic before the re-election
+
+    stop_controller_on_master
+    wait_for_recovery
+    sleep "${post_secs}"  # capture a few post-recovery replies
+
+    docker exec "${CLIENT}" pkill -INT tcpdump   >/dev/null 2>&1 || true
+    docker exec "${CLIENT}" pkill -f 'ping -n -i' >/dev/null 2>&1 || true
+    sleep 1  # let tcpdump flush and exit
+
+    if [ -n "${ARTIFACTS_DIR}" ]; then
+        mkdir -p "${ARTIFACTS_DIR}"
+        docker cp "${CLIENT}:${pcap}" "${ARTIFACTS_DIR}/failover-strict.pcap" \
+            >/dev/null 2>&1 || log "could not copy pcap into ${ARTIFACTS_DIR}"
+    fi
+
+    # The largest gap between consecutive echo replies is the outage; the
+    # span from the first to the last reply is how much of the failover the
+    # capture actually witnessed.
+    local stats outage replies span
+    stats=$(docker exec "${CLIENT}" \
+        tcpdump -tt -n -r "${pcap}" 'icmp[icmptype] = icmp-echoreply' 2>/dev/null \
+        | awk '{ n++; if (prev == "") first = $1; else { g = $1 - prev; if (g > max) max = g } prev = $1 }
+               END { printf "%.2f %d %.2f", max + 0, n + 0, (n ? prev - first : 0) }')
+    read -r outage replies span <<<"${stats}"
+    log "captured ${replies} echo replies spanning ${span}s; largest reply gap ${outage}s (budget ${LOSS_BUDGET}s)"
+
+    # The capture must cover the baseline, the re-election and the
+    # post-recovery replies. A reply-count floor cannot express this: the
+    # baseline alone yields baseline_secs/PROBE_INTERVAL replies (~20 at the
+    # defaults), so a flood that died at the failover still clears any small
+    # floor while its largest gap is one probe interval — the budget check
+    # then passes without the re-election ever being observed. A count floor
+    # scaled to the window would be wrong in the other direction: the flood
+    # is killed once wait_for_recovery returns, so it normally runs for far
+    # less than the window it is bounded by.
+    local min_span=$(( baseline_secs + post_secs ))
+    if awk -v s="${span}" -v m="${min_span}" 'BEGIN { exit !(s < m) }'; then
+        log "ERROR: echo replies span only ${span}s, expected >= ${min_span}s — the flood or capture died before the failover completed"
+        return 1
+    fi
+    if awk -v o="${outage}" -v b="${LOSS_BUDGET}" 'BEGIN { exit !(o > b) }'; then
+        log "ERROR: failover outage ${outage}s exceeds the ${LOSS_BUDGET}s budget"
+        return 1
+    fi
+    log "failover outage ${outage}s within the ${LOSS_BUDGET}s budget"
+    return 0
+}
+
 main() {
     sanity_gate
 
@@ -212,9 +308,16 @@ main() {
     fi
 
     trap restore_master EXIT
-    stop_controller_on_master
 
-    wait_for_recovery
+    # The strict variant measures the data-plane outage across the
+    # re-election; the default variant just polls for recovery.
+    local strict_rc=0
+    if [ -n "${LOSS_BUDGET}" ]; then
+        measured_failover || strict_rc=1
+    else
+        stop_controller_on_master
+        wait_for_recovery
+    fi
 
     # Guard against a false pass: a probe that succeeds because OVS on
     # MASTER kept executing stale flows after ovn-controller died is
@@ -228,7 +331,8 @@ main() {
         return 1
     fi
 
-    probe
+    probe || return 1
+    return "${strict_rc}"
 }
 
 main "$@"

--- a/test/integration/scenario_cleanup_no_drain_test.go
+++ b/test/integration/scenario_cleanup_no_drain_test.go
@@ -20,10 +20,14 @@ import (
 //     gateway path (no pre-existing default route in NB) because that is the
 //     only feature today that plants entries with the "ovn-network-agent" =
 //     "managed" external_ids tag.
-//   - No "drain:" log lines appear in the agent's stderr. The drain branch
-//     in Agent.Run() is gated entirely on cfg.DrainOnShutdown, so a regression
-//     that started running drain unconditionally (or that emitted a drain
-//     log line from a stray code path) would surface as a spurious match here.
+//   - No drain-branch log lines appear in the agent's stderr. The drain
+//     branch in Agent.Run() is gated entirely on cfg.DrainOnShutdown, so a
+//     regression that started running drain unconditionally (or that emitted
+//     a drain log line from a stray code path) would surface as a spurious
+//     match here. The takeover-readiness marker writer is exempt: it is the
+//     writer half of the drain handshake and runs on every active node
+//     regardless of drain_on_shutdown, so a chassis that itself has drain
+//     disabled can still release a draining peer.
 func TestScenario_FailureInjection_RemoveManagedNBEntriesNoDrain(t *testing.T) {
 	ctx, cancel, nb, sb := startScenario(t)
 	defer cancel()
@@ -78,14 +82,32 @@ func TestScenario_FailureInjection_RemoveManagedNBEntriesNoDrain(t *testing.T) {
 	// drain helpers in ovn_gateway.go use ("drain: no gateway chassis ...",
 	// "drain: gateway chassis priority lowered", "drain: complete, ...",
 	// "drain: timeout exceeded ...") plus the top-level "drain mode active"
-	// log line in agent.go.
-	for _, marker := range []string{
-		"drain mode active",
-		"drain:",
-		"drain failed",
-	} {
-		if strings.Contains(logs, marker) {
-			t.Errorf("spurious drain log line %q present; tail:\n%s", marker, a.LogTail(60))
+	// log line in agent.go. The takeover-readiness marker writer is the one
+	// legitimate "drain:" line on a non-draining node (MarkTakeoverReady is
+	// not gated on cfg.DrainOnShutdown — it signals a draining peer, not the
+	// local node), so it is skipped line by line rather than punching a hole
+	// into the blanket match.
+	const markerWritten = "drain: takeover readiness marker written"
+	for _, line := range strings.Split(logs, "\n") {
+		if strings.Contains(line, markerWritten) {
+			continue
 		}
+		for _, marker := range []string{
+			"drain mode active",
+			"drain:",
+			"drain failed",
+		} {
+			if strings.Contains(line, marker) {
+				t.Errorf("spurious drain log line %q present: %s\ntail:\n%s", marker, line, a.LogTail(60))
+			}
+		}
+	}
+
+	// The writer half of the handshake must keep running with drain
+	// disabled: a takeover chassis with drain_on_shutdown=false still has to
+	// release a draining peer. Asserted positively so a regression that
+	// gates MarkTakeoverReady on the local drain config surfaces here.
+	if !strings.Contains(logs, markerWritten) {
+		t.Errorf("takeover readiness marker was not written; tail:\n%s", a.LogTail(60))
 	}
 }

--- a/test/integration/scenario_failover_test.go
+++ b/test/integration/scenario_failover_test.go
@@ -51,6 +51,77 @@ func TestScenario_Failover(t *testing.T) {
 	testenv.AssertNoOVSFlow(t, "0x998", 20*time.Second)
 }
 
+// TestScenario_FailoverTakeoverAnnounceLatencyMetric (#131):
+//
+// TestScenario_Failover above covers the release direction (active →
+// standby); this covers the takeover direction (standby → active), which no
+// other scenario exercises, and asserts the failover-latency metric fires
+// end-to-end against real OVN + FRR.
+//
+// The chassisredirect Port_Binding starts bound to a peer chassis, so the
+// agent boots as standby and installs nothing. Rebinding the CR Port_Binding
+// to the local chassis — what ovn-northd does once this chassis wins the
+// gateway — is routed through the agent's immediate (non-debounced) SB event
+// path, which stamps the failover observation. The takeover reconcile must
+// then install the kernel + FRR routes for the FIP and record exactly one
+// ovn_network_agent_failover_announce_seconds sample, measured from the
+// chassisredirect observation to the completed BGP announce.
+func TestScenario_FailoverTakeoverAnnounceLatencyMetric(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	// Create the peer chassis first so the router's CR Port_Binding can start
+	// bound to it — the agent then boots as standby (no local routers).
+	peerChassis := testenv.MakeChassis(t, ctx, sb, "peer-host")
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "ftake",
+		LRPNetworks: []string{"198.51.100.11/24"},
+		ChassisUUID: peerChassis,
+	})
+	const fip = "198.51.100.66"
+	testenv.AddFIP(t, ctx, nb, router, fip, "10.0.0.66")
+
+	cfg := testenv.Defaults()
+	addr := testenv.FreeLoopbackAddr(t)
+	cfg.MetricsListen = addr
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// Standby pre-condition: with the CR port bound to the peer the agent must
+	// install nothing, so the post-takeover assertion really proves a takeover
+	// install (not a route that was there all along). Short timeouts suffice —
+	// nothing should ever appear.
+	testenv.AssertNoKernelRoute(t, fip, 5*time.Second)
+	testenv.AssertNoFRRRoute(t, fip, 5*time.Second)
+
+	// The histogram is registered from startup, so its _count series is
+	// present at 0 before any sample fires. The failover-record guard skips
+	// the startup trigger, so no takeover sample has been recorded yet.
+	testenv.AssertMetricEventually(t, addr,
+		"ovn_network_agent_failover_announce_seconds_count", nil,
+		func(v float64, present bool) bool { return present && v == 0 },
+		5*time.Second)
+
+	// Trigger the takeover: rebind the CR Port_Binding from the peer to the
+	// local chassis, as ovn-northd would once this chassis wins the gateway.
+	// The agent's SB event handler routes this through the immediate
+	// (non-debounced) path, which stamps the failover observation.
+	localUUID := testenv.LocalChassisUUID(t, ctx, sb)
+	testenv.SetCRPortChassis(t, ctx, sb, router.CRPortUUID, &localUUID)
+
+	// The takeover reconcile must install the kernel + FRR routes for the FIP
+	// — same routes as the steady active state, only the ordering differs.
+	testenv.AssertKernelRoute(t, fip, 20*time.Second)
+	testenv.AssertFRRRoute(t, fip, 20*time.Second)
+
+	// ...and record at least one failover-announce latency sample, closing the
+	// immediate-path stamp → takeover reconcile → announce → record chain.
+	testenv.AssertMetricEventually(t, addr,
+		"ovn_network_agent_failover_announce_seconds_count", nil,
+		func(v float64, present bool) bool { return present && v >= 1 },
+		20*time.Second)
+}
+
 // TestScenario_StaleChassisCleanup (#42 scenario 5):
 //
 // A managed NB static route tagged with the chassis name of a peer that

--- a/test/integration/setup.sh
+++ b/test/integration/setup.sh
@@ -135,6 +135,27 @@ configure_frr() {
         sleep 1
     done
 
+    # The frr package's postinst starts frr.service at install time with the
+    # stock daemons file (bgpd=no), and /etc/frr/daemons is only read on a
+    # service (re)start — `enable --now` on an already-running service is a
+    # no-op, leaving bgpd down and every `router bgp` line below rejected.
+    # Restart to pick up the edit; skipped when a re-run finds bgpd already
+    # registered with watchfrr.
+    if ! vtysh -c 'show daemons' 2>/dev/null | grep -qw bgpd; then
+        log "restarting frr to start bgpd"
+        systemctl restart frr
+    fi
+    for _ in $(seq 1 30); do
+        if vtysh -c 'show daemons' 2>/dev/null | grep -qw bgpd; then
+            break
+        fi
+        sleep 1
+    done
+    if ! vtysh -c 'show daemons' 2>/dev/null | grep -qw bgpd; then
+        echo "bgpd did not start (check /etc/frr/daemons and frr.service)" >&2
+        exit 1
+    fi
+
     # Create the provider VRF as a Linux device so FRR can attach to it.
     # On the GHA azure-flavoured kernel the vrf module lives in
     # linux-modules-extra-<uname>, which isn't installed by default; pull it
@@ -168,6 +189,14 @@ router bgp 65000 vrf vrf-provider
 end
 write memory
 EOF
+
+    # vtysh applies config line by line and exits 0 even when a whole block
+    # is rejected (e.g. its daemon is down), so verify the BGP instance
+    # actually exists in the running config.
+    if ! vtysh -c 'show running-config' | grep -q '^router bgp 65000 vrf vrf-provider'; then
+        echo "router bgp config was not applied (is bgpd running?)" >&2
+        exit 1
+    fi
 }
 
 ensure_nftables() {

--- a/tools/docgen/render.go
+++ b/tools/docgen/render.go
@@ -195,6 +195,8 @@ func renderMetrics(info *sourceInfo) string {
 	b.WriteString("- `inactive_routes > 0` for >2m — FIP `/32`s configured in FRR but not\n")
 	b.WriteString("  advertised via BGP (e.g. an unresolvable next-hop); those FIPs are\n")
 	b.WriteString("  unreachable from outside.\n")
+	b.WriteString("- `histogram_quantile(0.95, rate(failover_announce_seconds_bucket[1h])) > 2`\n")
+	b.WriteString("  — failover announces slower than the ~2s failover budget.\n")
 	b.WriteString("- `histogram_quantile(0.95, rate(reconcile_duration_seconds_bucket[5m])) > 5`\n")
 	b.WriteString("  — slow reconciles.\n")
 


### PR DESCRIPTION
Closes #131

Tightens the failover hot path so a takeover reconcile starts attracting traffic as early as possible, and adds a histogram that makes failover announce latency measurable (also giving the sibling failover issues a common yardstick).

## The change, in commit order

1. **`bb73f85` metrics: add the failover-announce latency histogram** — adds `ovn_network_agent_failover_announce_seconds` (buckets 0.1s→10s), the nil-safe `recordFailoverAnnounce` helper, and regenerates `docs/reference/metrics.md`. Collector only; the recording site lands in `8aaf67d`.

2. **`97929c0` agent: stamp the chassisredirect-observed time** — `ovn.go` records when a chassisredirect change is seen in the immediate-refresh path. Two details worth a reviewer's attention, both explained at length in the commit message: the stamp stays a `time.Time` so it keeps its **monotonic** clock reading (a gateway reboot both triggers the takeover and is when chronyd may step the wall clock backwards — a negative `Observe` sample would decrease the histogram `_sum` and make `rate()` see a counter reset); and it carries the state generation current when the change was observed, so `takeFailoverObservedAt` only hands it to a reconcile whose own snapshot already reflects the change. That bounds an observation's lifetime to one failover window.

3. **`8aaf67d` agent: run the BGP announce before the reconcile stability steps** — the core reorder. Reachability-critical path first (`EnsureOVSFlows` + hairpin flows → `EnsureGatewayRouting` → the announce); `EnsureActivePriorityLead`, `ReconcileVethLeakNetworks` and the post-change route verification now run after. `ensureRoutes` returns a `routeSyncResult` instead of calling `verifyRoutes` itself, so the caller verifies after the announce (same trigger as before — only when routes changed) and records the latency at announce completion. `announced` deliberately reflects whether the route-add *and* soft-refresh actually succeeded, not merely that they ran: a takeover chassis with a broken vtysh would otherwise report a fast, healthy announce while every FIP is unreachable. The set of routes/flows/NB entries installed is unchanged — only ordering.

4. **`931678b` e2e: add a strict failover variant with a ~2s outage budget** — opt-in via `LOSS_BUDGET`: a 0.1s-spaced ping flood captured with tcpdump across the re-election, asserting the largest gap between consecutive ICMP echo replies stays within budget; pcap saved to `ARTIFACTS_DIR`. Wired into CI as a second leg of the existing failover matrix (`LOSS_BUDGET=2`), plus a `make e2e-failover-strict` target. With `LOSS_BUDGET` unset, `failover.sh` behaves exactly as before.

5. **`d9da8ae` / `4111b94` docs** — the reconcile walkthrough in `how-it-works.md` is reordered to match the new order, with a note that the stability steps run after the announce deliberately; and a suggested alert on p95 announce latency exceeding the ~2s budget is added to both the docgen alert block and the hand-written list.

6. **`8ec8b09` test/integration: cover the takeover announce latency metric** — the existing scenario only covered the release direction (active → standby). This adds the takeover direction against real OVN/FRR, asserting both the route install and the `failover_announce_seconds` sample — locking the chain immediate-path stamp → takeover reconcile → announce → record.

7. **`0b0e1b6` agent: pin the announce-before-stability ordering** — the reorder itself was unpinned; a regression reverting it would still have passed. `TestReconcileAnnouncesBeforeStabilitySteps` drives a takeover reconcile through a vtysh recorder and asserts the call sequence (FRR route-add → BGP soft-refresh → prefix-list reconcile → route verification). Restoring the pre-#131 order inverts the assertion and fails.

## Divergences from the issue

- **`ReconcileFRRPrefixList` stays *before* the announce**, contrary to the literal wording of AC1. The prefix-list is the BGP outbound filter (`neighbor ... prefix-list ... out`) and is what permits the FIP /32s; a standby chassis empties it, so on a takeover the announce would advertise nothing if it ran first. It is reachability-critical, not a stability step. The intent behind AC1 — the announce is not gated behind non-critical work — is met; the specific step named in it is not moved. **Worth a reviewer's explicit sign-off.**
- **The vtysh route-add and `RefreshBGP` were *not* bundled** into a single invocation (issue proposal 2). Bundling lets the soft-refresh race the static→zebra→BGP redistribution, so the fresh /32s miss the immediate re-advertise and fall back to FRR's slower timing. `routing.go` is therefore untouched; the deferral of `verifyRoutes` / `checkFRRRouteActivity` off the hot path still removes those spawns from the critical section.
- **Metric name is `ovn_network_agent_failover_announce_seconds`**, not `ovn_network_failover_announce_seconds` as written in the issue — the `agent` part comes from the shared `metricsNamespace` every other metric in `metrics.go` already uses.

The ~2s E2E budget follows the issue and may need tuning against real CI runs on the containerlab harness.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) c4682b7 with Claude:claude-opus-4-8_
