### PR TITLE
fix: seed the gwnode BGP placeholder only where there is no real config

### DIFF
--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -214,8 +214,13 @@ diagnostics and retries.
 - each gateway's FRR (in `vrf-provider`): eBGP against its specific
   upstream `/30` endpoint, redistributing the FIP `/32` static
   routes that the agent installs in `vrf-provider`. The placeholder
-  neighbor pushed by `gwnode-entrypoint.sh` (`192.0.2.1`) is
-  replaced by `bootstrap.sh` once the underlay is up.
+  neighbor seeded by `gwnode-entrypoint.sh` (`192.0.2.1`) is
+  replaced by `bootstrap.sh` once the underlay is up. The entrypoint
+  only seeds that placeholder when it finds `vrf-provider` without a
+  BGP router — a restarted container reloads the real config from
+  `/etc/frr/frr.conf` (`bootstrap.sh` ends its push with `write
+  memory`), and pushing the placeholder on top of it would reset the
+  router-id to `127.0.0.1` and re-add the dead `192.0.2.1` neighbor.
 - `client-1`: `10.0.0.2/24` on `eth1`, default route via `10.0.0.1`.
 - `gateway-3` (the priority-10 chassis): a veth pair
   `vm1-host` ↔ `vm1-eth0` — the host side is bound to `br-int` with

--- a/test/e2e/bootstrap.sh
+++ b/test/e2e/bootstrap.sh
@@ -568,10 +568,15 @@ EOF
 }
 
 configure_gateway_frr() {
-    # The gwnode entrypoint pushes a placeholder BGP config with the
+    # The gwnode entrypoint seeds a placeholder BGP config with the
     # neighbour pinned to 192.0.2.1 (OVN's own LR port IP, which doesn't
     # speak BGP). That session can't establish; replace it now that the
     # underlay is up so each gateway peers with its specific upstream /30.
+    #
+    # The `write memory` below is what makes this the *last* word on the
+    # gateway's BGP config: a restarted container reloads it from
+    # /etc/frr/frr.conf, and the entrypoint only seeds the placeholder when
+    # it finds the VRF without a BGP router (issue #218).
     for entry in "${UNDERLAY_LINKS[@]}"; do
         local gw _gw_cidr _upstream_iface upstream_cidr
         read -r gw _gw_cidr _upstream_iface upstream_cidr <<<"${entry}"

--- a/test/e2e/chaos/lab.go
+++ b/test/e2e/chaos/lab.go
@@ -668,10 +668,14 @@ func (l *lab) verifyUnderlay(ctx context.Context, gw string, link underlayLink) 
 }
 
 // configureGatewayBGP replaces the placeholder BGP config the gwnode
-// entrypoint pushes on every container start with the real session
+// entrypoint seeds into a gateway that has none with the real session
 // against this gateway's upstream /30 — configure_gateway_frr in
 // bootstrap.sh. The block opens with `no router bgp ...`, so re-applying
 // it is self-cleaning.
