### PR TITLE
fix: leave a port-forward VIP dormant on a gateway without local routers

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -43,6 +43,10 @@ type Agent struct {
 	// staleCleanupJitter is a random duration (0-30s) added to the grace
 	// period to prevent multiple agents from cleaning up simultaneously.
 	staleCleanupJitter time.Duration
+
+	// dormantVIPs is the comma-joined set of port-forward VIPs last reported
+	// as dormant, so reportDormantVIPs logs a change rather than every cycle.
+	dormantVIPs string
 }
 
 // maxStaleCleanupJitter is the maximum random jitter added to the stale
@@ -302,7 +306,7 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 	// Everything the cycle needs to derive from OVN is a pure function of the
 	// snapshot plus the configured VIPs (see desired_state.go). Past this
 	// point reconcile only acts on the result.
-	desired := computeDesiredState(state, a.cfg.PortForwards)
+	desired := computeDesiredState(state, a.cfg.PortForwards, a.vipRoutesAnnounceable(state))
 	hairpinTargets := desired.HairpinTargets
 	desiredSegments := desired.Segments
 	desiredIPs := desired.DesiredIPs
@@ -311,6 +315,7 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 		slog.Debug("excluding non-IPv4 addresses from the route/announce plane, IPv6 support tracked in #85/#70",
 			"ips", desired.ExcludedNonV4)
 	}
+	a.reportDormantVIPs(desired.DormantVIPs)
 
 	setDesiredState(len(desiredIPs), len(state.LocalRouters), len(a.effectiveFilters))
 	setLocalnetSegments(len(desiredSegments))
@@ -432,9 +437,9 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 	}
 
 	// The BGP announce. Ensure routes for all desired IPs (FIPs, SNATs, and
-	// port forward VIPs). When no local routers are present but port
-	// forwards are configured, this still installs VIP routes on br-ex and
-	// in FRR.
+	// the port-forward VIPs this node can announce — see
+	// vipRoutesAnnounceable; dormant VIPs are not in desiredIPs and are
+	// withdrawn by the standby path below like any other undesired route).
 	var routeSync routeSyncResult
 	if len(desiredIPs) > 0 || state.HasLocalRouters {
 		routeSync = a.ensureRoutes(desiredIPs, ipDev, skipKernelRoute)
@@ -442,7 +447,7 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 	} else {
 		// The removeAllRoutes standby path leaves cycleOK true — a healthy
 		// standby is ready.
-		a.removeAllRoutes("no locally active routers and no port forward VIPs")
+		a.removeAllRoutes("no locally active routers and no announceable port forward VIPs")
 	}
 
 	// Failover-latency metric: time from observing the chassisredirect
@@ -590,6 +595,43 @@ func (a *Agent) computeEffectiveNetworks(discovered []*net.IPNet) []*net.IPNet {
 		}
 	}
 	return v4
+}
+
+// vipRoutesAnnounceable reports whether the configured port-forward VIPs should
+// get kernel and FRR routes this cycle.
+//
+// A VIP is only routable where the agent also maintains the FRR prefix-list that
+// permits it. Without local routers reconcile takes the standby path, which
+// empties that prefix-list and the veth-leak network routes — a VIP route
+// installed anyway could never be advertised. It would sit in FRR as a static
+// route that zebra never selects, holding ovn_network_agent_inactive_routes at a
+// non-zero value and logging at ERROR on every cycle, indefinitely (#206). Such
+// a VIP is dormant instead: nothing installed, reported once at info level.
+//
+// Port-forward-only mode never takes the standby path and serves its VIPs
+// without any OVN state at all, so it always announces them.
+func (a *Agent) vipRoutesAnnounceable(state OVNState) bool {
+	return a.cfg.PortForwardOnly || state.HasLocalRouters
+}
+
+// reportDormantVIPs logs the port-forward VIPs this node cannot announce, once
+// per change of the set rather than on every reconcile: the condition persists
+// for as long as the node holds no local routers, and the point of declining to
+// install the route is to stop the per-cycle noise. Recovery is logged too, so
+// the dormancy has a matching end in the journal.
+func (a *Agent) reportDormantVIPs(dormant []string) {
+	key := strings.Join(dormant, ",")
+	if key == a.dormantVIPs {
+		return
+	}
+	switch {
+	case len(dormant) > 0:
+		slog.Info("port-forward VIPs are dormant on this node — no locally active routers, so they cannot be advertised and no routes are installed",
+			"count", len(dormant), "vips", dormant)
+	case a.dormantVIPs != "":
+		slog.Info("port-forward VIPs are no longer dormant — installing their routes")
+	}
+	a.dormantVIPs = key
 }
 
 // segmentRouteUnresolved reports whether an IP on the given localnet segment

