### PR TITLE
fix: announce port-forward VIPs via their connected route, not a shadowed static

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -311,10 +311,15 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 	// Everything the cycle needs to derive from OVN is a pure function of the
 	// snapshot plus the configured VIPs (see desired_state.go). Past this
 	// point reconcile only acts on the result.
-	desired := computeDesiredState(state, a.cfg.PortForwards, a.vipRoutesAnnounceable(state))
+	// One announceability decision drives both the desired-state fork and the
+	// VIP-address gate below, so computeDesiredState and ReconcilePortForward
+	// can never disagree about whether this cycle announces the VIPs.
+	announce := a.vipRoutesAnnounceable(state)
+	desired := computeDesiredState(state, a.cfg.PortForwards, announce)
 	hairpinTargets := desired.HairpinTargets
 	desiredSegments := desired.Segments
 	desiredIPs := desired.DesiredIPs
+	frrStaticIPs := desired.FRRStaticIPs
 
 	if len(desired.ExcludedNonV4) > 0 {
 		slog.Debug("excluding non-IPv4 addresses from the route/announce plane, IPv6 support tracked in #85/#70",
@@ -412,7 +417,11 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 
 	// Port forwarding reconciliation runs regardless of local router
 	// presence — DNAT VIPs are managed independently of OVN gateway state.
-	if err := a.routing.ReconcilePortForward(a.effectiveFilters, state.SNATIPs); err != nil {
+	// announce gates the VIP address: an announceable VIP has its /32 added to
+	// port_forward_dev (so its connected route is exported), a dormant one has
+	// it withheld. This is now the dormancy lever (#206), the DNAT rules are
+	// unaffected either way.
+	if err := a.routing.ReconcilePortForward(a.effectiveFilters, state.SNATIPs, announce); err != nil {
 		slog.Error("failed to reconcile port forwarding", "error", err)
 	}
 
@@ -441,13 +450,16 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 		ipDev[ip] = a.routing.SegmentDev(target.Segment)
 	}
 
-	// The BGP announce. Ensure routes for all desired IPs (FIPs, SNATs, and
-	// the port-forward VIPs this node can announce — see
-	// vipRoutesAnnounceable; dormant VIPs are not in desiredIPs and are
-	// withdrawn by the standby path below like any other undesired route).
+	// The BGP announce. Ensure routes for all desired IPs: FIPs and SNATs get
+	// an FRR static route (the frrStaticIPs subset) plus a kernel route, while
+	// the port-forward VIPs this node can announce get only the kernel /32 —
+	// they are advertised through their connected route on port_forward_dev,
+	// not an FRR static (see desired_state.go FRRStaticIPs). Dormant VIPs are
+	// not in desiredIPs and their address was withheld by ReconcilePortForward
+	// above, so nothing announces them.
 	var routeSync routeSyncResult
 	if len(desiredIPs) > 0 || state.HasLocalRouters {
-		routeSync = a.ensureRoutes(desiredIPs, ipDev, skipKernelRoute)
+		routeSync = a.ensureRoutes(desiredIPs, frrStaticIPs, ipDev, skipKernelRoute)
 		cycleOK = routeSync.ready
 	} else {
 		// The removeAllRoutes standby path leaves cycleOK true — a healthy
@@ -496,12 +508,14 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 	// disappeared during the mutation. Runs after the announce and only
 	// when routes actually changed, matching the pre-#131 trigger.
 	if routeSync.changed {
-		a.verifyRoutes(desiredIPs, ipDev, skipKernelRoute)
+		a.verifyRoutes(desiredIPs, frrStaticIPs, ipDev, skipKernelRoute)
 	}
 
-	// Surface desired routes that are configured in FRR but not actually
-	// advertised via BGP — ensureRoutes alone cannot detect this.
-	a.checkFRRRouteActivity(desiredIPs)
+	// Surface FRR-static routes that are configured but not actually advertised
+	// via BGP — ensureRoutes alone cannot detect this. Only the OVN-derived set
+	// is checked: a VIP is announced through its connected route, so it has no
+	// static for this check to alarm on.
+	a.checkFRRRouteActivity(frrStaticIPs)
 
 	// Check for stale chassis entries from dead nodes (runs on every agent).
 	// This runs after gateway routing reconciliation so that a surviving agent
@@ -603,15 +617,17 @@ func (a *Agent) computeEffectiveNetworks(discovered []*net.IPNet) []*net.IPNet {
 }
 
 // vipRoutesAnnounceable reports whether the configured port-forward VIPs should
-// get kernel and FRR routes this cycle.
+// be announced this cycle: whether their /32 address is added to
+// port_forward_dev (so its connected route is exported via BGP) and whether
+// they join the kernel-route plane.
 //
-// A VIP is only routable where the agent also maintains the FRR prefix-list that
-// permits it. Without local routers reconcile takes the standby path, which
-// empties that prefix-list and the veth-leak network routes — a VIP route
-// installed anyway could never be advertised. It would sit in FRR as a static
-// route that zebra never selects, holding ovn_network_agent_inactive_routes at a
-// non-zero value and logging at ERROR on every cycle, indefinitely (#206). Such
-// a VIP is dormant instead: nothing installed, reported once at info level.
+// A VIP is only announceable where the agent also maintains the FRR prefix-list
+// that permits it. Without local routers reconcile takes the standby path,
+// which empties that prefix-list and the veth-leak network routes — a VIP
+// announced anyway could never be advertised, and with the route-map on
+// redistribute connected the deleted prefix-list stops the connected export
+// outright. Such a VIP is dormant instead: its address is withheld from
+// port_forward_dev, so nothing is announced, reported once at info level (#206).
 //
 // Port-forward-only mode never takes the standby path and serves its VIPs
 // without any OVN state at all, so it always announces them.
@@ -621,8 +637,8 @@ func (a *Agent) vipRoutesAnnounceable(state OVNState) bool {
 
 // reportDormantVIPs logs the port-forward VIPs this node cannot announce, once
 // per change of the set rather than on every reconcile: the condition persists
-// for as long as the node holds no local routers, and the point of declining to
-// install the route is to stop the per-cycle noise. Recovery is logged too, so
+// for as long as the node holds no local routers, and the point of withholding
+// the VIP address is to stop the per-cycle noise. Recovery is logged too, so
 // the dormancy has a matching end in the journal.
 func (a *Agent) reportDormantVIPs(dormant []string) {
 	key := strings.Join(dormant, ",")
@@ -631,10 +647,10 @@ func (a *Agent) reportDormantVIPs(dormant []string) {
 	}
 	switch {
 	case len(dormant) > 0:
-		slog.Info("port-forward VIPs are dormant on this node — no locally active routers, so they cannot be advertised and no routes are installed",
+		slog.Info("port-forward VIPs are dormant on this node — no locally active routers, so they cannot be advertised and their address is withheld from the port-forward device",
 			"count", len(dormant), "vips", dormant)
 	case a.dormantVIPs != "":
-		slog.Info("port-forward VIPs are no longer dormant — installing their routes")
+		slog.Info("port-forward VIPs are no longer dormant — restoring their address on the port-forward device")
 	}
 	a.dormantVIPs = key
 }
@@ -687,6 +703,10 @@ type routeSyncResult struct {
 }
 
 // ensureRoutes adds routes for all desired IPs and removes stale ones.
+// desiredIPs is the kernel-route plane (FIPs, SNATs, gateway IPs, and the
+// announceable VIPs); frrStaticIPs is the subset that also gets an FRR static
+// route via the veth next-hop — the OVN-derived IPs only, never a VIP, whose
+// connected route on port_forward_dev is its announce path.
 // ipDev names the kernel interface each IP's route belongs on; kernel routes
 // are reconciled as (IP, device) pairs so a route that sits on the wrong
 // segment interface is replaced. IPs in skipKernelRoute keep their existing
@@ -695,18 +715,22 @@ type routeSyncResult struct {
 // It returns what changed so the caller can run the post-announce route
 // verification, record the failover-latency metric, and decide whether to
 // write the takeover readiness marker.
-func (a *Agent) ensureRoutes(desiredIPs []string, ipDev map[string]string, skipKernelRoute map[string]bool) routeSyncResult {
+func (a *Agent) ensureRoutes(desiredIPs, frrStaticIPs []string, ipDev map[string]string, skipKernelRoute map[string]bool) routeSyncResult {
 	kernelOK := true
 	desiredSet := make(map[string]bool, len(desiredIPs))
 	for _, ip := range desiredIPs {
 		desiredSet[ip] = true
 	}
+	frrStaticSet := make(map[string]bool, len(frrStaticIPs))
+	for _, ip := range frrStaticIPs {
+		frrStaticSet[ip] = true
+	}
 
 	// Kernel routes live on the provider bridge (br-ex) or a per-VLAN
 	// segment interface on it. In port-forward-only mode the node need not
-	// have br-ex, so only FRR static routes are managed — the VIP is
-	// reachable as a local address on port_forward_dev, and the FRR route
-	// handles BGP announcement.
+	// have br-ex, so no kernel routes are managed at all — frrStaticIPs is
+	// empty there too, and each VIP is announced as a local address on
+	// port_forward_dev via its connected route rather than an FRR static.
 	manageKernel := !a.cfg.PortForwardOnly
 
 	// Collect current state so we only add what is actually missing.
@@ -743,7 +767,9 @@ func (a *Agent) ensureRoutes(desiredIPs []string, ipDev map[string]string, skipK
 	for _, ip := range desiredIPs {
 		dev := a.desiredRouteDev(ip, ipDev)
 		needsKernel := manageKernel && !skipKernelRoute[ip] && !currentKernelSet[kernelRouteEntry{IP: ip, Dev: dev}]
-		needsFRR := !currentFRRSet[ip]
+		// Only OVN-derived IPs get an FRR static; a VIP announces through its
+		// connected route, so it is never in frrStaticSet.
+		needsFRR := frrStaticSet[ip] && !currentFRRSet[ip]
 
 		if !needsKernel && !needsFRR {
 			slog.Debug("route already exists", "ip", ip)
@@ -794,9 +820,16 @@ func (a *Agent) ensureRoutes(desiredIPs []string, ipDev map[string]string, skipK
 		removedKernel = append(removedKernel, e)
 	}
 
-	// Collect orphaned FRR routes that have no corresponding kernel route.
+	// Collect orphaned FRR statics: any listed static whose IP is not in the
+	// FRR-static set (and not already queued for removal above). Comparing
+	// against frrStaticSet rather than the kernel-desired set is what withdraws
+	// a VIP's static — a VIP is kernel-desired, so the stale-kernel loop above
+	// skips it, but it is no longer an FRR-static IP, so this loop is the only
+	// path that removes the shadowed static a pre-upgrade agent left behind (on
+	// the first cycle after the upgrade). ListFRRRoutes scopes to the veth
+	// next-hop, so such a static is listed and caught here.
 	for _, ip := range currentFRR {
-		if !desiredSet[ip] && !removedSet[ip] {
+		if !frrStaticSet[ip] && !removedSet[ip] {
 			slog.Info("removing orphaned FRR route", "ip", ip)
 			delFRR = append(delFRR, ip)
 		}
@@ -948,8 +981,11 @@ const consecutiveReAddThreshold = 3
 // on every reconcile for as long as the condition lasts.
 const nexthopRepairCooldown = time.Minute
 
-// verifyRoutes checks that all desired IPs still have both a kernel route
-// (on the right interface) and an FRR static route after route mutations.
+// verifyRoutes checks that every desired IP still has its kernel route (on the
+// right interface) and that every FRR-static IP still has its FRR static route
+// after route mutations. frrStaticIPs is the OVN-derived subset of desiredIPs —
+// a VIP is not in it (its announce path is the connected route on
+// port_forward_dev, not a static), so verifyRoutes never re-adds a VIP static.
 // Any route that disappeared (e.g. due to a vtysh race or unexpected FRR
 // behaviour) is re-added immediately so that existing connections are not
 // disrupted. Every desired IP is agent-produced by construction, so all are
@@ -961,7 +997,7 @@ const nexthopRepairCooldown = time.Minute
 // skipKernelRoute are not re-added at the kernel level: their VLAN segment did
 // not resolve this cycle, so their existing route must be left untouched
 // rather than recreated on the bridge fallback.
-func (a *Agent) verifyRoutes(desiredIPs []string, ipDev map[string]string, skipKernelRoute map[string]bool) int {
+func (a *Agent) verifyRoutes(desiredIPs, frrStaticIPs []string, ipDev map[string]string, skipKernelRoute map[string]bool) int {
 	// Re-read current FRR routes.
 	currentFRR, err := a.routing.ListFRRRoutes()
 	if err != nil {
@@ -988,10 +1024,17 @@ func (a *Agent) verifyRoutes(desiredIPs []string, ipDev map[string]string, skipK
 		}
 	}
 
+	frrStaticSet := make(map[string]bool, len(frrStaticIPs))
+	for _, ip := range frrStaticIPs {
+		frrStaticSet[ip] = true
+	}
+
 	var reAddFRR []string
 	reAddKernel := 0
 	for _, ip := range desiredIPs {
-		if !frrSet[ip] {
+		// Only re-add the FRR static for an OVN-derived IP; a VIP has no static
+		// to miss (it announces through its connected route).
+		if frrStaticSet[ip] && !frrSet[ip] {
 			slog.Warn("FRR route missing after route change, re-adding", "ip", ip)
 			reAddFRR = append(reAddFRR, ip)
 		}
@@ -1077,16 +1120,19 @@ func (a *Agent) repairUnresolvableNexthop() {
 	}
 }
 
-// checkFRRRouteActivity surfaces desired routes that exist as FRR static
-// routes but are not selected/installed, and therefore not advertised via BGP.
-// Such a route is invisible to ensureRoutes — ListFRRRoutes still reports it as
-// present — yet leaves the FIP unreachable from outside. Re-adding would not
-// help (the route already exists; the next-hop is the fault), so the condition
-// is reported loudly and exposed through the inactive_routes metric for
-// alerting. A failed check leaves the metric at its previous value rather than
-// falsely resetting it to zero.
-func (a *Agent) checkFRRRouteActivity(desiredIPs []string) {
-	inactive, err := a.routing.InactiveFRRRoutes(desiredIPs)
+// checkFRRRouteActivity surfaces FRR-static routes that exist but are not
+// selected/installed, and therefore not advertised via BGP. It runs on
+// frrStaticIPs (the OVN-derived set), never on a port-forward VIP: a VIP is
+// announced through its connected route on port_forward_dev, so its absent
+// static is not this check's concern and can never hold inactive_routes
+// non-zero. Such a route is invisible to ensureRoutes — ListFRRRoutes still
+// reports it as present — yet leaves the FIP unreachable from outside. Re-adding
+// would not help (the route already exists; the next-hop is the fault), so the
+// condition is reported loudly and exposed through the inactive_routes metric
+// for alerting. A failed check leaves the metric at its previous value rather
+// than falsely resetting it to zero.
+func (a *Agent) checkFRRRouteActivity(frrStaticIPs []string) {
+	inactive, err := a.routing.InactiveFRRRoutes(frrStaticIPs)
 	if err != nil {
 		slog.Warn("could not verify FRR route activity", "error", err)
 		return

--- a/agent_test.go
+++ b/agent_test.go
@@ -109,7 +109,7 @@ func TestVerifyRoutesDryRun(t *testing.T) {
 	// lists (nil, nil). This means verifyRoutes sees every desired IP as
 	// missing and attempts re-adds — but those are also dry-run no-ops.
 	// This is by design: we exercise the full code path without side effects.
-	n := a.verifyRoutes([]string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}, nil, nil)
+	n := a.verifyRoutes([]string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}, []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}, nil, nil)
 	if n != 6 { // 3 FRR + 3 kernel
 		t.Errorf("expected 6 re-adds in dry-run, got %d", n)
 	}
@@ -129,7 +129,7 @@ func TestVerifyRoutesVerifiesDesiredRegardlessOfFilters(t *testing.T) {
 
 	// Two IPs outside the manual filter. In dry-run every list call returns
 	// empty, so each desired IP is seen as missing → 2 FRR + 2 kernel re-adds.
-	n := a.verifyRoutes([]string{"192.168.1.1", "172.16.0.1"}, nil, nil)
+	n := a.verifyRoutes([]string{"192.168.1.1", "172.16.0.1"}, []string{"192.168.1.1", "172.16.0.1"}, nil, nil)
 	if n != 4 {
 		t.Errorf("expected 4 re-adds for desired IPs outside the filter, got %d", n)
 	}
@@ -140,10 +140,10 @@ func TestVerifyRoutesEmptyDesired(t *testing.T) {
 	a := &Agent{routing: rm}
 
 	// Empty desired list should be a no-op.
-	if n := a.verifyRoutes(nil, nil, nil); n != 0 {
+	if n := a.verifyRoutes(nil, nil, nil, nil); n != 0 {
 		t.Errorf("expected 0 re-adds for nil desired, got %d", n)
 	}
-	if n := a.verifyRoutes([]string{}, nil, nil); n != 0 {
+	if n := a.verifyRoutes([]string{}, nil, nil, nil); n != 0 {
 		t.Errorf("expected 0 re-adds for empty desired, got %d", n)
 	}
 }
@@ -160,14 +160,14 @@ func TestVerifyRoutesConsecutiveReAddCounter(t *testing.T) {
 	// always reports all routes as missing since list calls return nil).
 	desired := []string{"10.0.0.1"}
 	for i := 1; i <= 5; i++ {
-		a.verifyRoutes(desired, nil, nil)
+		a.verifyRoutes(desired, desired, nil, nil)
 		if a.consecutiveReAdds != i {
 			t.Errorf("after cycle %d: expected consecutiveReAdds=%d, got %d", i, i, a.consecutiveReAdds)
 		}
 	}
 
 	// A cycle with an empty desired set (nothing to re-add) resets the counter.
-	a.verifyRoutes(nil, nil, nil)
+	a.verifyRoutes(nil, nil, nil, nil)
 	if a.consecutiveReAdds != 0 {
 		t.Errorf("expected consecutiveReAdds=0 after clean cycle, got %d", a.consecutiveReAdds)
 	}
@@ -228,13 +228,13 @@ func TestVerifyRoutesRepairsUnresolvableNexthop(t *testing.T) {
 	// Below the threshold the fault is not yet established: a single missing
 	// route is an ordinary race and must not cost an address flap.
 	for i := 1; i < consecutiveReAddThreshold; i++ {
-		a.verifyRoutes(desired, nil, nil)
+		a.verifyRoutes(desired, desired, nil, nil)
 		if len(*refreshed) != 0 {
 			t.Fatalf("repair ran after %d cycle(s), want none before the threshold of %d", i, consecutiveReAddThreshold)
 		}
 	}
 
-	a.verifyRoutes(desired, nil, nil)
+	a.verifyRoutes(desired, desired, nil, nil)
 	if len(*refreshed) != 1 {
 		t.Fatalf("repair ran %d times at the threshold, want 1", len(*refreshed))
 	}
@@ -243,7 +243,7 @@ func TestVerifyRoutesRepairsUnresolvableNexthop(t *testing.T) {
 	}
 
 	// Still broken on the next cycle: the diagnosis repeats, the flap does not.
-	a.verifyRoutes(desired, nil, nil)
+	a.verifyRoutes(desired, desired, nil, nil)
 	if len(*refreshed) != 1 {
 		t.Errorf("repair ran %d times, want 1 — the cooldown must suppress the second attempt", len(*refreshed))
 	}
@@ -251,7 +251,7 @@ func TestVerifyRoutesRepairsUnresolvableNexthop(t *testing.T) {
 	// Once the cooldown has elapsed the agent tries again: a flap that did not
 	// take must not leave the data plane down for good.
 	a.lastNexthopRepair = time.Now().Add(-2 * nexthopRepairCooldown)
-	a.verifyRoutes(desired, nil, nil)
+	a.verifyRoutes(desired, desired, nil, nil)
 	if len(*refreshed) != 2 {
 		t.Errorf("repair ran %d times after the cooldown elapsed, want 2", len(*refreshed))
 	}
@@ -266,7 +266,7 @@ func TestVerifyRoutesLeavesResolvableNexthopAlone(t *testing.T) {
 	desired := []string{"192.0.2.1"}
 
 	for i := 0; i < consecutiveReAddThreshold+2; i++ {
-		a.verifyRoutes(desired, nil, nil)
+		a.verifyRoutes(desired, desired, nil, nil)
 	}
 	if a.consecutiveReAdds < consecutiveReAddThreshold {
 		t.Fatalf("consecutiveReAdds = %d, want the instability detector to have fired", a.consecutiveReAdds)
@@ -284,7 +284,7 @@ func TestRepairUnresolvableNexthopSkipsWhenVethLeakDisabled(t *testing.T) {
 	a.cfg.VethLeakEnabled = false
 
 	for i := 0; i < consecutiveReAddThreshold+1; i++ {
-		a.verifyRoutes([]string{"192.0.2.1"}, nil, nil)
+		a.verifyRoutes([]string{"192.0.2.1"}, []string{"192.0.2.1"}, nil, nil)
 	}
 	if len(*refreshed) != 0 {
 		t.Errorf("repair ran %d times with veth leak disabled, want 0", len(*refreshed))
@@ -320,7 +320,7 @@ func TestEnsureRoutesDevMismatchDoesNotWithdrawFRR(t *testing.T) {
 	_, cidr, _ := net.ParseCIDR("198.51.100.0/24")
 	a := &Agent{cfg: Config{BridgeDev: "ovnagent-nonexistent-br"}, routing: rm, effectiveFilters: []*net.IPNet{cidr}}
 
-	a.ensureRoutes([]string{"198.51.100.10"}, map[string]string{"198.51.100.10": "br-ex.101"}, nil)
+	a.ensureRoutes([]string{"198.51.100.10"}, []string{"198.51.100.10"}, map[string]string{"198.51.100.10": "br-ex.101"}, nil)
 
 	for _, c := range rec.calls {
 		joined := strings.Join(c, " ")
@@ -349,7 +349,7 @@ func TestEnsureRoutesStaleEntryRemovedWithItsDevice(t *testing.T) {
 	_, cidr, _ := net.ParseCIDR("198.51.100.0/24")
 	a := &Agent{cfg: Config{BridgeDev: "ovnagent-nonexistent-br"}, routing: rm, effectiveFilters: []*net.IPNet{cidr}}
 
-	a.ensureRoutes(nil, nil, nil)
+	a.ensureRoutes(nil, nil, nil, nil)
 
 	sawDel := false
 	for _, c := range rec.calls {
@@ -381,13 +381,13 @@ func TestVerifyRoutesDetectsDevMismatch(t *testing.T) {
 	// The route exists but on the wrong device — one kernel re-add expected
 	// (the AddKernelRoute itself fails on the synthetic bridge, which is
 	// fine: the count is what matters).
-	n := a.verifyRoutes([]string{"198.51.100.10"}, map[string]string{"198.51.100.10": "br-ex.101"}, nil)
+	n := a.verifyRoutes([]string{"198.51.100.10"}, []string{"198.51.100.10"}, map[string]string{"198.51.100.10": "br-ex.101"}, nil)
 	if n != 1 {
 		t.Errorf("expected 1 re-add for dev mismatch, got %d", n)
 	}
 
 	// With the device matching, no re-adds.
-	n = a.verifyRoutes([]string{"198.51.100.10"}, nil, nil)
+	n = a.verifyRoutes([]string{"198.51.100.10"}, []string{"198.51.100.10"}, nil, nil)
 	if n != 0 {
 		t.Errorf("expected 0 re-adds when device matches, got %d", n)
 	}
@@ -502,7 +502,7 @@ func TestVerifyRoutesLeavesUnresolvedVLANRouteInPlace(t *testing.T) {
 	a := &Agent{cfg: Config{BridgeDev: "ovnagent-nonexistent-br"}, routing: rm, effectiveFilters: []*net.IPNet{cidr}}
 
 	skip := map[string]bool{"198.51.100.10": true}
-	if n := a.verifyRoutes([]string{"198.51.100.10"}, nil, skip); n != 0 {
+	if n := a.verifyRoutes([]string{"198.51.100.10"}, []string{"198.51.100.10"}, nil, skip); n != 0 {
 		t.Errorf("unresolved VLAN segment must leave the FIP route in place, got %d re-adds", n)
 	}
 }
@@ -566,6 +566,104 @@ func TestReconcileWritesMarkerAfterSuccessfulAnnounce(t *testing.T) {
 	if !hasMarkerUpdate(nb.writeTransacts(), "host-a") {
 		t.Fatalf("reconcile did not stamp the takeover marker for host-a; writes: %v", nb.writeTransacts())
 	}
+}
+
+// TestReconcileWithdrawsPreUpgradeVIPStaticAndAddsNoVIPStatic pins the
+// announce-path switch (#223). A port-forward VIP is advertised through its
+// connected route on port_forward_dev, never an FRR static — the static a
+// pre-upgrade agent wrote is permanently shadowed by that connected route and
+// so was never advertised. On the first cycle after the upgrade the agent must
+// therefore (a) issue no `ip route <vip>/32` add — the VIP is no longer in the
+// FRR-static set — and (b) withdraw the stale static through the orphan path
+// that compares ListFRRRoutes against FRRStaticIPs. The VIP's kernel /32 is
+// pre-seeded so AddKernelRoute is never called and the route is kept.
+//
+// Both modes are covered: full mode, where the VIP is announceable because a
+// local router is active, and port-forward-only mode, where FRRStaticIPs is
+// empty so every listed static is an orphan and withdrawn.
+func TestReconcileWithdrawsPreUpgradeVIPStaticAndAddsNoVIPStatic(t *testing.T) {
+	const (
+		vip    = "203.0.113.10"
+		bridge = "ovnagent-nonexistent-br"
+	)
+
+	assertNoAddButWithdraw := func(t *testing.T, rec *vtyshRecorder) {
+		t.Helper()
+		var added, withdrew bool
+		for _, call := range rec.calls {
+			joined := strings.Join(call, " ")
+			if strings.Contains(joined, "ip route "+vip+"/32") && !strings.Contains(joined, "no ip route") {
+				added = true
+			}
+			if strings.Contains(joined, "no ip route "+vip+"/32") {
+				withdrew = true
+			}
+		}
+		if added {
+			t.Errorf("a VIP must never get an FRR static (it announces through its connected route); calls: %v", rec.calls)
+		}
+		if !withdrew {
+			t.Errorf("the pre-upgrade VIP static must be withdrawn on the first cycle; calls: %v", rec.calls)
+		}
+	}
+
+	newRM := func(rec *vtyshRecorder) *RouteManager {
+		return &RouteManager{
+			cfg:           Config{BridgeDev: bridge, VRFName: "vrf-provider", VethNexthop: "169.254.0.1"},
+			execVtyshHook: rec.hook(),
+			execOVSHook: func(*exec.Cmd) ([]byte, error) {
+				return nil, errors.New("test: no ovs available")
+			},
+			// The VIP's /32 already sits on the bridge, so ensureRoutes never
+			// calls the Linux-only AddKernelRoute and the kernel route is kept.
+			listKernelRoutesHook: func() ([]kernelRouteEntry, error) {
+				return []kernelRouteEntry{{IP: vip, Dev: bridge}}, nil
+			},
+		}
+	}
+
+	seedStatic := func(rec *vtyshRecorder) {
+		// A pre-upgrade agent left the VIP's static via the agent's veth nexthop.
+		rec.on(
+			[]string{"vtysh", "-c", "show ip route vrf vrf-provider static json"},
+			frrStaticRoutesJSON("169.254.0.1", vip),
+			nil,
+		)
+	}
+
+	t.Run("full mode", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		seedStatic(rec)
+		c, _, _ := newOVNClientWithFakes(t, "host-a")
+		c.state.Replace(OVNState{
+			LocalRouters:    []LocalRouterInfo{{RouterName: "r1", RouterUUID: "lr1", LRPName: "lrp-r1"}},
+			HasLocalRouters: true,
+		})
+		a := &Agent{
+			cfg:            Config{BridgeDev: bridge, PortForwards: []PortForwardVIP{{VIP: vip, ManageVIP: true}}},
+			ovn:            c,
+			routing:        newRM(rec),
+			reconcileCh:    make(chan struct{}, 1),
+			missingChassis: make(map[string]time.Time),
+		}
+		a.reconcile(context.Background(), "test")
+		assertNoAddButWithdraw(t, rec)
+	})
+
+	t.Run("port-forward-only mode", func(t *testing.T) {
+		rec := newVtyshRecorder()
+		seedStatic(rec)
+		rm := newRM(rec)
+		rm.cfg.PortForwardOnly = true
+		a := &Agent{
+			cfg:            Config{PortForwardOnly: true, BridgeDev: bridge, PortForwards: []PortForwardVIP{{VIP: vip, ManageVIP: true}}},
+			routing:        rm,
+			reconcileCh:    make(chan struct{}, 1),
+			missingChassis: make(map[string]time.Time),
+		}
+		a.reconcile(context.Background(), "test")
+		assertNoAddButWithdraw(t, rec)
+	})
 }
 
 // TestReconcileMixedFamilyAnnouncesV4AndWritesMarker drives a non-dry-run
@@ -943,7 +1041,7 @@ func TestEnsureRoutesAddsMissingAndRemovesStale(t *testing.T) {
 	a := &Agent{routing: rm, effectiveFilters: []*net.IPNet{cidr}}
 
 	// Desired: 198.51.100.10 (new) and 198.51.100.20 (already in FRR).
-	res := a.ensureRoutes([]string{"198.51.100.10", "198.51.100.20"}, nil, nil)
+	res := a.ensureRoutes([]string{"198.51.100.10", "198.51.100.20"}, []string{"198.51.100.10", "198.51.100.20"}, nil, nil)
 	if !res.changed {
 		t.Error("routeSyncResult.changed = false, want true (routes were added and removed)")
 	}
@@ -994,7 +1092,7 @@ func TestEnsureRoutesReportsReadyOutcome(t *testing.T) {
 		rec := newVtyshRecorder()
 		// FRR reports no routes, so the desired IP is added and BGP refreshed;
 		// the recorder returns success for both.
-		if !newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, nil, nil).ready {
+		if !newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, []string{"198.51.100.10"}, nil, nil).ready {
 			t.Errorf("clean add cycle: ready = false, want true (calls: %v)", rec.calls)
 		}
 	})
@@ -1005,7 +1103,7 @@ func TestEnsureRoutesReportsReadyOutcome(t *testing.T) {
 		// removed, so no BGP refresh runs and the cycle is still ready.
 		rec.on([]string{"vtysh", "-c", "show ip route vrf vrf-provider static json"},
 			frrStaticRoutesJSON("169.254.0.1", "198.51.100.10"), nil)
-		if !newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, nil, nil).ready {
+		if !newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, []string{"198.51.100.10"}, nil, nil).ready {
 			t.Errorf("no-change cycle: ready = false, want true (calls: %v)", rec.calls)
 		}
 	})
@@ -1015,7 +1113,7 @@ func TestEnsureRoutesReportsReadyOutcome(t *testing.T) {
 		rec.on([]string{"vtysh", "-c", "conf t", "-c", "vrf vrf-provider",
 			"-c", "ip route 198.51.100.10/32 169.254.0.1", "-c", "exit-vrf", "-c", "end"},
 			"", errors.New("vtysh add failed"))
-		if newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, nil, nil).ready {
+		if newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, []string{"198.51.100.10"}, nil, nil).ready {
 			t.Errorf("FRR add failure: ready = true, want false")
 		}
 	})
@@ -1024,7 +1122,7 @@ func TestEnsureRoutesReportsReadyOutcome(t *testing.T) {
 		rec := newVtyshRecorder()
 		rec.on([]string{"vtysh", "-c", "clear ip bgp vrf vrf-provider * soft out"},
 			"", errors.New("bgp refresh failed"))
-		if newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, nil, nil).ready {
+		if newAgent(rec).ensureRoutes([]string{"198.51.100.10"}, []string{"198.51.100.10"}, nil, nil).ready {
 			t.Errorf("BGP refresh failure: ready = true, want false")
 		}
 	})
@@ -1061,6 +1159,7 @@ func inactiveRoutesGauge(t *testing.T, m *metricsRegistry) float64 {
 // caught by the "vtysh error keeps gauge" subtest.
 func TestCheckFRRRouteActivity(t *testing.T) {
 	const fip = "198.51.100.10"
+	const vip = "203.0.113.10"
 	const jsonCmd = "show ip route vrf vrf-provider static json"
 	newAgent := func(rec *vtyshRecorder) *Agent {
 		rm := &RouteManager{cfg: Config{VRFName: "vrf-provider"}, execVtyshHook: rec.hook()}
@@ -1118,6 +1217,32 @@ func TestCheckFRRRouteActivity(t *testing.T) {
 			t.Errorf("gauge with a healthy route = %v, want 0", got)
 		}
 	})
+
+	// #223: the activity check runs on the FRR-static set, never on a VIP. A
+	// pre-upgrade agent may have left an inactive static for the VIP in FRR, but
+	// reconcile passes only frrStaticIPs (the OVN-derived set) here — the VIP is
+	// announced through its connected route, so it is not in that set and can
+	// never reach InactiveFRRRoutes to hold the gauge non-zero.
+	t.Run("announceable VIP is not in the FRR set and never alarms", func(t *testing.T) {
+		m := withTestMetrics(t)
+		logs := captureSlog(t)
+
+		rec := newVtyshRecorder()
+		// FRR still carries an inactive static for the VIP; the OVN-derived FIP
+		// the reconcile actually checks is healthy.
+		rec.on([]string{"vtysh", "-c", jsonCmd},
+			`{"`+vip+`/32":[{"prefix":"`+vip+`/32","protocol":"static"}],`+
+				`"`+fip+`/32":[{"prefix":"`+fip+`/32","protocol":"static","selected":true,"installed":true}]}`, nil)
+		// The set passed is frrStaticIPs — the FIP only, never the VIP.
+		newAgent(rec).checkFRRRouteActivity([]string{fip})
+
+		if got := inactiveRoutesGauge(t, m); got != 0 {
+			t.Errorf("gauge = %v, want 0 — the VIP's static is not in the checked set", got)
+		}
+		if strings.Contains(logs.String(), "FRR static routes are configured but inactive") {
+			t.Errorf("an announceable VIP must never raise the inactive-route alarm; logs:\n%s", logs.String())
+		}
+	})
 }
 
 // TestEnsureRoutesKeepsAnnounceSeparateFromRouteAdd verifies that a takeover
@@ -1136,7 +1261,7 @@ func TestEnsureRoutesKeepsAnnounceSeparateFromRouteAdd(t *testing.T) {
 	rm := &RouteManager{cfg: Config{BridgeDev: "ovnagent-nonexistent-br", VRFName: "vrf-provider", VethNexthop: "169.254.0.1"}, execVtyshHook: rec.hook()}
 	a := &Agent{routing: rm}
 
-	res := a.ensureRoutes([]string{"198.51.100.10", "198.51.100.20"}, nil, nil)
+	res := a.ensureRoutes([]string{"198.51.100.10", "198.51.100.20"}, []string{"198.51.100.10", "198.51.100.20"}, nil, nil)
 	if !res.announced || !res.changed {
 		t.Fatalf("routeSyncResult = %+v, want changed+announced", res)
 	}
@@ -1907,7 +2032,7 @@ func TestEnsureRoutesRemovalOnlyIsNotAnnounce(t *testing.T) {
 	}
 
 	// Disjoint desired set: the stale /32 is withdrawn, nothing is added.
-	res := a.ensureRoutes(nil, nil, nil)
+	res := a.ensureRoutes(nil, nil, nil, nil)
 	if !res.changed {
 		t.Errorf("changed = false, want true — the stale /32 was withdrawn")
 	}
@@ -1959,7 +2084,7 @@ func TestEnsureRoutesAnnounceReportsOutcomeNotIntent(t *testing.T) {
 				missingChassis: make(map[string]time.Time),
 			}
 
-			res := a.ensureRoutes([]string{"198.51.100.7"}, nil, nil)
+			res := a.ensureRoutes([]string{"198.51.100.7"}, []string{"198.51.100.7"}, nil, nil)
 			if !res.changed {
 				t.Error("changed = false, want true — the cycle still touched FRR, so verification must run")
 			}

--- a/desired_state.go
+++ b/desired_state.go
@@ -39,9 +39,25 @@ type desiredState struct {
 	// because they are not IPv4, sorted. Reported by reconcile at debug level.
 	ExcludedNonV4 []string
 
-	// DesiredIPs is HairpinIPs plus the port-forward VIPs, deduplicated and
-	// sorted. This is the set that gets kernel routes and FRR announcements.
+	// DesiredIPs is HairpinIPs plus the announceable port-forward VIPs,
+	// deduplicated and sorted. This is the set that gets a kernel /32 route on
+	// the provider bridge. The VIPs are announced through their own connected
+	// route on port_forward_dev (a local address, administrative distance 0),
+	// not through an FRR static — the static would be shadowed by that
+	// connected route and never selected — so DesiredIPs is a superset of
+	// FRRStaticIPs by exactly the announceable VIPs.
 	DesiredIPs []string
+
+	// FRRStaticIPs is the subset of DesiredIPs that gets an FRR static route
+	// via the agent's veth next-hop: the OVN-derived IPv4 addresses
+	// (HairpinIPs) only, deduplicated and sorted. Port-forward VIPs are
+	// deliberately excluded — a VIP's connected route on port_forward_dev
+	// always wins over a static to the same /32, so the static would sit in
+	// FRR unadvertised and hold ovn_network_agent_inactive_routes non-zero.
+	// The VIP announces through the connected route instead, and dormancy
+	// (#206) is enforced by withholding the address, not the route. Empty in
+	// port-forward-only mode, where the zero OVNState yields no HairpinIPs.
+	FRRStaticIPs []string
 
 	// DormantVIPs lists the configured port-forward VIPs left out of
 	// DesiredIPs because this node cannot advertise them, sorted. Reported by
@@ -136,15 +152,20 @@ func splitIPv4(targets map[string]HairpinTarget) (v4, nonV4 []string) {
 // announceVIPs decides whether the configured port-forward VIPs join the route
 // plane this cycle; reconcile derives it from whether this node maintains the
 // FRR prefix-list that would permit them (see vipRoutesAnnounceable). When it is
-// false the VIPs are reported as DormantVIPs instead: no kernel route, no FRR
-// static route, and nothing for the inactive-route check to alarm on.
+// false the VIPs are reported as DormantVIPs instead — their address is withheld
+// from port_forward_dev (see nftables_linux.go), so nothing is announced. The
+// VIPs never join FRRStaticIPs in either case: they announce through their
+// connected route, not a static.
 func computeDesiredState(state OVNState, portForwards []PortForwardVIP, announceVIPs bool) desiredState {
 	targets := buildHairpinTargets(state)
 	hairpinIPs, excludedNonV4 := splitIPv4(targets)
 	segments, segmentByName := buildDesiredSegments(state.LocalRouters)
 
-	// desiredIPs extends hairpinIPs with the port-forward VIPs — these need
-	// kernel routes on br-ex and FRR static routes for BGP announcement.
+	// desiredIPs extends hairpinIPs with the announceable port-forward VIPs.
+	// hairpinIPs (the OVN-derived FIP/SNAT/gateway addresses) get both a kernel
+	// route on the provider bridge and an FRR static route; the VIPs get a
+	// kernel /32 on the bridge but announce through their connected route on
+	// port_forward_dev, so they join DesiredIPs but never FRRStaticIPs.
 	desiredIPs := make([]string, 0, len(hairpinIPs)+len(portForwards))
 	desiredIPs = append(desiredIPs, hairpinIPs...)
 	var dormantVIPs []string
@@ -163,6 +184,7 @@ func computeDesiredState(state OVNState, portForwards []PortForwardVIP, announce
 		HairpinIPs:     hairpinIPs,
 		ExcludedNonV4:  excludedNonV4,
 		DesiredIPs:     uniqueIPs(desiredIPs),
+		FRRStaticIPs:   uniqueIPs(hairpinIPs),
 		DormantVIPs:    uniqueIPs(dormantVIPs),
 	}
 }

--- a/desired_state_test.go
+++ b/desired_state_test.go
@@ -167,6 +167,19 @@ func TestComputeDesiredState(t *testing.T) {
 	if want := []string{"198.51.100.50"}; !reflect.DeepEqual(got.HairpinIPs, want) {
 		t.Errorf("HairpinIPs = %v, want %v (VIPs excluded, v6 excluded)", got.HairpinIPs, want)
 	}
+	// #223: the VIP is in DesiredIPs (kernel plane) but never in FRRStaticIPs —
+	// it announces through its connected route, not an FRR static. FRRStaticIPs
+	// equals HairpinIPs (the OVN-derived set).
+	if want := []string{"198.51.100.50"}; !reflect.DeepEqual(got.FRRStaticIPs, want) {
+		t.Errorf("FRRStaticIPs = %v, want %v (VIPs excluded, equal to HairpinIPs)", got.FRRStaticIPs, want)
+	}
+	for _, vip := range []string{"203.0.113.10"} {
+		for _, ip := range got.FRRStaticIPs {
+			if ip == vip {
+				t.Errorf("an announceable VIP %s must not appear in FRRStaticIPs %v", vip, got.FRRStaticIPs)
+			}
+		}
+	}
 	if want := []string{"2001:db8::50"}; !reflect.DeepEqual(got.ExcludedNonV4, want) {
 		t.Errorf("ExcludedNonV4 = %v, want %v", got.ExcludedNonV4, want)
 	}
@@ -176,6 +189,14 @@ func TestComputeDesiredState(t *testing.T) {
 	}
 	if len(got.Segments) != 1 || got.Segments[0].LocalnetPort != "physnet1-port" {
 		t.Errorf("Segments = %+v, want the single physnet1-port segment", got.Segments)
+	}
+
+	// With no port forwards at all, FRRStaticIPs equals HairpinIPs — there is no
+	// VIP to exclude, and the OVN-derived set is exactly what gets a static.
+	noForwards := computeDesiredState(state, nil, true)
+	if !reflect.DeepEqual(noForwards.FRRStaticIPs, noForwards.HairpinIPs) {
+		t.Errorf("FRRStaticIPs = %v, want it to equal HairpinIPs %v when portForwards is empty",
+			noForwards.FRRStaticIPs, noForwards.HairpinIPs)
 	}
 }
 
@@ -187,6 +208,11 @@ func TestComputeDesiredStatePortForwardOnly(t *testing.T) {
 
 	if want := []string{"203.0.113.10"}; !reflect.DeepEqual(got.DesiredIPs, want) {
 		t.Errorf("DesiredIPs = %v, want %v", got.DesiredIPs, want)
+	}
+	// #223: in port-forward-only mode the zero OVNState yields no HairpinIPs, so
+	// FRRStaticIPs is empty — the VIP announces through its connected route.
+	if len(got.FRRStaticIPs) != 0 {
+		t.Errorf("FRRStaticIPs = %v, want empty in port-forward-only mode", got.FRRStaticIPs)
 	}
 	if len(got.HairpinTargets) != 0 {
 		t.Errorf("HairpinTargets = %v, want empty with no OVN state", got.HairpinTargets)
@@ -213,6 +239,11 @@ func TestComputeDesiredStateDormantVIPs(t *testing.T) {
 	if len(got.DesiredIPs) != 0 {
 		t.Errorf("DesiredIPs = %v, want empty — dormant VIPs get no routes", got.DesiredIPs)
 	}
+	// A dormant VIP is never an FRR static either — it is withheld by address,
+	// not by route (#223), and FRRStaticIPs is the OVN-derived set, empty here.
+	if len(got.FRRStaticIPs) != 0 {
+		t.Errorf("FRRStaticIPs = %v, want empty — a dormant VIP gets no static", got.FRRStaticIPs)
+	}
 	if want := []string{"192.0.2.99", "203.0.113.10"}; !reflect.DeepEqual(got.DormantVIPs, want) {
 		t.Errorf("DormantVIPs = %v, want %v (deduped, sorted)", got.DormantVIPs, want)
 	}
@@ -230,6 +261,11 @@ func TestComputeDesiredStateDormantVIPsKeepFIPs(t *testing.T) {
 
 	if want := []string{"198.51.100.50"}; !reflect.DeepEqual(got.DesiredIPs, want) {
 		t.Errorf("DesiredIPs = %v, want %v — the FIP stays, only the VIP is dormant", got.DesiredIPs, want)
+	}
+	// The FIP keeps its FRR static; the dormant VIP was never one. FRRStaticIPs
+	// equals HairpinIPs (the FIP alone).
+	if want := []string{"198.51.100.50"}; !reflect.DeepEqual(got.FRRStaticIPs, want) {
+		t.Errorf("FRRStaticIPs = %v, want %v — the FIP static stays, the VIP is not one", got.FRRStaticIPs, want)
 	}
 	if want := []string{"203.0.113.10"}; !reflect.DeepEqual(got.DormantVIPs, want) {
 		t.Errorf("DormantVIPs = %v, want %v", got.DormantVIPs, want)

--- a/docs/explanation/port-forwarding.md
+++ b/docs/explanation/port-forwarding.md
@@ -393,7 +393,9 @@ What still runs in this mode:
   above.
 - The veth pair between the default VRF and `vrf-provider`, used by the
   DNAT return path.
-- FRR static routes for the VIP addresses, so BGP announces them.
+- The managed VIP addresses on `port_forward_dev`, whose connected routes BGP
+  redistributes to announce them (no FRR static route is written for a VIP — it
+  would be shadowed by the connected route and never advertised).
 - The periodic reconcile ticker, which re-asserts the VIP and DNAT state.
 
 What is skipped, because it is OVN-specific:
@@ -403,8 +405,9 @@ What is skipped, because it is OVN-specific:
   drain-on-shutdown, and FIP/SNAT-IP route management.
 - Provider-bridge setup (`br-ex`). A pure VIP-service node need not have
   `br-ex`: no `<vip>/32` kernel route is installed on it, the VIP is
-  reachable as a local address on `port_forward_dev`, and the FRR static
-  route carries the BGP announcement.
+  reachable as a local address on `port_forward_dev`, and the connected route
+  of that address carries the BGP announcement (via `redistribute connected`
+  through the `ANNOUNCED-NETWORKS` route-map).
 
 Because router SNAT IPs and provider CIDRs are normally discovered from
 OVN, the two source-selective masquerade options that rely on them are
@@ -415,37 +418,47 @@ requires an explicit `network_cidr`.
 
 ## Dormant VIPs on a gateway without local routers
 
-A VIP is only routable on a node where the agent also maintains the FRR
+A VIP is only announceable on a node where the agent also maintains the FRR
 prefix-list that permits it. On a gateway that hosts no locally active
 router — a standby chassis, or one whose routers have failed over
 elsewhere — reconcile takes the standby path and empties both that
-prefix-list and the veth-leak network routes. A VIP route installed there
-could never be advertised.
+prefix-list and the veth-leak network routes. A VIP announced there could
+never be advertised.
 
-The agent therefore treats such a VIP as **dormant**: it installs no
-`<vip>/32` kernel route and no FRR static route, and reports the condition
-once at INFO level:
+Because a VIP's announce path is now the connected route of its address on
+`port_forward_dev`, the only lever that model leaves is the address itself.
+The agent therefore treats such a VIP as **dormant**: it **withholds the VIP
+address** from `port_forward_dev` (so no connected route exists to export),
+installs no `<vip>/32` kernel route, and reports the condition once at INFO
+level:
 
 ```
 port-forward VIPs are dormant on this node — no locally active routers,
-so they cannot be advertised and no routes are installed
+so they cannot be advertised and their address is withheld from the
+port-forward device
 ```
 
-The DNAT plane is *not* withheld. The nftables rules, the VIP address on
-`port_forward_dev`, the conntrack zones, and the policy routing are all
-still asserted, so a gateway that later gains a local router only needs the
-announce — the data path is already in place. When that happens the agent
-logs `port-forward VIPs are no longer dormant` and installs the routes on
-the next reconcile.
+The DNAT plane is *not* withheld. The nftables rules, the conntrack zones,
+and the policy routing are all still asserted, so a gateway that later gains
+a local router only needs the address and the announce — the DNAT data path
+is already in place. When that happens the agent logs `port-forward VIPs are
+no longer dormant` and restores the address (and its kernel route) on the
+next reconcile.
 
 Port-forward-only mode never takes the standby path, so its VIPs are never
 dormant — a pure VIP-service node serves them without any OVN state at all.
 
-::: tip Why not install the route anyway?
-It was installed unconditionally before, and the result was an FRR static
-route that zebra never selected: not advertised, but present. That held
-`ovn_network_agent_inactive_routes` at a non-zero value — which the shipped
-`OVNNetworkAgentInactiveRoutes` alert fires on — and logged
+::: tip Why withhold the address rather than the route?
+The connected route of a local address always wins over a static to the same
+`/32`, so the agent no longer writes a VIP static at all — the connected
+route is the single announce path. That leaves the address as the only thing
+to withhold. Withholding it is also belt-and-suspenders with the BGP config:
+`redistribute connected` runs through a route-map matching `ANNOUNCED-NETWORKS`,
+and on a standby that list is empty, so even a briefly-present address would
+not be exported. The earlier design installed an FRR static unconditionally,
+which zebra never selected (the connected route shadowed it): not advertised,
+but present. That held `ovn_network_agent_inactive_routes` at a non-zero value
+— which the shipped `OVNNetworkAgentInactiveRoutes` alert fires on — and logged
 `FRR static routes are configured but inactive` at ERROR level on every
 reconcile, indefinitely.
 :::

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -67,8 +67,12 @@ also serves any configured `port_forwards`.
 
 When `port_forwards` is configured but **both** OVN remotes are left unset,
 the agent runs as a standalone VIP service: it manages only the configured
-port-forward VIPs — DNAT rules, VIP addresses, connmark return routing, and
-FRR static routes for BGP announcement — and never connects to OVN.
+port-forward VIPs — DNAT rules, VIP addresses, and connmark return routing —
+and never connects to OVN. Each managed VIP address is announced via BGP
+through its connected route on `port_forward_dev` (the gateway's FRR must
+`redistribute connected` through the `ANNOUNCED-NETWORKS` route-map — see the
+[port-forwarding guide](port-forwarding#vip-address-management)), not through
+an FRR static route.
 
 Use this for a node that should only expose configured VIPs (for example a
 DNS resolver, monitoring collector, or API proxy) and is not an OVN gateway

--- a/docs/guides/frr-prefix-list.md
+++ b/docs/guides/frr-prefix-list.md
@@ -4,7 +4,9 @@ By default the agent maintains an FRR prefix-list named `ANNOUNCED-NETWORKS`
 that controls which prefixes are eligible for BGP redistribution. On every
 reconciliation cycle, the agent emits `permit <network> ge 32 le 32` entries
 for each discovered (or manually configured) provider network so FRR will
-re-advertise the per-FIP `/32` static routes the agent writes.
+re-advertise the `/32`s the agent exposes: the per-FIP static routes it writes,
+and — filtered through the same list — the connected routes of any managed
+port-forward VIP addresses.
 
 ## Defaults
 
@@ -30,9 +32,25 @@ keeps the prefix list synchronised with `permit <network> ge 32 le 32`
 entries for each network. Entries for networks the agent no longer manages
 are removed during the next reconciliation.
 
-The prefix list itself must already be referenced from your BGP route-map /
-redistribute statements. The agent only manages the prefix-list contents — it
-does not modify your BGP configuration.
+The prefix list itself must already be referenced from your BGP configuration.
+There are two reference points, and a complete gateway config uses both:
+
+1. The neighbor outbound filter — `neighbor <peer> prefix-list ANNOUNCED-NETWORKS
+   out` — which gates what is sent to the upstream peer.
+2. The route-map on `redistribute connected` — `redistribute connected route-map
+   ANNOUNCE-CONNECTED`, where `route-map ANNOUNCE-CONNECTED permit 10` carries
+   `match ip address prefix-list ANNOUNCED-NETWORKS`. This is what lets a managed
+   port-forward VIP's connected route be announced while keeping the underlay
+   `/30`s out (see the
+   [port-forwarding guide](port-forwarding#vip-address-management)).
+
+The route-map reference matters on a standby: the agent empties the list there,
+and an undefined list inside a route-map `match` is a no-match (nothing
+exported), whereas an undefined list in the neighbor filter alone is treated as
+permit-all.
+
+The agent only manages the prefix-list contents — it does not modify your BGP
+configuration.
 
 ## Where to go next
 

--- a/docs/guides/port-forwarding.md
+++ b/docs/guides/port-forwarding.md
@@ -90,8 +90,39 @@ port_forwards:
 
 Each VIP can optionally be managed by the agent (`manage_vip: true`). When
 enabled, the agent adds the VIP as a `/32` address on the configured loopback
-interface (default: `loopback1`) inside `vrf-provider`. This is the address
-that FRR announces via BGP to make the VIP reachable from the external fabric.
+interface (default: `loopback1`) inside `vrf-provider`. That address is the
+VIP's BGP announce path: its **connected route** is what FRR redistributes to
+the external fabric. The agent does *not* write an FRR static route for the VIP
+— a static to the same `/32` would be permanently shadowed by the connected
+route (a local address always wins over a static to the same prefix) and never
+advertised.
+
+For the announcement to leave the box, the gateway's BGP configuration must
+redistribute connected routes through the `ANNOUNCED-NETWORKS` prefix-list, via
+a route-map:
+
+```
+router bgp <asn> vrf vrf-provider
+ address-family ipv4 unicast
+  redistribute connected route-map ANNOUNCE-CONNECTED
+ exit-address-family
+!
+route-map ANNOUNCE-CONNECTED permit 10
+ match ip address prefix-list ANNOUNCED-NETWORKS
+```
+
+The route-map form is deliberate. An undefined prefix-list inside a route-map
+`match` is a *no-match* that falls through to the route-map's terminal deny, so
+a standby that has emptied `ANNOUNCED-NETWORKS` exports nothing via connected —
+whereas a bare `redistribute connected`, or only a neighbor `prefix-list … out`
+naming an undefined list, would treat the missing list as permit-all and leak
+the underlay `/30`s.
+
+On a full-mode gateway that hosts no local routers the agent **removes** the
+managed VIP address (see the dormancy section in the port-forwarding
+explanation). The reasoning: on such a standby the agent has emptied
+`ANNOUNCED-NETWORKS`, so a present address must not be exportable — withholding
+the address is what keeps the standby from announcing a VIP it does not own.
 
 When `manage_vip: false`, the VIP address must already exist on the interface
 (e.g. configured statically or by another tool).

--- a/nftables_linux.go
+++ b/nftables_linux.go
@@ -50,9 +50,20 @@ func (rm *RouteManager) SetupPortForward() error {
 		return fmt.Errorf("nft binary not found in PATH (required for port forwarding): %w", err)
 	}
 
-	// 1. Manage VIP addresses on loopback device.
-	if err := rm.reconcilePortForwardVIPs(); err != nil {
-		return fmt.Errorf("manage VIP addresses: %w", err)
+	// 1. Manage VIP addresses on the port-forward device. In port-forward-only
+	// mode the VIPs are always announceable, so ensure them at startup. In full
+	// mode announceability is unknown before the first OVN snapshot, so only
+	// verify the device exists — preserving the fail-fast the gwnode entrypoint
+	// documents — and neither add nor remove addresses: deleting one would blip
+	// the VIP across an agent restart on an active gateway, adding one would
+	// announce from a standby. The first reconcile settles the address once the
+	// OVN view is in.
+	if rm.cfg.PortForwardOnly {
+		if err := rm.reconcilePortForwardVIPs(true); err != nil {
+			return fmt.Errorf("manage VIP addresses: %w", err)
+		}
+	} else if _, err := netlink.LinkByName(rm.cfg.PortForwardDev); err != nil {
+		return fmt.Errorf("find device %s: %w", rm.cfg.PortForwardDev, err)
 	}
 
 	// 2. Apply nftables ruleset (initial, without provider networks or SNAT IPs).
@@ -84,16 +95,20 @@ func (rm *RouteManager) SetupPortForward() error {
 // veth leak return traffic in addition to DNAT return traffic).
 // snatIPs are the router SNAT external IPs from OVN state, used for
 // router_masquerade rules.
-func (rm *RouteManager) ReconcilePortForward(providerNetworks []*net.IPNet, snatIPs []string) error {
+// announceVIPs gates the managed VIP addresses: true adds any missing /32 so
+// its connected route is exported, false withholds them (dormancy, #206). The
+// caller derives it from vipRoutesAnnounceable, the same value it hands
+// computeDesiredState, so the address and the route plane never disagree.
+func (rm *RouteManager) ReconcilePortForward(providerNetworks []*net.IPNet, snatIPs []string, announceVIPs bool) error {
 	if !rm.cfg.PortForwardEnabled {
 		return nil
 	}
 	if rm.cfg.DryRun {
-		slog.Info("[dry-run] would reconcile port forwarding", "vips", len(rm.cfg.PortForwards))
+		slog.Info("[dry-run] would reconcile port forwarding", "vips", len(rm.cfg.PortForwards), "announce_vips", announceVIPs)
 		return nil
 	}
 
-	if err := rm.reconcilePortForwardVIPs(); err != nil {
+	if err := rm.reconcilePortForwardVIPs(announceVIPs); err != nil {
 		return fmt.Errorf("reconcile VIP addresses: %w", err)
 	}
 	if err := rm.applyNftRuleset(providerNetworks, snatIPs); err != nil {
@@ -278,12 +293,36 @@ func (rm *RouteManager) cleanupDNATRouting() {
 	}
 }
 
-// reconcilePortForwardVIPs ensures managed VIP /32 addresses are present on the
-// loopback device. Uses AddrReplace for idempotency.
-func (rm *RouteManager) reconcilePortForwardVIPs() error {
+// reconcilePortForwardVIPs brings the managed VIP /32 addresses on
+// port_forward_dev into line with announceVIPs.
+//
+// The VIP's own connected route on this device (administrative distance 0) is
+// its BGP announce path — it always wins over a static to the same /32 — so the
+// address is the only dormancy lever the model leaves (#206). When announceVIPs
+// is true it adds any missing ManageVIP address and leaves present ones alone:
+// add-if-missing, not the per-cycle AddrReplace it used to run, which recreated
+// zebra's connected route on every reconcile (the ~2s route ages seen in
+// artifact dumps). When false it deletes each managed address, treating an
+// already-absent one (EADDRNOTAVAIL) as done; any other delete error is a real
+// one and is surfaced. VIPs with ManageVIP off are never touched either way.
+func (rm *RouteManager) reconcilePortForwardVIPs(announceVIPs bool) error {
 	link, err := netlink.LinkByName(rm.cfg.PortForwardDev)
 	if err != nil {
 		return fmt.Errorf("find device %s: %w", rm.cfg.PortForwardDev, err)
+	}
+
+	// On the announce path, list the device's addresses once so we only write
+	// the genuinely missing /32s (the check-then-add shape of ensureIPOnDev).
+	var present map[string]bool
+	if announceVIPs {
+		addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+		if err != nil {
+			return fmt.Errorf("list addrs on %s: %w", rm.cfg.PortForwardDev, err)
+		}
+		present = make(map[string]bool, len(addrs))
+		for _, a := range addrs {
+			present[a.IP.String()] = true
+		}
 	}
 
 	for _, pf := range rm.cfg.PortForwards {
@@ -294,10 +333,22 @@ func (rm *RouteManager) reconcilePortForwardVIPs() error {
 		addr := &netlink.Addr{
 			IPNet: &net.IPNet{IP: vipIP, Mask: net.CIDRMask(32, 32)},
 		}
-		if err := netlink.AddrReplace(link, addr); err != nil {
+		if !announceVIPs {
+			// Dormant: withhold the address. Already absent is the end state.
+			if err := netlink.AddrDel(link, addr); err != nil && !isNoSuchAddr(err) {
+				return fmt.Errorf("remove VIP %s: %w", pf.VIP, err)
+			}
+			slog.Debug("VIP address withheld while dormant", "vip", pf.VIP, "dev", rm.cfg.PortForwardDev)
+			continue
+		}
+		if present[vipIP.String()] {
+			slog.Debug("VIP address already present", "vip", pf.VIP, "dev", rm.cfg.PortForwardDev)
+			continue
+		}
+		if err := netlink.AddrAdd(link, addr); err != nil && !isFileExists(err) {
 			return fmt.Errorf("add VIP %s/32 to %s: %w", pf.VIP, rm.cfg.PortForwardDev, err)
 		}
-		slog.Debug("VIP address ensured", "vip", pf.VIP, "dev", rm.cfg.PortForwardDev)
+		slog.Info("VIP address added", "vip", pf.VIP, "dev", rm.cfg.PortForwardDev)
 	}
 	return nil
 }

--- a/nftables_notlinux.go
+++ b/nftables_notlinux.go
@@ -19,7 +19,7 @@ func (rm *RouteManager) SetupPortForward() error {
 	return fmt.Errorf("port forwarding is only supported on Linux")
 }
 
-func (rm *RouteManager) ReconcilePortForward(providerNetworks []*net.IPNet, snatIPs []string) error {
+func (rm *RouteManager) ReconcilePortForward(providerNetworks []*net.IPNet, snatIPs []string, announceVIPs bool) error {
 	if !rm.cfg.PortForwardEnabled {
 		return nil
 	}

--- a/routing_test.go
+++ b/routing_test.go
@@ -662,7 +662,7 @@ func TestDryRunPortForward(t *testing.T) {
 	}
 
 	_, cidr, _ := net.ParseCIDR("198.51.100.0/24")
-	if err := rm.ReconcilePortForward([]*net.IPNet{cidr}, nil); err != nil {
+	if err := rm.ReconcilePortForward([]*net.IPNet{cidr}, nil, true); err != nil {
 		t.Errorf("ReconcilePortForward() dry-run error: %v", err)
 	}
 
@@ -683,7 +683,7 @@ func TestDisabledPortForward(t *testing.T) {
 	if err := rm.SetupPortForward(); err != nil {
 		t.Errorf("SetupPortForward() disabled error: %v", err)
 	}
-	if err := rm.ReconcilePortForward(nil, nil); err != nil {
+	if err := rm.ReconcilePortForward(nil, nil, true); err != nil {
 		t.Errorf("ReconcilePortForward() disabled error: %v", err)
 	}
 	if err := rm.TeardownPortForward(); err != nil {

--- a/test/e2e/bootstrap.sh
+++ b/test/e2e/bootstrap.sh
@@ -583,8 +583,19 @@ configure_gateway_frr() {
         local node="clab-${LAB_NAME}-${gw}"
         local upstream_ip="${upstream_cidr%/*}"
         log "configuring ${gw} FRR (BGP neighbor ${upstream_ip} in vrf-provider)"
+        # redistribute connected via ANNOUNCE-CONNECTED is the port-forward
+        # VIP's announce path (#223): the VIP is a local /32 on
+        # port_forward_dev, so its connected route — filtered through a
+        # route-map matching ANNOUNCED-NETWORKS — is what BGP exports. The
+        # route-map form is deliberate: on a standby the agent deletes
+        # ANNOUNCED-NETWORKS, and an undefined list inside a route-map `match`
+        # is a no-match that hits the terminal deny (exporting nothing),
+        # whereas a bare `redistribute connected` would leak the underlay /30s.
         docker exec -i "${node}" vtysh <<EOF
 configure terminal
+route-map ANNOUNCE-CONNECTED permit 10
+ match ip address prefix-list ANNOUNCED-NETWORKS
+exit
 no router bgp ${BGP_ASN_GATEWAYS} vrf vrf-provider
 router bgp ${BGP_ASN_GATEWAYS} vrf vrf-provider
  bgp router-id ${upstream_ip%.*}.2
@@ -593,6 +604,7 @@ router bgp ${BGP_ASN_GATEWAYS} vrf vrf-provider
  neighbor ${upstream_ip} remote-as ${BGP_ASN_UPSTREAM}
  address-family ipv4 unicast
   redistribute static
+  redistribute connected route-map ANNOUNCE-CONNECTED
   neighbor ${upstream_ip} activate
   neighbor ${upstream_ip} prefix-list ANNOUNCED-NETWORKS out
  exit-address-family

--- a/test/e2e/chaos/expect.go
+++ b/test/e2e/chaos/expect.go
@@ -146,10 +146,12 @@ type gatewayExpectation struct {
 	SkipKernel     bool
 
 	// FRRStatic is the set of /32 IPs expected as FRR static routes via the
-	// veth nexthop. It equals DesiredIPs in both modes: ensureRoutes manages
-	// FRR for every desired IP, active or standby, full or pf-only. On a
-	// full-mode standby that set is empty — the dormant VIPs are not in it,
-	// which is what keeps inactive_routes at 0 there (#206).
+	// veth nexthop: the OVN-derived hairpin set (NAT external IPs + LRP gateway
+	// IPs) only, never a port-forward VIP. A VIP announces through its connected
+	// route on PortForwardDev, not a static (#223) — a static to the same /32
+	// would be shadowed by that connected route and sit unadvertised, holding
+	// inactive_routes non-zero. Empty in pf-only mode (no OVN view) and on a
+	// full-mode standby (no locally-active routers).
 	FRRStatic []string
 
 	// PrefixList is the sorted set of CIDR strings the ANNOUNCED-NETWORKS
@@ -184,8 +186,12 @@ type gatewayExpectation struct {
 	// non-empty provider-network set, per buildNftRuleset's writeSNATChain).
 	HairpinMasquerade []string
 
-	// ManagedVIPs is the set of VIP addresses expected as /32 on
-	// PortForwardDev, for VIPs with manage_vip on. Empty otherwise.
+	// ManagedVIPs is the set of VIP addresses expected as /32 on PortForwardDev,
+	// for VIPs with manage_vip on — but only where the agent announces them:
+	// always in pf-only mode, in full mode only on an active gateway. On a
+	// full-mode standby the address is withheld (dormancy is now enforced by the
+	// address, not the route — #223/#206), so this is nil there. The connected
+	// route of a present address is the VIP's announce path.
 	ManagedVIPs    []string
 	PortForwardDev string
 
@@ -243,13 +249,15 @@ func computeExpectation(snap ovnSnapshot, gw string, doc map[string]any, mgmtIP 
 	natIPs, lrpIPs, ipTag := ovnDesired(local, effective)
 	hairpin := sortedUnique(append(append([]string{}, natIPs...), lrpIPs...))
 
-	// Rule 4b (#206) — a port-forward VIP joins the route plane only where the
+	// Rule 4b (#206/#223) — a port-forward VIP is announceable only where the
 	// agent also maintains the prefix-list that would permit it: always in
 	// pf-only mode, in full mode only on an active gateway. On a full-mode
-	// standby the VIPs are dormant (agent.go vipRoutesAnnounceable): no kernel
-	// route, no FRR static route, so nothing can sit in FRR unadvertised and
-	// hold the inactive-routes gauge non-zero. The DNAT plane below is
-	// unaffected — dormancy withholds the routes, not the nftables rules.
+	// standby the VIP is dormant (agent.go vipRoutesAnnounceable): its address
+	// is withheld from PortForwardDev (see rule 11 ManagedVIPs) and it gets no
+	// kernel route, so nothing announces it. The FRR-static plane never carried
+	// the VIP in the first place — it announces through the connected route of
+	// its address, not a static. The DNAT plane below is unaffected: dormancy
+	// withholds the address, not the nftables rules.
 	routableVIPs := vips
 	if !pfOnly && !active {
 		routableVIPs = nil
@@ -257,10 +265,14 @@ func computeExpectation(snap ovnSnapshot, gw string, doc map[string]any, mgmtIP 
 	desired := sortedUnique(append(append([]string{}, hairpin...), routableVIPs...))
 
 	exp := gatewayExpectation{
-		Mode:           mode,
-		Active:         active,
-		DesiredIPs:     desired,
-		FRRStatic:      desired, // rule 6 — FRR static routes are exactly the desired IPs, in both modes.
+		Mode:   mode,
+		Active: active,
+		// rule 5/12 — the kernel-route and announce-staleness plane: the
+		// OVN-derived IPs plus the announceable VIPs.
+		DesiredIPs: desired,
+		// rule 6 — FRR static routes are exactly the OVN-derived set; a VIP is
+		// never a static, it announces through its connected route (#223).
+		FRRStatic:      hairpin,
 		PortForwardDev: docString(doc, "port_forward_dev", "loopback1"),
 		MACTweakFlows:  -1,
 		AnnounceBound:  desired, // rule 12 — announced ⊆ desired always.
@@ -308,12 +320,16 @@ func computeExpectation(snap ovnSnapshot, gw string, doc map[string]any, mgmtIP 
 		exp.MACTweakFlows = 2 * distinctSegments(local)
 	}
 
-	// Rules 10+11 — nftables. DNAT rules and managed-VIP addresses are managed
-	// independently of OVN state (ReconcilePortForward runs every cycle), so
-	// they follow the config alone.
+	// Rules 10+11 — nftables. The DNAT rules follow the config alone: they are
+	// managed independently of OVN state (ReconcilePortForward runs every
+	// cycle). The managed-VIP address is now the VIP's announce path (#223), so
+	// it is gated by announceability like the routes: present in pf-only mode or
+	// on a full-mode active gateway, withheld on a full-mode standby.
 	exp.DNAT = dnatExpectations(forwards)
 	exp.HairpinMasquerade = hairpinMasqueradeVIPs(forwards, effective)
-	exp.ManagedVIPs = managedVIPs(forwards)
+	if pfOnly || active {
+		exp.ManagedVIPs = managedVIPs(forwards)
+	}
 
 	// Rule 12 — announced presence bound.
 	switch {

--- a/test/e2e/chaos/expect_test.go
+++ b/test/e2e/chaos/expect_test.go
@@ -189,7 +189,12 @@ func TestExpectationPortForwardOnlySkipsEveryOVNPlane(t *testing.T) {
 	}
 	// Desired is the VIP alone — no FIPs, no gateway IPs.
 	assertSet(t, "DesiredIPs", exp.DesiredIPs, []string{apiVIPAddr})
-	assertSet(t, "FRRStatic", exp.FRRStatic, []string{apiVIPAddr})
+	// #223: the VIP is desired (kernel/announce plane) but is never an FRR
+	// static — it announces through its connected route. In pf-only mode there
+	// is no OVN view, so the FRR-static set is empty.
+	if len(exp.FRRStatic) != 0 {
+		t.Fatalf("FRRStatic = %v, want empty — the VIP announces via its connected route, not a static", exp.FRRStatic)
+	}
 	if !exp.SkipKernel || !exp.SkipHairpin || !exp.SkipPrefixList {
 		t.Fatalf("pf-only must skip the kernel/OVS/prefix planes: skipKernel=%v skipHairpin=%v skipPrefix=%v",
 			exp.SkipKernel, exp.SkipHairpin, exp.SkipPrefixList)
@@ -258,7 +263,12 @@ func TestExpectationDormantVIPOnStandbyGateway(t *testing.T) {
 	assertDNAT(t, exp.DNAT, []dnatExpectation{
 		{VIP: apiVIPAddr, Proto: "tcp", Port: apiVIPPort, Backend: "172.20.20.5", DestPort: apiVIPPort},
 	})
-	assertSet(t, "ManagedVIPs", exp.ManagedVIPs, []string{apiVIPAddr})
+	// #223: the VIP address is the announce path, so a full-mode standby
+	// withholds it — the managed-VIP set is empty even though the config carries
+	// manage_vip. This is the new mechanism the dormancy (#206) is enforced by.
+	if len(exp.ManagedVIPs) != 0 {
+		t.Fatalf("ManagedVIPs = %v, want none — a standby withholds the VIP address", exp.ManagedVIPs)
+	}
 }
 
 // With no port_forwards the agent's nftables table carries no DNAT chains and

--- a/test/e2e/chaos/lab.go
+++ b/test/e2e/chaos/lab.go
@@ -676,11 +676,24 @@ func (l *lab) verifyUnderlay(ctx context.Context, gw string, link underlayLink) 
 // It no longer races the entrypoint for the last word: configure_frr
 // skips its placeholder whenever the VRF already carries a BGP router
 // (issue #218), so this config survives whichever of the two runs second.
+//
+// `redistribute connected route-map ANNOUNCE-CONNECTED` is the port-forward
+// VIP's announce path (#223): the VIP is a local /32 on port_forward_dev, so
+// its connected route — filtered through a route-map that matches
+// ANNOUNCED-NETWORKS — is what BGP exports. The route-map form is deliberate:
+// on a standby the agent deletes ANNOUNCED-NETWORKS, and an undefined list
+// inside a route-map `match` is a no-match that falls through to the terminal
+// deny, exporting nothing — whereas a bare `redistribute connected` would leak
+// the underlay /30s. The route-map rides in the same transaction and is
+// persisted by the existing `write memory`.
 func (l *lab) configureGatewayBGP(ctx context.Context, gw string, link underlayLink) error {
 	upstreamIP := addrOf(link.upstreamCIDR)
 	routerID := addrOf(link.gatewayCIDR)
 	config := strings.Join([]string{
 		"configure terminal",
+		"route-map ANNOUNCE-CONNECTED permit 10",
+		" match ip address prefix-list ANNOUNCED-NETWORKS",
+		"exit",
 		"no router bgp 65000 vrf vrf-provider",
 		"router bgp 65000 vrf vrf-provider",
 		" bgp router-id " + routerID,
@@ -689,6 +702,7 @@ func (l *lab) configureGatewayBGP(ctx context.Context, gw string, link underlayL
 		" neighbor " + upstreamIP + " remote-as 65001",
 		" address-family ipv4 unicast",
 		"  redistribute static",
+		"  redistribute connected route-map ANNOUNCE-CONNECTED",
 		"  neighbor " + upstreamIP + " activate",
 		"  neighbor " + upstreamIP + " prefix-list ANNOUNCED-NETWORKS out",
 		" exit-address-family",

--- a/test/e2e/chaos/observe.go
+++ b/test/e2e/chaos/observe.go
@@ -673,11 +673,16 @@ func atoi(s string) int {
 // Upstream announcements
 // =============================================================================
 
-// upstreamRoutes maps each announced /32 (bare IP) to the set of gateways
-// announcing it, as read from the upstream BGP router.
+// upstreamRoutes maps each gateway-attributed announced prefix to the set of
+// gateways announcing it, as read from the upstream BGP router. A /32 is keyed
+// by its bare IP (matching AnnounceBound, which holds bare /32 IPs); any other
+// prefix keeps its full CIDR string, so a leaked non-/32 (an underlay /30 a
+// mis-filtered redistribute connected would export) lands in the "unexpected"
+// half of the oracle's announced check (#223).
 type upstreamRoutes map[string]map[string]bool
 
-// announcedBy returns the /32 IPs gw is currently announcing upstream.
+// announcedBy returns the prefixes gw is currently announcing upstream, keyed
+// as upstreamRoutes documents (bare IP for a /32, full CIDR otherwise).
 func (u upstreamRoutes) announcedBy(gw string) map[string]bool {
 	out := map[string]bool{}
 	for ip, gws := range u {
@@ -718,10 +723,17 @@ func observeUpstream(ctx context.Context, l *lab) (upstreamRoutes, error) {
 
 	routes := upstreamRoutes{}
 	for prefix, paths := range doc.Routes {
-		if !strings.HasSuffix(prefix, "/32") {
-			continue
+		// A /32 keeps its bare-IP key (so it matches AnnounceBound); any other
+		// prefix keeps its full CIDR string, so a gateway-attributed non-/32 —
+		// an underlay /30 a bare `redistribute connected` would leak — is
+		// recorded and flagged as unexpected by the announce bound. Only
+		// gateway-attributed prefixes land here at all: an upstream-originated
+		// route resolves to no gateway (byNexthop maps only gateway addresses)
+		// and stays invisible, as before.
+		key := prefix
+		if strings.HasSuffix(prefix, "/32") {
+			key = strings.TrimSuffix(prefix, "/32")
 		}
-		ip := strings.TrimSuffix(prefix, "/32")
 		for _, p := range paths {
 			addrs := make([]string, 0, len(p.Nexthops)+1)
 			for _, nh := range p.Nexthops {
@@ -732,10 +744,10 @@ func observeUpstream(ctx context.Context, l *lab) (upstreamRoutes, error) {
 			}
 			for _, addr := range addrs {
 				if gw := byNexthop[addr]; gw != "" {
-					if routes[ip] == nil {
-						routes[ip] = map[string]bool{}
+					if routes[key] == nil {
+						routes[key] = map[string]bool{}
 					}
-					routes[ip][gw] = true
+					routes[key][gw] = true
 				}
 			}
 		}

--- a/test/e2e/gwnode-entrypoint.sh
+++ b/test/e2e/gwnode-entrypoint.sh
@@ -417,6 +417,14 @@ frr_config() {
     # An empty vrf node renders as nothing in the running config, so there
     # is no state to probe for here — and re-asserting it is a no-op.
     printf 'vrf %s\nexit-vrf\n' "${VRF_NAME}"
+    # The route-map `redistribute connected` filters the VIP /32 through (#223).
+    # Asserted unconditionally like the vrf stanza — re-applying the identical
+    # route-map is a no-op, and unlike the BGP block below it must exist whether
+    # or not a real BGP router already owns the VRF (the two writers of the real
+    # config assert the same route-map in their own transactions). The match on
+    # ANNOUNCED-NETWORKS means a standby that deleted that list exports nothing
+    # via connected, so a present VIP address there is never advertised.
+    printf 'route-map ANNOUNCE-CONNECTED permit 10\n match ip address prefix-list ANNOUNCED-NETWORKS\nexit\n'
     if grep -q '^ip prefix-list ANNOUNCED-NETWORKS ' <<<"${running}"; then
         # The agent owns the entries at runtime and replaces this seed with
         # the real /32s, so re-seeding would put a permit-everything entry
@@ -439,6 +447,7 @@ router bgp 65000 vrf ${VRF_NAME}
  neighbor 192.0.2.1 remote-as 65001
  address-family ipv4 unicast
   redistribute static
+  redistribute connected route-map ANNOUNCE-CONNECTED
   neighbor 192.0.2.1 activate
   neighbor 192.0.2.1 prefix-list ANNOUNCED-NETWORKS out
  exit-address-family

--- a/test/integration/scenario_port_forward_test.go
+++ b/test/integration/scenario_port_forward_test.go
@@ -238,9 +238,16 @@ func TestScenario_PortForwardMatrix(t *testing.T) {
 		// manage_vip:true should add the VIP/32 to loopback1; manage_vip:false
 		// (the default) should leave it absent. Verified via
 		// `ip -j addr show dev loopback1`.
+		//
+		// Runs in port-forward-only mode (both OVN remotes cleared, the config
+		// writer omits empty keys): pf-only is where "manage_vip adds the
+		// address" holds unconditionally, because the VIP is always announceable.
+		// Routerless full mode would now withhold the address as dormant (#223).
 		{
 			name: "manage_vip_on_off",
 			setup: func(t *testing.T, cfg *testenv.AgentConfig) {
+				cfg.OVNNBRemote = ""
+				cfg.OVNSBRemote = ""
 				cfg.PortForwards = []testenv.PortForwardVIPFixture{
 					{
 						VIP:       "198.51.100.10",
@@ -559,8 +566,11 @@ func TestScenario_PortForwardVIPDormantWithoutLocalRouters(t *testing.T) {
 	cfg := startPFScenario(t)
 
 	const vip = "198.51.100.42"
+	// manage_vip so the address is the thing under test: a full-mode standby
+	// must withhold it — the new dormancy mechanism (#223).
 	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
-		VIP: vip,
+		VIP:       vip,
+		ManageVIP: true,
 		Rules: []testenv.PortForwardRuleFixture{{
 			Proto: "tcp", Port: 80, DestAddr: "10.0.0.100",
 		}},
@@ -575,10 +585,13 @@ func TestScenario_PortForwardVIPDormantWithoutLocalRouters(t *testing.T) {
 		func(r testenv.NftRule) bool { return r.HasMatch("ip", "daddr", vip) },
 		30*time.Second, "DNAT rule for dormant VIP "+vip)
 
-	// Neither route may appear. Both assertions poll for their whole timeout,
-	// so this covers several reconcile cycles at the 5s default interval.
+	// Neither route may appear, and the VIP address must be withheld from the
+	// port-forward device — the announce path itself is what dormancy withholds
+	// now (#223). All three assertions poll for their whole timeout, so this
+	// covers several reconcile cycles at the 5s default interval.
 	testenv.AssertNoFRRRoute(t, vip, 15*time.Second)
 	testenv.AssertNoKernelRoute(t, vip, 5*time.Second)
+	testenv.AssertVIPNotOnLoopback(t, vip, 15*time.Second)
 
 	logs := a.LogTail(100000)
 	if strings.Contains(logs, "FRR static routes are configured but inactive") {
@@ -586,6 +599,66 @@ func TestScenario_PortForwardVIPDormantWithoutLocalRouters(t *testing.T) {
 	}
 	if !strings.Contains(logs, "port-forward VIPs are dormant on this node") {
 		t.Errorf("expected the dormancy to be reported once at info level; last logs:\n%s", a.LogTail(40))
+	}
+}
+
+// TestScenario_PortForwardVIPAnnouncedViaConnected (#223).
+//
+// The active-gateway counterpart of the dormant scenario, and the direct pin
+// for the bug this issue fixes. On a gateway that owns a local router the
+// managed VIP is announceable, so the agent installs its /32 address on
+// port_forward_dev (whose connected route is the BGP announce path) and its
+// kernel /32 on the provider bridge — but writes no FRR static for it. The
+// pre-fix agent wrote that static and the connected route permanently shadowed
+// it, so the VIP was never advertised while the agent logged the inactive-route
+// ERROR every cycle. Here the static must be absent *while active*, no
+// inactive-route alarm may fire, and the two other planes (address, kernel
+// route) must be present.
+func TestScenario_PortForwardVIPAnnouncedViaConnected(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+	testenv.EnsureLoopback1(t)
+	testenv.ScrubPortForwardResidue(t)
+
+	// A locally-active router makes this gateway active, so its managed VIP is
+	// announceable — the condition under which the bug manifested.
+	_ = testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "pfannouncer",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	const vip = "198.51.100.50"
+	cfg := pfDefaults(t)
+	cfg.PortForwards = []testenv.PortForwardVIPFixture{{
+		VIP:       vip,
+		ManageVIP: true,
+		Rules: []testenv.PortForwardRuleFixture{{
+			Proto: "tcp", Port: 80, DestAddr: "10.0.0.100",
+		}},
+	}}
+
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+	// A SIGKILL from a failing assertion would leave nft / loopback residue.
+	t.Cleanup(func() { testenv.ScrubPortForwardResidue(t) })
+
+	// The announce path exists: the VIP address on the port-forward device
+	// (its connected route is what BGP redistributes) and the kernel /32 on the
+	// provider bridge.
+	testenv.AssertVIPOnLoopback(t, vip, 15*time.Second)
+	testenv.AssertKernelRoute(t, vip, 15*time.Second)
+
+	// The shadowed static must be gone while the gateway is active — the actual
+	// bug. The negative assertion polls its whole timeout, covering several
+	// reconcile cycles at the 5s default interval.
+	testenv.AssertNoFRRRoute(t, vip, 15*time.Second)
+
+	// And no inactive-route alarm: with the VIP out of the FRR-static set,
+	// nothing sits in FRR unadvertised holding ovn_network_agent_inactive_routes
+	// non-zero.
+	logs := a.LogTail(100000)
+	if strings.Contains(logs, "FRR static routes are configured but inactive") {
+		t.Errorf("an announced VIP must not raise the inactive-route alarm; last logs:\n%s", a.LogTail(40))
 	}
 }
 
@@ -688,6 +761,11 @@ func TestScenario_PortForwardOutputChains(t *testing.T) {
 // AgentProc.Stop, and assert both the table and the VIP are gone.
 func TestScenario_PortForwardCleanupOnSIGTERM(t *testing.T) {
 	cfg := startPFScenario(t)
+	// Port-forward-only mode (both remotes cleared): pf-only is where a
+	// manage_vip address is added unconditionally, so there is a managed VIP to
+	// clean up. Routerless full mode would now withhold it as dormant (#223).
+	cfg.OVNNBRemote = ""
+	cfg.OVNSBRemote = ""
 
 	const vip = "198.51.100.99"
 	cfg.PortForwards = []testenv.PortForwardVIPFixture{{

--- a/test/integration/setup.sh
+++ b/test/integration/setup.sh
@@ -171,9 +171,16 @@ configure_frr() {
     # Push minimal FRR config: vrf-provider + ANNOUNCED-NETWORKS prefix-list +
     # a dummy BGP peer (192.0.2.1, no real session). Idempotent: re-running
     # the conf-t block overwrites prior state for these objects.
+    # The redistribute-connected route-map is inert here (the dummy neighbor
+    # never establishes) but kept for parity with the gateway configs the chaos
+    # lab and gwnode entrypoint write — the port-forward VIP's announce path
+    # (#223).
     vtysh <<'EOF'
 configure terminal
 ip prefix-list ANNOUNCED-NETWORKS seq 5 permit 0.0.0.0/0 ge 32 le 32
+route-map ANNOUNCE-CONNECTED permit 10
+ match ip address prefix-list ANNOUNCED-NETWORKS
+exit
 vrf vrf-provider
 exit-vrf
 router bgp 65000 vrf vrf-provider
@@ -183,6 +190,7 @@ router bgp 65000 vrf vrf-provider
  neighbor 192.0.2.1 update-source lo
  address-family ipv4 unicast
   redistribute static
+  redistribute connected route-map ANNOUNCE-CONNECTED
   neighbor 192.0.2.1 activate
   neighbor 192.0.2.1 prefix-list ANNOUNCED-NETWORKS out
  exit-address-family


### PR DESCRIPTION
## Summary

A port-forward VIP with `manage_vip: true` was never announced via BGP: the agent installed, for the same `/32` in `vrf-provider`, both the VIP address on `port_forward_dev` (connected route, administrative distance 0) and an FRR static via the veth next-hop (distance 1). Connected always wins, `redistribute static` never exports the shadowed static, and nothing exported the connected route — the VIP stayed dark while `ovn_network_agent_inactive_routes` held at 1 and the `FRR static routes are configured but inactive` ERROR repeated on every reconcile of a healthy gateway. Exactly the three chaos profiles that probe the API VIP (`flat-dnat`, `pf-only`, `heterogeneous`) failed their start-state gate on this.

This PR adopts the model `docs/guides/port-forwarding.md` already documents: **the connected route on `port_forward_dev` is the VIP's announce path.**

- Port-forward VIPs leave the FRR static plane: `desiredState` gains `FRRStaticIPs` (OVN-derived IPs only), threaded through `ensureRoutes`, `verifyRoutes`, and `checkFRRRouteActivity`. The VIP's kernel `/32` on the provider bridge stays. A pre-upgrade VIP static is withdrawn by the orphan path on the first cycle.
- Dormancy (#206) moves from withholding the static to withholding the address: a full-mode standby removes managed VIP addresses; an active or pf-only gateway ensures them add-if-missing, ending the per-cycle `AddrReplace`/`RTM_NEWADDR` churn. `SetupPortForward` in full mode only verifies the device — the first reconcile settles the address.
- The four harness BGP configs gain `redistribute connected route-map ANNOUNCE-CONNECTED` with `match ip address prefix-list ANNOUNCED-NETWORKS`: an active gateway exports the VIP `/32` (the `/30`s fail `ge 32 le 32`), a standby whose prefix-list the agent deleted exports nothing (undefined list in a route-map match is a no-match → terminal deny), and pf-only mode passes via the entrypoint placeholder.
- The chaos oracle expects the new model: `FRRStatic` is the OVN-derived set, `ManagedVIPs` is gated by announceability, and `observeUpstream` now attributes non-`/32` prefixes too, so any leaked underlay prefix fails the `AnnounceBound` check.
- Integration tests cover all three states — active (new `TestScenario_PortForwardVIPAnnouncedViaConnected`: no VIP static, no inactive-route alarm, address present), full-mode standby (dormant test now pins the absent address), pf-only (`manage_vip_on_off` and the SIGTERM cleanup scenario moved there).
- Docs (`guides/port-forwarding`, `guides/frr-prefix-list`, `guides/configuration`, `explanation/port-forwarding`) describe the connected-route model, the required FRR snippet, and the standby behavior.

Closes #223.

## Verification

- `make vet` and `make test` green (unit tests plus the chaos harness's own tests).
- `GOOS=linux go build ./...` and `GOOS=linux go build -tags integration ./test/integration/...` green; `gofmt -l` clean; `bash -n` on the three edited shell scripts.
- The integration and containerlab suites need Linux/root and run in CI; the chaos start-state gate for `flat-dnat`, `pf-only`, and `heterogeneous` is the end-to-end acceptance check for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
