### PR TITLE
fix: make the chaos restore survive the container reincarnating under it

### DIFF
--- a/test/e2e/chaos/actions_test.go
+++ b/test/e2e/chaos/actions_test.go
@@ -101,8 +101,16 @@ func TestGatewayKillRestoreRewiresTheUnderlay(t *testing.T) {
 // re-created when it is still there — `veth create` would fail on an
 // existing interface.
 func TestRewireSkipsTheVethWhenTheInterfaceSurvived(t *testing.T) {
-	// Unlike healthyLabResponses, this lab still has its eth1.
-	cmd := &fakeCommander{}
+	// Unlike healthyLabResponses, this lab still has its eth1, so the
+	// `ip link show eth1` probe succeeds and the veth is not re-created. Its
+	// address and BGP config are answered by healthyLabResponses, which the
+	// rewire's own verification reads back.
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "ip link show eth1") {
+			return "", nil
+		}
+		return healthyLabResponses(argv)
+	}}
 	l := newTestLab(cmd, newFakeClock())
 
 	if err := l.rewireUnderlay(context.Background(), "gateway-1"); err != nil {

--- a/test/e2e/chaos/engine.go
+++ b/test/e2e/chaos/engine.go
@@ -69,12 +69,16 @@ const convergePollInterval = 5 * time.Second
 // action's recovery budget: the budget is the SLO the *lab* is held to
 // once the node is back, while the restore is the runner reassembling
 // what a container lifecycle event destroyed. The longest restore path
-// (a gateway-kill on the workload host) chains four wait loops that sum
-// to 190s on their own — bounding it by the 180s budget would cut a slow
-// but healthy bring-up off half-way and report the runner's own
-// arithmetic as an action the lab could not recover from. Every command
-// underneath is bounded by cmdTimeout, so this is a backstop against a
-// wedged restore, not the thing that paces it.
+// (a gateway-kill on the workload host) now front-loads a gatewayBack wait
+// (#217) that absorbs a #216 double boot (~87s, bounded by gatewayBackTimeout)
+// before the daemon-ready waits inside rewireUnderlay — which then return at
+// once, since gatewayBack already proved the daemons up — plus the netns
+// reprovision; a rewire re-run against a reincarnation adds one more
+// gatewayBack wait. Every branch stays comfortably inside 5m, and bounding it
+// by the 180s recovery budget would instead cut a slow but healthy bring-up
+// off half-way and report the runner's own arithmetic as an action the lab
+// could not recover from. Every command underneath is bounded by cmdTimeout,
+// so this is a backstop against a wedged restore, not the thing that paces it.
 const restoreTimeout = 5 * time.Minute
 
 // action is one fault the engine can inject. inject and restore are the

--- a/test/e2e/chaos/fakes_test.go
+++ b/test/e2e/chaos/fakes_test.go
@@ -92,9 +92,14 @@ func (f *fakeCommander) count(substr string) int {
 
 // healthyLabResponses answers every query the runner makes about a lab
 // that is behaving: daemons up, chassis registered, cr-lr0-public bound.
-// The one thing it models as gone is eth1 — a container lifecycle event
-// destroys the containerlab veth, which is the whole reason the restore
-// path exists.
+// The one thing it models as gone is eth1 (the `ip link show eth1` probe) —
+// a container lifecycle event destroys the containerlab veth, which is the
+// whole reason the restore path exists. The restore's own verification reads
+// eth1 back with a *different* probe (`ip -o -4 addr show eth1`) after the
+// rewire has re-created it, so the two answers stand for two points in the
+// restore rather than contradicting each other. The container's identity
+// (.State.StartedAt) is stable, so no reincarnation is detected unless a test
+// varies it deliberately (#217).
 func healthyLabResponses(argv []string) (string, error) {
 	line := strings.Join(argv, " ")
 	switch {
@@ -102,8 +107,25 @@ func healthyLabResponses(argv []string) (string, error) {
 		return "healthy\n", nil
 	case strings.Contains(line, "{{.State.Running}}"):
 		return "false\n", nil // a killed container stays down until started
+	case strings.Contains(line, "{{.State.StartedAt}}"):
+		return "2026-07-20T12:00:00.000000000Z\n", nil
 	case strings.Contains(line, "ip link show eth1"):
 		return "Device \"eth1\" does not exist.", errBoom
+	case strings.Contains(line, "ip -o -4 addr show eth1"):
+		// The rewire re-created eth1 and gave it the underlay address; the
+		// verification reads it back on the incarnation the rewire ran against.
+		if link, ok := linkFor(gatewayOf(line)); ok {
+			return fmt.Sprintf("2: eth1    inet %s scope global eth1\n", link.gatewayCIDR), nil
+		}
+		return "", nil
+	case strings.Contains(line, "show running-config"):
+		// configureGatewayBGP has replaced the entrypoint placeholder with the
+		// real session; the verification greps this for the router-id and peer.
+		if link, ok := linkFor(gatewayOf(line)); ok {
+			return fmt.Sprintf("router bgp 65000 vrf vrf-provider\n bgp router-id %s\n"+
+				" neighbor %s remote-as 65001\n", addrOf(link.gatewayCIDR), addrOf(link.upstreamCIDR)), nil
+		}
+		return "", nil
 	case strings.Contains(line, "pgrep -f /usr/local/bin/ovn-network-agent"):
 		return "1\n", nil
 	case strings.Contains(line, "pgrep -x bgpd"):

--- a/test/e2e/chaos/lab.go
+++ b/test/e2e/chaos/lab.go
@@ -272,6 +272,27 @@ func (l *lab) containerHealth(ctx context.Context, gw string) string {
 	return strings.TrimSpace(out)
 }
 
+// containerIdentity returns a token that changes when the container is
+// replaced by a fresh incarnation. .State.StartedAt is the cheapest stable
+// identity: docker restamps it every time it (re)starts the container, so a
+// value that differs across a restore means the netns the restore's repairs
+// went into is gone — the container reincarnated under them, the way a failed
+// first FRR start does after a `docker restart` (#216). An inspect docker
+// could not answer is handed to the caller, never folded into "unchanged":
+// fabricating a stable identity from a failed read would let a reincarnation
+// pass unnoticed.
+func (l *lab) containerIdentity(ctx context.Context, gw string) (string, error) {
+	out, err := l.docker(ctx, "inspect", "-f", "{{.State.StartedAt}}", l.node(gw))
+	if err != nil {
+		return "", fmt.Errorf("read the identity of %s: %w", gw, err)
+	}
+	id := strings.TrimSpace(out)
+	if id == "" {
+		return "", fmt.Errorf("%s reports no start time — cannot tell one incarnation from the next", gw)
+	}
+	return id, nil
+}
+
 // agentAlive reports whether the agent process is running on gw. pgrep
 // exits 1 when nothing matches — the condition under test, and a negative
 // answer. Every other failure means the question could not be asked at
@@ -384,6 +405,38 @@ func (l *lab) gatewayBack(ctx context.Context, gw string) bool {
 		return false
 	}
 	return l.chassisInSB(ctx, gw)
+}
+
+// gatewayBackTimeout bounds the wait for a returning gateway to finish its
+// entrypoint before the restore repairs it. It is sized to absorb a #216
+// double boot (~87s: a failed first FRR start suicides PID 1 and docker boots
+// a second incarnation) with margin — a clean boot execs the agent in a second
+// or two — while staying well inside restoreTimeout, so even a rewire that has
+// to be re-run against a reincarnation cannot push one restore past its
+// backstop.
+const gatewayBackTimeout = 120 * time.Second
+
+// waitGatewayBack holds until gw has finished coming back after a container
+// lifecycle event — container healthy, agent exec'd, chassis re-registered
+// (gatewayBack) — or the budget expires. restoreNode waits on it before it
+// touches the netns, so the repairs land on the incarnation the entrypoint
+// finished with rather than one a failed FRR start is about to reboot out from
+// under them (#216). gatewayBack's transient "not back yet" (a docker daemon
+// under load) costs a poll, not a verdict; the loop gives up as soon as ctx is
+// done, since restoreTimeout expires long before this clock would.
+func (l *lab) waitGatewayBack(ctx context.Context, gw string) error {
+	deadline := l.now().Add(gatewayBackTimeout)
+	for l.now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("waiting for %s to come back: %w", gw, err)
+		}
+		if l.gatewayBack(ctx, gw) {
+			return nil
+		}
+		l.sleep(convergePollInterval)
+	}
+	return fmt.Errorf("%s did not come back within %s after its container was recycled",
+		gw, gatewayBackTimeout)
 }
 
 // chassisInSB reports whether gw still has (or has re-registered) its
@@ -573,7 +626,45 @@ func (l *lab) rewireUnderlay(ctx context.Context, gw string) error {
 	if err := l.waitReady(ctx, gw, "vtysh -c 'show version'"); err != nil {
 		return fmt.Errorf("wait for FRR on %s: %w", gw, err)
 	}
-	return l.configureGatewayBGP(ctx, gw, link)
+	if err := l.configureGatewayBGP(ctx, gw, link); err != nil {
+		return err
+	}
+	return l.verifyUnderlay(ctx, gw, link)
+}
+
+// verifyUnderlay asserts the rewire's own outcome before the restore declares
+// the node back: eth1 exists and carries the expected underlay address, and
+// FRR's running-config names the real upstream neighbor with the real
+// router-id rather than the entrypoint's placeholder. A rewire that cannot
+// satisfy this has landed nowhere useful — most often because the container
+// reincarnated under it (#216), taking the netns the rewire configured with
+// it — and must fail the restore truthfully instead of returning a success the
+// recovery gate then spends its whole budget contradicting. It does not wait
+// for the session to reach Established: that legitimately takes seconds and is
+// what the converge gate's end-to-end probes already prove.
+func (l *lab) verifyUnderlay(ctx context.Context, gw string, link underlayLink) error {
+	addr, err := l.sh(ctx, gw, "ip -o -4 addr show eth1")
+	if err != nil {
+		return fmt.Errorf("verify eth1 on %s: %w", gw, err)
+	}
+	if !strings.Contains(addr, link.gatewayCIDR) {
+		return fmt.Errorf("eth1 on %s does not carry %s after the rewire: %q",
+			gw, link.gatewayCIDR, strings.TrimSpace(addr))
+	}
+	cfg, err := l.sh(ctx, gw, "vtysh -c 'show running-config'")
+	if err != nil {
+		return fmt.Errorf("read the BGP config on %s: %w", gw, err)
+	}
+	routerID := addrOf(link.gatewayCIDR)
+	if !strings.Contains(cfg, "bgp router-id "+routerID) {
+		return fmt.Errorf("BGP on %s is not configured with router-id %s after the rewire "+
+			"(entrypoint placeholder still in place?)", gw, routerID)
+	}
+	neighbor := addrOf(link.upstreamCIDR)
+	if !strings.Contains(cfg, "neighbor "+neighbor) {
+		return fmt.Errorf("BGP on %s names no neighbor %s after the rewire", gw, neighbor)
+	}
+	return nil
 }
 
 // configureGatewayBGP replaces the placeholder BGP config the gwnode

--- a/test/e2e/chaos/state.go
+++ b/test/e2e/chaos/state.go
@@ -357,11 +357,74 @@ func ensureResponders(ctx context.Context, l *lab, p *profile) error {
 // container up or recycle the whole lab. A chaos run has to put the node
 // back, because the guardrails only re-target a node that has returned
 // and converged.
+//
+// The restore is reincarnation-proof (#217). A `docker restart` can make the
+// gwnode entrypoint suicide on a failed first FRR start, and `restart: always`
+// then boots a second incarnation whose fresh netns discards every repair the
+// restore applied against the first (#216). So restoreNode waits for the
+// entrypoint to finish before it touches anything, and — should a container
+// still manage to die after going healthy — notices the identity change and
+// repairs the incarnation that survived, rather than returning a success the
+// artifacts contradict.
 func restoreNode(ctx context.Context, l *lab, p *profile, gw string) error {
-	if err := l.rewireUnderlay(ctx, gw); err != nil {
+	// (1) Repair the final incarnation, not the first one. Wait until the
+	// container is healthy, its agent has exec'd and its chassis is back
+	// (gatewayBack): repairs applied after the agent execs cannot be wiped by
+	// an entrypoint-driven reboot, because the entrypoint has nothing left to
+	// fail on. This is the load-bearing fix — (2) and (3) below only keep the
+	// run truthful if some future container dies after going healthy anyway.
+	if err := l.waitGatewayBack(ctx, gw); err != nil {
+		return err
+	}
+	if err := restoreUnderlay(ctx, l, gw); err != nil {
 		return err
 	}
 	return reprovisionNode(ctx, l, p, gw)
+}
+
+// restoreUnderlay rewires the underlay and proves the result stuck on the
+// incarnation it landed on, re-running the rewire once if the container
+// reincarnated under it.
+//
+// rewireUnderlay ends by verifying its own outcome (verifyUnderlay), so a
+// rewire that returns nil has an eth1 with the right address and a real BGP
+// session — on whichever container was running when it ran. (2) reads the
+// container's identity either side of the rewire: an identity that changed
+// means the netns those repairs went into is gone, so the rewire is re-run
+// against the new incarnation after waiting for it to come back. A restore
+// that still cannot satisfy this after one re-attempt fails the action —
+// naming the reincarnation — a truthful verdict the artifacts can be read
+// against, instead of a 3-minute recovery-timeout pointing at convergence.
+func restoreUnderlay(ctx context.Context, l *lab, gw string) error {
+	const attempts = 2
+	var reincarnation error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		before, err := l.containerIdentity(ctx, gw)
+		if err != nil {
+			return fmt.Errorf("read %s identity before rewiring its underlay: %w", gw, err)
+		}
+		rewireErr := l.rewireUnderlay(ctx, gw)
+		after, err := l.containerIdentity(ctx, gw)
+		if err != nil {
+			return fmt.Errorf("read %s identity after rewiring its underlay: %w", gw, err)
+		}
+		if after == before {
+			// The container the rewire configured is still the one running: its
+			// result — success or a genuine failure — stands.
+			return rewireErr
+		}
+		// The container reincarnated while the rewire ran: everything it wrote
+		// went into a netns that died with the previous incarnation. Wait for
+		// the new one and rewire it — once.
+		reincarnation = fmt.Errorf("%s reincarnated during restore (started %s, now %s); "+
+			"the rewired underlay landed in a netns that no longer exists", gw, before, after)
+		if attempt < attempts {
+			if err := l.waitGatewayBack(ctx, gw); err != nil {
+				return fmt.Errorf("wait for %s after it reincarnated during restore: %w", gw, err)
+			}
+		}
+	}
+	return reincarnation
 }
 
 // reprovisionNode re-creates the node-local state a container restart

--- a/test/e2e/chaos/state_test.go
+++ b/test/e2e/chaos/state_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -101,6 +102,76 @@ func TestRestoreNodeRewiresBeforeReprovisioning(t *testing.T) {
 	}
 	if rewire > responder {
 		t.Fatalf("the workloads were rebuilt before the underlay was back: %v", cmd.lines())
+	}
+}
+
+// A container that reincarnates while restoreNode is repairing it — a failed
+// first FRR start makes the gwnode entrypoint suicide as PID 1 and docker
+// boots a second incarnation (#216) — wipes the netns the rewire configured.
+// The restore must notice the identity change, re-run its rewire against the
+// second incarnation, and only then declare the node back: eth1 and the BGP
+// session asserted on the container that survived, not the one that is gone.
+func TestRestoreNodeRewiresTheSecondIncarnationAfterAReincarnation(t *testing.T) {
+	incarnation := 0
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		line := strings.Join(argv, " ")
+		switch {
+		case strings.Contains(line, "{{.State.StartedAt}}"):
+			return fmt.Sprintf("2026-07-20T12:00:%02dZ\n", incarnation), nil
+		case strings.Contains(line, "containerlab tools veth create"):
+			// The first rewire lands on incarnation 0; as it wires the veth the
+			// container reincarnates once, so the identity read after it differs.
+			if incarnation == 0 {
+				incarnation = 1
+			}
+			return "", nil
+		}
+		return healthyLabResponses(argv)
+	}}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := restoreNode(context.Background(), l, defaultTestProfile(t), "gateway-1"); err != nil {
+		t.Fatalf("restore did not survive the reincarnation: %v", err)
+	}
+
+	if got := cmd.count("containerlab tools veth create"); got != 2 {
+		t.Fatalf("the rewire ran %d times, want it re-run once against the second incarnation: %v",
+			got, cmd.lines())
+	}
+}
+
+// A container that keeps dying after every rewire cannot be restored. The
+// restore fails truthfully after one re-attempt, naming the reincarnation, so
+// the run records an action-failed the artifacts can be read against instead
+// of burning the recovery budget on a node that structurally cannot converge
+// and blaming the lab with a recovery-timeout.
+func TestRestoreNodeFailsNamingTheReincarnationWhenItNeverStabilizes(t *testing.T) {
+	incarnation := 0
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		line := strings.Join(argv, " ")
+		switch {
+		case strings.Contains(line, "{{.State.StartedAt}}"):
+			return fmt.Sprintf("2026-07-20T12:00:%02dZ\n", incarnation), nil
+		case strings.Contains(line, "containerlab tools veth create"):
+			incarnation++ // the container is reborn during every rewire
+			return "", nil
+		}
+		return healthyLabResponses(argv)
+	}}
+	l := newTestLab(cmd, newFakeClock())
+
+	err := restoreNode(context.Background(), l, defaultTestProfile(t), "gateway-1")
+	if err == nil {
+		t.Fatal("a container that never stopped reincarnating was reported as restored")
+	}
+	if !strings.Contains(err.Error(), "reincarnated") {
+		t.Fatalf("error %q does not name the reincarnation", err)
+	}
+	// One re-attempt, no more: the rewire runs on the first incarnation and one
+	// more, then the restore gives up rather than chasing an unstable container.
+	if got := cmd.count("containerlab tools veth create"); got != 2 {
+		t.Fatalf("the rewire ran %d times, want exactly the attempt and one re-attempt: %v",
+			got, cmd.lines())
 	}
 }
 


