### PR TITLE
fix: give every announceable port-forward VIP its own prefix-list /32

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -392,14 +392,18 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 			slog.Error("failed to ensure gateway routing", "error", err)
 		}
 
-		// Reconcile FRR prefix-list entries for discovered networks. The
-		// prefix-list is the BGP outbound filter (neighbor ... prefix-list
-		// ... out) and it is what permits the FIP /32s, so the announce
-		// below advertises nothing until it is populated. A standby chassis
-		// empties it via the default: branch, so on a takeover this must run
-		// BEFORE the announce — it is reachability-critical, not a stability
-		// step.
-		if err := a.routing.ReconcileFRRPrefixList(a.effectiveFilters); err != nil {
+		// Reconcile FRR prefix-list entries for discovered networks plus an
+		// exact /32 per announceable port-forward VIP. The prefix-list is the
+		// BGP outbound filter (neighbor ... prefix-list ... out) and the
+		// route-map filter on redistribute connected, so the announce below
+		// advertises nothing until it is populated. The VIP entries are
+		// load-bearing, not redundant: a VIP outside every hosted network
+		// (flat-range VIP on a chassis hosting only VLAN routers) has no
+		// network entry covering its connected route (#226). A standby
+		// chassis empties the list via the default: branch, so on a takeover
+		// this must run BEFORE the announce — it is reachability-critical,
+		// not a stability step.
+		if err := a.routing.ReconcileFRRPrefixList(a.effectiveFilters, desired.AnnouncedVIPs); err != nil {
 			slog.Error("failed to reconcile FRR prefix-list", "error", err)
 		}
 	default:
@@ -407,7 +411,7 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 		if err := a.routing.ReconcileVethLeakNetworks(nil); err != nil {
 			slog.Error("failed to clean veth leak networks", "error", err)
 		}
-		if err := a.routing.ReconcileFRRPrefixList(nil); err != nil {
+		if err := a.routing.ReconcileFRRPrefixList(nil, nil); err != nil {
 			slog.Error("failed to clean FRR prefix-list", "error", err)
 		}
 		if err := a.routing.ReconcileOVSHairpinFlows(nil); err != nil {
@@ -622,7 +626,10 @@ func (a *Agent) computeEffectiveNetworks(discovered []*net.IPNet) []*net.IPNet {
 // they join the kernel-route plane.
 //
 // A VIP is only announceable where the agent also maintains the FRR prefix-list
-// that permits it. Without local routers reconcile takes the standby path,
+// that permits it — and maintaining it means writing an exact "permit <vip>/32"
+// entry per announceable VIP, not relying on a hosted network's entry to cover
+// the VIP (#226: a flat-range VIP on a chassis hosting only VLAN routers has no
+// covering network). Without local routers reconcile takes the standby path,
 // which empties that prefix-list and the veth-leak network routes — a VIP
 // announced anyway could never be advertised, and with the route-map on
 // redistribute connected the deleted prefix-list stops the connected export
@@ -931,7 +938,7 @@ func (a *Agent) cleanup() {
 	a.removeAllRoutes("shutdown cleanup")
 
 	// Clean up FRR prefix-list entries.
-	if err := a.routing.ReconcileFRRPrefixList(nil); err != nil {
+	if err := a.routing.ReconcileFRRPrefixList(nil, nil); err != nil {
 		slog.Error("failed to cleanup FRR prefix-list", "error", err)
 	}
 

--- a/agent_test.go
+++ b/agent_test.go
@@ -2018,6 +2018,68 @@ func TestReconcileSkipsFailoverMetricOnStartup(t *testing.T) {
 // withdraws routes reports changed (so verification still runs) but not
 // announced: withdrawing a /32 attracts no traffic, so it is not a takeover
 // announce and must not feed the failover-latency metric.
+// TestReconcilePrefixListCarriesVIPOutsideHostedNetworks pins #226: a
+// port-forward VIP outside every hosted network must still get its own exact
+// "permit <vip>/32" prefix-list entry. The VIP announces through its connected
+// route filtered by that list; before the fix the list held only the hosted
+// networks' CIDRs, so a flat-range VIP on a chassis hosting only VLAN routers
+// passed the announceability gate (HasLocalRouters), had its address and DNAT
+// installed — and was silently never exported. The nightly heterogeneous chaos
+// profile blackholed its API VIP exactly this way the moment a priority flip
+// moved the flat router elsewhere.
+func TestReconcilePrefixListCarriesVIPOutsideHostedNetworks(t *testing.T) {
+	rec := newVtyshRecorder()
+	rm := &RouteManager{
+		cfg:                  Config{BridgeDev: "br-ex", VRFName: "vrf-provider", VethNexthop: "169.254.0.1", FRRPrefixList: "fip-out"},
+		execVtyshHook:        rec.hook(),
+		execOVSHook:          newOVSRecorder().hook(),
+		listKernelRoutesHook: func() ([]kernelRouteEntry, error) { return nil, nil },
+	}
+
+	// One locally-active VLAN router; the VIP 192.0.2.80 lies outside its
+	// 198.51.100.0/24 network — the heterogeneous split.
+	_, cidr, _ := net.ParseCIDR("198.51.100.0/24")
+	c, _, _ := newOVNClientWithFakes(t, "host-a")
+	c.state.Replace(OVNState{
+		LocalRouters: []LocalRouterInfo{{
+			RouterName:  "router-vlan101",
+			LRPName:     "lrp-vlan101",
+			LRPMAC:      "aa:aa:aa:aa:aa:aa",
+			LRPNetworks: []string{"198.51.100.0/24"},
+		}},
+		HasLocalRouters:    true,
+		DiscoveredNetworks: []*net.IPNet{cidr},
+	})
+	a := &Agent{
+		cfg:            Config{PortForwards: []PortForwardVIP{{VIP: "192.0.2.80", ManageVIP: true}}},
+		ovn:            c,
+		routing:        rm,
+		reconcileCh:    make(chan struct{}, 1),
+		missingChassis: make(map[string]time.Time),
+	}
+
+	a.reconcile(context.Background(), "test")
+
+	var sawVIP, sawNetwork bool
+	for _, args := range rec.calls {
+		j := strings.Join(args, " ")
+		if strings.Contains(j, "ip prefix-list fip-out seq") &&
+			strings.HasSuffix(j, "permit 192.0.2.80/32 -c end") &&
+			!strings.Contains(j, "no ip prefix-list") {
+			sawVIP = true
+		}
+		if strings.Contains(j, "permit 198.51.100.0/24 ge 32 le 32") {
+			sawNetwork = true
+		}
+	}
+	if !sawVIP {
+		t.Errorf("reconcile must add an exact permit for the VIP /32 even though no hosted network covers it; calls: %v", rec.calls)
+	}
+	if !sawNetwork {
+		t.Errorf("the hosted network's ge/le entry must still be added; calls: %v", rec.calls)
+	}
+}
+
 func TestEnsureRoutesRemovalOnlyIsNotAnnounce(t *testing.T) {
 	rec := newVtyshRecorder()
 	// FRR still carries a /32 that is no longer desired.

--- a/desired_state.go
+++ b/desired_state.go
@@ -63,6 +63,14 @@ type desiredState struct {
 	// DesiredIPs because this node cannot advertise them, sorted. Reported by
 	// reconcile at info level on change.
 	DormantVIPs []string
+
+	// AnnouncedVIPs is the complement of DormantVIPs: the configured
+	// port-forward VIPs that join the announce plane this cycle, sorted.
+	// Each gets an exact "permit <vip>/32" entry in the FRR prefix-list
+	// (ReconcileFRRPrefixList) so its connected route is exported even when
+	// no hosted network covers the VIP (#226). Empty when the VIPs are
+	// dormant.
+	AnnouncedVIPs []string
 }
 
 // buildHairpinTargets collects every IP that needs a hairpin flow: the NAT
@@ -168,13 +176,14 @@ func computeDesiredState(state OVNState, portForwards []PortForwardVIP, announce
 	// port_forward_dev, so they join DesiredIPs but never FRRStaticIPs.
 	desiredIPs := make([]string, 0, len(hairpinIPs)+len(portForwards))
 	desiredIPs = append(desiredIPs, hairpinIPs...)
-	var dormantVIPs []string
+	var dormantVIPs, announcedVIPs []string
 	for _, pf := range portForwards {
 		if !announceVIPs {
 			dormantVIPs = append(dormantVIPs, pf.VIP)
 			continue
 		}
 		desiredIPs = append(desiredIPs, pf.VIP)
+		announcedVIPs = append(announcedVIPs, pf.VIP)
 	}
 
 	return desiredState{
@@ -186,5 +195,6 @@ func computeDesiredState(state OVNState, portForwards []PortForwardVIP, announce
 		DesiredIPs:     uniqueIPs(desiredIPs),
 		FRRStaticIPs:   uniqueIPs(hairpinIPs),
 		DormantVIPs:    uniqueIPs(dormantVIPs),
+		AnnouncedVIPs:  uniqueIPs(announcedVIPs),
 	}
 }

--- a/desired_state_test.go
+++ b/desired_state_test.go
@@ -161,6 +161,12 @@ func TestComputeDesiredState(t *testing.T) {
 	if len(got.DormantVIPs) != 0 {
 		t.Errorf("DormantVIPs = %v, want empty when the VIPs are announceable", got.DormantVIPs)
 	}
+	// #226: the announceable VIPs are exposed for the prefix-list — including
+	// one that duplicates a FIP, since its /32 entry is what permits the
+	// connected route regardless of network coverage.
+	if want := []string{"198.51.100.50", "203.0.113.10"}; !reflect.DeepEqual(got.AnnouncedVIPs, want) {
+		t.Errorf("AnnouncedVIPs = %v, want %v (deduped, sorted)", got.AnnouncedVIPs, want)
+	}
 	if want := []string{"198.51.100.50", "203.0.113.10"}; !reflect.DeepEqual(got.DesiredIPs, want) {
 		t.Errorf("DesiredIPs = %v, want %v (VIPs merged, deduped, sorted)", got.DesiredIPs, want)
 	}
@@ -246,6 +252,10 @@ func TestComputeDesiredStateDormantVIPs(t *testing.T) {
 	}
 	if want := []string{"192.0.2.99", "203.0.113.10"}; !reflect.DeepEqual(got.DormantVIPs, want) {
 		t.Errorf("DormantVIPs = %v, want %v (deduped, sorted)", got.DormantVIPs, want)
+	}
+	// A dormant VIP gets no prefix-list entry either (#226).
+	if len(got.AnnouncedVIPs) != 0 {
+		t.Errorf("AnnouncedVIPs = %v, want empty when the VIPs are dormant", got.AnnouncedVIPs)
 	}
 }
 

--- a/docs/explanation/port-forwarding.md
+++ b/docs/explanation/port-forwarding.md
@@ -419,8 +419,12 @@ requires an explicit `network_cidr`.
 ## Dormant VIPs on a gateway without local routers
 
 A VIP is only announceable on a node where the agent also maintains the FRR
-prefix-list that permits it. On a gateway that hosts no locally active
-router — a standby chassis, or one whose routers have failed over
+prefix-list that permits it — and "permits it" means an entry of the VIP's
+own: on an active gateway the agent writes an exact `permit <vip>/32`
+alongside the per-network entries, so the VIP's connected route is exported
+even when no hosted network covers the VIP (a flat-range VIP on a chassis
+hosting only VLAN routers, for example). On a gateway that hosts no locally
+active router — a standby chassis, or one whose routers have failed over
 elsewhere — reconcile takes the standby path and empties both that
 prefix-list and the veth-leak network routes. A VIP announced there could
 never be advertised.

--- a/docs/guides/frr-prefix-list.md
+++ b/docs/guides/frr-prefix-list.md
@@ -29,8 +29,12 @@ When set to an empty string the agent does not touch the prefix list at all
 Once provider networks are known (auto-discovered from
 `Logical_Router_Port.Networks` or specified via `network_cidr`), the agent
 keeps the prefix list synchronised with `permit <network> ge 32 le 32`
-entries for each network. Entries for networks the agent no longer manages
-are removed during the next reconciliation.
+entries for each network. In addition, every announceable port-forward VIP
+gets its own exact `permit <vip>/32` entry — the VIP announces through its
+connected route filtered by this list, and its address need not lie inside
+any network the gateway currently hosts, so a network entry cannot be relied
+on to cover it. Entries the agent no longer manages (removed networks,
+dormant VIPs) are removed during the next reconciliation.
 
 The prefix list itself must already be referenced from your BGP configuration.
 There are two reference points, and a complete gateway config uses both:

--- a/docs/guides/port-forwarding.md
+++ b/docs/guides/port-forwarding.md
@@ -118,6 +118,15 @@ whereas a bare `redistribute connected`, or only a neighbor `prefix-list … out
 naming an undefined list, would treat the missing list as permit-all and leak
 the underlay `/30`s.
 
+The agent itself keeps the prefix-list entries the VIPs need: alongside the
+per-network `permit <network> ge 32 le 32` entries, every announceable VIP
+gets its own exact `permit <vip>/32` entry. The VIP entry is load-bearing, not
+redundancy — a VIP need not lie inside any network the gateway currently
+hosts (a flat-range VIP on a chassis that hosts only VLAN routers has no
+covering network entry), and without its own entry the connected route would
+be silently filtered while the address, DNAT, and kernel route all look
+healthy.
+
 On a full-mode gateway that hosts no local routers the agent **removes** the
 managed VIP address (see the dormancy section in the port-forwarding
 explanation). The reasoning: on such a standby the agent has emptied

--- a/routing.go
+++ b/routing.go
@@ -466,10 +466,18 @@ func (rm *RouteManager) RefreshBGP() error {
 // FRR prefix-list management
 // =============================================================================
 
-// prefixListEntry represents a single entry in an FRR ip prefix-list.
+// prefixListEntry represents a single entry in an FRR ip prefix-list. The
+// agent manages two entry shapes: "permit <network> ge 32 le 32" for a
+// provider network (Exact false) and "permit <vip>/32" for a port-forward VIP
+// (Exact true). The exact form is FRR's canonical spelling for a single /32
+// (ge/le qualifiers add nothing at full length, and Cisco-style prefix-list
+// semantics require len < ge), and the distinct shape lets reconcile tell a
+// VIP entry from a network entry: removal must regenerate the config line the
+// entry was created with, which is why the shape is carried here.
 type prefixListEntry struct {
 	Seq     int
-	Network string // e.g. "198.51.100.0/24"
+	Network string // e.g. "198.51.100.0/24" or "192.0.2.80/32"
+	Exact   bool   // true: "permit <p>"; false: "permit <p> ge 32 le 32"
 }
 
 // frrPrefixList is the subset of an FRR `show ip prefix-list <name> json`
@@ -492,9 +500,10 @@ type frrPrefixListEntry struct {
 	MaxPrefixLen   int    `json:"maximumPrefixLength"`
 }
 
-// ListFRRPrefixListEntries returns the current "permit ... ge 32 le 32" entries
-// in the configured FRR prefix-list. Returns nil if no prefix-list is configured
-// or the list does not exist yet.
+// ListFRRPrefixListEntries returns the current entries of the configured FRR
+// prefix-list in the two agent-managed shapes: "permit <network> ge 32 le 32"
+// and exact "permit <vip>/32". Returns nil if no prefix-list is configured or
+// the list does not exist yet.
 //
 // Read as JSON rather than by parsing the human-readable table: the entries
 // drive add/remove of the announced-networks list, so a change to FRR's text
@@ -545,30 +554,56 @@ func (rm *RouteManager) ListFRRPrefixListEntries() ([]prefixListEntry, error) {
 				continue
 			}
 			for _, e := range list.Entries {
-				// Only the agent-managed shape: permit <network> ge 32 le 32.
-				if e.Type != "permit" || e.MinPrefixLen != 32 || e.MaxPrefixLen != 32 {
+				// Only the agent-managed shapes: "permit <network> ge 32
+				// le 32" (min and max both present as 32) and the exact
+				// "permit <vip>/32", whose JSON carries no
+				// minimumPrefixLength/maximumPrefixLength keys at all
+				// (verified against the shipped FRR), so both decode to 0.
+				if e.Type != "permit" {
+					continue
+				}
+				exact := e.MinPrefixLen == 0 && e.MaxPrefixLen == 0
+				if !exact && (e.MinPrefixLen != 32 || e.MaxPrefixLen != 32) {
+					continue
+				}
+				if exact && !strings.HasSuffix(e.Prefix, "/32") {
 					continue
 				}
 				if seen[e.SequenceNumber] {
 					continue
 				}
 				seen[e.SequenceNumber] = true
-				entries = append(entries, prefixListEntry{Seq: e.SequenceNumber, Network: e.Prefix})
+				entries = append(entries, prefixListEntry{Seq: e.SequenceNumber, Network: e.Prefix, Exact: exact})
 			}
 		}
 	}
 	return entries, nil
 }
 
+// prefixListLine renders the config line body shared by add and remove:
+// "ip prefix-list <name> seq <n> permit <p>[ ge 32 le 32]".
+func (rm *RouteManager) prefixListLine(seq int, network string, exact bool) string {
+	line := fmt.Sprintf("ip prefix-list %s seq %d permit %s", rm.cfg.FRRPrefixList, seq, network)
+	if !exact {
+		line += " ge 32 le 32"
+	}
+	return line
+}
+
 // ReconcileFRRPrefixList ensures the managed prefix-list contains exactly one
-// "permit <network> ge 32 le 32" entry per desired network.
-// Pass nil to remove all managed entries (cleanup).
-func (rm *RouteManager) ReconcileFRRPrefixList(networks []*net.IPNet) error {
+// "permit <network> ge 32 le 32" entry per desired network and one exact
+// "permit <vip>/32" entry per announceable port-forward VIP. The VIP entries
+// exist because a VIP need not lie inside any hosted network: the connected
+// route it announces through is filtered by this list, and relying on a
+// network entry to cover it silently blackholes the VIP as soon as the flat
+// and VLAN planes land on different chassis (#226).
+// Pass nil, nil to remove all managed entries (cleanup).
+func (rm *RouteManager) ReconcileFRRPrefixList(networks []*net.IPNet, vips []string) error {
 	if rm.cfg.FRRPrefixList == "" {
 		return nil
 	}
 	if rm.cfg.DryRun {
-		slog.Info("[dry-run] would reconcile FRR prefix-list", "name", rm.cfg.FRRPrefixList, "networks", len(networks))
+		slog.Info("[dry-run] would reconcile FRR prefix-list", "name", rm.cfg.FRRPrefixList, "networks", len(networks), "vips", len(vips))
 		return nil
 	}
 
@@ -577,49 +612,57 @@ func (rm *RouteManager) ReconcileFRRPrefixList(networks []*net.IPNet) error {
 		return fmt.Errorf("list prefix-list entries: %w", err)
 	}
 
-	// Build current and desired maps.
-	currentByNetwork := make(map[string]int, len(current)) // network → seq
+	// Key current and desired by prefix + shape: the same prefix string in the
+	// other shape is a different config line and must not satisfy the check.
+	type entryKey struct {
+		network string
+		exact   bool
+	}
+	currentByKey := make(map[entryKey]int, len(current)) // → seq
 	maxSeq := 0
 	for _, e := range current {
-		currentByNetwork[e.Network] = e.Seq
+		currentByKey[entryKey{e.Network, e.Exact}] = e.Seq
 		if e.Seq > maxSeq {
 			maxSeq = e.Seq
 		}
 	}
 
-	desired := make(map[string]bool, len(networks))
+	desired := make(map[entryKey]bool, len(networks)+len(vips))
 	for _, n := range networks {
-		desired[n.String()] = true
+		desired[entryKey{n.String(), false}] = true
+	}
+	for _, vip := range vips {
+		desired[entryKey{vip + "/32", true}] = true
 	}
 
 	// Add missing entries (before removing stale ones, to avoid a window with no entries).
-	for network := range desired {
-		if _, exists := currentByNetwork[network]; !exists {
+	for key := range desired {
+		if _, exists := currentByKey[key]; !exists {
 			maxSeq += 5
 			output, err := rm.runVtysh(
 				"-c", "conf t",
-				"-c", fmt.Sprintf("ip prefix-list %s seq %d permit %s ge 32 le 32", rm.cfg.FRRPrefixList, maxSeq, network),
+				"-c", rm.prefixListLine(maxSeq, key.network, key.exact),
 				"-c", "end",
 			)
 			if err != nil {
-				return fmt.Errorf("add prefix-list entry %s seq %d: %w (output: %s)", network, maxSeq, err, strings.TrimSpace(string(output)))
+				return fmt.Errorf("add prefix-list entry %s seq %d: %w (output: %s)", key.network, maxSeq, err, strings.TrimSpace(string(output)))
 			}
-			slog.Info("FRR prefix-list entry added", "name", rm.cfg.FRRPrefixList, "network", network, "seq", maxSeq)
+			slog.Info("FRR prefix-list entry added", "name", rm.cfg.FRRPrefixList, "network", key.network, "seq", maxSeq)
 		}
 	}
 
 	// Remove stale entries.
-	for network, seq := range currentByNetwork {
-		if !desired[network] {
+	for key, seq := range currentByKey {
+		if !desired[key] {
 			output, err := rm.runVtysh(
 				"-c", "conf t",
-				"-c", fmt.Sprintf("no ip prefix-list %s seq %d permit %s ge 32 le 32", rm.cfg.FRRPrefixList, seq, network),
+				"-c", "no "+rm.prefixListLine(seq, key.network, key.exact),
 				"-c", "end",
 			)
 			if err != nil {
-				return fmt.Errorf("remove prefix-list entry %s seq %d: %w (output: %s)", network, seq, err, strings.TrimSpace(string(output)))
+				return fmt.Errorf("remove prefix-list entry %s seq %d: %w (output: %s)", key.network, seq, err, strings.TrimSpace(string(output)))
 			}
-			slog.Info("FRR prefix-list entry removed", "name", rm.cfg.FRRPrefixList, "network", network, "seq", seq)
+			slog.Info("FRR prefix-list entry removed", "name", rm.cfg.FRRPrefixList, "network", key.network, "seq", seq)
 		}
 	}
 

--- a/routing_test.go
+++ b/routing_test.go
@@ -56,6 +56,14 @@ func frrStaticRoutesJSON(nexthop string, ips ...string) string {
 func frrPrefixListDoc(daemon, name string, entries ...prefixListEntry) string {
 	rows := make([]string, 0, len(entries))
 	for _, e := range entries {
+		if e.Exact {
+			// FRR omits minimumPrefixLength/maximumPrefixLength entirely
+			// for an exact entry (verified against the shipped FRR 8.4.4).
+			rows = append(rows, fmt.Sprintf(
+				`{"sequenceNumber":%d,"type":"permit","prefix":%q}`,
+				e.Seq, e.Network))
+			continue
+		}
 		rows = append(rows, fmt.Sprintf(
 			`{"sequenceNumber":%d,"type":"permit","prefix":%q,`+
 				`"minimumPrefixLength":32,"maximumPrefixLength":32}`,
@@ -550,7 +558,7 @@ func TestNewRouteManagerFRRPrefixList(t *testing.T) {
 func TestReconcileFRRPrefixListDisabled(t *testing.T) {
 	rm := &RouteManager{cfg: Config{FRRPrefixList: ""}}
 	_, cidr, _ := net.ParseCIDR("10.0.0.0/24")
-	if err := rm.ReconcileFRRPrefixList([]*net.IPNet{cidr}); err != nil {
+	if err := rm.ReconcileFRRPrefixList([]*net.IPNet{cidr}, nil); err != nil {
 		t.Errorf("ReconcileFRRPrefixList() with empty name should be no-op, got: %v", err)
 	}
 }
@@ -558,7 +566,7 @@ func TestReconcileFRRPrefixListDisabled(t *testing.T) {
 func TestReconcileFRRPrefixListDryRun(t *testing.T) {
 	rm := &RouteManager{cfg: Config{FRRPrefixList: "ANNOUNCED-NETWORKS", DryRun: true}}
 	_, cidr, _ := net.ParseCIDR("10.0.0.0/24")
-	if err := rm.ReconcileFRRPrefixList([]*net.IPNet{cidr}); err != nil {
+	if err := rm.ReconcileFRRPrefixList([]*net.IPNet{cidr}, []string{"192.0.2.80"}); err != nil {
 		t.Errorf("ReconcileFRRPrefixList() in dry-run should not error, got: %v", err)
 	}
 }
@@ -1263,7 +1271,7 @@ func TestReconcileFRRPrefixList_AddsMissingAndRemovesStale(t *testing.T) {
 
 	_, desired1, _ := net.ParseCIDR("198.51.100.0/24")
 	_, desired2, _ := net.ParseCIDR("203.0.113.0/24") // new
-	if err := rm.ReconcileFRRPrefixList([]*net.IPNet{desired1, desired2}); err != nil {
+	if err := rm.ReconcileFRRPrefixList([]*net.IPNet{desired1, desired2}, nil); err != nil {
 		t.Fatalf("ReconcileFRRPrefixList: %v", err)
 	}
 
@@ -1293,6 +1301,121 @@ func TestReconcileFRRPrefixList_AddsMissingAndRemovesStale(t *testing.T) {
 	}
 }
 
+// TestListFRRPrefixListEntries_ExactVIPShape pins the second managed entry
+// shape (#226): an exact "permit <vip>/32" comes back from FRR with no
+// minimumPrefixLength/maximumPrefixLength keys and must be parsed with
+// Exact set, while a foreign exact entry that is not a /32 stays invisible
+// to reconcile.
+func TestListFRRPrefixListEntries_ExactVIPShape(t *testing.T) {
+	vip := prefixListEntry{Seq: 20, Network: "192.0.2.80/32", Exact: true}
+	network := prefixListEntry{Seq: 10, Network: "198.51.100.0/24"}
+	foreign := prefixListEntry{Seq: 30, Network: "10.0.0.0/8", Exact: true}
+
+	rec := newVtyshRecorder()
+	rec.on(
+		[]string{"vtysh", "-c", "show ip prefix-list ANNOUNCED-NETWORKS json"},
+		frrPrefixListJSON("ANNOUNCED-NETWORKS", network, vip, foreign),
+		nil,
+	)
+	rm := &RouteManager{cfg: Config{FRRPrefixList: "ANNOUNCED-NETWORKS"}, execVtyshHook: rec.hook()}
+	got, err := rm.ListFRRPrefixListEntries()
+	if err != nil {
+		t.Fatalf("ListFRRPrefixListEntries: %v", err)
+	}
+	want := []prefixListEntry{network, vip}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("entries = %+v, want %+v", got, want)
+	}
+}
+
+// TestReconcileFRRPrefixList_VIPEntries pins the announceable-VIP half of the
+// reconcile (#226): a missing VIP gets an exact "permit <vip>/32" entry with
+// no ge/le qualifier, a stale VIP entry is removed with the exact form it was
+// created with, and a present VIP entry is left alone.
+func TestReconcileFRRPrefixList_VIPEntries(t *testing.T) {
+	rec := newVtyshRecorder()
+	// Initial state: the desired network, a kept VIP, and a stale VIP.
+	rec.on(
+		[]string{"vtysh", "-c", "show ip prefix-list ANNOUNCED-NETWORKS json"},
+		frrPrefixListJSON("ANNOUNCED-NETWORKS",
+			prefixListEntry{Seq: 10, Network: "198.51.100.0/24"},
+			prefixListEntry{Seq: 15, Network: "192.0.2.80/32", Exact: true},
+			prefixListEntry{Seq: 20, Network: "192.0.2.99/32", Exact: true},
+		),
+		nil,
+	)
+
+	rm := &RouteManager{cfg: Config{FRRPrefixList: "ANNOUNCED-NETWORKS"}, execVtyshHook: rec.hook()}
+
+	_, network, _ := net.ParseCIDR("198.51.100.0/24")
+	if err := rm.ReconcileFRRPrefixList([]*net.IPNet{network}, []string{"192.0.2.80", "192.0.2.81"}); err != nil {
+		t.Fatalf("ReconcileFRRPrefixList: %v", err)
+	}
+
+	// Expect: 1 list call + 1 add (192.0.2.81/32) + 1 remove (192.0.2.99/32).
+	if len(rec.calls) != 3 {
+		t.Fatalf("expected 3 vtysh calls (list+add+remove), got %d: %v", len(rec.calls), rec.calls)
+	}
+
+	var sawAdd, sawRemove bool
+	for _, c := range rec.calls {
+		j := strings.Join(c, " ")
+		if strings.HasSuffix(j, "permit 192.0.2.81/32 -c end") &&
+			strings.Contains(j, "ip prefix-list ANNOUNCED-NETWORKS seq") &&
+			!strings.Contains(j, "no ip prefix-list") {
+			sawAdd = true
+		}
+		if strings.HasSuffix(j, "permit 192.0.2.99/32 -c end") &&
+			strings.Contains(j, "no ip prefix-list ANNOUNCED-NETWORKS seq 20") {
+			sawRemove = true
+		}
+	}
+	if !sawAdd {
+		t.Errorf("expected an exact-form add for 192.0.2.81/32, got: %v", rec.calls)
+	}
+	if !sawRemove {
+		t.Errorf("expected an exact-form remove for 192.0.2.99/32, got: %v", rec.calls)
+	}
+}
+
+// TestReconcileFRRPrefixList_ShapeMismatchConverges pins the shape keying: the
+// same prefix string in the wrong shape (a leftover "permit <vip>/32 ge 32 le
+// 32") does not satisfy the desired exact entry — reconcile adds the exact
+// form and removes the ge/le form, regenerating each config line in the shape
+// it was created with.
+func TestReconcileFRRPrefixList_ShapeMismatchConverges(t *testing.T) {
+	rec := newVtyshRecorder()
+	rec.on(
+		[]string{"vtysh", "-c", "show ip prefix-list ANNOUNCED-NETWORKS json"},
+		frrPrefixListJSON("ANNOUNCED-NETWORKS",
+			prefixListEntry{Seq: 5, Network: "192.0.2.80/32"}, // ge/le shape
+		),
+		nil,
+	)
+
+	rm := &RouteManager{cfg: Config{FRRPrefixList: "ANNOUNCED-NETWORKS"}, execVtyshHook: rec.hook()}
+	if err := rm.ReconcileFRRPrefixList(nil, []string{"192.0.2.80"}); err != nil {
+		t.Fatalf("ReconcileFRRPrefixList: %v", err)
+	}
+
+	var sawExactAdd, sawGeLeRemove bool
+	for _, c := range rec.calls {
+		j := strings.Join(c, " ")
+		if strings.HasSuffix(j, "permit 192.0.2.80/32 -c end") && !strings.Contains(j, "no ip prefix-list") {
+			sawExactAdd = true
+		}
+		if strings.Contains(j, "no ip prefix-list ANNOUNCED-NETWORKS seq 5 permit 192.0.2.80/32 ge 32 le 32") {
+			sawGeLeRemove = true
+		}
+	}
+	if !sawExactAdd {
+		t.Errorf("expected an exact-form add for 192.0.2.80/32, got: %v", rec.calls)
+	}
+	if !sawGeLeRemove {
+		t.Errorf("expected a ge/le-form remove for 192.0.2.80/32, got: %v", rec.calls)
+	}
+}
+
 func TestReconcileFRRPrefixList_AddFailureBailsOut(t *testing.T) {
 	calls := 0
 	rm := &RouteManager{cfg: Config{FRRPrefixList: "ANNOUNCED-NETWORKS"}, execVtyshHook: func(cmd *exec.Cmd) ([]byte, error) {
@@ -1304,7 +1427,7 @@ func TestReconcileFRRPrefixList_AddFailureBailsOut(t *testing.T) {
 		return []byte("error output"), errors.New("vtysh add failed")
 	}}
 	_, n, _ := net.ParseCIDR("198.51.100.0/24")
-	if err := rm.ReconcileFRRPrefixList([]*net.IPNet{n}); err == nil {
+	if err := rm.ReconcileFRRPrefixList([]*net.IPNet{n}, nil); err == nil {
 		t.Fatal("expected error when add command fails, got nil")
 	}
 }

--- a/test/e2e/chaos/expect.go
+++ b/test/e2e/chaos/expect.go
@@ -154,11 +154,14 @@ type gatewayExpectation struct {
 	// full-mode standby (no locally-active routers).
 	FRRStatic []string
 
-	// PrefixList is the sorted set of CIDR strings the ANNOUNCED-NETWORKS
-	// prefix-list is reconciled to (the effective networks) on a full-mode
-	// active gateway. nil means the list is expected absent — the agent cleans
-	// it on a full-mode standby. SkipPrefixList is set in pf-only, where the
-	// agent never touches the list (the entrypoint placeholder survives).
+	// PrefixList is the sorted set of prefix strings the ANNOUNCED-NETWORKS
+	// prefix-list is reconciled to on a full-mode active gateway: the
+	// effective networks plus one exact <vip>/32 per announceable
+	// port-forward VIP (#226 — the VIP entry is what exports the VIP's
+	// connected route when no hosted network covers it). nil means the list
+	// is expected absent — the agent cleans it on a full-mode standby.
+	// SkipPrefixList is set in pf-only, where the agent never touches the
+	// list (the entrypoint placeholder survives).
 	PrefixList     []string
 	SkipPrefixList bool
 
@@ -197,9 +200,10 @@ type gatewayExpectation struct {
 
 	// MustAnnounce is the presence bound: the IPs the upstream must currently
 	// be announcing. On a full-mode active gateway it is the desired IPs that
-	// fall inside an effective network (the only ones the prefix-list permits);
-	// in pf-only it is the VIPs (the entrypoint placeholder permits all /32s);
-	// on a full-mode standby it is empty.
+	// fall inside an effective network plus the announceable VIPs — a VIP is
+	// permitted by its own /32 prefix-list entry regardless of network
+	// coverage (#226); in pf-only it is the VIPs (the entrypoint placeholder
+	// permits all /32s); on a full-mode standby it is empty.
 	MustAnnounce []string
 
 	// AnnounceBound is the staleness bound: announced ⊆ this set must hold in
@@ -295,14 +299,18 @@ func computeExpectation(snap ovnSnapshot, gw string, doc map[string]any, mgmtIP 
 		exp.KernelRouteDev = dev
 	}
 
-	// Rule 7 — prefix-list: reconciled to the effective networks on a full-mode
-	// active gateway, cleaned (nil) on a full-mode standby, never touched in
-	// pf-only.
+	// Rule 7 — prefix-list: reconciled to the effective networks plus an exact
+	// /32 per announceable VIP on a full-mode active gateway (#226), cleaned
+	// (nil) on a full-mode standby, never touched in pf-only.
 	switch {
 	case pfOnly:
 		exp.SkipPrefixList = true
 	case active:
-		exp.PrefixList = networkStrings(effective)
+		entries := networkStrings(effective)
+		for _, vip := range routableVIPs {
+			entries = append(entries, vip+"/32")
+		}
+		exp.PrefixList = sortedUnique(entries)
 	}
 
 	// Rule 8 — hairpin flows: the hairpin targets when active, removed on
@@ -331,12 +339,17 @@ func computeExpectation(snap ovnSnapshot, gw string, doc map[string]any, mgmtIP 
 		exp.ManagedVIPs = managedVIPs(forwards)
 	}
 
-	// Rule 12 — announced presence bound.
+	// Rule 12 — announced presence bound. On an active gateway the
+	// OVN-derived IPs are bounded by network coverage (only covered NAT IPs
+	// have a permitting entry), while the announceable VIPs are present
+	// unconditionally — their own /32 entry permits them (#226). This is the
+	// bound that catches a VIP silently filtered by the prefix-list, which
+	// before #226 only the black-box probe could see.
 	switch {
 	case pfOnly:
 		exp.MustAnnounce = desired // = VIPs
 	case active:
-		exp.MustAnnounce = coveredBy(desired, effective)
+		exp.MustAnnounce = sortedUnique(append(coveredBy(desired, effective), routableVIPs...))
 	}
 
 	return exp

--- a/test/e2e/chaos/expect_test.go
+++ b/test/e2e/chaos/expect_test.go
@@ -271,6 +271,69 @@ func TestExpectationDormantVIPOnStandbyGateway(t *testing.T) {
 	}
 }
 
+// A port-forward VIP outside every hosted network must still be announced by
+// an active gateway (#226): its own exact /32 prefix-list entry permits the
+// connected route, so neither the entry nor the announce may depend on a
+// hosted network covering the VIP. This is the heterogeneous blackhole — the
+// flat router moves to another chassis, the VIP-carrying gateway keeps only
+// its VLAN routers, and before #226 nothing exported the VIP anywhere.
+func TestExpectationVIPOutsideHostedNetworksIsStillAnnounced(t *testing.T) {
+	// gateway-1 is active for the VLAN-101 router alone; the flat router
+	// lr0-public lives on gateway-3. gateway-1 carries the API VIP
+	// (192.0.2.80), which no VLAN network covers.
+	snap := ovnSnapshot{
+		CRPortChassis: map[string]string{
+			"cr-lr0-public":        "gateway-3",
+			"cr-lr-vlan101-public": "gateway-1",
+		},
+		LRPs: map[string]lrpRow{
+			"lr0-public":        {Networks: []string{"192.0.2.1/24"}},
+			"lr-vlan101-public": {Networks: []string{"198.51.100.1/24"}},
+		},
+		LRPNameByUUID: map[string]string{
+			"uuid-lr0-public":        "lr0-public",
+			"uuid-lr-vlan101-public": "lr-vlan101-public",
+		},
+		Routers: map[string]routerRow{
+			"lr0": {LRPUUIDs: []string{"uuid-lr0-public"}},
+			"lr-vlan101": {
+				LRPUUIDs: []string{"uuid-lr-vlan101-public"},
+				NATs:     []natRow{{ExternalIP: "198.51.100.10", Type: "dnat_and_snat"}},
+			},
+		},
+		Chassis:         map[string]bool{"gateway-1": true, "gateway-3": true},
+		SegmentTagByLRP: map[string]int{"lr0-public": 0, "lr-vlan101-public": 101},
+	}
+	// The heterogeneous profile puts the API VIP on gateway-1 (#225).
+	doc := render(t, profileGateway(t, "heterogeneous", "gateway-1"), "172.20.20.4")
+
+	exp := computeExpectation(snap, "gateway-1", doc, "172.20.20.4")
+
+	if exp.Mode != "full" || !exp.Active {
+		t.Fatalf("mode=%q active=%v, want a full-mode active gateway", exp.Mode, exp.Active)
+	}
+	// Rule 7: the prefix-list holds the hosted VLAN network plus the VIP's own
+	// exact /32 — and no entry for the flat network hosted elsewhere.
+	if !containsStr(exp.PrefixList, apiVIPAddr+"/32") {
+		t.Fatalf("PrefixList = %v, want the VIP's own /32 entry", exp.PrefixList)
+	}
+	if !containsStr(exp.PrefixList, "198.51.100.0/24") {
+		t.Fatalf("PrefixList = %v, want the hosted VLAN network entry", exp.PrefixList)
+	}
+	if containsStr(exp.PrefixList, "192.0.2.0/24") {
+		t.Fatalf("PrefixList = %v, must not expect the flat network hosted on gateway-3", exp.PrefixList)
+	}
+	// Rule 12: the VIP must be announced although no effective network covers
+	// it — the bound that turns the heterogeneous blackhole into a sweep
+	// violation instead of a probe-only failure.
+	if !containsStr(exp.MustAnnounce, apiVIPAddr) {
+		t.Fatalf("MustAnnounce = %v, want the VIP required regardless of network coverage", exp.MustAnnounce)
+	}
+	if !containsStr(exp.DesiredIPs, apiVIPAddr) {
+		t.Fatalf("DesiredIPs = %v, want the VIP on an active gateway", exp.DesiredIPs)
+	}
+}
+
 // With no port_forwards the agent's nftables table carries no DNAT chains and
 // manages no VIP address; with the API VIP it carries exactly the one DNAT rule
 // to the gateway's mgmtIP, and the hairpin-masquerade set follows the flag.

--- a/test/e2e/chaos/observe.go
+++ b/test/e2e/chaos/observe.go
@@ -490,9 +490,11 @@ func observeFRRStatic(ctx context.Context, l *lab, gw string, obs *observedGatew
 	return nil
 }
 
-// observePrefixList reads the ANNOUNCED-NETWORKS prefix-list, keeping the CIDR
-// of each `permit <cidr> ge 32 le 32` entry and distinguishing a list that
-// does not exist at all (which the agent cleans on a standby gateway).
+// observePrefixList reads the ANNOUNCED-NETWORKS prefix-list, keeping the
+// prefix of each permit entry — `permit <cidr> ge 32 le 32` for a network,
+// exact `permit <vip>/32` for an announceable VIP (#226) — and distinguishing
+// a list that does not exist at all (which the agent cleans on a standby
+// gateway).
 func observePrefixList(ctx context.Context, l *lab, gw string, obs *observedGateway) error {
 	out, err := l.exec(ctx, gw, "vtysh", "-c", "show ip prefix-list "+announcedPrefixList)
 	if err != nil {


### PR DESCRIPTION
Closes #226. Fixes the last red nightly chaos profile (`heterogeneous`, run [29895683462](https://github.com/osism/ovn-network-agent/actions/runs/29895683462)).

## What broke

A port-forward VIP announces through the connected route of its address on `port_forward_dev`, filtered by the `ANNOUNCE-CONNECTED` route-map matching `ANNOUNCED-NETWORKS` (#223). The agent reconciled that list to the **effective networks only** (the CIDRs of the routers this chassis hosts), while `vipRoutesAnnounceable` only checks `HasLocalRouters`. A VIP outside every hosted network — the flat-range API VIP on a gateway hosting only VLAN routers — passed the gate, got its address/DNAT/kernel route, and was silently never exported. In the failing run, the tick-12 priority flip moved `lr0-public` to gateway-3; gateway-1 dropped `192.0.2.0/24` from its prefix-list at 06:16:58 and the api-vip probe went permanently red three seconds later, with no gateway left announcing `192.0.2.80`.

## The fix

- `ReconcileFRRPrefixList(networks, vips)` emits one **exact** `permit <vip>/32` entry per announceable VIP alongside the `permit <cidr> ge 32 le 32` network entries. Verified against the shipped FRR 8.4.4: the exact form is accepted, matches only the `/32`, is removable with the same line, and its JSON carries no `minimumPrefixLength`/`maximumPrefixLength` keys — `ListFRRPrefixListEntries` learns the second shape, and removal regenerates the config line each entry was created with (shape-keyed reconcile).
- `computeDesiredState` exposes `AnnouncedVIPs` (empty when dormant); reconcile threads it into the prefix-list call on the active branch. The standby and cleanup paths pass `nil, nil` — #206 dormancy is untouched, and pf-only mode stays hands-off (the entrypoint placeholder permits all /32s).
- Chaos oracle: rule 7 expects the VIP `/32` entries on a full-mode active gateway; rule 12 requires the announceable VIPs upstream **unconditionally** — before this, `MustAnnounce` was bounded by network coverage, so the sweeps modelled the blackhole as correct and only the probe caught it.
- Docs: `frr-prefix-list.md`, both port-forwarding docs.

## Tests

- `TestReconcilePrefixListCarriesVIPOutsideHostedNetworks` — reconcile-level pin: VLAN-only router state + flat-range VIP ⇒ the vtysh stream contains the exact `/32` add.
- `TestListFRRPrefixListEntries_ExactVIPShape`, `TestReconcileFRRPrefixList_VIPEntries`, `TestReconcileFRRPrefixList_ShapeMismatchConverges` — parser + reconcile of both entry shapes, including a leftover ge/le-form `/32` converging to the exact form.
- `TestExpectationVIPOutsideHostedNetworksIsStillAnnounced` — the oracle expects the VIP entry and the announcement in the exact post-flip heterogeneous state.
- Full suite + Linux cross-build/vet (incl. `-tags=integration`) green.

## Verification suggestion

After merge, a dispatch replay of profile `heterogeneous` with seed `29895683462` should reproduce the tick-12/13 sequence and stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
