### PR TITLE
test/e2e: carry the heterogeneous API VIP on gateway-1 too

### DIFF
--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -1030,7 +1030,7 @@ The set is curated, not combinatorial:
 | `flat-dnat` | hairpin + port-forward | the API VIP (`port_forwards` + `port_forward_l3mdev_accept`) | `fip-vm1`, `fip-vm2`, `pf-vip`, `api-vip` |
 | `vlan-no-dnat` | hairpin + VLAN | the baked lab config, unchanged | `fip-vm1`, `fip-vm2`, both VLAN FIPs |
 | `pf-only` | baseline only | **no OVN remotes** + the API VIP + `network_cidr` | `api-vip` |
-| `heterogeneous` | hairpin + VLAN + port-forward | `gateway-1` baked, `gateway-2` API VIP + drain, `gateway-3` manual `network_cidr` + 15 s cadence + cleanup | the four FIPs + `pf-vip` + `api-vip` |
+| `heterogeneous` | hairpin + VLAN + port-forward | `gateway-1` API VIP, `gateway-2` API VIP + drain, `gateway-3` manual `network_cidr` + 15 s cadence + cleanup | the four FIPs + `pf-vip` + `api-vip` |
 
 The **API VIP** (`192.0.2.80:8080`) is the agent's own DNAT path, as
 opposed to `pf-vip`, which is an OVN `Load_Balancer`. Its backend is a
@@ -1043,9 +1043,14 @@ exactly the effective networks: a VIP outside every covered prefix is
 never announced. In `pf-only` that filter has to be set by hand
 (`network_cidr`) — without OVN there is nothing to discover it from.
 
-Under `heterogeneous`, `api-vip` is announced by `gateway-2` alone, so it
-is legitimately dark while `gateway-2` is held down — the same
-pinned-resource semantics the VLAN FIPs already have on `gateway-1`.
+Under `heterogeneous`, the API VIP sits on `gateway-1` *and*
+`gateway-2`: a full-mode gateway only announces its port-forward VIPs
+while it holds a locally active router (the dormant gate), and at start
+every router is active on `gateway-1`, the highest-priority chassis —
+carried by `gateway-2` alone the VIP would be dormant on every gateway
+and the `api-vip` probe could never go green. With both carrying it, the
+active chassis announces it from the start, and losing `gateway-1` hands
+`lr0` — and with it the announce — to `gateway-2`.
 
 **How a profile is applied.** No image rebuild, no redeploy: the config
 file is the only thing that changes, and the gwnode entrypoint `exec`s

--- a/test/e2e/chaos/apply_test.go
+++ b/test/e2e/chaos/apply_test.go
@@ -146,34 +146,28 @@ func TestApplyProfileSkipsGatewaysThatAreAlreadyOnTheConfig(t *testing.T) {
 // gateways roll one at a time: each is back — container healthy, chassis
 // re-registered — before the next one is touched.
 func TestApplyProfileRollsTheGatewaysOneAtATime(t *testing.T) {
-	// gateway-1 is already on the config the heterogeneous profile leaves
-	// it on — the baked one — so only the other two have to roll.
-	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
-		line := strings.Join(argv, " ")
-		if strings.Contains(line, "cat "+agentConfigPath) && strings.Contains(line, "gateway-1") {
-			return string(baseConfig(t)), nil
-		}
-		return labWithConfig("stale config\n")(argv)
-	}}
+	// The heterogeneous profile overlays all three gateways, so all
+	// three have to roll.
+	cmd := &fakeCommander{respond: labWithConfig("stale config\n")}
 	a := newTestApplier(t, cmd, "heterogeneous")
 
 	if err := a.applyProfile(context.Background()); err != nil {
 		t.Fatalf("applyProfile: %v", err)
 	}
 
