### PR TITLE
fix: pin the lab's management addresses so a restart cannot swap encap IPs

### DIFF
--- a/test/e2e/chaos/topology_test.go
+++ b/test/e2e/chaos/topology_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"net/netip"
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestTopologyPinsManagementAddresses guards the `mgmt-ipv4` pins in
+// topology.clab.yml.
+//
+// A gateway's management address is its geneve encap IP (ENCAP_IP in
+// gwnode-entrypoint.sh reads it off eth0), and SB's Encap table carries a
+// unique index on (type, ip). Left to Docker's IPAM, an address is
+// released when a container stops and handed back out in start order — so
+// a fault that stops two gateways at once can restart them holding each
+// other's address. Each ovn-controller then tries to claim the address
+// the other chassis' stale Encap row still holds, both transactions abort
+// on the index, and neither can go first. That deadlock is permanent: it
+// is what left every probe red for the whole recovery budget in the
+// 2026-07-18 nightly `double-failover` (issue #208).
+//
+// Pinning every node closes it, but only for as long as every node stays
+// pinned — one unpinned gateway added later re-opens exactly the same
+// hole, and the next occurrence would again look like an agent failover
+// regression rather than a lab defect. Hence this test.
+func TestTopologyPinsManagementAddresses(t *testing.T) {
+	raw, err := os.ReadFile("../topology.clab.yml")
+	if err != nil {
+		t.Fatalf("read the lab topology: %v", err)
+	}
+
+	var doc struct {
+		Mgmt struct {
+			IPv4Subnet string `yaml:"ipv4-subnet"`
+		} `yaml:"mgmt"`
+		Topology struct {
+			Nodes map[string]struct {
+				MgmtIPv4 string `yaml:"mgmt-ipv4"`
+			} `yaml:"nodes"`
+		} `yaml:"topology"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse the lab topology: %v", err)
+	}
+
+	subnet, err := netip.ParsePrefix(doc.Mgmt.IPv4Subnet)
+	if err != nil {
+		t.Fatalf("parse the management subnet %q: %v", doc.Mgmt.IPv4Subnet, err)
+	}
+	if len(doc.Topology.Nodes) == 0 {
+		t.Fatal("the topology declares no nodes — the parse shape has drifted")
+	}
+
+	// The first address of the subnet is the Docker bridge's own gateway,
+	// so a node claiming it would fail to deploy rather than deadlock.
+	bridge := subnet.Masked().Addr().Next()
+
+	owner := make(map[netip.Addr]string, len(doc.Topology.Nodes))
+	for name, node := range doc.Topology.Nodes {
+		if node.MgmtIPv4 == "" {
+			t.Errorf("node %s does not pin mgmt-ipv4: Docker's IPAM may hand it a different address after a restart, "+
+				"which for a gateway swaps its geneve encap IP and deadlocks SB's unique (type, ip) Encap index", name)
+			continue
+		}
+		addr, err := netip.ParseAddr(node.MgmtIPv4)
+		if err != nil {
+			t.Errorf("node %s pins an unparseable mgmt-ipv4 %q: %v", name, node.MgmtIPv4, err)
+			continue
+		}
+		if !subnet.Contains(addr) {
+			t.Errorf("node %s pins mgmt-ipv4 %s, outside the declared subnet %s", name, addr, subnet)
+			continue
+		}
+		if addr == bridge {
+			t.Errorf("node %s pins mgmt-ipv4 %s, which is the management bridge's own address", name, addr)
+			continue
+		}
+		if other, dup := owner[addr]; dup {
+			t.Errorf("nodes %s and %s both pin mgmt-ipv4 %s — a duplicate encap IP is the very collision the pins exist to prevent",
+				other, name, addr)
+			continue
+		}
+		owner[addr] = name
+	}
+}

--- a/test/e2e/gwnode-entrypoint.sh
+++ b/test/e2e/gwnode-entrypoint.sh
@@ -177,7 +177,13 @@ resolve_sb_remote() {
 }
 
 configure_ovs() {
-    log "configuring Open_vSwitch external_ids for ovn-controller"
+    # The encap IP is logged because it is the one value here that is not
+    # fixed by the topology file: it is read off eth0 at every boot. When
+    # the 2026-07-18 chaos run deadlocked two chassis on SB's unique
+    # (type, ip) Encap index (issue #208), nothing in the container log
+    # said which address each gateway had claimed, and the swap had to be
+    # reconstructed from the collected OVS dumps.
+    log "configuring Open_vSwitch external_ids for ovn-controller (chassis=${CHASSIS_NAME} encap-ip=${ENCAP_IP})"
     ovs-vsctl set Open_vSwitch . \
         external_ids:ovn-remote="${OVN_SB_REMOTE}" \
         external_ids:ovn-encap-type=geneve \

--- a/test/e2e/topology.clab.yml
+++ b/test/e2e/topology.clab.yml
@@ -21,6 +21,27 @@ name: ovn-e2e
 mgmt:
   network: ovn-e2e-mgmt
   ipv4-subnet: 172.30.0.0/24
+  # Every node below pins its `mgmt-ipv4`. Leaving them to Docker's IPAM
+  # is what broke the 2026-07-18 nightly chaos run (issue #208): the
+  # `double-failover` fault stops two gateways at once, and on restart
+  # IPAM handed the two freed addresses back in start order — so
+  # gateway-1 and gateway-2 came back with each other's address.
+  #
+  # A gateway's management address is its geneve encap IP (see ENCAP_IP
+  # in gwnode-entrypoint.sh), and SB's Encap table carries a unique index
+  # on (type, ip). After the swap each ovn-controller tried to claim the
+  # address the other chassis' stale row still held, both transactions
+  # aborted on that index, and neither could go first: a permanent,
+  # symmetric deadlock. The two controllers logged ~93k "OVNSB commit
+  # failed, force recompute next time" lines in four minutes, geneve
+  # tunnels stayed pointed at the wrong nodes (gateway-1 built one to
+  # itself), and all five probes stayed red until the run gave up. The
+  # agent was blameless throughout — it held all three cr-* ports and
+  # advertised its eight FIP routes the whole time.
+  #
+  # Pinning the addresses makes a restart return the same encap IP, so
+  # the index can never be contended. TestTopologyPinsManagementAddresses
+  # guards the pins against a node being added without one.
 
 topology:
   defaults:
@@ -50,6 +71,7 @@ topology:
     central:
       kind: linux
       image: ovn-network-agent/central:e2e
+      mgmt-ipv4: 172.30.0.2
       ports:
         - 6641:6641/tcp
         - 6642:6642/tcp
@@ -57,6 +79,9 @@ topology:
     gateway-1:
       kind: linux
       image: ovn-network-agent/gwnode:e2e
+      # Pinned: this address becomes the chassis' geneve encap IP. See the
+      # mgmt block above for what an unpinned one costs.
+      mgmt-ipv4: 172.30.0.11
       env:
         CHASSIS_NAME: gateway-1
       # Create the gateways only after `central` is up: the gwnode
@@ -74,6 +99,8 @@ topology:
     gateway-2:
       kind: linux
       image: ovn-network-agent/gwnode:e2e
+      # See gateway-1.
+      mgmt-ipv4: 172.30.0.12
       env:
         CHASSIS_NAME: gateway-2
       # See gateway-1.
@@ -86,6 +113,8 @@ topology:
     gateway-3:
       kind: linux
       image: ovn-network-agent/gwnode:e2e
+      # See gateway-1.
+      mgmt-ipv4: 172.30.0.13
       env:
         CHASSIS_NAME: gateway-3
       # See gateway-1.
@@ -105,18 +134,21 @@ topology:
       # upgrading to a maintained FRR is a separate, behavior-changing
       # step.
       image: frrouting/frr:latest@sha256:990e83490108b686fd6df3b1cafa6bdbb2714acb00eedb9a89693946f46f45ce
+      mgmt-ipv4: 172.30.0.3
 
     client-1:
       kind: linux
       # v0.16 is the exact image `latest` resolved to when the pin
       # landed — same content, now immutable and Renovate-updatable.
       image: nicolaka/netshoot:v0.16@sha256:b09d9b21381f47a79b3cbcb30da25266dc17186ea00ae65e99fdc51396f48e70
+      mgmt-ipv4: 172.30.0.4
       # Stay alive without a service — netshoot exits otherwise.
       cmd: "sleep infinity"
 
     client-2:
       kind: linux
       image: nicolaka/netshoot:v0.16@sha256:b09d9b21381f47a79b3cbcb30da25266dc17186ea00ae65e99fdc51396f48e70
+      mgmt-ipv4: 172.30.0.5
       cmd: "sleep infinity"
 
   links:


### PR DESCRIPTION
Replays and closes the investigation in #208. The 2026-07-18 nightly's four-minute non-convergence was **a lab weakness, not an agent failover defect and not runner slowness**.

## What actually happened

`double-failover` SIGTERMs one gateway's agent and SIGKILLs the ring-next peer, then restarts both containers. `mgmt` declared only an `ipv4-subnet`, so Docker's IPAM owned the addresses — it released both when the containers stopped and handed the two freed ones back in start order. **gateway-1 and gateway-2 came back holding each other's address.**

The collected state shows the inversion directly:

| | `containerlab inspect` (actual) | SB `Encap` (registered) |
|---|---|---|
| gateway-1 | 172.30.0.6 | 172.30.0.7 |
| gateway-2 | 172.30.0.7 | 172.30.0.6 |

A gateway's management address is its geneve encap IP (`ENCAP_IP` reads it off `eth0` at every boot), and SB's `Encap` table carries a unique index on `(type, ip)` — confirmed in `schemas/ovn-sb.ovsschema`. After the swap each `ovn-controller` tried to claim the address the other chassis' stale row still held. Both transactions aborted on that index, and neither could go first: a symmetric deadlock with no timeout behind it.

Consequences in the artifact bundle:

- **29,908** and **62,913** `OVNSB commit failed, force recompute next time` lines on gateway-1/gateway-2 in the four minutes after the restore.
- Geneve tunnels left pointing at the wrong nodes — gateway-1 built one **to itself** (`remote_ip == local_ip == 172.30.0.6`).
- All five probes red from 05:40:57 until the run gave up at 05:45:26 and parked gateway-1.

## The agent was blameless

Throughout the outage gateway-1 held all three `cr-*` ports, logged `has_local_routers=true local_routers=3 desired_ips=8` every 5s, kept its BGP session up and advertised all eight FIP prefixes to upstream (`PfxRcd 8`). The failure is entirely below it.

**No budget recalibration would have helped** — the deadlock is permanent, so widening the recovery window would only trade a false positive for a false negative. Note also that a replay would not reliably reproduce this: the address assignment is not seeded, it is IPAM ordering.

## The fix

Pin every node's `mgmt-ipv4` so a restart returns the same encap IP and the index can never be contended. `TestTopologyPinsManagementAddresses` guards the pins — one gateway added later without one re-opens exactly this hole, and the next occurrence would again read as an agent regression.

The entrypoint now also logs the encap IP it claims: it is the one value not fixed by the topology file, and its absence from the container log is why the swap had to be reconstructed from OVS dumps.

## Not in scope here

The sibling `vlan-no-dnat` failure of the same night turns out to have **a different root cause** than #208 assumed — zebra is missing the connected route for `veth-provider` on gateway-1 only, leaving all eight static FIP routes unresolvable. Filed separately.

Closes #208

Assisted-by: Claude:claude-opus-4-8