+//
+// It no longer races the entrypoint for the last word: configure_frr
+// skips its placeholder whenever the VRF already carries a BGP router
+// (issue #218), so this config survives whichever of the two runs second.
 func (l *lab) configureGatewayBGP(ctx context.Context, gw string, link underlayLink) error {
 	upstreamIP := addrOf(link.upstreamCIDR)
 	routerID := addrOf(link.gatewayCIDR)

--- a/test/e2e/gwnode-entrypoint.sh
+++ b/test/e2e/gwnode-entrypoint.sh
@@ -255,6 +255,11 @@ setup_loopback() {
 
 FRR_READY_ATTEMPTS="${FRR_READY_ATTEMPTS:-30}"
 FRR_CONFIG_ATTEMPTS="${FRR_CONFIG_ATTEMPTS:-30}"
+# The daemons the entrypoint's config is addressed to. configure_frr reads
+# the running config before it decides what to push, and vtysh renders that
+# config from the daemons it happened to reach — so all of these must be in
+# `show daemons` before the answer means anything. See frr_config_daemons_ready.
+FRR_CONFIG_DAEMONS="${FRR_CONFIG_DAEMONS:-zebra bgpd staticd}"
 # How many times start_frr may run the whole clean + start + probe cycle
 # before it gives up and lets PID 1 die. See the retry loop for why the
 # second attempt is worth its own FRR_READY_ATTEMPTS budget.
@@ -353,17 +358,81 @@ start_frr() {
     exit 1
 }
 
+# The daemons this vtysh invocation reached, one per line. `show daemons`
+# prints them space-separated on a single line.
+frr_connected_daemons() {
+    vtysh -c 'show daemons' 2>/dev/null | tr ' ' '\n' | sed '/^$/d'
+}
+
+# Whether vtysh reached every daemon in FRR_CONFIG_DAEMONS.
+#
+# This is the gate in front of the running-config read, and the whole
+# reason the read can be trusted. `show running-config` renders the config
+# of the daemons vtysh connected to at that moment: zebra answers first,
+# bgpd registers its vty socket a moment later — and a read that lands in
+# between reports no BGP block no matter what bgpd is at that instant
+# loading out of /etc/frr/frr.conf. Deciding "nothing configured, push the
+# placeholder" on that answer is exactly the clobber frr_config exists to
+# avoid, so the caller's retry loop waits the daemons out instead.
+frr_config_daemons_ready() {
+    local connected d
+    connected="$(frr_connected_daemons)" || return 1
+    for d in ${FRR_CONFIG_DAEMONS}; do
+        grep -qxF -- "${d}" <<<"${connected}" || return 1
+    done
+    return 0
+}
+
 # The config the agent expects, on stdin for vtysh: the prefix-list it
 # writes /32 entries into, and a vrf-provider BGP router with a
 # placeholder upstream neighbour. The neighbour does not need to
 # establish a session for the lab to come up — per issue #44 the upstream
 # peer may stay idle.
+#
+# Both of those are seeds for a container that has neither — not
+# assertions. This function runs on *every* container start, including the
+# ones that come back up with the real config already loaded (issue #218):
+# `write memory` in bootstrap.sh's configure_gateway_frr persists the real
+# BGP session into /etc/frr/frr.conf, the container filesystem survives
+# `docker restart`, so FRR reloads it long before the entrypoint gets
+# here. The push is additive — it never issues `no router bgp` first — so
+# landing it on top of the real config merges the two: the router-id is
+# reset to 127.0.0.1 (dropping and re-forming every established session)
+# and the dead 192.0.2.1 placeholder neighbour is re-added beside the real
+# one. Same story when the chaos harness's rewireUnderlay
+# (test/e2e/chaos/lab.go) reaches vtysh first after a gateway restart.
+#
+# So whatever the running config already carries wins, and only the
+# genuinely missing pieces are emitted. Opening the placeholder with `no
+# router bgp ... vrf ${VRF_NAME}` instead — self-cleaning, the way the two
+# writers of the real config are — was the alternative and is worse: it
+# would destroy the real config deterministically on every restart rather
+# than merging into it.
+#
+# `$1` is the current running config, read by configure_frr once the
+# daemons that own it are all up.
 frr_config() {
-    cat <<EOF
-configure terminal
-ip prefix-list ANNOUNCED-NETWORKS seq 5 permit 0.0.0.0/0 ge 32 le 32
-vrf ${VRF_NAME}
-exit-vrf
+    local running="$1"
+    printf 'configure terminal\n'
+    # An empty vrf node renders as nothing in the running config, so there
+    # is no state to probe for here — and re-asserting it is a no-op.
+    printf 'vrf %s\nexit-vrf\n' "${VRF_NAME}"
+    if grep -q '^ip prefix-list ANNOUNCED-NETWORKS ' <<<"${running}"; then
+        # The agent owns the entries at runtime and replaces this seed with
+        # the real /32s, so re-seeding would put a permit-everything entry
+        # back underneath them until the next reconcile removes it again.
+        log "ANNOUNCED-NETWORKS already exists; leaving its entries to the agent"
+    else
+        printf 'ip prefix-list ANNOUNCED-NETWORKS seq 5 permit 0.0.0.0/0 ge 32 le 32\n'
+    fi
+    # The ASN is a wildcard on purpose: the question is whether *any* BGP
+    # router already owns this VRF, and the two writers that install the
+    # real one (configure_gateway_frr in bootstrap.sh, configureGatewayBGP
+    # in test/e2e/chaos/lab.go) take their ASN from their own variables.
+    if grep -qE "^router bgp [0-9]+ vrf ${VRF_NAME}$" <<<"${running}"; then
+        log "BGP is already configured in vrf ${VRF_NAME}; not pushing the placeholder over it"
+    else
+        cat <<EOF
 router bgp 65000 vrf ${VRF_NAME}
  bgp router-id 127.0.0.1
  no bgp default ipv4-unicast
@@ -373,28 +442,35 @@ router bgp 65000 vrf ${VRF_NAME}
   neighbor 192.0.2.1 activate
   neighbor 192.0.2.1 prefix-list ANNOUNCED-NETWORKS out
  exit-address-family
-end
 EOF
+    fi
+    printf 'end\n'
 }
 
 configure_frr() {
-    log "pushing minimal FRR config (vrf ${VRF_NAME} + ANNOUNCED-NETWORKS)"
+    log "ensuring the FRR config the agent expects (vrf ${VRF_NAME} + ANNOUNCED-NETWORKS)"
     # `show version` answering does not mean bgpd and staticd have both
-    # finished registering with zebra, so the push is retried rather than
-    # trusted on the first try. The config is idempotent, so re-running it
-    # after a partial apply is safe. vtysh's output is captured so the last
-    # failure can be reported: it went to the container's stdout before,
-    # which the caller never saw once `set -e` had already killed PID 1.
-    local attempt out
+    # finished registering with zebra, so both halves — the running-config
+    # read that decides what is missing and the push that fills it in — are
+    # retried rather than trusted on the first try. What gets pushed is
+    # idempotent, so re-running it after a partial apply is safe. The
+    # reason for the last failure is captured so it can be reported: vtysh's
+    # output went to the container's stdout before, which the caller never
+    # saw once `set -e` had already killed PID 1.
+    local attempt out="" running
     for attempt in $(seq 1 "${FRR_CONFIG_ATTEMPTS}"); do
-        if out="$(frr_config | vtysh 2>&1)"; then
+        if ! frr_config_daemons_ready; then
+            out="vtysh has not reached all of [${FRR_CONFIG_DAEMONS}] yet; connected: $(frr_connected_daemons | tr '\n' ' ')"
+        elif ! running="$(vtysh -c 'show running-config' 2>&1)"; then
+            out="${running}"
+        elif out="$(frr_config "${running}" | vtysh 2>&1)"; then
             return 0
         fi
-        log "vtysh config push failed (attempt ${attempt}/${FRR_CONFIG_ATTEMPTS}), retrying"
+        log "FRR config not applied yet (attempt ${attempt}/${FRR_CONFIG_ATTEMPTS}), retrying"
         sleep 1
     done
-    log "ERROR: vtysh never accepted the FRR config after ${FRR_CONFIG_ATTEMPTS} attempts"
-    log "last vtysh output:"
+    log "ERROR: the FRR config was not applied after ${FRR_CONFIG_ATTEMPTS} attempts"
+    log "last failure:"
     printf '%s\n' "${out}" | sed 's/^/[gwnode]   /' >&2
     dump_frr_diagnostics
     exit 1


### PR DESCRIPTION
`configure_frr` in the gwnode entrypoint pushed its placeholder BGP block on **every** container start, unconditionally and additively — it never opens with `no router bgp`. When a real configuration was already in the daemon, the two merged: the router-id dropped back to `127.0.0.1`, tearing down and re-forming every established session, and the dead placeholder neighbor `192.0.2.1` was re-added beside the real one. Since `192.0.2.1` is the flat provider gateway address, bgpd then kept opening TCP/179 into the provider network for the rest of the container's life.

The real config is present in two ordinary situations:

1. **Any plain `docker restart`.** Bootstrap's `write memory` persisted it to `/etc/frr/frr.conf`, the container filesystem survives, FRR boots with it loaded — and the entrypoint pushes the placeholder on top.
2. **The chaos restore.** `rewireUnderlay` calls `configureGatewayBGP` as soon as vtysh answers, which is the same point in the boot where `configure_frr` runs, so the two race for the last word.

Both writers of the real config (`configure_gateway_frr` in `bootstrap.sh`, `configureGatewayBGP` in `test/e2e/chaos/lab.go`) are self-cleaning in the opposite direction, and neither can defend against a placeholder that lands after them. Run [29753967271](https://github.com/osism/ovn-network-agent/actions/runs/29753967271) collected the merged config verbatim.

## What changed

`test/e2e/gwnode-entrypoint.sh`:

- **The seed is now conditional.** `configure_frr` reads the running config first, and `frr_config` emits only what is genuinely missing — the placeholder BGP block when the VRF carries no BGP router at all, the `ANNOUNCED-NETWORKS` `0.0.0.0/0` seed when the prefix-list does not exist. The ASN in the existence probe is a wildcard on purpose: the question is whether *any* BGP router already owns the VRF. The `vrf` stanza stays unconditional — it renders as nothing in the running config and re-asserting it is a no-op.
- **The read is gated on the daemons behind it.** `frr_config_daemons_ready` requires `show daemons` to name every daemon the config belongs to (`zebra bgpd staticd`). zebra answers vtysh before bgpd has registered its vty socket, and a running-config read in that window reports the BGP block absent no matter what bgpd is at that instant loading out of `frr.conf` — deciding "nothing here, push the placeholder" on that answer would reproduce the clobber through the front door. The gate lives inside the existing retry loop, so a vtysh that cannot answer yet is waited out exactly as before, and the failure path now names which daemons were missing.

Opening the placeholder with `no router bgp ... vrf ${VRF_NAME}` instead — self-cleaning, the way the two real writers are — was the alternative and is worse: it would destroy the real config *deterministically* on every restart rather than merging into it.

Comments in `bootstrap.sh` and `chaos/lab.go` and the E2E docs are pulled along.

## Verification

Run against the real `gwnode:e2e` image (FRR 8.4.4), driving `start_frr` + `configure_frr` out of the actual script:

| Case | Result |
|---|---|
| Boot with the real config persisted in `frr.conf` (a `docker restart`) | keeps `bgp router-id 100.64.1.2` and its single `100.64.1.1` neighbor — no `127.0.0.1`, no `192.0.2.1` ✅ |
| Pristine container from the image | placeholder pushed byte-for-byte as before ✅ |
| Agent-owned prefix-list already present, no BGP | prefix-list untouched, BGP block seeded ✅ |
| A config daemon vtysh cannot reach | retries exhaust and **nothing** is pushed; the diagnostic names the missing daemon ✅ |

`shellcheck` clean, `go vet ./test/e2e/chaos/` green.

**Not verified here:** a full `make e2e-up` / chaos run — that needs containerlab on a Linux host. Acceptance criteria 3 (restore no longer races the entrypoint) and 4 (no router-id flap) follow constructively from the skip but are not measured end-to-end in the lab; CI's e2e jobs are the check.

Closes #218

Assisted-by: Claude:claude-opus-4-8