-	firstRestart := cmd.indexOf("docker restart clab-ovn-e2e-gateway-2")
-	firstBack := cmd.indexOf("find Chassis name=gateway-2")
-	secondRestart := cmd.indexOf("docker restart clab-ovn-e2e-gateway-3")
-	if firstRestart < 0 || firstBack < 0 || secondRestart < 0 {
-		t.Fatalf("the roll did not restart and gate both overlaid gateways: %v", cmd.lines())
+	firstRestart := cmd.indexOf("docker restart clab-ovn-e2e-gateway-1")
+	firstBack := cmd.indexOf("find Chassis name=gateway-1")
+	secondRestart := cmd.indexOf("docker restart clab-ovn-e2e-gateway-2")
+	secondBack := cmd.indexOf("find Chassis name=gateway-2")
+	thirdRestart := cmd.indexOf("docker restart clab-ovn-e2e-gateway-3")
+	if firstRestart < 0 || firstBack < 0 || secondRestart < 0 || secondBack < 0 || thirdRestart < 0 {
+		t.Fatalf("the roll did not restart and gate all three overlaid gateways: %v", cmd.lines())
 	}
 	if firstBack > secondRestart {
-		t.Fatalf("gateway-3 was restarted before gateway-2 was back: %v", cmd.lines())
+		t.Fatalf("gateway-2 was restarted before gateway-1 was back: %v", cmd.lines())
 	}
-	// gateway-1 runs the baked config under this profile, so it is never
-	// restarted at all.
-	if cmd.called("docker restart clab-ovn-e2e-gateway-1") {
-		t.Fatalf("a gateway the profile leaves alone was restarted: %v", cmd.lines())
+	if secondBack > thirdRestart {
+		t.Fatalf("gateway-3 was restarted before gateway-2 was back: %v", cmd.lines())
 	}
 	if !cmd.called("printf '%s' 'heterogeneous' > " + profileMarkerPath) {
 		t.Fatalf("the reconfigured gateways were not marked as profile-owned: %v", cmd.lines())

--- a/test/e2e/chaos/flips_test.go
+++ b/test/e2e/chaos/flips_test.go
@@ -101,7 +101,7 @@ func TestInapplicableFlips(t *testing.T) {
 		},
 		{
 			flip: "masquerade-toggle", profile: "heterogeneous", gw: "gateway-3",
-			reason: "only gateway-2 carries the API VIP under this profile",
+			reason: "the profile keeps the API VIP off this gateway",
 		},
 		{
 			flip: "cidr-toggle", profile: "heterogeneous", gw: "gateway-3",

--- a/test/e2e/chaos/profiles.go
+++ b/test/e2e/chaos/profiles.go
@@ -219,16 +219,23 @@ func profiles() []*profile {
 		},
 		{
 			// What a rollout looks like from the inside: the gateways run
-			// different configurations at the same time. The API VIP is
-			// announced by gateway-2 alone, so it is legitimately dark
-			// while gateway-2 is held down — the same pinned-resource
-			// semantics the VLAN FIPs already have on gateway-1.
+			// different configurations at the same time. The API VIP sits
+			// on gateway-1 *and* gateway-2: a full-mode gateway only
+			// announces its port-forward VIPs while it holds a locally
+			// active router (the dormant gate, #206), and at start every
+			// router is active on gateway-1, the highest-priority chassis
+			// — pinned to gateway-2 alone the VIP would be dormant on
+			// every gateway and the api-vip probe could never go green.
+			// Carried by both, the active chassis announces it from the
+			// start, and losing gateway-1 hands lr0 — and with it the
+			// announce — to gateway-2.
 			name:        "heterogeneous",
 			description: "each gateway on a different configuration, as mid-rollout",
 			hairpin:     true,
 			vlans:       true,
 			ovnLB:       true,
 			gateways: map[string]gwConfig{
+				"gateway-1": {apiVIP: true},
 				"gateway-2": {apiVIP: true, drainOnShutdown: true},
 				"gateway-3": {
 					networkCIDRs:      explicitCIDRs,

--- a/test/e2e/chaos/profiles_test.go
+++ b/test/e2e/chaos/profiles_test.go
@@ -173,13 +173,12 @@ func TestHeterogeneousProfileRendersOneConfigPerGateway(t *testing.T) {
 		t.Fatalf("profileByName: %v", err)
 	}
 
-	base := baseConfig(t)
-	first, err := renderConfig(base, p.gwConfig("gateway-1"), "172.20.20.4")
-	if err != nil {
-		t.Fatalf("render gateway-1: %v", err)
+	first := render(t, p.gwConfig("gateway-1"), "172.20.20.4")
+	if vipsIn(t, first)[apiVIPAddr] == nil {
+		t.Fatalf("gateway-1 = %v, want the API VIP", first)
 	}
-	if !bytes.Equal(first, base) {
-		t.Fatalf("gateway-1 was meant to stay on the baked config:\n%s", first)
+	if first["drain_on_shutdown"] == true {
+		t.Fatalf("gateway-1 = %v, want the VIP without the drain — that is gateway-2's variant", first)
 	}
 
 	second := render(t, p.gwConfig("gateway-2"), "172.20.20.5")
@@ -198,8 +197,8 @@ func TestHeterogeneousProfileRendersOneConfigPerGateway(t *testing.T) {
 		t.Fatalf("gateway-3 was handed a DNAT config it never asked for: %v", third["port_forwards"])
 	}
 
-	if got := p.apiVIPGateways(); len(got) != 1 || got[0] != "gateway-2" {
-		t.Fatalf("apiVIPGateways = %v, want only the gateway whose config carries the VIP", got)
+	if got := strings.Join(p.apiVIPGateways(), ","); got != "gateway-1,gateway-2" {
+		t.Fatalf("apiVIPGateways = %v, want exactly the gateways whose configs carry the VIP", got)
 	}
 }
 

--- a/test/e2e/chaos/state_test.go
+++ b/test/e2e/chaos/state_test.go
@@ -283,14 +283,16 @@ func TestStartStateStartsTheAPIBackendOnlyOnItsGateways(t *testing.T) {
 		t.Fatalf("applyStartState: %v", err)
 	}
 
-	if !cmd.called("exec -d clab-ovn-e2e-gateway-2 /usr/local/bin/pf-backend -addr :8080 -log " + apiBackendLog) {
-		t.Fatalf("the API backend was not started on the gateway that announces the VIP: %v", cmd.lines())
+	for _, gw := range []string{"gateway-1", "gateway-2"} {
+		if !cmd.called("exec -d clab-ovn-e2e-" + gw + " /usr/local/bin/pf-backend -addr :8080 -log " + apiBackendLog) {
+			t.Fatalf("the API backend was not started on %s, whose config carries the VIP: %v", gw, cmd.lines())
+		}
 	}
-	if cmd.called("exec -d clab-ovn-e2e-gateway-1 /usr/local/bin/pf-backend") {
+	if cmd.called("exec -d clab-ovn-e2e-gateway-3 /usr/local/bin/pf-backend") {
 		t.Fatalf("the API backend was started on a gateway whose config has no VIP: %v", cmd.lines())
 	}
-	if cmd.count("pkill -f "+apiBackendLog) != 1 {
-		t.Fatalf("the API backend was reset on more than its own gateway: %v", cmd.lines())
+	if cmd.count("pkill -f "+apiBackendLog) != 2 {
+		t.Fatalf("the API backend was reset on more than its own gateways: %v", cmd.lines())
 	}
 	for _, line := range cmd.lines() {
 		if strings.Contains(line, "pkill") && strings.Contains(line, "/usr/local/bin/pf-backend") {
@@ -314,9 +316,10 @@ func TestReprovisionRestartsTheAPIBackendOnItsGateways(t *testing.T) {
 	}
 
 	// A gateway with neither node-local workloads nor an API VIP has
-	// nothing to reprovision.
+	// nothing to reprovision — under this profile every gateway carries
+	// something, so the empty case needs one without any DNAT at all.
 	peer := &fakeCommander{respond: healthyLabResponses}
-	if err := reprovisionNode(context.Background(), newTestLab(peer, newFakeClock()), p, "gateway-1"); err != nil {
+	if err := reprovisionNode(context.Background(), newTestLab(peer, newFakeClock()), testProfile(t, "vlan-no-dnat"), "gateway-1"); err != nil {
 		t.Fatalf("reprovision gateway-1: %v", err)
 	}
 	if len(peer.lines()) != 0 {


### PR DESCRIPTION
The `heterogeneous` chaos profile has **never been green** — six runs since it landed, six failures — and since the dormant gate (#206) the failure is deterministic: the run dies before the first tick with `start-state-not-green: api-vip`. Nightly 29806008161 and its exact replay 29840249636 (same seed, on `main` with #224 already in) both fail this way, while #224 fixed the same start-state symptom for `flat-dnat` and `pf-only` — their replays are green. `heterogeneous` was the remaining red.

## Root cause

The profile pinned the API VIP (`192.0.2.80`) to gateway-2 alone, on the assumption that it is only "legitimately dark while gateway-2 is *held down*". The dormant gate changed that invariant: a full-mode gateway withholds its port-forward VIPs while it holds **no locally active router** (`vipRoutesAnnounceable = PortForwardOnly || HasLocalRouters`), because the standby path empties the prefix-list the announce depends on. And at start, gateway-2 is always that standby — `lr0-public`'s `Gateway_Chassis` priorities are gateway-1 30, gateway-2 20, gateway-3 10, and both VLAN routers are pinned to gateway-1 outright.

The replay's artifacts show the whole chain:

- gateway-2's agent, right after the profile roll: `port-forward VIPs are dormant on this node — no locally active routers … vips=[192.0.2.80]`, then `has_local_routers=false` on every reconcile for the full two-minute start window.
- gateway-2/-3's FRR running-config carries neither the static VIP routes nor the `ANNOUNCED-NETWORKS` prefix-list; upstream shows `PfxRcd 0` from both, 8 prefixes from gateway-1 only.

The harness's own expectation model already encodes the gate (rule 4b in `expect.go`) — only the profile's unconditional start probe contradicted it. No seed can pass; a replay could never help.

## Fix

Give gateway-1 the `apiVIP` overlay too. The active chassis announces the VIP from the start, and losing gateway-1 hands `lr0` — and with it the announce — to gateway-2. The profile stays heterogeneous: three gateways, three distinct configurations (gateway-1 VIP only, gateway-2 VIP + drain, gateway-3 manual filter + slow cadence + cleanup). This mirrors what `flat-dnat` already proves green: a VIP carried by the gateway that holds the routers.

## Adjusted alongside

- `profiles_test.go` — gateway-1 now renders the VIP (previously asserted byte-identity with the baked config); `apiVIPGateways` = `[gateway-1, gateway-2]`.
- `apply_test.go` — the roll test expects three sequential restarts, each gated on the previous gateway being back (gateway-1 no longer sits out the roll).
- `state_test.go` — the API backend starts on gateway-1 *and* gateway-2, not on gateway-3; the nothing-to-reprovision case moves to `vlan-no-dnat`, since under `heterogeneous` every gateway now carries something.
- `flips_test.go` — stale reason string; the gateway-3 inapplicability itself is unchanged.
- `docs/contributing/e2e-tests.md` — profile table and the VIP-placement paragraph rewritten around the dormant gate.

`go vet` and `go test ./test/e2e/chaos/...` are green. End-to-end validation: dispatch the workflow on this branch with seed `29806008161`, profile `heterogeneous` — the exact failing case.

Assisted-by: Claude:claude-fable-5