### PR DESCRIPTION
## Problem

`restoreNode` repairs what a container lifecycle event destroyed — the underlay veth, its VRF wiring and BGP session, the workload responders — but assumed the container stayed up while it worked. A `docker restart` can trip the #216 double boot: a failed first FRR start suicides the entrypoint as PID 1, `restart: always` boots a second incarnation, and its fresh netns discards every repair applied against the first. `restoreNode` still returned success, so the engine burned its full 3-minute budget converging a gateway that structurally could not recover and mislabelled it `recovery-timeout` — pointing at the lab's convergence instead of the reincarnation that broke the restore.

Surfaced in dispatch run [29753967271](https://github.com/osism/ovn-network-agent/actions/runs/29753967271) (replay of seed `29721714851`, profile `everything-on`), tick 11 `gateway-restart` on gateway-1.

## Changes

Three cooperating changes in `test/e2e/chaos`, per the issue's proposal:

1. **Repair the final incarnation, not the first (load-bearing).** `restoreNode` waits for `gatewayBack` (the #205 health triple: container healthy + agent exec'd + chassis registered) before touching the netns, so repairs land after the agent execs — where an entrypoint reboot can no longer wipe them. This front-loads the daemon waits, so the `waitReady` calls inside `rewireUnderlay` return at once.
2. **Detect reincarnation.** `containerIdentity` reads `docker inspect .State.StartedAt` either side of the rewire; a changed identity means the netns the repair went into is gone, so `restoreUnderlay` re-runs the rewire against the new incarnation once before giving up.
3. **Verify before declaring restored.** `rewireUnderlay` ends with `verifyUnderlay`: `eth1` carries the expected address and FRR's running-config names the real `bgp router-id` and `neighbor`, not the entrypoint placeholder. A restore that cannot satisfy this fails as `action-failed` naming the reincarnation — a truthful verdict the artifacts can be read against — instead of a `recovery-timeout`.

The `restoreTimeout` comment is updated for the new arithmetic (the wait front-loads what previously overlapped; even a reincarnation re-attempt stays well inside 5m).

## Acceptance criteria

- [x] Unit test reincarnates the fake mid-restore → rewire re-runs, `eth1` + BGP asserted on incarnation 2 (`TestRestoreNodeRewiresTheSecondIncarnationAfterAReincarnation`).
- [x] Unverifiable restore fails as `action-failed` naming the reincarnation, not `recovery-timeout` (`TestRestoreNodeFailsNamingTheReincarnationWhenItNeverStabilizes`; the engine's `failAction` turns any restore error into `violationActionFailed`).
- [ ] Replay of seed `29721714851` survives tick 11 — CI/live check (needs a deployed lab); green given #216, or green via re-run-on-reincarnation while #216 is open.
- [x] Existing chaos unit tests still pass (full suite green, incl. `-race`).

## Testing

`go build`, `go vet`, `gofmt`, and the full `test/e2e/chaos` unit suite (with `-race`) all pass locally. `make e2e-chaos` and the seed replay run against a deployed containerlab lab and are left to CI.

Closes #217. Companion to #216.

Assisted-by: Claude:claude-opus-4-8
