### PR TITLE
test/e2e: retry the next-hop MAC binding write against a racing agent

### DIFF
--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -145,10 +145,24 @@ chassis registration for every gateway, and the upstream `bgpd`. The
 `bgpd` start — the one daemon bootstrap starts itself — is retried up
 to `BGPD_START_ATTEMPTS` (default `3`) times, each attempt waiting
 `BGPD_WAIT_SECS` (default `30` s) for the daemon to register, so a
-one-off startup hiccup heals itself instead of failing the job. When
-any gate times out, the awaited daemon's own output and surrounding
-state are dumped into the job log (and, for a CI run, the collected
-artifacts — see [Triaging a failed run](#triaging-a-failed-run)) so
+one-off startup hiccup heals itself instead of failing the job.
+
+The upstream next-hop `Static_MAC_Binding` is written the same way, for
+a different reason: the gateway agents maintain that same row and have
+been running since their containers started, so one can insert it
+between bootstrap's own existence check and its insert. `--may-exist`
+is not an atomic upsert — `ovn-nbctl` picks insert-vs-update from its
+IDL snapshot — and the losing insert is rejected as a uniqueness
+violation on `(logical_port, ip)`, which `ovn-nbctl` treats as fatal.
+The write is retried up to `MAC_BINDING_ADD_ATTEMPTS` (default `5`)
+times; the next attempt's snapshot contains the agent's row, so it
+updates that row instead of inserting a second one. Which MAC survives
+the last write is irrelevant — the owning agent re-asserts its own on
+its next reconcile pass.
+
+When any gate times out, the awaited daemon's own output and
+surrounding state are dumped into the job log (and, for a CI run, the
+collected artifacts — see [Triaging a failed run](#triaging-a-failed-run)) so
 the failure can be root-caused after the fact. The mid-run lab recycle
 in `drain-hitless` re-runs the same gates, so it inherits the same
 diagnostics and retries.

--- a/test/e2e/bootstrap.sh
+++ b/test/e2e/bootstrap.sh
@@ -70,8 +70,10 @@
 # start honours:
 #   BGPD_WAIT_SECS=30      # readiness wait per start attempt, seconds
 #   BGPD_START_ATTEMPTS=3  # bounded retries before bring-up is failed
-# and the gateway-entrypoint gate honours:
+# the gateway-entrypoint gate honours:
 #   GWNODE_READY_SECS=120  # wait for the agent process per bring-up
+# and the next-hop MAC binding write honours:
+#   MAC_BINDING_ADD_ATTEMPTS=5  # retries against a racing agent write
 
 set -euo pipefail
 
@@ -134,6 +136,13 @@ BGPD_START_ATTEMPTS="${BGPD_START_ATTEMPTS:-3}"
 # gives up and says why, so the gate must not time out earlier and
 # steal that diagnostic.
 GWNODE_READY_SECS="${GWNODE_READY_SECS:-120}"
+
+# Budget for the upstream next-hop Static_MAC_Binding write, which has a
+# second writer racing it — see ensure_upstream_nexthop_mac_binding. One
+# retry is enough to converge in practice (the losing attempt's own
+# error proves the winning row is already committed); the rest of the
+# budget is headroom.
+MAC_BINDING_ADD_ATTEMPTS="${MAC_BINDING_ADD_ATTEMPTS:-5}"
 
 CLIENT_NAME="${CLIENT_NAME:-client-1}"
 CLIENT_NODE="clab-${LAB_NAME}-${CLIENT_NAME}"
@@ -596,9 +605,42 @@ ensure_upstream_nexthop_mac_binding() {
     # lookup so the egress packet leaves OVN and the agent's catch-all
     # flow on br-ex then redirects it into the kernel + vrf-provider
     # path.
+    #
+    # This row has a second writer. Every gateway agent maintains the
+    # same binding — once it binds the localnet segment it rewrites the
+    # MAC to that segment's own interface, inserting the row when it is
+    # absent — and the agents have been running since their containers
+    # started, so one of them can reach the row first. `--may-exist` is
+    # not an atomic upsert: ovn-nbctl decides insert-vs-update from the
+    # snapshot its IDL holds, and nothing in the resulting transaction
+    # asserts that the row is *still* absent at commit time. An agent
+    # insert landing in that window makes OVSDB reject our insert for
+    # duplicating (logical_port, ip) — a constraint violation, which
+    # ovn-nbctl treats as fatal rather than retryable, so the whole
+    # bring-up dies before any scenario runs (issue #207).
+    #
+    # Retrying converges the two writers on one row: the failure itself
+    # proves the agent's row is committed, so the next attempt's fresh
+    # snapshot sees it and takes the update path. Whichever MAC wins the
+    # last write does not matter — the agent re-asserts its own on the
+    # next reconcile pass, exactly as it does in a race-free bring-up.
     log "ensuring static MAC binding ${UPSTREAM_NEXTHOP_IP} → ${UPSTREAM_NEXTHOP_MAC} on ${LR_PUBLIC_PORT}"
-    nbctl --may-exist static-mac-binding-add "${LR_PUBLIC_PORT}" \
-        "${UPSTREAM_NEXTHOP_IP}" "${UPSTREAM_NEXTHOP_MAC}"
+    local attempt output
+    for attempt in $(seq 1 "${MAC_BINDING_ADD_ATTEMPTS}"); do
+        if output="$(nbctl --may-exist static-mac-binding-add "${LR_PUBLIC_PORT}" \
+                "${UPSTREAM_NEXTHOP_IP}" "${UPSTREAM_NEXTHOP_MAC}" 2>&1)"; then
+            return 0
+        fi
+        log "static MAC binding write attempt" \
+            "${attempt}/${MAC_BINDING_ADD_ATTEMPTS} failed: ${output}"
+        if [ "${attempt}" -ne "${MAC_BINDING_ADD_ATTEMPTS}" ]; then
+            sleep 1
+        fi
+    done
+    echo "static MAC binding ${UPSTREAM_NEXTHOP_IP} on ${LR_PUBLIC_PORT} could not" \
+        "be written after ${MAC_BINDING_ADD_ATTEMPTS} attempts" >&2
+    nbctl static-mac-binding-list >&2 || true
+    exit 1
 }
 
 configure_client() {


### PR DESCRIPTION
Closes #207.

## The race

Bring-up seeds the upstream next-hop `Static_MAC_Binding` with an idempotent `--may-exist` add. That is **not** an atomic upsert: per `nbctl_static_mac_binding_add` in OVN's `utilities/ovn-nbctl.c`, ovn-nbctl picks insert-vs-update from the snapshot its IDL holds, and the resulting transaction never asserts that the row is still absent at commit time.

The gateway agents maintain the same row — `ensureStaticMACBinding` rewrites the MAC to the segment's own interface once a gateway binds the localnet segment, inserting the row when it is absent — and they have been running since their containers started. An agent insert landing between bring-up's existence check and its own insert makes OVSDB reject the transaction for duplicating the table's `(logical_port, ip)` index:

```
ovn-nbctl: transaction error: {"details":"Transaction causes multiple rows in
"Static_MAC_Binding" table to have identical values (lr0-public and
"192.0.2.254") … ","error":"constraint violation"}
```

ovn-nbctl treats a constraint violation as `TXN_ERROR` — fatal, not retryable — so the whole bring-up dies before any scenario produces a signal. The 2026-07-20 nightly chaos run lost its heterogeneous job that way (run 29721714851).

## The fix

Retry the write within a bounded budget (`MAC_BINDING_ADD_ATTEMPTS`, default `5`), in the style of the existing `configure_upstream_frr` bgpd-start budget: each failed attempt logs the real nbctl error, and after the last one `static-mac-binding-list` is dumped before the bring-up aborts.

One retry is enough in practice — the failure itself proves the agent's row is committed, so the next attempt's fresh snapshot finds it and takes the update path. The two writers converge on one row instead of colliding. Which MAC survives the last write does not matter: the owning agent re-asserts its own on the next reconcile pass, exactly as it does in a race-free bring-up.

## Scope

`Static_MAC_Binding` is the only place the two writers can collide this way. The agent creates just two kinds of NB rows (`ovn_gateway.go:395` static route, `:510` MAC binding), and of those only this table carries a uniqueness index — the route table has none, so it cannot produce a constraint violation.

The agent side is deliberately left alone: `ensureStaticMACBinding` has the same check-then-insert shape, but a lost race there is logged, joined into `EnsureGatewayRouting`'s error, and healed on the next reconcile pass. The agent does not die of it; bring-up did.

## Verification

- `shellcheck` and `bash -n` clean on `bootstrap.sh`.
- Retry loop exercised against the original error message with a stubbed `nbctl`: success on the first attempt, convergence after 1 and 2 lost races, and exit 1 with the state dump when the budget is exhausted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeEceixCMd5Y7rFDwCGELo