### PR TITLE
fix: re-create the workload netns when its anchor is dead

### DIFF
--- a/test/e2e/bootstrap.sh
+++ b/test/e2e/bootstrap.sh
@@ -635,8 +635,17 @@ ovs-vsctl --may-exist add-port br-int "${WORKLOAD_HOST_VETH}" \
     -- set Interface "${WORKLOAD_HOST_VETH}" external_ids:iface-id="${WORKLOAD_LSP}"
 ip link set "${WORKLOAD_HOST_VETH}" up
 
-# Workload netns + peer-side veth.
-if ! ip netns list | awk '{print $1}' | grep -qx "${WORKLOAD_NETNS}"; then
+# Workload netns + peer-side veth. The guard enters the namespace rather
+# than asking `ip netns list` whether it exists: a container restart
+# destroys the namespace but leaves its anchor under /run/netns behind as
+# a dead regular file — the gwnode image mounts no tmpfs on /run — so it
+# stays listed while every use of it fails ("Peer netns reference is
+# invalid", EINVAL) and `ip netns add` fails with EEXIST. Clearing the dead
+# anchor first is what makes the re-create possible; `ip netns delete`
+# covers both states, detaching a live mount and unlinking the file. A
+# healthy namespace is left alone, so the workload's processes survive.
+if ! ip netns exec "${WORKLOAD_NETNS}" true 2>/dev/null; then
+    ip netns delete "${WORKLOAD_NETNS}" 2>/dev/null || true
     ip netns add "${WORKLOAD_NETNS}"
 fi
 if ! ip -n "${WORKLOAD_NETNS}" link show "${WORKLOAD_NS_VETH}" >/dev/null 2>&1; then

--- a/test/e2e/chaos/state.go
+++ b/test/e2e/chaos/state.go
@@ -319,7 +319,17 @@ func ensureResponders(ctx context.Context, l *lab, p *profile) error {
 			fmt.Sprintf("ovs-vsctl --may-exist add-port br-int %s -- set Interface %s external_ids:iface-id=%s",
 				hostVeth, hostVeth, n.lsp),
 			fmt.Sprintf("ip link set %s up", hostVeth),
-			fmt.Sprintf("ip netns list | awk '{print $1}' | grep -qx %s || ip netns add %s", n.name, n.name),
+			// Enter the namespace rather than asking `ip netns list`
+			// whether it exists. A container restart destroys the
+			// namespace but leaves its anchor under /run/netns behind as
+			// a dead regular file — the gateway image mounts no tmpfs on
+			// /run — so it stays listed while every use of it fails
+			// ("Peer netns reference is invalid", EINVAL). Clearing the
+			// dead anchor first is what makes the re-create possible;
+			// `ip netns delete` covers both states, detaching a live
+			// mount and unlinking the file.
+			fmt.Sprintf("ip netns exec %s true 2>/dev/null || { ip netns delete %s 2>/dev/null || true; ip netns add %s; }",
+				n.name, n.name, n.name),
 			fmt.Sprintf("ip -n %s link show %s >/dev/null 2>&1 || ip link set %s netns %s",
 				n.name, nsVeth, nsVeth, n.name),
 			fmt.Sprintf("ip -n %s link set lo up", n.name),

--- a/test/e2e/chaos/state_test.go
+++ b/test/e2e/chaos/state_test.go
@@ -137,6 +137,39 @@ func TestEveryProbedFIPHasARestoredResponder(t *testing.T) {
 	}
 }
 
+// The namespace guard must establish that the namespace is usable, not
+// merely that it is listed. A container restart destroys the namespace but
+// leaves a dead anchor under /run/netns, which keeps `ip netns list`
+// answering yes; provisioning then skips the re-create and fails moving the
+// veth in ("Peer netns reference is invalid", EINVAL). That is deterministic
+// after every gateway restart — a profile apply or a lifecycle-fault
+// restore — so the listing guard must not come back.
+func TestResponderGuardSurvivesADeadNamespaceAnchor(t *testing.T) {
+	cmd := &fakeCommander{respond: healthyLabResponses}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := ensureResponders(context.Background(), l, defaultTestProfile(t)); err != nil {
+		t.Fatalf("ensureResponders: %v", err)
+	}
+
+	for _, n := range responders(defaultTestProfile(t)) {
+		if cmd.called("ip netns list | awk '{print $1}' | grep -qx " + n.name) {
+			t.Fatalf("responder %s is guarded by a listing that a dead anchor satisfies: %v",
+				n.name, cmd.lines())
+		}
+		if !cmd.called("ip netns exec " + n.name + " true 2>/dev/null") {
+			t.Fatalf("responder %s is not probed for usability before it is trusted: %v",
+				n.name, cmd.lines())
+		}
+		// The dead anchor has to go before `ip netns add`, which would
+		// otherwise fail with EEXIST and leave the namespace unusable.
+		if !cmd.called("ip netns delete " + n.name + " 2>/dev/null || true; ip netns add " + n.name) {
+			t.Fatalf("responder %s re-creates its namespace without clearing the dead anchor: %v",
+				n.name, cmd.lines())
+		}
+	}
+}
+
 // A profile that puts up no VLAN networks must not layer them anyway: the
 // point of flat-minimal is a lab whose agents have less to reconcile, and
 // a stray VLAN network would leave residue no probe measures.