--- a/agent_test.go
+++ b/agent_test.go
@@ -280,6 +280,61 @@ func TestVerifyRoutesDetectsDevMismatch(t *testing.T) {
 // to resolve is skipped. A flat segment (bridge is correct), a resolved VLAN
 // segment, and an unknown segment must all route normally — misclassifying any
 // of them would either mis-deliver traffic or needlessly freeze a route.
+// TestVIPRoutesAnnounceable pins the #206 gate: a port-forward VIP only gets a
+// route where the agent also maintains the FRR prefix-list that would permit it.
+func TestVIPRoutesAnnounceable(t *testing.T) {
+	tests := []struct {
+		name            string
+		portForwardOnly bool
+		hasLocalRouters bool
+		want            bool
+	}{
+		// The defect: no local routers means reconcile empties the
+		// prefix-list, so a VIP route could never be advertised.
+		{"gateway without local routers", false, false, false},
+		{"gateway with local routers", false, true, true},
+		// Port-forward-only mode never takes the standby path and serves
+		// its VIPs without any OVN state at all.
+		{"port-forward-only", true, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Agent{cfg: Config{PortForwardOnly: tt.portForwardOnly}}
+			got := a.vipRoutesAnnounceable(OVNState{HasLocalRouters: tt.hasLocalRouters})
+			if got != tt.want {
+				t.Errorf("vipRoutesAnnounceable = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReportDormantVIPsLogsOnChange is the other half of the #206 fix: the
+// dormancy is reported when the set changes, not on every reconcile. The old
+// behaviour logged at ERROR every cycle for as long as the condition held.
+func TestReportDormantVIPsLogsOnChange(t *testing.T) {
+	a := &Agent{}
+
+	a.reportDormantVIPs([]string{"192.0.2.99"})
+	if a.dormantVIPs != "192.0.2.99" {
+		t.Fatalf("dormantVIPs = %q, want the reported set memoized", a.dormantVIPs)
+	}
+	// Same set again — nothing changes, so nothing is re-reported.
+	a.reportDormantVIPs([]string{"192.0.2.99"})
+	if a.dormantVIPs != "192.0.2.99" {
+		t.Errorf("dormantVIPs = %q, want unchanged on a repeat", a.dormantVIPs)
+	}
+	// A second VIP joining is a change and must be picked up.
+	a.reportDormantVIPs([]string{"192.0.2.99", "203.0.113.10"})
+	if a.dormantVIPs != "192.0.2.99,203.0.113.10" {
+		t.Errorf("dormantVIPs = %q, want the grown set", a.dormantVIPs)
+	}
+	// Recovery clears the memo so a later dormancy is reported again.
+	a.reportDormantVIPs(nil)
+	if a.dormantVIPs != "" {
+		t.Errorf("dormantVIPs = %q, want cleared on recovery", a.dormantVIPs)
+	}
+}
+
 func TestSegmentRouteUnresolved(t *testing.T) {
 	tag := 101
 	desired := map[string]DesiredSegment{

--- a/desired_state.go
+++ b/desired_state.go
@@ -42,6 +42,11 @@ type desiredState struct {
 	// DesiredIPs is HairpinIPs plus the port-forward VIPs, deduplicated and
 	// sorted. This is the set that gets kernel routes and FRR announcements.
 	DesiredIPs []string
+
+	// DormantVIPs lists the configured port-forward VIPs left out of
+	// DesiredIPs because this node cannot advertise them, sorted. Reported by
+	// reconcile at info level on change.
+	DormantVIPs []string
 }
 
 // buildHairpinTargets collects every IP that needs a hairpin flow: the NAT
@@ -127,17 +132,27 @@ func splitIPv4(targets map[string]HairpinTarget) (v4, nonV4 []string) {
 // computeDesiredState derives everything reconcile needs from an OVN snapshot
 // and the configured port forwards. In port-forward-only mode state is the zero
 // OVNState, so the result reduces to the VIPs alone.
-func computeDesiredState(state OVNState, portForwards []PortForwardVIP) desiredState {
+//
+// announceVIPs decides whether the configured port-forward VIPs join the route
+// plane this cycle; reconcile derives it from whether this node maintains the
+// FRR prefix-list that would permit them (see vipRoutesAnnounceable). When it is
+// false the VIPs are reported as DormantVIPs instead: no kernel route, no FRR
+// static route, and nothing for the inactive-route check to alarm on.
+func computeDesiredState(state OVNState, portForwards []PortForwardVIP, announceVIPs bool) desiredState {
 	targets := buildHairpinTargets(state)
 	hairpinIPs, excludedNonV4 := splitIPv4(targets)
 	segments, segmentByName := buildDesiredSegments(state.LocalRouters)
 
 	// desiredIPs extends hairpinIPs with the port-forward VIPs — these need
-	// kernel routes on br-ex and FRR static routes for BGP announcement,
-	// independent of whether any OVN routers are locally active.
+	// kernel routes on br-ex and FRR static routes for BGP announcement.
 	desiredIPs := make([]string, 0, len(hairpinIPs)+len(portForwards))
 	desiredIPs = append(desiredIPs, hairpinIPs...)
+	var dormantVIPs []string
 	for _, pf := range portForwards {
+		if !announceVIPs {
+			dormantVIPs = append(dormantVIPs, pf.VIP)
+			continue
+		}
 		desiredIPs = append(desiredIPs, pf.VIP)
 	}
 
@@ -148,5 +163,6 @@ func computeDesiredState(state OVNState, portForwards []PortForwardVIP) desiredS
 		HairpinIPs:     hairpinIPs,
 		ExcludedNonV4:  excludedNonV4,
 		DesiredIPs:     uniqueIPs(desiredIPs),
+		DormantVIPs:    uniqueIPs(dormantVIPs),
 	}
 }

--- a/desired_state_test.go
+++ b/desired_state_test.go
@@ -137,8 +137,8 @@ func TestSplitIPv4Empty(t *testing.T) {
 }
 
 // TestComputeDesiredState drives the whole derivation, including the VIP merge:
-// port-forward VIPs join the desired set even with no local routers, and a VIP
-// that duplicates a FIP must appear once.
+// announceable port-forward VIPs join the desired set, and a VIP that duplicates
+// a FIP must appear once.
 func TestComputeDesiredState(t *testing.T) {
 	state := OVNState{
 		NATIPToRouterMAC: map[string]string{
@@ -156,8 +156,11 @@ func TestComputeDesiredState(t *testing.T) {
 		{VIP: "198.51.100.50"},
 	}
 
-	got := computeDesiredState(state, forwards)
+	got := computeDesiredState(state, forwards, true)
 
+	if len(got.DormantVIPs) != 0 {
+		t.Errorf("DormantVIPs = %v, want empty when the VIPs are announceable", got.DormantVIPs)
+	}
 	if want := []string{"198.51.100.50", "203.0.113.10"}; !reflect.DeepEqual(got.DesiredIPs, want) {
 		t.Errorf("DesiredIPs = %v, want %v (VIPs merged, deduped, sorted)", got.DesiredIPs, want)
 	}
@@ -180,7 +183,7 @@ func TestComputeDesiredState(t *testing.T) {
 // where reconcile passes the zero OVNState: the derivation must reduce to the
 // VIPs alone without touching any nil map.
 func TestComputeDesiredStatePortForwardOnly(t *testing.T) {
-	got := computeDesiredState(OVNState{}, []PortForwardVIP{{VIP: "203.0.113.10"}})
+	got := computeDesiredState(OVNState{}, []PortForwardVIP{{VIP: "203.0.113.10"}}, true)
 
 	if want := []string{"203.0.113.10"}; !reflect.DeepEqual(got.DesiredIPs, want) {
 		t.Errorf("DesiredIPs = %v, want %v", got.DesiredIPs, want)
@@ -190,5 +193,45 @@ func TestComputeDesiredStatePortForwardOnly(t *testing.T) {
 	}
 	if len(got.Segments) != 0 {
 		t.Errorf("Segments = %+v, want empty with no OVN state", got.Segments)
+	}
+}
+
+// TestComputeDesiredStateDormantVIPs covers the routerless gateway of #206: with
+// the VIPs not announceable they must leave the route plane entirely — no kernel
+// route, no FRR static route — and be reported as dormant instead. Installing
+// them anyway left an unadvertisable FRR route that alarmed on every cycle.
+func TestComputeDesiredStateDormantVIPs(t *testing.T) {
+	forwards := []PortForwardVIP{
+		{VIP: "203.0.113.10"},
+		{VIP: "192.0.2.99"},
+		// A duplicate must not be reported twice.
+		{VIP: "203.0.113.10"},
+	}
+
+	got := computeDesiredState(OVNState{}, forwards, false)
+
+	if len(got.DesiredIPs) != 0 {
+		t.Errorf("DesiredIPs = %v, want empty — dormant VIPs get no routes", got.DesiredIPs)
+	}
+	if want := []string{"192.0.2.99", "203.0.113.10"}; !reflect.DeepEqual(got.DormantVIPs, want) {
+		t.Errorf("DormantVIPs = %v, want %v (deduped, sorted)", got.DormantVIPs, want)
+	}
+}
+
+// TestComputeDesiredStateDormantVIPsKeepFIPs guards the blast radius: dormancy
+// applies to the VIPs alone. A node that somehow holds FIPs must still announce
+// them, so only the VIP entries are withheld from DesiredIPs.
+func TestComputeDesiredStateDormantVIPsKeepFIPs(t *testing.T) {
+	state := OVNState{
+		NATIPToRouterMAC: map[string]string{"198.51.100.50": "aa:aa:aa:aa:aa:01"},
+	}
+
+	got := computeDesiredState(state, []PortForwardVIP{{VIP: "203.0.113.10"}}, false)
+
+	if want := []string{"198.51.100.50"}; !reflect.DeepEqual(got.DesiredIPs, want) {
+		t.Errorf("DesiredIPs = %v, want %v — the FIP stays, only the VIP is dormant", got.DesiredIPs, want)
+	}
+	if want := []string{"203.0.113.10"}; !reflect.DeepEqual(got.DormantVIPs, want) {
+		t.Errorf("DormantVIPs = %v, want %v", got.DormantVIPs, want)
 	}
 }

--- a/docs/explanation/port-forwarding.md
+++ b/docs/explanation/port-forwarding.md
@@ -368,9 +368,10 @@ locally (INPUT chain), and the reply originates from the OUTPUT hook. The
 ## Running as a standalone VIP service (port-forward-only mode)
 
 Port forwarding does not depend on OVN. The DNAT rules, the VIP addresses,
-the connmark-based return routing, and the FRR static routes that announce
-the VIPs are all managed independently of any OVN gateway state — the
-reconcile loop already asserts them regardless of local router presence.
+and the connmark-based return routing are all managed independently of any
+OVN gateway state — the reconcile loop asserts them regardless of local
+router presence (see [Dormant VIPs](#dormant-vips-on-a-gateway-without-local-routers)
+for the one part that is gated: the routes that announce the VIPs).
 
 That makes it useful to run the agent as a *pure* VIP service on a node
 that is **not** an OVN gateway chassis at all: a node hosting DNS
@@ -411,3 +412,40 @@ constrained in this mode (see
 [Configure the agent](../guides/configuration#port-forward-only-mode)):
 `router_masquerade` is rejected outright, and `hairpin_masquerade`
 requires an explicit `network_cidr`.
+
+## Dormant VIPs on a gateway without local routers
+
+A VIP is only routable on a node where the agent also maintains the FRR
+prefix-list that permits it. On a gateway that hosts no locally active
+router — a standby chassis, or one whose routers have failed over
+elsewhere — reconcile takes the standby path and empties both that
+prefix-list and the veth-leak network routes. A VIP route installed there
+could never be advertised.
+
+The agent therefore treats such a VIP as **dormant**: it installs no
+`<vip>/32` kernel route and no FRR static route, and reports the condition
+once at INFO level:
+
+```
+port-forward VIPs are dormant on this node — no locally active routers,
+so they cannot be advertised and no routes are installed
+```
+
+The DNAT plane is *not* withheld. The nftables rules, the VIP address on
+`port_forward_dev`, the conntrack zones, and the policy routing are all
+still asserted, so a gateway that later gains a local router only needs the
+announce — the data path is already in place. When that happens the agent
+logs `port-forward VIPs are no longer dormant` and installs the routes on
+the next reconcile.
+
+Port-forward-only mode never takes the standby path, so its VIPs are never
+dormant — a pure VIP-service node serves them without any OVN state at all.
+
+::: tip Why not install the route anyway?
+It was installed unconditionally before, and the result was an FRR static
+route that zebra never selected: not advertised, but present. That held
+`ovn_network_agent_inactive_routes` at a non-zero value — which the shipped
+`OVNNetworkAgentInactiveRoutes` alert fires on — and logged
+`FRR static routes are configured but inactive` at ERROR level on every
+reconcile, indefinitely.
+:::

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -225,6 +225,10 @@ the next-hop is the fault.
 unresolvable — the veth pair is missing or down, or the VRF is misconfigured —
 so FRR keeps the route but never installs or advertises it.
 
+A port-forward VIP on a gateway without locally active routers is *not* a cause:
+such a VIP is [dormant](../explanation/port-forwarding#dormant-vips-on-a-gateway-without-local-routers)
+and gets no route at all, so it cannot contribute to this alert.
+
 **Diagnosis.** The agent logs `FRR static routes are configured but inactive —
 these FIPs are not advertised via BGP` with the affected `ips` and `vrf`.
 Confirm with step 5 of [Agent up but no routes

--- a/test/e2e/chaos/expect.go
+++ b/test/e2e/chaos/expect.go
@@ -135,7 +135,8 @@ type gatewayExpectation struct {
 	// DesiredIPs is the sorted, deduplicated set of IPv4 addresses that need a
 	// route and an announcement: the locally-active routers' NAT external IPs
 	// (filtered by the effective networks) and LRP gateway IPs, plus the
-	// configured port-forward VIPs. Mirrors desired_state.go DesiredIPs.
+	// port-forward VIPs this gateway can announce. Mirrors desired_state.go
+	// DesiredIPs, including the dormant-VIP gate (see rule 4b below).
 	DesiredIPs []string
 
 	// KernelRouteDev maps each desired IP to the kernel device its proto-44
@@ -146,7 +147,9 @@ type gatewayExpectation struct {
 
 	// FRRStatic is the set of /32 IPs expected as FRR static routes via the
 	// veth nexthop. It equals DesiredIPs in both modes: ensureRoutes manages
-	// FRR for every desired IP, active or standby, full or pf-only.
+	// FRR for every desired IP, active or standby, full or pf-only. On a
+	// full-mode standby that set is empty — the dormant VIPs are not in it,
+	// which is what keeps inactive_routes at 0 there (#206).
 	FRRStatic []string
 
 	// PrefixList is the sorted set of CIDR strings the ANNOUNCED-NETWORKS
@@ -239,7 +242,19 @@ func computeExpectation(snap ovnSnapshot, gw string, doc map[string]any, mgmtIP 
 	// the VIPs.
 	natIPs, lrpIPs, ipTag := ovnDesired(local, effective)
 	hairpin := sortedUnique(append(append([]string{}, natIPs...), lrpIPs...))
-	desired := sortedUnique(append(append([]string{}, hairpin...), vips...))
+
+	// Rule 4b (#206) — a port-forward VIP joins the route plane only where the
+	// agent also maintains the prefix-list that would permit it: always in
+	// pf-only mode, in full mode only on an active gateway. On a full-mode
+	// standby the VIPs are dormant (agent.go vipRoutesAnnounceable): no kernel
+	// route, no FRR static route, so nothing can sit in FRR unadvertised and
+	// hold the inactive-routes gauge non-zero. The DNAT plane below is
+	// unaffected — dormancy withholds the routes, not the nftables rules.
+	routableVIPs := vips
+	if !pfOnly && !active {
+		routableVIPs = nil
+	}
+	desired := sortedUnique(append(append([]string{}, hairpin...), routableVIPs...))
 
 	exp := gatewayExpectation{
 		Mode:           mode,

--- a/test/e2e/chaos/expect_test.go
+++ b/test/e2e/chaos/expect_test.go
@@ -211,6 +211,56 @@ func TestExpectationPortForwardOnlySkipsEveryOVNPlane(t *testing.T) {
 	})
 }
 
+// A port-forward VIP on a full-mode standby gateway is dormant (#206): it gets
+// no kernel route and no FRR static route, because the standby path empties the
+// prefix-list that would advertise it. The route planes must therefore expect
+// nothing — the whole point is that no unadvertisable static route sits in FRR
+// holding inactive_routes non-zero, which the oracle's settle gate refuses to
+// pass. The DNAT plane is unaffected: dormancy withholds the routes, not the
+// nftables rules.
+func TestExpectationDormantVIPOnStandbyGateway(t *testing.T) {
+	// gateway-1 owns the only CR port, so gateway-2 is a standby — while both
+	// carry the API VIP in their configuration.
+	snap := ovnSnapshot{
+		CRPortChassis: map[string]string{"cr-lr0-public": "gateway-1"},
+		LRPs:          map[string]lrpRow{"lr0-public": {Networks: []string{"192.0.2.1/24"}}},
+		LRPNameByUUID: map[string]string{"uuid-lr0-public": "lr0-public"},
+		Routers: map[string]routerRow{"lr0": {
+			LRPUUIDs: []string{"uuid-lr0-public"},
+			NATs:     []natRow{{ExternalIP: "192.0.2.10", Type: "dnat_and_snat"}},
+		}},
+		Chassis:         map[string]bool{"gateway-1": true, "gateway-2": true},
+		SegmentTagByLRP: map[string]int{"lr0-public": 0},
+	}
+	// flat-dnat is the full-mode profile that puts the API VIP on every
+	// gateway, so gateway-2 carries a VIP it cannot announce.
+	doc := render(t, profileGateway(t, "flat-dnat", "gateway-2"), "172.20.20.5")
+
+	exp := computeExpectation(snap, "gateway-2", doc, "172.20.20.5")
+
+	if exp.Mode != "full" || exp.Active {
+		t.Fatalf("mode=%q active=%v, want a full-mode standby gateway", exp.Mode, exp.Active)
+	}
+	if len(exp.DesiredIPs) != 0 {
+		t.Fatalf("DesiredIPs = %v, want none — the VIP is dormant on a standby", exp.DesiredIPs)
+	}
+	if len(exp.FRRStatic) != 0 {
+		t.Fatalf("FRRStatic = %v, want no FRR route for a dormant VIP", exp.FRRStatic)
+	}
+	if len(exp.KernelRouteDev) != 0 {
+		t.Fatalf("KernelRouteDev = %v, want no kernel route for a dormant VIP", exp.KernelRouteDev)
+	}
+	if len(exp.MustAnnounce) != 0 {
+		t.Fatalf("MustAnnounce = %v, want nothing announced from a standby", exp.MustAnnounce)
+	}
+	// The DNAT plane still follows the config alone, so a gateway that later
+	// wins the CR port only needs the announce.
+	assertDNAT(t, exp.DNAT, []dnatExpectation{
+		{VIP: apiVIPAddr, Proto: "tcp", Port: apiVIPPort, Backend: "172.20.20.5", DestPort: apiVIPPort},
+	})
+	assertSet(t, "ManagedVIPs", exp.ManagedVIPs, []string{apiVIPAddr})
+}
+
 // With no port_forwards the agent's nftables table carries no DNAT chains and
 // manages no VIP address; with the API VIP it carries exactly the one DNAT rule
 // to the gateway's mgmtIP, and the hairpin-masquerade set follows the flag.

--- a/test/integration/scenario_port_forward_test.go
+++ b/test/integration/scenario_port_forward_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -535,6 +536,57 @@ func TestScenario_PortForwardRouterMasquerade(t *testing.T) {
 				r.HasMasquerade()
 		},
 		30*time.Second, "router masquerade rule for VIP "+vip+" with SNAT IP "+snatIP)
+}
+
+// TestScenario_PortForwardVIPDormantWithoutLocalRouters (#206).
+//
+// A gateway whose config carries a port-forward VIP but which hosts no local
+// routers cannot advertise that VIP: reconcile takes the standby path, which
+// empties the FRR prefix-list and the veth-leak network routes. Installing the
+// VIP's routes anyway left an FRR static route zebra never selects — the agent
+// logged "FRR static routes are configured but inactive" at ERROR on every
+// reconcile and held ovn_network_agent_inactive_routes at 1 indefinitely, which
+// the shipped alert rule fires on.
+//
+// The VIP is dormant instead: no kernel route, no FRR route, one info-level
+// report, and nothing for the inactive-route check to alarm on. The DNAT plane
+// is deliberately still asserted — dormancy withholds the routes, not the
+// nftables rules, so a gateway that later gains routers only needs the announce.
+func TestScenario_PortForwardVIPDormantWithoutLocalRouters(t *testing.T) {
+	// No MakeLocalRouter call: the agent connects to OVN (gateway mode, not
+	// port-forward-only — Defaults() sets both remotes) and finds no locally
+	// active router, which is exactly the reported condition.
+	cfg := startPFScenario(t)
+
+	const vip = "198.51.100.42"
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+		VIP: vip,
+		Rules: []testenv.PortForwardRuleFixture{{
+			Proto: "tcp", Port: 80, DestAddr: "10.0.0.100",
+		}},
+	}}
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// The DNAT rule still lands — proof the agent reconciled the VIP and did
+	// not simply ignore the config block.
+	testenv.AssertNftRuleInChain(t, pfTable, "prerouting_dnat",
+		func(r testenv.NftRule) bool { return r.HasMatch("ip", "daddr", vip) },
+		30*time.Second, "DNAT rule for dormant VIP "+vip)
+
+	// Neither route may appear. Both assertions poll for their whole timeout,
+	// so this covers several reconcile cycles at the 5s default interval.
+	testenv.AssertNoFRRRoute(t, vip, 15*time.Second)
+	testenv.AssertNoKernelRoute(t, vip, 5*time.Second)
+
+	logs := a.LogTail(100000)
+	if strings.Contains(logs, "FRR static routes are configured but inactive") {
+		t.Errorf("dormant VIP must not raise the inactive-route alarm; last logs:\n%s", a.LogTail(40))
+	}
+	if !strings.Contains(logs, "port-forward VIPs are dormant on this node") {
+		t.Errorf("expected the dormancy to be reported once at info level; last logs:\n%s", a.LogTail(40))
+	}
 }
 
 // TestScenario_PortForwardL3mdevSysctls (#43 scenario 6).


### PR DESCRIPTION
## What & why

Closes #206.

A gateway whose configuration carries a port-forward VIP but which hosts no locally active router installed the VIP's kernel route and FRR static route anyway. That route can never be advertised — the same standby branch reconcile takes in this state empties the `ANNOUNCED-NETWORKS` prefix-list (the BGP outbound filter) and the per-network veth-leak routes. The static route sat in FRR unselected, so the VIP was dark, `ovn_network_agent_inactive_routes` stuck non-zero, and the agent logged `FRR static routes are configured but inactive` at ERROR on every reconcile, indefinitely. The shipped `OVNNetworkAgentInactiveRoutes` alert fires on exactly that.

The defect was the middle ground: install, fail, alarm forever. The issue carried the choice of behaviour as an open decision; this takes the second option — **decline to install**. A VIP the node cannot advertise is now dormant: no kernel route, no FRR static route, nothing for the inactive-route check to find, and the condition reported once per change at INFO (with a matching line when it ends) instead of an ERROR every cycle.

### Design notes

- **The gate is router presence, not prefix coverage.** A manual `network_cidr` covering the VIP does not help on a standby, because the standby branch clears the prefix-list regardless. So `PortForwardOnly || HasLocalRouters` is what actually decides whether an announce is possible. Port-forward-only mode never takes that branch and serves its VIPs without any OVN state at all, so its VIPs are never dormant.
- **The DNAT plane is deliberately untouched.** The nftables rules, the managed VIP address, the conntrack zones and the policy routing still reconcile every cycle, so a gateway that later wins the CR port needs only the announce — the data path is already in place.
- **The chaos oracle's expected-state model had to learn the same gate.** Its `FRRStatic`, `KernelRouteDev` and `MustAnnounce` sets previously expected VIP routes on a full-mode standby and would have failed against the fixed agent. The settle gate that detected this is unchanged, as the issue asked.

### Caveat worth a reviewer's eye

The next-hop mechanism the issue describes could not be confirmed. `veth-leak-enabled` defaults to `true` and `SetupVethLeak` runs at startup, so `veth-provider`'s connected `169.254.0.0/30` should already resolve `veth_nexthop` inside the VRF whether or not the per-network leak routes are present. Why zebra leaves the static unselected is still open — declining to install the route sidesteps the question rather than answering it. If the "make it activatable" path is ever revisited, that has to be pinned down on real FRR first.

Also worth recording: the chaos metric read exactly `1` because `everything-on` carries no `port_forwards` at all — only `flat-dnat` puts the API VIP on every gateway — so the flipped VIP was the profile's only one.

### Testing

`make test` passes. New coverage:

- `TestComputeDesiredStateDormantVIPs` / `...KeepFIPs` — dormant VIPs leave the route plane; FIPs on the same node do not.
- `TestVIPRoutesAnnounceable`, `TestReportDormantVIPsLogsOnChange` — the gate and the log-once behaviour.
- `TestExpectationDormantVIPOnStandbyGateway` — the chaos oracle expects no VIP routes on a full-mode standby, while the DNAT plane is still asserted.
- `TestScenario_PortForwardVIPDormantWithoutLocalRouters` — end-to-end against real FRR: no routes, no ERROR line, the INFO report present, DNAT rule still installed. **This one has not run locally** (integration tag, needs Linux + OVN/FRR/nftables), so CI is the first place it is proven.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] `make test` passes.
- [x] `make docs-gen` was run if `config.go`, `metrics.go`, or the config surface changed. *(n/a — no config or metric surface change)*
- [x] Documentation is updated for any user-visible change. *(new "Dormant VIPs" section in `docs/explanation/port-forwarding.md`, cross-referenced from the `OVNNetworkAgentInactiveRoutes` runbook)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHK67cARMAFX3XA82pDygq