### PR TITLE
Observability: build_info, truthful readiness, shipped alert rules, and an operator runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Full documentation is published at
   - [Configure gateway drain](https://osism.github.io/ovn-network-agent/guides/gateway-drain)
   - [Configure the FRR prefix list](https://osism.github.io/ovn-network-agent/guides/frr-prefix-list)
   - [Enable metrics and alerts](https://osism.github.io/ovn-network-agent/guides/metrics)
+  - [Troubleshooting](https://osism.github.io/ovn-network-agent/guides/troubleshooting)
 - Reference:
   - [Configuration](https://osism.github.io/ovn-network-agent/reference/configuration)
   - [Metrics](https://osism.github.io/ovn-network-agent/reference/metrics)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ sudo ./ovn-network-agent --config /etc/ovn-network-agent/config.yaml --log-level
 See the [tutorial](https://osism.github.io/ovn-network-agent/tutorials/first-agent)
 for the full walkthrough.
 
+## Known limitations
+
+See [Known limitations](https://osism.github.io/ovn-network-agent/#known-limitations)
+in the docs for detail. In brief:
+
+- **IPv4-only FIP routing plane** — kernel routes, FRR announcements, and the virtual gateway are IPv4 only ([#85](https://github.com/osism/ovn-network-agent/issues/85) / [#70](https://github.com/osism/ovn-network-agent/issues/70)).
+- **No runtime configuration reload** — config is read once at startup; restart the agent to apply changes ([#91](https://github.com/osism/ovn-network-agent/issues/91)).
+- **Port forwarding is IPv4-only** — multi-backend VIPs use `jhash ip saddr mod N`: sticky per client but not a consistent hash (a backend change remaps most clients), with no backend health checks.
+- **Single provider bridge per agent** — one `bridge_dev` per instance; VLAN localnet segments all ride that one bridge.
+- **Sizing** — the OVSDB monitors replicate whole Southbound/Northbound tables into every agent, so memory and reconcile time grow with cloud size, not node-local state alone.
+
 ## Origin
 
 This agent is based on the shell script

--- a/agent.go
+++ b/agent.go
@@ -263,10 +263,17 @@ func drainOutcome(err, ctxErr error, drained bool) string {
 // The trigger label identifies why the cycle ran (event, periodic, startup).
 func (a *Agent) reconcile(ctx context.Context, trigger string) {
 	start := time.Now()
+	// cycleOK tracks whether this cycle can forward: it is defined by
+	// routeSyncResult.ready — the same signal the drain takeover handshake
+	// trusts for "this node can forward". Best-effort steps that only log
+	// (EnsureSegments, EnsureGatewayRouting, prefix-list) intentionally do not
+	// flip readiness.
+	cycleOK := true
 	setReconcileInProgress(true)
 	defer func() {
 		setReconcileInProgress(false)
 		recordReconcile(trigger, time.Since(start))
+		setLastReconcileStatus(cycleOK)
 	}()
 
 	// This cycle's FRR readers share one static-route document; drop the memo
@@ -431,7 +438,10 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 	var routeSync routeSyncResult
 	if len(desiredIPs) > 0 || state.HasLocalRouters {
 		routeSync = a.ensureRoutes(desiredIPs, ipDev, skipKernelRoute)
+		cycleOK = routeSync.ready
 	} else {
+		// The removeAllRoutes standby path leaves cycleOK true — a healthy
+		// standby is ready.
 		a.removeAllRoutes("no locally active routers and no port forward VIPs")
 	}
 

--- a/agent.go
+++ b/agent.go
@@ -205,17 +205,12 @@ func (a *Agent) Run(ctx context.Context) error {
 				drainCtx, drainCancel := context.WithTimeout(context.Background(), a.cfg.DrainTimeout)
 				slog.Info("drain mode active, migrating gateways away", "timeout", a.cfg.DrainTimeout)
 				drainStart := time.Now()
-				err := a.ovn.DrainGateways(drainCtx, a.ovn.GetState().LocalChassisName)
+				drained, err := a.ovn.DrainGateways(drainCtx, a.ovn.GetState().LocalChassisName)
 				drainElapsed := time.Since(drainStart)
-				switch {
-				case err != nil:
+				if err != nil {
 					slog.Error("drain failed", "error", err)
-					recordDrain("error", drainElapsed)
-				case drainCtx.Err() != nil:
-					recordDrain("timeout", drainElapsed)
-				default:
-					recordDrain("completed", drainElapsed)
 				}
+				recordDrain(drainOutcome(err, drainCtx.Err(), drained), drainElapsed)
 				drainCancel()
 
 				// The OVN refresh loop stopped the moment ctx was cancelled,
@@ -245,6 +240,22 @@ func (a *Agent) Run(ctx context.Context) error {
 			slog.Debug("periodic reconciliation")
 			a.reconcile(ctx, triggerPeriodic)
 		}
+	}
+}
+
+// drainOutcome maps a shutdown drain result to its drain_total outcome
+// label. Precedence: error, then timeout, then noop (nothing was
+// drained), then completed.
+func drainOutcome(err, ctxErr error, drained bool) string {
+	switch {
+	case err != nil:
+		return "error"
+	case ctxErr != nil:
+		return "timeout"
+	case !drained:
+		return "noop"
+	default:
+		return "completed"
 	}
 }
 

--- a/agent_test.go
+++ b/agent_test.go
@@ -1814,3 +1814,32 @@ func TestAgentRunPortForwardOnly(t *testing.T) {
 		t.Fatal("Run() did not return within 2s in port-forward-only mode")
 	}
 }
+
+// TestDrainOutcome pins the drain_total outcome precedence: a drain error
+// outranks a timeout, a timeout outranks a noop, and only an unqualified
+// success — something drained, no error, no deadline — reports "completed".
+func TestDrainOutcome(t *testing.T) {
+	errBoom := errors.New("boom")
+	tests := []struct {
+		name    string
+		err     error
+		ctxErr  error
+		drained bool
+		want    string
+	}{
+		{"error outranks timeout, noop and a drained result", errBoom, context.DeadlineExceeded, false, "error"},
+		{"error outranks a clean drained result", errBoom, nil, true, "error"},
+		{"timeout outranks noop when nothing drained", nil, context.DeadlineExceeded, false, "timeout"},
+		{"timeout outranks a drained result", nil, context.DeadlineExceeded, true, "timeout"},
+		{"nothing drained is noop", nil, nil, false, "noop"},
+		{"drained with no error or deadline is completed", nil, nil, true, "completed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := drainOutcome(tt.err, tt.ctxErr, tt.drained); got != tt.want {
+				t.Errorf("drainOutcome(%v, %v, %v) = %q, want %q", tt.err, tt.ctxErr, tt.drained, got, tt.want)
+			}
+		})
+	}
+}

--- a/agent_test.go
+++ b/agent_test.go
@@ -593,6 +593,137 @@ func TestReconcileFailedAnnounceWithholdsMarker(t *testing.T) {
 	}
 }
 
+// TestReconcileRecordsReadinessOutcome pins the /readyz feed: reconcile stamps
+// the last-reconcile outcome via setLastReconcileStatus(cycleOK), where cycleOK
+// tracks routeSyncResult.ready. A successful announce and a healthy standby
+// cycle both report ready; a failed announce reports not-ready.
+func TestReconcileRecordsReadinessOutcome(t *testing.T) {
+	// a. Successful announce — modelled on
+	// TestReconcileWritesMarkerAfterSuccessfulAnnounce. Dry-run FRR/BGP never
+	// fail, so ensureRoutes reports ready and the cycle is OK.
+	t.Run("successful announce is ready", func(t *testing.T) {
+		m := withTestMetrics(t)
+		rm := &RouteManager{cfg: Config{BridgeDev: "ovnagent-nonexistent-br", VRFName: "vrf-provider", VethNexthop: "169.254.0.1", DryRun: true}}
+		c, nb, _ := newOVNClientWithFakes(t, "host-a")
+		c.state.Replace(OVNState{
+			LocalRouters:    []LocalRouterInfo{{RouterName: "r1", RouterUUID: "lr1", LRPName: "lrp-r1"}},
+			HasLocalRouters: true,
+		})
+		nb.setRows("Logical_Router", &NBLogicalRouter{UUID: "lr1", Name: "r1", StaticRoutes: []string{"sr1"}})
+		nb.setRows("Logical_Router_Static_Route", &NBLogicalRouterStaticRoute{
+			UUID:     "sr1",
+			IPPrefix: "0.0.0.0/0",
+			ExternalIDs: map[string]string{
+				"ovn-network-agent":         "managed",
+				"ovn-network-agent-chassis": "host-b",
+				takeoverReadyMarkerKey:      "host-b",
+			},
+		})
+
+		a := &Agent{
+			cfg:            Config{},
+			ovn:            c,
+			routing:        rm,
+			reconcileCh:    make(chan struct{}, 1),
+			missingChassis: make(map[string]time.Time),
+		}
+		a.reconcile(context.Background(), "test")
+
+		if !m.readiness.reconcileRan.Load() {
+			t.Error("reconcileRan not set after a completed reconcile")
+		}
+		if !m.readiness.lastReconcileOK.Load() {
+			t.Error("lastReconcileOK false after a successful announce")
+		}
+	})
+
+	// b. Failed announce — modelled on TestReconcileFailedAnnounceWithholdsMarker.
+	// The FRR batch add errors, so ensureRoutes reports not-ready.
+	t.Run("failed announce is not ready", func(t *testing.T) {
+		m := withTestMetrics(t)
+		const (
+			fip    = "198.51.100.50"
+			bridge = "ovnagent-nonexistent-br"
+			lrpMAC = "fa:16:3e:aa:aa:aa"
+		)
+		rec := newVtyshRecorder()
+		rec.on([]string{"vtysh", "-c", "conf t", "-c", "vrf vrf-provider",
+			"-c", "ip route " + fip + "/32 169.254.0.1", "-c", "exit-vrf", "-c", "end"},
+			"", errors.New("test: vtysh add failed"))
+		rm := &RouteManager{
+			cfg: Config{
+				BridgeDev:   bridge,
+				VRFName:     "vrf-provider",
+				VethNexthop: "169.254.0.1",
+			},
+			execVtyshHook: rec.hook(),
+			execOVSHook: func(*exec.Cmd) ([]byte, error) {
+				return nil, errors.New("test: no ovs available")
+			},
+			listKernelRoutesHook: func() ([]kernelRouteEntry, error) {
+				return []kernelRouteEntry{{IP: fip, Dev: bridge}}, nil
+			},
+		}
+
+		c, nb, _ := newOVNClientWithFakes(t, "host-a")
+		c.state.Replace(OVNState{
+			LocalRouters:     []LocalRouterInfo{{RouterName: "r1", RouterUUID: "lr1", LRPName: "lrp-r1", LRPMAC: lrpMAC}},
+			HasLocalRouters:  true,
+			NATIPToRouterMAC: map[string]string{fip: lrpMAC},
+		})
+		nb.setRows("Logical_Router", &NBLogicalRouter{UUID: "lr1", Name: "r1", StaticRoutes: []string{"sr1"}})
+		nb.setRows("Logical_Router_Static_Route", &NBLogicalRouterStaticRoute{
+			UUID:     "sr1",
+			IPPrefix: "0.0.0.0/0",
+			ExternalIDs: map[string]string{
+				"ovn-network-agent":         "managed",
+				"ovn-network-agent-chassis": "host-b",
+				takeoverReadyMarkerKey:      "host-b",
+			},
+		})
+
+		a := &Agent{
+			cfg:            Config{},
+			ovn:            c,
+			routing:        rm,
+			reconcileCh:    make(chan struct{}, 1),
+			missingChassis: make(map[string]time.Time),
+		}
+		a.reconcile(context.Background(), "test")
+
+		if !m.readiness.reconcileRan.Load() {
+			t.Error("reconcileRan not set after a completed reconcile")
+		}
+		if m.readiness.lastReconcileOK.Load() {
+			t.Error("lastReconcileOK true after a failed announce")
+		}
+	})
+
+	// c. Healthy standby — modelled on
+	// TestReconcileNoLocalRoutersInvokesRemoveAllRoutes. No local routers and
+	// no VIPs takes the removeAllRoutes branch, which leaves cycleOK true.
+	t.Run("healthy standby is ready", func(t *testing.T) {
+		m := withTestMetrics(t)
+		rm := &RouteManager{cfg: Config{BridgeDev: "br-ex", VRFName: "vrf-provider", VethNexthop: "169.254.0.1", DryRun: true}}
+		c, _, _ := newOVNClientWithFakes(t, "host-a")
+		a := &Agent{
+			cfg:            Config{},
+			ovn:            c,
+			routing:        rm,
+			reconcileCh:    make(chan struct{}, 1),
+			missingChassis: make(map[string]time.Time),
+		}
+		a.reconcile(context.Background(), "test")
+
+		if !m.readiness.reconcileRan.Load() {
+			t.Error("reconcileRan not set after a completed reconcile")
+		}
+		if !m.readiness.lastReconcileOK.Load() {
+			t.Error("lastReconcileOK false for a healthy standby cycle")
+		}
+	})
+}
+
 // hasMarkerUpdate reports whether any recorded write updates a
 // Logical_Router_Static_Route external_ids with a takeover readiness marker
 // naming chassis.

--- a/contrib/prometheus-rules.yaml
+++ b/contrib/prometheus-rules.yaml
@@ -1,0 +1,76 @@
+# Prometheus alerting rules for ovn-network-agent.
+#
+# Implements the suggested alerts from the generated metrics reference
+# (docs/reference/metrics.md) with ready-to-load expressions. Keep the
+# expressions in sync with the alert bullets in tools/docgen/render.go.
+#
+# Load via prometheus.yml:
+#   rule_files:
+#     - /etc/prometheus/rules/ovn-network-agent.yaml
+groups:
+  - name: ovn-network-agent
+    rules:
+      - alert: OVNNetworkAgentRouteInstability
+        expr: 'ovn_network_agent_consecutive_readds >= 3'
+        labels:
+          severity: warning
+        annotations:
+          summary: "Persistent route instability on {{ $labels.instance }}"
+          description: >-
+            The agent has re-added managed routes for at least three
+            consecutive reconcile cycles on {{ $labels.instance }},
+            indicating persistent route instability (FRR or kernel races).
+          runbook_url: "https://osism.github.io/ovn-network-agent/guides/troubleshooting#alert-ovnnetworkagentrouteinstability"
+      - alert: OVNNetworkAgentNBDisconnected
+        expr: 'ovn_network_agent_ovn_connection_state{database="nb"} == 0'
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "OVN Northbound DB unreachable from {{ $labels.instance }}"
+          description: >-
+            The OVN NB database has been unreachable for over 2m on
+            {{ $labels.instance }}; the agent cannot write OVN state.
+          runbook_url: "https://osism.github.io/ovn-network-agent/guides/troubleshooting#alert-ovnnetworkagentnbdisconnected"
+      - alert: OVNNetworkAgentRouteFlapping
+        expr: 'rate(ovn_network_agent_route_readds_total[10m]) > 0'
+        labels:
+          severity: warning
+        annotations:
+          summary: "Routes flapping on {{ $labels.instance }}"
+          description: >-
+            Managed routes are being re-added by post-change verification
+            on {{ $labels.instance }} (flapping routes).
+          runbook_url: "https://osism.github.io/ovn-network-agent/guides/troubleshooting#alert-ovnnetworkagentrouteflapping"
+      - alert: OVNNetworkAgentInactiveRoutes
+        expr: 'ovn_network_agent_inactive_routes > 0'
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "FIP routes not advertised via BGP on {{ $labels.instance }}"
+          description: >-
+            FIP /32s are configured in FRR but not advertised via BGP (e.g.
+            an unresolvable next-hop) on {{ $labels.instance }}; those FIPs
+            are unreachable from outside.
+          runbook_url: "https://osism.github.io/ovn-network-agent/guides/troubleshooting#alert-ovnnetworkagentinactiveroutes"
+      - alert: OVNNetworkAgentSlowFailoverAnnounce
+        expr: 'histogram_quantile(0.95, rate(ovn_network_agent_failover_announce_seconds_bucket[1h])) > 2'
+        labels:
+          severity: warning
+        annotations:
+          summary: "Slow failover BGP announces on {{ $labels.instance }}"
+          description: >-
+            The p95 failover announce time on {{ $labels.instance }} exceeds
+            2s — slower than the ~2s failover budget.
+          runbook_url: "https://osism.github.io/ovn-network-agent/guides/troubleshooting#alert-ovnnetworkagentslowfailoverannounce"
+      - alert: OVNNetworkAgentSlowReconcile
+        expr: 'histogram_quantile(0.95, rate(ovn_network_agent_reconcile_duration_seconds_bucket[5m])) > 5'
+        labels:
+          severity: warning
+        annotations:
+          summary: "Slow reconcile cycles on {{ $labels.instance }}"
+          description: >-
+            The p95 reconcile duration on {{ $labels.instance }} exceeds 5s
+            (slow reconciles).
+          runbook_url: "https://osism.github.io/ovn-network-agent/guides/troubleshooting#alert-ovnnetworkagentslowreconcile"

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
           { text: 'Configure gateway drain', link: '/guides/gateway-drain' },
           { text: 'Configure the FRR prefix list', link: '/guides/frr-prefix-list' },
           { text: 'Enable metrics and alerts', link: '/guides/metrics' },
+          { text: 'Troubleshooting', link: '/guides/troubleshooting' },
         ],
       },
       {

--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -17,21 +17,80 @@ ovn-network-agent --metrics-listen 127.0.0.1:9273
 curl -s http://127.0.0.1:9273/metrics
 ```
 
-Two paths are served:
+Three paths are served:
 
 - `/metrics` — Prometheus exposition format.
-- `/healthz` — returns `200 ok` for liveness probes.
+- `/healthz` — always returns `200 ok` while the process is up (liveness
+  only).
+- `/readyz` — returns `200` only when the agent is functional (OVN
+  connected, last reconcile succeeded); `503` otherwise.
 
 All metrics are prefixed with `ovn_network_agent_`.
 
+## Health and readiness probes
+
+The listener serves two orthogonal signals. `/healthz` is pure liveness: it
+returns `200 ok` whenever the process is up. `/readyz` is readiness — it
+returns `200` only when the agent is actually functional, and `503`
+otherwise.
+
+`/readyz` reports ready only when all of these hold:
+
+- OVN NB and SB are connected. This check is skipped in port-forward-only
+  mode, where there is no OVN client.
+- At least one reconcile cycle has completed.
+- The last reconcile's route sync succeeded.
+
+On a `503`, the body carries one `unready: …` line per failing check, so you
+can read the reason without opening the logs. The possible lines are
+`unready: ovn nb disconnected`, `unready: ovn sb disconnected`,
+`unready: awaiting first reconcile`, and `unready: last reconcile failed`.
+
+Probe both endpoints with curl:
+
+```bash
+curl -i http://127.0.0.1:9273/healthz
+curl -i http://127.0.0.1:9273/readyz
+```
+
+A ready agent answers `200 ok`. When `/readyz` returns `503`, read the
+`unready:` lines in the body to see which check is failing.
+
+Wire the probes into your platform's health checks, and treat `/healthz` as
+the restart signal and `/readyz` as the traffic/serving signal. A
+Kubernetes-style HTTP readiness probe, for example, checks `/readyz` and
+expects `200`:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 9273
+  periodSeconds: 10
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: 9273
+  periodSeconds: 10
+```
+
+Both probes exist only when `metrics_listen` is set, which is off by default
+(see the [configuration reference](../reference/configuration)).
+
+The systemd unit intentionally stays `Type=simple`. A start-gating `READY=1`
+(`Type=notify`) would conflict with the agent's deliberate connect-retry
+startup contract: when OVN is unreachable on cold start the agent keeps
+retrying rather than failing its unit, which systemd would only restart in a
+tight loop anyway. A health-tied watchdog would likewise make systemd
+restart-loop a degraded-but-recovering agent. Monitor readiness from the
+monitoring plane via `/readyz` instead.
+
 ## Suggested alerts
 
-- `consecutive_readds >= 3` — persistent route instability (FRR or kernel
-  races).
-- `ovn_connection_state{database="nb"} == 0` for >2m — NB DB unreachable;
-  agent cannot write OVN state.
-- `rate(route_readds_total[10m]) > 0` — flapping routes.
-- `histogram_quantile(0.95, rate(failover_announce_seconds_bucket[1h])) > 2`
-  — failover announces slower than the ~2s failover budget.
-- `histogram_quantile(0.95, rate(reconcile_duration_seconds_bucket[5m])) > 5`
-  — slow reconciles.
+The complete, generated alert list lives in the
+[metrics reference](../reference/metrics#suggested-alerts). Ready-to-load
+rules implementing them ship in
+[`contrib/prometheus-rules.yaml`](https://github.com/osism/ovn-network-agent/blob/main/contrib/prometheus-rules.yaml),
+and each alert has a cause→diagnosis→remediation section in the
+[troubleshooting guide](./troubleshooting). This page deliberately does not
+reproduce the expressions, so it can never drift from the reference.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1,0 +1,357 @@
+# Troubleshooting
+
+This runbook is for the on-call operator diagnosing a live agent: the process
+is running but Floating IPs are unreachable, an alert has fired, or a drain
+misbehaved during a reboot. Every Prometheus alert shipped in
+[`contrib/prometheus-rules.yaml`](https://github.com/osism/ovn-network-agent/blob/main/contrib/prometheus-rules.yaml)
+links to its section on this page, so you can jump straight from the alert to
+its causes, diagnosis, and remediation.
+
+The commands below use the shipped default names. Substitute the values you
+configured wherever they differ (see the [configuration
+reference](../reference/configuration)).
+
+## Is the process alive? Is the agent functional?
+
+Run these two first — they separate a crashed unit from a running-but-stuck
+agent:
+
+```bash
+systemctl status ovn-network-agent
+journalctl -u ovn-network-agent -n 200 --no-pager
+```
+
+Liveness and readiness are two different questions, answered by two endpoints
+on the metrics listener. Both require `metrics_listen` to be set (it is **off
+by default**); enable it as shown in the [metrics guide](metrics).
+
+- `/healthz` is **unconditional liveness**: it returns `200 ok` whenever the
+  process is up, regardless of whether the agent can do useful work.
+- `/readyz` reports whether the agent is **functional**. It returns `200`
+  only when OVN NB and SB are connected (unless the agent runs
+  port-forward-only), at least one reconcile has completed, and the last
+  reconcile's route sync succeeded. Otherwise it returns `503` with one
+  `unready: …` line per failing check.
+
+```bash
+curl -s http://127.0.0.1:9273/healthz
+curl -s http://127.0.0.1:9273/readyz
+```
+
+If `/healthz` fails or the unit is not active, the process is down — restart it
+and read the journal for the fatal error (see [Actionable error-level log
+messages](#actionable-error-level-log-messages)). If `/healthz` passes but
+`/readyz` returns `503`, the agent is alive but not doing its job; the
+`unready:` lines tell you where to look next.
+
+## Agent up but no routes appear
+
+The instances behind a Floating IP are up, the agent is running, but the FIP is
+unreachable from outside. Walk this checklist in order — it follows a packet
+from the agent's intent down to the OVS flows on the wire.
+
+All names below — `vrf-provider`, `ANNOUNCED-NETWORKS`, `br-ex`, tables `200`
+and `201`, and the metrics address `127.0.0.1:9273` — are the shipped defaults.
+Substitute the values you configured for `vrf_name`, `frr_prefix_list`,
+`bridge_dev`, `veth_leak_table_id`, `port_forward_table_id`, and
+`metrics_listen` respectively.
+
+1. **Read `/readyz`.** Start with the agent's own verdict:
+
+   ```bash
+   curl -s http://127.0.0.1:9273/readyz
+   ```
+
+   `unready: ovn nb disconnected` / `unready: ovn sb disconnected` — the agent
+   cannot see OVN; fix connectivity first. `unready: awaiting first reconcile`
+   — the agent has connected but not completed a cycle yet. `unready: last
+   reconcile failed` — a cycle ran but its route sync did not succeed; the
+   journal has the reason.
+
+2. **Read the `reconciling` journal line.** Each cycle logs one at info level:
+
+   ```bash
+   journalctl -u ovn-network-agent | grep reconciling | tail -1
+   ```
+
+   Interpret its fields:
+
+   - `has_local_routers=false` (and `local_routers=0`) — **no logical router
+     has its chassisredirect port active on this chassis.** This node is not
+     the gateway for anything right now, so it announces nothing. On a standby
+     this is normal; on the node you expect to be active, it means the
+     chassisredirect port lives elsewhere (continue at step 3).
+   - `desired_ips=0` — the agent found no IPs to route for (no FIPs, SNAT IPs,
+     or port-forward VIPs). If you expect some, a `network_cidr` filter may be
+     excluding them, or OVN has not published them yet.
+   - `effective_networks=0` — no provider networks are in effect (none
+     configured via `network_cidr` and none auto-discovered from OVN). The
+     prefix-list and veth-leak reconciliation then have nothing to populate.
+
+3. **Confirm the chassisredirect port is on this chassis.** A FIP is only
+   announced from the node currently hosting the router's gateway:
+
+   ```bash
+   ovn-sbctl find Port_Binding type=chassisredirect
+   ```
+
+   Compare each row's `chassis` column against this node's chassis. If it
+   points at another chassis, that node is the active gateway — this is
+   expected on a standby, and the FIP should be announced from there.
+
+4. **Confirm the FRR prefix-list is populated.** It is the BGP outbound
+   filter; an empty list means nothing is advertised:
+
+   ```bash
+   vtysh -c 'show ip prefix-list ANNOUNCED-NETWORKS'
+   ```
+
+5. **Confirm the FRR static routes are present *and* selected.** A route can
+   exist as a static route yet not be installed (unresolvable next-hop), in
+   which case it is never advertised:
+
+   ```bash
+   vtysh -c 'show ip route vrf vrf-provider static'
+   ```
+
+   Routes marked as not selected are the same condition the
+   [`OVNNetworkAgentInactiveRoutes`](#alert-ovnnetworkagentinactiveroutes) alert
+   catches.
+
+6. **Check the kernel routes.** The FIP `/32` and the policy-routing tables:
+
+   ```bash
+   ip route show <fip>/32
+   ip route show table 200
+   ip route show table 201
+   ```
+
+   Table `200` holds the veth-leak default route (owned by
+   `veth_leak_table_id`); table `201` holds the DNAT return route (owned by
+   `port_forward_table_id`). The FIP `/32` lives in the main table unless
+   `route_table_id` is set to a non-zero table, in which case query that table
+   instead.
+
+7. **Check the nftables table.** Note the family is `ip`, not `inet`:
+
+   ```bash
+   nft list table ip ovn-network-agent
+   ```
+
+8. **Check the OVS flows on the provider bridge.** Two cookie families matter —
+   the MAC-tweak flows and the hairpin flows:
+
+   ```bash
+   ovs-ofctl dump-flows br-ex 'cookie=0x999/-1'
+   ovs-ofctl dump-flows br-ex 'cookie=0x998/-1'
+   ```
+
+   Cookie `0x999` marks the per-segment MAC-tweak flows; `0x998` marks the
+   same-chassis hairpin flows.
+
+## Alert: OVNNetworkAgentRouteInstability
+
+Fires on `consecutive_readds >= 3`.
+
+**Meaning.** The agent's post-change verification found managed routes missing
+and re-added them for at least three consecutive reconcile cycles. Something
+outside the agent keeps deleting the FRR or kernel routes it installs.
+
+**Likely causes.** A competing agent or script managing the same VRF/table, an
+FRR daemon restarting or racing on `vtysh`, or a kernel route being flushed by
+another controller.
+
+**Diagnosis.** Look for the escalated error line `persistent route instability
+detected: routes required re-adding for multiple consecutive cycles` (it
+carries `consecutive_cycles` and `re_added_this_cycle`). Then compare the FRR
+and kernel state against the agent's intent using steps 5 and 6 of [Agent up
+but no routes appear](#agent-up-but-no-routes-appear).
+
+**Remediation.** Find and stop the other writer of these routes. The agent
+re-adds routes each cycle, so connectivity is usually preserved, but the churn
+must be resolved at its source — the agent cannot win a fight with a competing
+controller.
+
+## Alert: OVNNetworkAgentNBDisconnected
+
+Fires on `ovn_connection_state{database="nb"} == 0` for 2m.
+
+**Meaning.** The agent has lost its connection to the OVN Northbound database.
+
+**Likely causes.** `ovn-northd` / the NB `ovsdb-server` is down or failing over,
+a network partition to the NB endpoint, or TLS/authentication problems.
+
+**Diagnosis.** The agent keeps retrying by contract — look for repeated
+`failed to connect to OVN, retrying` lines in the journal (each logs `retry_in`).
+Verify NB reachability from this node with `ovn-nbctl --db=<nb-remote> show`.
+
+**Remediation.** While NB is unreachable, all agent-managed NB writes stall —
+gatewayless default routes and static MAC bindings are not updated. Restore NB
+availability; the agent reconnects and reconciles automatically once it is back,
+with no restart required.
+
+## Alert: OVNNetworkAgentRouteFlapping
+
+Fires on `rate(route_readds_total[10m]) > 0`.
+
+**Meaning.** Routes are being re-added by post-change verification, i.e. they
+are disappearing and being reinstalled. This is the same underlying condition
+as [`OVNNetworkAgentRouteInstability`](#alert-ovnnetworkagentrouteinstability),
+caught earlier: any re-add at all raises the rate, before it has persisted for
+three consecutive cycles.
+
+**Likely causes.** Intermittent `vtysh` races, an FRR reload, or another process
+occasionally clearing a route.
+
+**Diagnosis.** Split the flapping by plane with the `plane` label
+(`route_readds_total{plane="frr"}` vs `{plane="kernel"}`) to see whether FRR or
+the kernel is losing routes, then follow the diagnosis for
+[`OVNNetworkAgentRouteInstability`](#alert-ovnnetworkagentrouteinstability).
+
+**Remediation.** Same as route instability: identify the competing writer. Brief
+flapping around an FRR reload or a deploy is expected; sustained flapping is
+not.
+
+## Alert: OVNNetworkAgentInactiveRoutes
+
+Fires on `inactive_routes > 0` for 2m.
+
+**Meaning.** One or more desired FIP `/32`s exist as FRR static routes but are
+not selected/installed, so they are **not advertised via BGP** and the FIPs are
+unreachable from outside. Re-adding does not help — the route already exists;
+the next-hop is the fault.
+
+**Likely causes.** The static route's next-hop (`veth_nexthop` in the VRF) is
+unresolvable — the veth pair is missing or down, or the VRF is misconfigured —
+so FRR keeps the route but never installs or advertises it.
+
+**Diagnosis.** The agent logs `FRR static routes are configured but inactive —
+these FIPs are not advertised via BGP` with the affected `ips` and `vrf`.
+Confirm with step 5 of [Agent up but no routes
+appear](#agent-up-but-no-routes-appear) and check that the veth-leak plumbing
+(step 6, table `200`) and the next-hop are in place.
+
+**Remediation.** Fix the next-hop resolution: bring up the veth pair, verify the
+VRF membership, and confirm the nexthop is reachable in the VRF. Once the
+next-hop resolves, FRR selects and advertises the routes on the next cycle.
+
+## Alert: OVNNetworkAgentSlowFailoverAnnounce
+
+Fires on
+`histogram_quantile(0.95, rate(failover_announce_seconds_bucket[1h])) > 2`.
+
+**Meaning.** The p95 time from observing a chassisredirect change to completing
+the BGP announce of the takeover FIP routes exceeds the ~2s failover budget.
+Slow announces widen the packet-loss window during gateway failover.
+
+**Likely causes.** `vtysh`/FRR latency during the announce, slow OVSDB reads on
+the takeover reconcile, or an overloaded node.
+
+**Diagnosis.** Correlate `failover_announce_seconds` spikes with reconcile
+duration (`reconcile_duration_seconds`) and with FRR/`vtysh` responsiveness on
+the node during the failover window.
+
+**Remediation.** Reduce contention on the takeover node and on FRR; ensure
+`vtysh` responds promptly. Persistent breaches point at an undersized or
+overloaded gateway node.
+
+## Alert: OVNNetworkAgentSlowReconcile
+
+Fires on
+`histogram_quantile(0.95, rate(reconcile_duration_seconds_bucket[5m])) > 5`.
+
+**Meaning.** The p95 reconcile cycle takes longer than 5 seconds. Slow
+reconciles delay the agent's reaction to OVN changes.
+
+**Likely causes.** High `vtysh`/FRR or OVSDB latency, or simply a large cloud —
+many routers, FIPs, and networks make each cycle do more work.
+
+**Diagnosis.** Check `desired_ips`, `local_routers`, and `effective_networks`
+to gauge the workload size, and watch for slow OVSDB or `vtysh` calls in the
+journal at debug level.
+
+**Remediation.** Address the slow dependency (OVSDB/FRR latency). If the cause
+is genuine scale, this may be the expected steady state — raise the alert
+threshold to match the cloud rather than chasing a non-problem.
+
+## Drain outcomes
+
+The `drain_total` counter is labelled by `outcome`. The failure and no-op
+outcomes are the ones to watch:
+
+- `drain_total{outcome="timeout"}` — the drain did not finish migrating the
+  gateways away within `drain_timeout`; the agent proceeded with shutdown
+  anyway. Traffic may have blackholed briefly during the reboot.
+- `drain_total{outcome="error"}` — the drain failed (e.g. an NB write to lower
+  `Gateway_Chassis` priority did not go through).
+- `drain_total{outcome="noop"}` — there was nothing to drain: no
+  `Gateway_Chassis` rows with priority > 0 for this chassis. This is **normal**
+  on a standby that was already at priority 0, but **suspicious** on a node you
+  believe is an active gateway (it suggests a chassis-name mismatch or a
+  previous drain that was never restored).
+
+**Diagnosis.** Read the `drain:` lines from the shutdown in the journal:
+
+```bash
+journalctl -u ovn-network-agent | grep 'drain:'
+```
+
+The informative ones are `drain: no gateway chassis entries to drain on this
+chassis` (the noop path — it logs `local_chassis_name` and `cache_entries` so
+you can spot a name mismatch), `drain: gateway chassis priority lowered`,
+`drain: waiting for gateway migration`, and `drain: timeout exceeded, proceeding
+with shutdown`. Cross-check the priorities directly:
+
+```bash
+ovn-nbctl list Gateway_Chassis
+```
+
+For a noop on a supposedly active gateway, also confirm the standby chassis is
+healthy enough to take over.
+
+**Remediation.** For timeouts, verify the standby chassis can take over and, if
+migration is genuinely slow, raise `drain_timeout`; tune `drain_settle_delay`
+for the post-readiness safety margin. For errors, treat it as an NB write
+failure (see below). For the conceptual model and the shutdown sequence, see
+[Gateway drain mode](../explanation/gateway-drain); to change the behaviour see
+[Configure gateway drain](../guides/gateway-drain).
+
+## Stale-chassis cleanup errors
+
+`stale_chassis_cleanup_total{outcome="error"}` counts failed attempts to remove
+OVN NB entries belonging to a chassis that has disappeared from the SB Chassis
+table.
+
+**Likely causes.** An NB write failure or lost NB connectivity at the moment the
+cleanup ran.
+
+**Diagnosis.** The agent logs `failed to clean up stale chassis entries` with the
+error. Watch the `missing_chassis` gauge: a non-zero value that never returns to
+zero means the cleanup keeps failing for the same chassis.
+
+**Remediation.** Restore NB reachability (see
+[`OVNNetworkAgentNBDisconnected`](#alert-ovnnetworkagentnbdisconnected)). No
+manual intervention is needed for the cleanup itself — it retries on the next
+reconcile cycle once NB is writable again.
+
+## Actionable error-level log messages
+
+Not every `error`-level line demands action: many reconcile steps are
+best-effort and the next cycle retries them automatically. This table separates
+the messages that need you from the ones that heal themselves. Message text is
+quoted by its prefix, exactly as it appears in the journal.
+
+| Message | What it means | Action |
+|---------|---------------|--------|
+| `persistent route instability detected…` | Managed routes were re-added for ≥3 consecutive cycles. | **Act.** Find the competing route writer — see [OVNNetworkAgentRouteInstability](#alert-ovnnetworkagentrouteinstability). |
+| `FRR static routes are configured but inactive…` | FIP `/32`s exist in FRR but are not advertised via BGP. | **Act.** Fix the next-hop — see [OVNNetworkAgentInactiveRoutes](#alert-ovnnetworkagentinactiveroutes). |
+| `drain failed` | The shutdown drain returned an error; the agent still proceeds with shutdown. | **Act.** Check `Gateway_Chassis` priorities and standby health — see [Drain outcomes](#drain-outcomes). |
+| `failed to start metrics endpoint` | The metrics listener could not bind; the process exits. | **Act.** Free the `metrics_listen` address or fix permissions, then restart. |
+| `failed to create agent` / `agent exited with error` | Fatal startup or run error; the process exits. | **Act.** Read the accompanying `error` and the journal. |
+| `failed to connect to OVN, retrying` | NB/SB endpoint unreachable at connect time. | **Self-healing.** The agent retries every `retry_in`; act only if it never connects — see [OVNNetworkAgentNBDisconnected](#alert-ovnnetworkagentnbdisconnected). |
+| `failed to ensure gateway routing` | An NB write for a managed default route or MAC binding failed this cycle. | **Self-healing** if transient; the next reconcile retries. Investigate if it persists (NB connectivity). |
+| `failed to ensure OVS flows` / `failed to reconcile OVS hairpin flows` | Programming OVS flows failed this cycle. | **Self-healing**; retried next cycle. Investigate if it persists (OVS reachable via `ovs-wrapper`?). |
+| `failed to reconcile FRR prefix-list` | Updating the BGP outbound filter failed this cycle. | **Self-healing**; retried next cycle. Investigate if it persists (`vtysh`/FRR reachable?). |
+| `failed to reconcile veth leak networks` | Programming the veth-leak routes/rules failed this cycle. | **Self-healing**; retried next cycle. |
+| `failed to reconcile port forwarding` | Programming the DNAT rules failed this cycle. | **Self-healing**; retried next cycle. |
+| `failed to clean up stale chassis entries` | Removing a departed chassis's NB entries failed. | **Self-healing**; retried next cycle — see [Stale-chassis cleanup errors](#stale-chassis-cleanup-errors). |

--- a/docs/guides/upgrade.md
+++ b/docs/guides/upgrade.md
@@ -86,6 +86,17 @@ systemctl is-active ovn-network-agent
 Optionally confirm Floating IP reachability from a client and check the
 [metrics endpoint](./metrics) before proceeding to the next node.
 
+To confirm the roll from Prometheus rather than node by node, count the
+fleet-wide `build_info` gauge by version — each agent exports one
+`ovn_network_agent_build_info` series carrying its `version` label:
+
+```text
+count by (version) (ovn_network_agent_build_info)
+```
+
+The result lists every version currently running across the fleet; it
+collapses to a single row once every node is upgraded.
+
 ## Mixed-version fleets
 
 While the fleet is half-upgraded, a peer still running a pre-handshake
@@ -95,6 +106,11 @@ node never releases its routes early, it is only slower. If you need
 faster drains during the upgrade window, temporarily lower `drain_timeout`
 or set `drain_settle_delay: 0` (see
 [Configure gateway drain](./gateway-drain)).
+
+The `count by (version) (ovn_network_agent_build_info)` query above pins down
+the window: while the counts straddle two versions the fleet is still mixed,
+and the per-instance `ovn_network_agent_build_info` series names exactly which
+nodes still run the old version.
 
 ## Downgrade / rollback
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,3 +28,33 @@ features:
   - title: Prometheus metrics
     details: Exposes reconcile counters, drain durations, OVN connection state, and stale-chassis cleanup events on an optional HTTP endpoint, with suggested alert rules.
 ---
+
+## Known limitations
+
+Weigh these current constraints before planning a deployment:
+
+- **IPv4-only FIP routing plane** — kernel routes, FRR announcements, and the
+  virtual-gateway path are IPv4 only. IPv6 NAT and LRP addresses are filtered
+  out of the kernel/FRR desired set at ingest, while the per-port IPv6
+  MAC-tweak OVS flow variant is kept. See the scope note in
+  [gatewayless provider networks](./explanation/gatewayless-networks) and issues
+  [#85](https://github.com/osism/ovn-network-agent/issues/85) /
+  [#70](https://github.com/osism/ovn-network-agent/issues/70).
+- **No runtime configuration reload** — configuration is read once at startup
+  and there is no SIGHUP reload, so restart the agent to apply any change
+  ([#91](https://github.com/osism/ovn-network-agent/issues/91)).
+- **Port forwarding is IPv4-only with modulo hashing** — multi-backend VIPs
+  distribute clients with `jhash ip saddr mod N` over the backend count. This
+  is sticky per client but not a consistent hash, so adding or removing a
+  backend remaps roughly `(N-1)/N` of clients, and there are no backend health
+  checks. See
+  [sticky load balancing](./guides/port-forwarding#sticky-load-balancing-multi-backend).
+- **Single provider bridge per agent** — each agent instance drives one
+  provider bridge (`bridge_dev`, default `br-ex`); VLAN localnet segments are
+  all served on that one bridge as `<bridge_dev>.<tag>` subinterfaces.
+- **Sizing and scale** — the OVSDB monitors replicate whole tables into every
+  agent — Southbound `Port_Binding` and `Chassis`, and Northbound `NAT`,
+  `Logical_Router`, `Logical_Router_Port`, `Logical_Router_Static_Route`,
+  `Static_MAC_Binding`, and `Gateway_Chassis` — so an agent's memory footprint
+  and reconcile time scale with the size of the whole cloud, not with
+  node-local state alone.

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -46,6 +46,11 @@ regenerate it with `go generate ./...`.
 
 ## Suggested alerts
 
+Ready-to-load rules implementing these alerts ship in
+[`contrib/prometheus-rules.yaml`](https://github.com/osism/ovn-network-agent/blob/main/contrib/prometheus-rules.yaml),
+and each alert has a cause→diagnosis→remediation section in the
+[troubleshooting guide](../guides/troubleshooting).
+
 - `consecutive_readds >= 3` — persistent route instability (FRR or kernel
   races).
 - `ovn_connection_state{database="nb"} == 0` for >2m — NB DB unreachable;

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -25,6 +25,7 @@ regenerate it with `go generate ./...`.
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
+| `ovn_network_agent_build_info` | gauge (vec) | `version` | Always 1, labelled with the running agent version (from -ldflags "-X main.version=…"). |
 | `ovn_network_agent_reconcile_total` | counter (vec) | `trigger`={`event`,`periodic`,`startup`} | Total reconcile cycles, labelled by trigger source. |
 | `ovn_network_agent_reconcile_duration_seconds` | histogram | — | Duration of a single reconcile cycle in seconds. |
 | `ovn_network_agent_reconcile_in_progress` | gauge | — | 1 while a reconcile cycle is running, 0 otherwise. |

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -13,10 +13,11 @@ ovn-network-agent --metrics-listen 127.0.0.1:9273
 curl -s http://127.0.0.1:9273/metrics
 ```
 
-Two paths are served:
+Three paths are served:
 
 - `/metrics` — Prometheus exposition format
-- `/healthz` — returns `200 ok` for liveness probes
+- `/healthz` — always returns `200 ok` while the process is up (liveness only)
+- `/readyz` — returns `200` only when the agent is functional (OVN connected, last reconcile succeeded); `503` otherwise
 
 All metrics are prefixed with `ovn_network_agent_`. The table below is generated from the
 `prometheus.New*` constructors in

--- a/main.go
+++ b/main.go
@@ -92,7 +92,8 @@ func main() {
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
 	if cfg.MetricsListen != "" {
-		if err := startMetricsServer(ctx, cfg.MetricsListen, initMetrics()); err != nil {
+		m := initMetricsForConfig(cfg)
+		if err := startMetricsServer(ctx, cfg.MetricsListen, m); err != nil {
 			slog.Error("failed to start metrics endpoint", "addr", cfg.MetricsListen, "error", err)
 			os.Exit(1)
 		}
@@ -116,6 +117,14 @@ func main() {
 	}
 
 	slog.Info("ovn-network-agent stopped")
+}
+
+// initMetricsForConfig builds the process-wide metrics registry for cfg. In
+// port-forward-only mode there is no OVN client, so OVN connection state must
+// not gate /readyz: ovnRequired is the negation of PortForwardOnly. Keeping the
+// derivation here (rather than inline in main) makes it testable.
+func initMetricsForConfig(cfg Config) *metricsRegistry {
+	return initMetrics(!cfg.PortForwardOnly)
 }
 
 func setupLogging(level string) {

--- a/metrics.go
+++ b/metrics.go
@@ -21,6 +21,9 @@ const metricsNamespace = "ovn_network_agent"
 type metricsRegistry struct {
 	registry *prometheus.Registry
 
+	// Build metadata
+	buildInfo *prometheus.GaugeVec
+
 	// Reconcile metrics
 	reconcileTotal      *prometheus.CounterVec
 	reconcileDuration   prometheus.Histogram
@@ -72,6 +75,12 @@ func newMetricsRegistry() *metricsRegistry {
 	reg := prometheus.NewRegistry()
 	m := &metricsRegistry{
 		registry: reg,
+
+		buildInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "build_info",
+			Help:      "Always 1, labelled with the running agent version (from -ldflags \"-X main.version=…\").",
+		}, []string{"version"}),
 
 		reconcileTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
@@ -174,6 +183,7 @@ func newMetricsRegistry() *metricsRegistry {
 	}
 
 	reg.MustRegister(
+		m.buildInfo,
 		m.reconcileTotal,
 		m.reconcileDuration,
 		m.reconcileInProgress,
@@ -195,6 +205,7 @@ func newMetricsRegistry() *metricsRegistry {
 	// Initialise label series so they appear in /metrics with a zero value
 	// from the first scrape, instead of materialising only on the first
 	// observation.
+	m.buildInfo.WithLabelValues(version).Set(1)
 	m.reconcileTotal.WithLabelValues("event").Add(0)
 	m.reconcileTotal.WithLabelValues("periodic").Add(0)
 	m.reconcileTotal.WithLabelValues("startup").Add(0)

--- a/metrics.go
+++ b/metrics.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -13,6 +14,18 @@ import (
 )
 
 const metricsNamespace = "ovn_network_agent"
+
+// readinessState feeds the /readyz endpoint. ovnRequired is written once in
+// initMetrics before the HTTP server starts and read-only afterwards; the
+// remaining fields are updated concurrently by the reconcile loop and the
+// OVN connection callbacks, hence atomic.
+type readinessState struct {
+	ovnRequired     bool
+	nbConnected     atomic.Bool
+	sbConnected     atomic.Bool
+	reconcileRan    atomic.Bool
+	lastReconcileOK atomic.Bool
+}
 
 // metricsRegistry holds the Prometheus collectors used by the agent. Tests
 // can construct a fresh registry; production uses a process-wide singleton
@@ -53,6 +66,9 @@ type metricsRegistry struct {
 	// Stale chassis cleanup
 	staleChassisCleanupTotal *prometheus.CounterVec
 	missingChassis           prometheus.Gauge
+
+	// Readiness signals backing the /readyz endpoint
+	readiness readinessState
 }
 
 // metrics is the process-wide registry. It is non-nil after initMetrics()
@@ -62,9 +78,12 @@ var metrics *metricsRegistry
 
 // initMetrics builds the process-wide metrics registry. Calling it twice
 // would re-register collectors and panic, so callers must invoke it at most
-// once. Returns the registry for the HTTP handler.
-func initMetrics() *metricsRegistry {
+// once. Returns the registry for the HTTP handler. ovnRequired gates the OVN
+// connection checks in /readyz: it is false in port-forward-only mode, where
+// there is no OVN client and OVN state must not gate readiness.
+func initMetrics(ovnRequired bool) *metricsRegistry {
 	m := newMetricsRegistry()
+	m.readiness.ovnRequired = ovnRequired
 	metrics = m
 	return m
 }
@@ -235,10 +254,14 @@ func startMetricsServer(ctx context.Context, listenAddr string, m *metricsRegist
 	mux.Handle("/metrics", promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{
 		Registry: m.registry,
 	}))
+	// /healthz is liveness-only by design: it reports 200 whenever the
+	// process is up. Use /readyz for readiness (OVN connected, reconcile
+	// succeeded).
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok\n"))
 	})
+	mux.HandleFunc("/readyz", readyzHandler(m))
 
 	listener, err := net.Listen("tcp", listenAddr)
 	if err != nil {
@@ -268,6 +291,40 @@ func startMetricsServer(ctx context.Context, listenAddr string, m *metricsRegist
 	}()
 
 	return nil
+}
+
+// readyzHandler reports whether the agent is functional, as opposed to the
+// liveness-only /healthz: OVN NB and SB connected (unless running
+// port-forward-only), at least one reconcile completed, and the last
+// reconcile's route sync succeeded. Returns 200 "ok" when ready, 503 with
+// one plain-text line per failing check otherwise.
+func readyzHandler(m *metricsRegistry) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		var failures []string
+		if m.readiness.ovnRequired {
+			if !m.readiness.nbConnected.Load() {
+				failures = append(failures, "unready: ovn nb disconnected")
+			}
+			if !m.readiness.sbConnected.Load() {
+				failures = append(failures, "unready: ovn sb disconnected")
+			}
+		}
+		if !m.readiness.reconcileRan.Load() {
+			failures = append(failures, "unready: awaiting first reconcile")
+		} else if !m.readiness.lastReconcileOK.Load() {
+			failures = append(failures, "unready: last reconcile failed")
+		}
+
+		if len(failures) > 0 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			for _, f := range failures {
+				_, _ = w.Write([]byte(f + "\n"))
+			}
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok\n"))
+	}
 }
 
 // =============================================================================
@@ -353,6 +410,12 @@ func setOVNConnectionState(database string, connected bool) {
 		v = 1
 	}
 	metrics.ovnConnectionState.WithLabelValues(database).Set(v)
+	switch database {
+	case "nb":
+		metrics.readiness.nbConnected.Store(connected)
+	case "sb":
+		metrics.readiness.sbConnected.Store(connected)
+	}
 }
 
 func recordDrain(outcome string, duration time.Duration) {
@@ -378,4 +441,14 @@ func setMissingChassis(n int) {
 		return
 	}
 	metrics.missingChassis.Set(float64(n))
+}
+
+// setLastReconcileStatus records the outcome of the most recent reconcile
+// cycle for the /readyz endpoint.
+func setLastReconcileStatus(ok bool) {
+	if metrics == nil {
+		return
+	}
+	metrics.readiness.reconcileRan.Store(true)
+	metrics.readiness.lastReconcileOK.Store(ok)
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -406,6 +406,7 @@ func TestRecordDrainCountsByOutcome(t *testing.T) {
 	recordDrain("completed", 750*time.Millisecond)
 	recordDrain("timeout", 5*time.Second)
 	recordDrain("completed", 250*time.Millisecond)
+	recordDrain("noop", 10*time.Millisecond)
 
 	got, _ := m.registry.Gather()
 	for _, mf := range got {
@@ -420,8 +421,8 @@ func TestRecordDrainCountsByOutcome(t *testing.T) {
 				}
 			}
 		}
-		if seen["completed"] != 2 || seen["timeout"] != 1 {
-			t.Errorf("drain_total = %v, want completed=2 timeout=1", seen)
+		if seen["completed"] != 2 || seen["timeout"] != 1 || seen["noop"] != 1 {
+			t.Errorf("drain_total = %v, want completed=2 timeout=1 noop=1", seen)
 		}
 	}
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -53,6 +53,7 @@ func TestNewMetricsRegistryRegistersAllCollectors(t *testing.T) {
 		t.Fatalf("Gather() error: %v", err)
 	}
 	wantMetrics := []string{
+		"ovn_network_agent_build_info",
 		"ovn_network_agent_reconcile_total",
 		"ovn_network_agent_reconcile_duration_seconds",
 		"ovn_network_agent_desired_ips",
@@ -76,6 +77,43 @@ func TestNewMetricsRegistryRegistersAllCollectors(t *testing.T) {
 		if !gotNames[name] {
 			t.Errorf("metric %s missing from registry", name)
 		}
+	}
+}
+
+func TestBuildInfoGaugeCarriesVersionLabel(t *testing.T) {
+	m := newMetricsRegistry()
+
+	got, err := m.registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather() error: %v", err)
+	}
+
+	var found bool
+	for _, mf := range got {
+		if mf.GetName() != "ovn_network_agent_build_info" {
+			continue
+		}
+		found = true
+		series := mf.GetMetric()
+		if len(series) != 1 {
+			t.Fatalf("build_info series count = %d, want 1", len(series))
+		}
+		item := series[0]
+		var version string
+		for _, l := range item.GetLabel() {
+			if l.GetName() == "version" {
+				version = l.GetValue()
+			}
+		}
+		if version != "dev" {
+			t.Errorf("build_info version label = %q, want %q", version, "dev")
+		}
+		if v := item.GetGauge().GetValue(); v != 1 {
+			t.Errorf("build_info value = %v, want 1", v)
+		}
+	}
+	if !found {
+		t.Error("build_info gauge missing from registry")
 	}
 }
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -41,6 +42,7 @@ func TestRecordingHelpersAreNilSafe(t *testing.T) {
 	recordDrain("completed", time.Second)
 	recordStaleChassisCleanup("success", 2)
 	setMissingChassis(1)
+	setLastReconcileStatus(true)
 }
 
 func TestNewMetricsRegistryRegistersAllCollectors(t *testing.T) {
@@ -225,6 +227,111 @@ func TestStartMetricsServerServesMetricsEndpoint(t *testing.T) {
 	if !strings.Contains(string(body), "ovn_network_agent_reconcile_total") {
 		t.Errorf("body missing reconcile_total; got:\n%s", body)
 	}
+
+	// /healthz is liveness-only and always 200 while the process is up.
+	healthz, err := http.Get("http://" + addr + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz: %v", err)
+	}
+	defer func() { _ = healthz.Body.Close() }()
+	if healthz.StatusCode != http.StatusOK {
+		t.Errorf("/healthz status = %d, want 200", healthz.StatusCode)
+	}
+
+	// /readyz on a fresh registry with no reconcile recorded is not ready.
+	readyz, err := http.Get("http://" + addr + "/readyz")
+	if err != nil {
+		t.Fatalf("GET /readyz: %v", err)
+	}
+	defer func() { _ = readyz.Body.Close() }()
+	if readyz.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("/readyz status = %d, want 503", readyz.StatusCode)
+	}
+}
+
+// callReadyz drives readyzHandler against the given registry and returns the
+// response recorder so callers can assert on status and body.
+func callReadyz(m *metricsRegistry) *httptest.ResponseRecorder {
+	rr := httptest.NewRecorder()
+	readyzHandler(m)(rr, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	return rr
+}
+
+// TestReadyzNotReadyBeforeFirstReconcile proves a fresh agent that has not yet
+// completed a reconcile reports 503, even with OVN checks disabled.
+func TestReadyzNotReadyBeforeFirstReconcile(t *testing.T) {
+	m := withTestMetrics(t) // ovnRequired stays false
+
+	rr := callReadyz(m)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "awaiting first reconcile") {
+		t.Errorf("body missing 'awaiting first reconcile'; got:\n%s", rr.Body.String())
+	}
+}
+
+// TestReadyzReflectsReconcileOutcome proves readiness flips with the recorded
+// reconcile outcome once at least one cycle has run.
+func TestReadyzReflectsReconcileOutcome(t *testing.T) {
+	m := withTestMetrics(t) // ovnRequired stays false
+
+	setLastReconcileStatus(true)
+	if rr := callReadyz(m); rr.Code != http.StatusOK || rr.Body.String() != "ok\n" {
+		t.Errorf("after ok reconcile: status = %d body = %q, want 200 %q", rr.Code, rr.Body.String(), "ok\n")
+	}
+
+	setLastReconcileStatus(false)
+	rr := callReadyz(m)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("after failed reconcile: status = %d, want 503", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "last reconcile failed") {
+		t.Errorf("body missing 'last reconcile failed'; got:\n%s", rr.Body.String())
+	}
+}
+
+// TestReadyzRequiresOVNWhenConfigured proves that OVN connection state gates
+// readiness only when ovnRequired is set.
+func TestReadyzRequiresOVNWhenConfigured(t *testing.T) {
+	t.Run("ovn required", func(t *testing.T) {
+		m := withTestMetrics(t)
+		m.readiness.ovnRequired = true
+		setLastReconcileStatus(true)
+
+		// nb/sb disconnected: both checks fail even though reconcile is OK.
+		rr := callReadyz(m)
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Errorf("disconnected: status = %d, want 503", rr.Code)
+		}
+		if body := rr.Body.String(); !strings.Contains(body, "nb disconnected") || !strings.Contains(body, "sb disconnected") {
+			t.Errorf("body missing nb/sb disconnected lines; got:\n%s", body)
+		}
+
+		// Both connected: ready.
+		setOVNConnectionState("nb", true)
+		setOVNConnectionState("sb", true)
+		if rr := callReadyz(m); rr.Code != http.StatusOK {
+			t.Errorf("connected: status = %d, want 200", rr.Code)
+		}
+
+		// SB drops again: unready.
+		setOVNConnectionState("sb", false)
+		if rr := callReadyz(m); rr.Code != http.StatusServiceUnavailable {
+			t.Errorf("sb dropped: status = %d, want 503", rr.Code)
+		}
+	})
+
+	t.Run("ovn not required ignores connection state", func(t *testing.T) {
+		m := withTestMetrics(t) // ovnRequired stays false
+		setLastReconcileStatus(true)
+		setOVNConnectionState("nb", false)
+		setOVNConnectionState("sb", false)
+
+		if rr := callReadyz(m); rr.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200 despite disconnected OVN", rr.Code)
+		}
+	})
 }
 
 // TestInitMetricsAssignsProcessRegistry verifies that initMetrics builds a
@@ -235,7 +342,7 @@ func TestInitMetricsAssignsProcessRegistry(t *testing.T) {
 	metrics = nil
 	t.Cleanup(func() { metrics = prev })
 
-	m := initMetrics()
+	m := initMetrics(false)
 	if m == nil {
 		t.Fatal("initMetrics returned nil")
 	}
@@ -245,6 +352,39 @@ func TestInitMetricsAssignsProcessRegistry(t *testing.T) {
 	if m.registry == nil {
 		t.Error("returned registry has no underlying prometheus.Registry")
 	}
+}
+
+// TestInitMetricsForConfigDerivesOVNRequired guards the config→ovnRequired
+// mapping wired into main: flipping the negation would make /readyz gate on OVN
+// connectivity in port-forward-only mode (perpetual 503) or ignore it in full
+// mode (ready with OVN down). Both subtests go red if that derivation breaks.
+func TestInitMetricsForConfigDerivesOVNRequired(t *testing.T) {
+	prev := metrics
+	t.Cleanup(func() { metrics = prev })
+
+	t.Run("port-forward-only leaves OVN out of readiness", func(t *testing.T) {
+		m := initMetricsForConfig(Config{PortForwardOnly: true})
+		if m.readiness.ovnRequired {
+			t.Error("ovnRequired = true in port-forward-only mode, want false")
+		}
+		// A successful reconcile is enough: /readyz is 200 with no OVN connection.
+		setLastReconcileStatus(true)
+		if rr := callReadyz(m); rr.Code != http.StatusOK {
+			t.Errorf("/readyz = %d in port-forward-only mode, want 200", rr.Code)
+		}
+	})
+
+	t.Run("full mode gates readiness on OVN", func(t *testing.T) {
+		m := initMetricsForConfig(Config{PortForwardOnly: false})
+		if !m.readiness.ovnRequired {
+			t.Error("ovnRequired = false in full mode, want true")
+		}
+		// Reconcile OK but OVN never connected: /readyz stays 503.
+		setLastReconcileStatus(true)
+		if rr := callReadyz(m); rr.Code != http.StatusServiceUnavailable {
+			t.Errorf("/readyz = %d with OVN disconnected, want 503", rr.Code)
+		}
+	})
 }
 
 func TestSetReconcileInProgressTogglesGauge(t *testing.T) {

--- a/ovn_gateway.go
+++ b/ovn_gateway.go
@@ -809,11 +809,14 @@ func (o *OVNClient) CleanupStaleChassisManagedEntries(ctx context.Context, stale
 // shortly after the agent's initial subscription (see issue #115). When the
 // cache shows no row at all for the local chassis, fall back to a direct
 // OVSDB select so the drain does not silently no-op.
-func (o *OVNClient) DrainGateways(ctx context.Context, localChassisName string) error {
+//
+// It reports whether any Gateway_Chassis priorities were actually lowered, so
+// the caller can distinguish a real drain from a no-op.
+func (o *OVNClient) DrainGateways(ctx context.Context, localChassisName string) (drained bool, err error) {
 	// Step 1: Find all Gateway_Chassis entries for this chassis with priority > 0.
 	var gwChassisList []NBGatewayChassis
 	if err := o.nbClient.List(ctx, &gwChassisList); err != nil {
-		return fmt.Errorf("list gateway chassis: %w", err)
+		return false, fmt.Errorf("list gateway chassis: %w", err)
 	}
 
 	toDrain, hasLocalRow := filterDrainCandidates(gwChassisList, localChassisName)
@@ -829,7 +832,7 @@ func (o *OVNClient) DrainGateways(ctx context.Context, localChassisName string) 
 		var err error
 		serverList, err = o.selectLocalGatewayChassis(ctx, localChassisName)
 		if err != nil {
-			return fmt.Errorf("drain: cache miss + NB select fallback failed: %w", err)
+			return false, fmt.Errorf("drain: cache miss + NB select fallback failed: %w", err)
 		}
 		toDrain, _ = filterDrainCandidates(serverList, localChassisName)
 		if len(toDrain) > 0 {
@@ -858,7 +861,7 @@ func (o *OVNClient) DrainGateways(ctx context.Context, localChassisName string) 
 				"server_entries", summarizeGatewayChassis(serverList))
 		}
 		slog.Info("drain: no gateway chassis entries to drain on this chassis", attrs...)
-		return nil
+		return false, nil
 	}
 
 	// Step 2: Set priority to 0 in a single batched transaction.
@@ -879,7 +882,7 @@ func (o *OVNClient) DrainGateways(ctx context.Context, localChassisName string) 
 	}
 	if len(allOps) > 0 {
 		if err := o.transactOps(ctx, allOps); err != nil {
-			return fmt.Errorf("drain: failed to lower gateway chassis priorities: %w", err)
+			return false, fmt.Errorf("drain: failed to lower gateway chassis priorities: %w", err)
 		}
 	}
 
@@ -894,19 +897,19 @@ func (o *OVNClient) DrainGateways(ctx context.Context, localChassisName string) 
 	for {
 		remaining, err := o.countLocalCRPorts(ctx, localChassisName)
 		if err != nil {
-			return fmt.Errorf("drain: failed to query port bindings: %w", err)
+			return true, fmt.Errorf("drain: failed to query port bindings: %w", err)
 		}
 		if remaining == 0 {
 			slog.Info("drain: complete, all gateways migrated away")
 			o.awaitTakeoverReady(ctx, localChassisName)
-			return nil
+			return true, nil
 		}
 		slog.Info("drain: waiting for gateway migration", "remaining_gateways", remaining)
 
 		select {
 		case <-ctx.Done():
 			slog.Warn("drain: timeout exceeded, proceeding with shutdown", "remaining_gateways", remaining)
-			return nil
+			return true, nil
 		case <-o.drainWatchCh:
 			// A chassisredirect Port_Binding changed — re-check without waiting
 			// for the safety re-poll tick.

--- a/ovn_gateway_writes_test.go
+++ b/ovn_gateway_writes_test.go
@@ -1198,8 +1198,12 @@ func TestDrainGateways_NothingToDrain(t *testing.T) {
 	)
 	_ = sb
 
-	if err := c.DrainGateways(context.Background(), "host-a"); err != nil {
+	drained, err := c.DrainGateways(context.Background(), "host-a")
+	if err != nil {
 		t.Fatalf("DrainGateways: %v", err)
+	}
+	if drained {
+		t.Errorf("drained = true, want false — nothing to drain")
 	}
 	if got := nb.recordedTransacts(); len(got) != 0 {
 		t.Errorf("expected no transacts, got %+v", got)
@@ -1217,8 +1221,12 @@ func TestDrainGateways_BatchesAndCompletesWhenSBDrained(t *testing.T) {
 	// SB shows no chassisredirect ports for host-a → first poll returns 0.
 	sb.setRows("Chassis", &SBChassis{UUID: "ch-a", Name: "ch-a", Hostname: "host-a"})
 
-	if err := c.DrainGateways(context.Background(), "host-a"); err != nil {
+	drained, err := c.DrainGateways(context.Background(), "host-a")
+	if err != nil {
 		t.Fatalf("DrainGateways: %v", err)
+	}
+	if !drained {
+		t.Errorf("drained = false, want true — priorities were lowered")
 	}
 
 	tx := nb.recordedTransacts()
@@ -1259,8 +1267,12 @@ func TestDrainGateways_TimeoutReturnsNilWithRemainingPorts(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	if err := c.DrainGateways(ctx, "host-a"); err != nil {
+	drained, err := c.DrainGateways(ctx, "host-a")
+	if err != nil {
 		t.Fatalf("DrainGateways: %v", err)
+	}
+	if !drained {
+		t.Errorf("drained = false, want true — priorities were lowered before the timeout")
 	}
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Errorf("drain blocked too long: %v (ctx should fire promptly)", elapsed)
@@ -1296,8 +1308,12 @@ func TestDrainGateways_FallsBackToServerSelectOnCacheMiss(t *testing.T) {
 	})
 	sb.setRows("Chassis", &SBChassis{UUID: "ch-a", Name: "ch-a", Hostname: "host-a"})
 
-	if err := c.DrainGateways(context.Background(), "host-a"); err != nil {
+	drained, err := c.DrainGateways(context.Background(), "host-a")
+	if err != nil {
 		t.Fatalf("DrainGateways: %v", err)
+	}
+	if !drained {
+		t.Errorf("drained = false, want true — the recovered row was drained")
 	}
 
 	tx := nb.recordedTransacts()
@@ -1348,8 +1364,12 @@ func TestDrainGateways_EmptyMatchAfterCacheMissLogsServerRows(t *testing.T) {
 		"priority":     float64(0),
 	})
 
-	if err := c.DrainGateways(context.Background(), "host-a"); err != nil {
+	drained, err := c.DrainGateways(context.Background(), "host-a")
+	if err != nil {
 		t.Fatalf("DrainGateways: %v", err)
+	}
+	if drained {
+		t.Errorf("drained = true, want false — the recovered row was already at priority 0")
 	}
 
 	out := logs.String()
@@ -1374,8 +1394,12 @@ func TestDrainGateways_NoFallbackWhenLocalRowPresentAtZero(t *testing.T) {
 		&NBGatewayChassis{UUID: "g1", Name: "lrp-a_host-a", ChassisName: "host-a", Priority: 0},
 	)
 
-	if err := c.DrainGateways(context.Background(), "host-a"); err != nil {
+	drained, err := c.DrainGateways(context.Background(), "host-a")
+	if err != nil {
 		t.Fatalf("DrainGateways: %v", err)
+	}
+	if drained {
+		t.Errorf("drained = true, want false — the local row was already at priority 0")
 	}
 	if got := nb.recordedTransacts(); len(got) != 0 {
 		t.Errorf("expected no transacts (cache has the row), got %+v", got)
@@ -1393,7 +1417,7 @@ func TestDrainGateways_FallbackReturnsErrorOnTransactFailure(t *testing.T) {
 	)
 	nb.transactErr = errors.New("connection refused")
 
-	err := c.DrainGateways(context.Background(), "host-a")
+	_, err := c.DrainGateways(context.Background(), "host-a")
 	if err == nil || !strings.Contains(err.Error(), "NB select fallback failed") {
 		t.Errorf("expected fallback error to be surfaced, got %v", err)
 	}
@@ -1516,8 +1540,12 @@ func TestDrainGateways_EventSignalWakesMigrationWait(t *testing.T) {
 	}()
 
 	start := time.Now()
-	if err := c.DrainGateways(context.Background(), "host-a"); err != nil {
+	drained, err := c.DrainGateways(context.Background(), "host-a")
+	if err != nil {
 		t.Fatalf("DrainGateways: %v", err)
+	}
+	if !drained {
+		t.Errorf("drained = false, want true — priorities were lowered before the wait")
 	}
 	if elapsed := time.Since(start); elapsed >= 500*time.Millisecond {
 		t.Errorf("drain returned after %v; expected the event to wake it well under the %v re-poll", elapsed, drainRecheckInterval)
@@ -1659,8 +1687,12 @@ func TestDrainGateways_SettleDelayHoldsBeforeReturn(t *testing.T) {
 	sb.setRows("Chassis", &SBChassis{UUID: "ch-a", Name: "ch-a", Hostname: "host-a"})
 
 	start := time.Now()
-	if err := c.DrainGateways(context.Background(), "host-a"); err != nil {
+	drained, err := c.DrainGateways(context.Background(), "host-a")
+	if err != nil {
 		t.Fatalf("DrainGateways: %v", err)
+	}
+	if !drained {
+		t.Errorf("drained = false, want true — priorities were lowered before the settle hold")
 	}
 	elapsed := time.Since(start)
 	if elapsed < c.cfg.DrainSettleDelay {
@@ -1684,8 +1716,12 @@ func TestDrainGateways_SettleDelaySkippedWhenNothingToDrain(t *testing.T) {
 	)
 
 	start := time.Now()
-	if err := c.DrainGateways(context.Background(), "host-a"); err != nil {
+	drained, err := c.DrainGateways(context.Background(), "host-a")
+	if err != nil {
 		t.Fatalf("DrainGateways: %v", err)
+	}
+	if drained {
+		t.Errorf("drained = true, want false — nothing to drain")
 	}
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Errorf("drain held for %v with nothing to drain; settle delay must not apply", elapsed)

--- a/test/integration/scenario_metrics_test.go
+++ b/test/integration/scenario_metrics_test.go
@@ -250,3 +250,57 @@ func TestScenario_MetricsDesiredStateGauges(t *testing.T) {
 		func(v float64, present bool) bool { return present && v == 1 },
 		5*time.Second)
 }
+
+// TestScenario_MetricsBuildInfoAndReadyz (#165):
+//
+// The observability-readiness work exposes two process-health signals on the
+// metrics listener: an ovn_network_agent_build_info gauge (constant 1, carrying
+// the build version as a label) and a /readyz endpoint that returns 200 only
+// once the agent is functional — OVN connected and a route-synced reconcile
+// completed. This scenario brings a real agent up against OVN and asserts
+// build_info is exposed as a single series valued 1, that the liveness-only
+// /healthz answers 200, and that /readyz flips to 200 once the startup
+// reconcile lands. The version label carries git describe output in the
+// integration build, so we assert only that exactly one series exists at 1.
+func TestScenario_MetricsBuildInfoAndReadyz(t *testing.T) {
+	_, cancel, _, _ := startScenario(t)
+	defer cancel()
+
+	cfg := testenv.Defaults()
+	addr := testenv.FreeLoopbackAddr(t)
+	cfg.MetricsListen = addr
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// ovn_network_agent_build_info is a constant gauge exposed as a single
+	// version-labelled series valued 1. The version label carries git describe
+	// output in the integration build, so match label-agnostically: iterate the
+	// family's inner map, requiring exactly one series whose value is 1.
+	deadline := time.Now().Add(10 * time.Second)
+	var family map[string]float64
+	for {
+		family = testenv.ScrapeMetrics(t, addr)["ovn_network_agent_build_info"]
+		exactlyOne := len(family) == 1
+		valueIsOne := false
+		for _, v := range family {
+			valueIsOne = v == 1
+		}
+		if exactlyOne && valueIsOne {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("ovn_network_agent_build_info: want exactly one series "+
+				"valued 1, got %v", family)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	// /healthz is unconditional liveness — 200 while the process is up.
+	testenv.AssertHTTPStatusEventually(t, addr, "/healthz", 200, 5*time.Second)
+
+	// /readyz turns 200 once the agent connects to OVN and its startup
+	// reconcile syncs routes; the startup reconcile completes shortly after
+	// readyAgent returns, so a modest budget suffices.
+	testenv.AssertHTTPStatusEventually(t, addr, "/readyz", 200, 15*time.Second)
+}

--- a/test/integration/scenario_reconnect_test.go
+++ b/test/integration/scenario_reconnect_test.go
@@ -90,6 +90,8 @@ func TestScenario_OVNDatabasePauseResume(t *testing.T) {
 //   - ovn_connection_state drops to 0 for both DBs — the proof the inactivity
 //     probe fired and libovsdb disconnected rather than merely stalling — and
 //     recovers to 1 after resume,
+//   - /readyz tracks that transition (200 -> 503 -> 200), proving it
+//     distinguishes an alive-but-disconnected agent from a functional one,
 //   - the agent stays alive across the whole outage,
 //   - the FIP route installed before the outage survives it, and
 //   - a NB change made AFTER reconnect still drives reconciliation, proving
@@ -129,10 +131,12 @@ func TestScenario_OVNReconnectAfterLongOutage(t *testing.T) {
 			timeout)
 	}
 
-	// Pre-condition: the route landed and both DB connections read as up.
+	// Pre-condition: the route landed, both DB connections read as up, and
+	// /readyz reports the agent functional.
 	testenv.AssertKernelRoute(t, fip1, 15*time.Second)
 	assertConnState("nb", 1, 10*time.Second)
 	assertConnState("sb", 1, 10*time.Second)
+	testenv.AssertHTTPStatusEventually(t, addr, "/readyz", 200, 10*time.Second)
 
 	if !a.Alive() {
 		t.Fatalf("agent exited before the outage; setup is broken (last logs:\n%s)", a.LogTail(40))
@@ -151,6 +155,13 @@ func TestScenario_OVNReconnectAfterLongOutage(t *testing.T) {
 	assertConnState("nb", 0, 90*time.Second)
 	assertConnState("sb", 0, 90*time.Second)
 
+	// With both DBs disconnected the agent is alive but not functional, so
+	// /readyz must report 503 even though the process is up and /healthz still
+	// answers 200 — the #165 acceptance criterion distinguishing process-alive
+	// from agent-functional. Readiness flipped with the gauges above, so a
+	// short timeout suffices.
+	testenv.AssertHTTPStatusEventually(t, addr, "/readyz", 503, 10*time.Second)
+
 	// Honour the >40s outage floor deterministically by holding the remainder
 	// of 45s (the gauge-drop asserts above already consumed most of it).
 	if held := time.Since(start); held < 45*time.Second {
@@ -164,9 +175,11 @@ func TestScenario_OVNReconnectAfterLongOutage(t *testing.T) {
 
 	resume()
 
-	// Recovery: both gauges climb back to 1.
+	// Recovery: both gauges climb back to 1, and /readyz returns to 200 once a
+	// post-reconnect reconcile completes.
 	assertConnState("nb", 1, 45*time.Second)
 	assertConnState("sb", 1, 45*time.Second)
+	testenv.AssertHTTPStatusEventually(t, addr, "/readyz", 200, 30*time.Second)
 
 	// The pre-outage route survived the disconnect/reconnect.
 	testenv.AssertKernelRoute(t, fip1, 15*time.Second)

--- a/test/integration/testenv/metrics.go
+++ b/test/integration/testenv/metrics.go
@@ -125,6 +125,47 @@ func AssertMetricEventually(
 	}
 }
 
+// AssertHTTPStatusEventually polls GET http://addr<path> until the response
+// status equals want or timeout expires. Useful for asserting that a readiness
+// endpoint has flipped (e.g. /readyz 200 <-> 503) without baking in a fixed
+// sleep. Transport errors are tolerated across the deadline — the listener may
+// briefly refuse connections around startup — and surface only if the timeout
+// is reached. On timeout it fails with the last observed status and body.
+func AssertHTTPStatusEventually(
+	t *testing.T,
+	addr, path string,
+	want int,
+	timeout time.Duration,
+) {
+	t.Helper()
+	url := "http://" + addr + path
+	client := &http.Client{Timeout: 5 * time.Second}
+	deadline := time.Now().Add(timeout)
+	var lastStatus int
+	var lastBody string
+	for {
+		resp, err := client.Get(url)
+		if err != nil {
+			lastStatus = 0
+			lastBody = err.Error()
+		} else {
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			lastStatus = resp.StatusCode
+			lastBody = string(body)
+			if lastStatus == want {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("GET %s did not return status %d within %s "+
+				"(last status=%d, body:\n%s)",
+				url, want, timeout, lastStatus, lastBody)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
 // FreeLoopbackAddr returns a 127.0.0.1:<port> address whose port is currently
 // free. The listener is opened and closed before returning, leaving a small
 // TOCTOU window — the agent re-listens immediately on startup, so collisions

--- a/tools/docgen/render.go
+++ b/tools/docgen/render.go
@@ -188,6 +188,11 @@ func renderMetrics(info *sourceInfo) string {
 	}
 
 	b.WriteString("\n## Suggested alerts\n\n")
+	b.WriteString("Ready-to-load rules implementing these alerts ship in\n")
+	b.WriteString("[`contrib/prometheus-rules.yaml`](https://github.com/osism/ovn-network-agent/blob/main/contrib/prometheus-rules.yaml),\n")
+	b.WriteString("and each alert has a cause→diagnosis→remediation section in the\n")
+	b.WriteString("[troubleshooting guide](../guides/troubleshooting).\n\n")
+	// Keep these bullets in sync with contrib/prometheus-rules.yaml.
 	b.WriteString("- `consecutive_readds >= 3` — persistent route instability (FRR or kernel\n")
 	b.WriteString("  races).\n")
 	b.WriteString("- `ovn_connection_state{database=\"nb\"} == 0` for >2m — NB DB unreachable;\n")

--- a/tools/docgen/render.go
+++ b/tools/docgen/render.go
@@ -159,9 +159,10 @@ func renderMetrics(info *sourceInfo) string {
 	b.WriteString("ovn-network-agent --metrics-listen 127.0.0.1:9273\n")
 	b.WriteString("curl -s http://127.0.0.1:9273/metrics\n")
 	b.WriteString("```\n\n")
-	b.WriteString("Two paths are served:\n\n")
+	b.WriteString("Three paths are served:\n\n")
 	b.WriteString("- `/metrics` — Prometheus exposition format\n")
-	b.WriteString("- `/healthz` — returns `200 ok` for liveness probes\n\n")
+	b.WriteString("- `/healthz` — always returns `200 ok` while the process is up (liveness only)\n")
+	b.WriteString("- `/readyz` — returns `200` only when the agent is functional (OVN connected, last reconcile succeeded); `503` otherwise\n\n")
 	if info.Namespace != "" {
 		fmt.Fprintf(&b, "All metrics are prefixed with `%s_`. The table below is generated from the\n", info.Namespace)
 	} else {


### PR DESCRIPTION
Closes #165

Turns the observability story from "the metrics exist" into "an on-call operator can act on them": a `build_info` gauge for fleet-skew visibility, a truthful `/readyz` probe, shipped Prometheus alert rules, and a full troubleshooting runbook. Also fixes a mis-recorded drain outcome surfaced while auditing the metrics.

## Change set (commit order)

1. **`feat: export a build_info gauge with the running agent version`** — adds `ovn_network_agent_build_info{version}` (constant `1`) from the existing ldflags version, so fleet version skew is one PromQL query away: `count by (version) (ovn_network_agent_build_info)`. This matters during rolling upgrades where mixed-version agents drain differently.

2. **`feat: record the drain noop outcome instead of completed`** — `DrainGateways` now reports whether any `Gateway_Chassis` priority was actually lowered, so the shutdown path records `drain_total{outcome="noop"}` for the nothing-to-drain case. The label was initialized but never recorded (issue's final task); the noop path had been misreported as `completed`.

3. **`feat: serve /readyz reflecting OVN connectivity and reconcile health`** — `/healthz` stays pure liveness (200 whenever the process is up); the new `/readyz` distinguishes process-alive from agent-functional. Readiness derives from two existing signals — the `setOVNConnectionState` funnel and `routeSyncResult.ready` (the same signal the drain takeover handshake trusts). A cycle is ready when OVN NB **and** SB are connected, at least one reconcile completed, and the last reconcile's route sync succeeded; best-effort steps that only log do not flip readiness. In port-forward-only mode there is no OVN client, so OVN state does not gate readiness.

4. **`test: cover build_info and /readyz in the integration scenarios`** — adds an `AssertHTTPStatusEventually` testenv helper mirroring `AssertMetricEventually`; a metrics scenario asserting `build_info` is a single series valued `1` and that `/healthz` (unconditional 200) is distinct from `/readyz`; and extends the long-outage reconnect scenario to prove `/readyz` goes `200 -> 503 -> 200` across a real OVN outage — the end-to-end evidence for the "process-alive vs agent-functional" acceptance criterion.

5. **`docs: add an operator troubleshooting runbook`** — new `docs/guides/troubleshooting.md`: cause → diagnosis → remediation for every shipped alert plus the drain and stale-cleanup outcomes, an "agent up but no routes" checklist, and a curated table of actionable error-level log messages. Linked from the sidebar and README.

6. **`feat: ship Prometheus alert rules matching the metrics reference`** — `contrib/prometheus-rules.yaml` implements the suggested alerts from the generated reference verbatim (full metric names), each with a severity and a `runbook_url` into the troubleshooting guide. Cross-sync comments tie the rules file to the reference.

7. **`docs: replace the hand-written alert list and document the probes`** — the guide's alert list had drifted from the generated reference (missing `inactive_routes`); it now links the reference, the shipped rules file, and the runbook instead of reproducing expressions. Adds a probe section documenting `/healthz` vs `/readyz` semantics.

8. **`docs: consolidate known limitations on the home page and README`** — scattered scope footnotes (IPv4-only, no config reload, port-forward hashing, single physnet) become one section on the docs home page with a compact README mirror, plus a sizing note on full-table OVSDB replication; the upgrade guide gains the `build_info` fleet-skew PromQL.

## Acceptance criteria

- A Kubernetes-style probe / external LB check can distinguish "process alive" from "agent functional" — `/readyz` (commit 3), proven end-to-end (commit 4).
- Version skew across a fleet is one PromQL query away — `build_info` (commit 1).
- Every shipped alert has a documented cause → diagnosis → remediation path — runbook (commit 5) + rules with `runbook_url` (commit 6).

## Notes on divergence from the issue

- The issue lists **five** suggested alerts; the rules file ships **six**. The extra one is `inactive_routes > 0`, whose absence was the documented drift the issue flagged — the reference already carries it, so shipping it verbatim is the fix, not scope creep.
- The optional Grafana dashboard JSON and the systemd `Type=notify` + watchdog stretch goal were **not** taken. Commit 7 records the deliberate decision to keep systemd `Type=simple`; readiness is exposed via the HTTP `/readyz` probe instead.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) c4682b7 with Claude:claude-opus-4-8_