--- a/test/e2e/scenarios/hairpin.sh
+++ b/test/e2e/scenarios/hairpin.sh
@@ -187,7 +187,12 @@ ovs-vsctl --may-exist add-port br-int "${FIP_B_HOST_VETH}" \
     -- set Interface "${FIP_B_HOST_VETH}" external_ids:iface-id="${FIP_B_LSP}"
 ip link set "${FIP_B_HOST_VETH}" up
 
-if ! ip netns list | awk '{print $1}' | grep -qx "${FIP_B_NETNS}"; then
+# Enter the namespace rather than asking `ip netns list` whether it exists:
+# a container restart leaves a dead anchor under /run/netns that keeps it
+# listed while every use of it fails. See ensure_workload_netns in
+# bootstrap.sh for the full rationale.
+if ! ip netns exec "${FIP_B_NETNS}" true 2>/dev/null; then
+    ip netns delete "${FIP_B_NETNS}" 2>/dev/null || true
     ip netns add "${FIP_B_NETNS}"
 fi
 if ! ip -n "${FIP_B_NETNS}" link show "${FIP_B_NS_VETH}" >/dev/null 2>&1; then

--- a/test/e2e/scenarios/multi-vlan.sh
+++ b/test/e2e/scenarios/multi-vlan.sh
@@ -222,7 +222,12 @@ ovs-vsctl --may-exist add-port br-int "${VM_HOST_VETH}" \
     -- set Interface "${VM_HOST_VETH}" external_ids:iface-id="${VM_LSP}"
 ip link set "${VM_HOST_VETH}" up
 
-if ! ip netns list | awk '{print $1}' | grep -qx "${VM_NETNS}"; then
+# Enter the namespace rather than asking `ip netns list` whether it exists:
+# a container restart leaves a dead anchor under /run/netns that keeps it
+# listed while every use of it fails. See ensure_workload_netns in
+# bootstrap.sh for the full rationale.
+if ! ip netns exec "${VM_NETNS}" true 2>/dev/null; then
+    ip netns delete "${VM_NETNS}" 2>/dev/null || true
     ip netns add "${VM_NETNS}"
 fi
 if ! ip -n "${VM_NETNS}" link show "${VM_NS_VETH}" >/dev/null 2>&1; then


### PR DESCRIPTION
Closes #204.

## Problem

The workload responders are provisioned behind a guard that asks `ip netns list` whether the namespace exists. A container restart destroys the namespace but leaves its anchor under `/run/netns` behind as a **dead regular file** — the gwnode image mounts no tmpfs on `/run` — so it stays listed. The guard skips `ip netns add`, and moving the freshly created veth end into the dead anchor fails.

## Fix

The guards now **enter** the namespace instead of listing it, and clear a dead anchor before re-creating it:

```sh
if ! ip netns exec "${NS}" true 2>/dev/null; then
    ip netns delete "${NS}" 2>/dev/null || true
    ip netns add "${NS}"
fi
```

`ip netns delete` covers both states — it detaches a live mount and unlinks the file. A healthy namespace is left untouched, so the workload's processes survive re-provisioning. This is the idiom `pf-hairpin.sh` already uses (`verify_vmc_netns`).

Sites changed:

| Site | Reachability |
|---|---|
| `chaos/state.go:ensureResponders` | the failing path — every profile apply and lifecycle-fault restore |
| `bootstrap.sh:ensure_workload_netns` | escapes today only because it never runs against a restarted container |
| `scenarios/hairpin.sh`, `scenarios/multi-vlan.sh` | identical guard, reachable once an earlier scenario (failover, drain-hitless) has restarted a container |

Teardown guards are deliberately left alone: a dead anchor is still *listed*, so the `ip netns delete` they gate cleans it up correctly.

## Verification

Reproduced and fixed byte-for-byte in a privileged `ubuntu:24.04` container — provision, `docker restart`, re-provision:

```
== 2. docker restart ==
---------- 1 root root 0 /run/netns/vm1        <- dead anchor, still listed
== 3. re-provision with the OLD guard ==
Error: Peer netns reference is invalid.
Error: Peer netns reference is invalid.
RTNETLINK answers: Invalid argument
   -> exit=255
== 4. re-provision with the NEW guard ==
   -> exit=0
vm1-eth0@if13    UP    192.168.10.10/24
```

Also verified with the exact `bootstrap.sh` heredoc shape: fresh provision, idempotent re-run, recovery after two consecutive restarts — all `exit=0` with the address and default route intact, and a healthy namespace is not re-created (pids inside it preserved).

`TestResponderGuardSurvivesADeadNamespaceAnchor` locks the guard shape in; confirmed it fails against the old code. `go build ./...`, `go vet`, `gofmt`, `golangci-lint` (0 issues), `shellcheck -S warning` and the chaos package tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)