### PR TITLE
fix: quote the lb-vip-churn remove key and name harness faults in the verdict

### DIFF
--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -1466,12 +1466,19 @@ loss buckets, the per-action recovery durations, a `settles` section (one
 entry per settle window: its tick, `converged_ms`, whether it passed, and
 how many violations it raised), and every violation — each now stamped
 with the `journal_offset` of the last executed action, so it points back
-into `journal.jsonl`.
+into `journal.jsonl`. Its `result` is one of `pass` (no violation),
+`harness-fault` (there are violations and every one of them is an
+`action-failed` — the runner's own inject or restore command failed, so
+the defect is in the harness rather than in the agent) or `fail` (any
+other violation, including a run that mixed an `action-failed` with one).
 
 **Exit codes:** `0` the run passed, `1` the run recorded a violation,
 `2` the runner could not set the run up (bad flags, an unknown profile, a
 configuration the agent rejected, a start state that never went green, an
-oracle that could not prime against it).
+oracle that could not prime against it). A `harness-fault` run also exits
+`1`: the failing action parks its node and aborts injection, so the run's
+fault coverage was cut short whoever's defect it was — the verdict tells
+the two apart, the exit code keeps the job red.
 On any non-zero exit the lab's existing `collect-artifacts.sh` bundle is
 dumped into `<out>/lab-state`.
 

--- a/test/e2e/chaos/churn.go
+++ b/test/e2e/chaos/churn.go
@@ -128,7 +128,12 @@ func (c *churner) lbVIPChurn(ctx context.Context, _ *lab, _ string, _ int) error
 	}
 	from, to := "present", "absent"
 	if strings.Contains(vips, churnLBVIP) {
-		if _, err := c.lab.nbctl(ctx, "remove", "load_balancer", "pf-external", "vips", churnLBVIP); err != nil {
+		// The key is an OVSDB string atom holding a colon, so it only parses
+		// in its double-quoted form — the same quoting the add branch below
+		// puts around it. nbctl runs argv-style with no shell in between, so
+		// the quotes have to be in the argument itself.
+		if _, err := c.lab.nbctl(ctx, "remove", "load_balancer", "pf-external", "vips",
+			`"`+churnLBVIP+`"`); err != nil {
 			return fmt.Errorf("remove the churn VIP entry: %w", err)
 		}
 	} else {

--- a/test/e2e/chaos/churn_test.go
+++ b/test/e2e/chaos/churn_test.go
@@ -141,8 +141,81 @@ func TestLBVIPChurnTogglesTheVIPSEntry(t *testing.T) {
 	if err := act.inject(context.Background(), ch.lab, centralNode, 0); err != nil {
 		t.Fatalf("inject (present): %v", err)
 	}
-	if !cmd.called("remove load_balancer pf-external vips 192.0.2.50:81") {
+	// The key carries its double quotes into the argv: an OVSDB string atom
+	// holding a colon is unparsable bare, and nbctl gets no shell to add them.
+	if !cmd.called(`remove load_balancer pf-external vips "192.0.2.50:81"`) {
 		t.Fatalf("the churn did not remove the vips entry: %v", cmd.lines())
+	}
+}
+
+// A vips lookup the runner cannot answer must fail the churn rather than
+// guess which way to toggle, exactly as the FIP churn's does.
+func TestLBVIPChurnReportsAFailedLookup(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "find Load_Balancer name=pf-external") {
+			return "", errBoom
+		}
+		return healthyLabResponses(argv)
+	}}
+	ch, _ := newTestChurner(cmd)
+	act := churnActionNamed(t, defaultTestProfile(t), ch, "lb-vip-churn")
+
+	err := act.inject(context.Background(), ch.lab, centralNode, 0)
+	if err == nil {
+		t.Fatal("a failed vips lookup was swallowed")
+	}
+	if !strings.Contains(err.Error(), "look up the port-forward Load_Balancer vips") {
+		t.Fatalf("error = %v, want it wrapped as the vips lookup", err)
+	}
+}
+
+// A remove the runner cannot issue must surface as an error — this is the
+// path a malformed command takes, and the engine turns it into the
+// action-failed violation that says the harness, not the agent, failed.
+func TestLBVIPChurnReportsAFailedRemove(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		line := strings.Join(argv, " ")
+		switch {
+		case strings.Contains(line, "find Load_Balancer name=pf-external"):
+			return "{192.0.2.50:80=192.168.10.10:8080, 192.0.2.50:81=192.168.10.10:8080}\n", nil
+		case strings.Contains(line, "remove load_balancer"):
+			return "", errBoom
+		}
+		return healthyLabResponses(argv)
+	}}
+	ch, _ := newTestChurner(cmd)
+	act := churnActionNamed(t, defaultTestProfile(t), ch, "lb-vip-churn")
+
+	err := act.inject(context.Background(), ch.lab, centralNode, 0)
+	if err == nil {
+		t.Fatal("a failed vips remove was swallowed")
+	}
+	if !strings.Contains(err.Error(), "remove the churn VIP entry") {
+		t.Fatalf("error = %v, want it wrapped as the churn VIP removal", err)
+	}
+}
+
+// An empty vips column is the absent case: the Load_Balancer exists with no
+// entries at all, so the churn adds rather than removes.
+func TestLBVIPChurnAddsWhenTheVIPSColumnIsEmpty(t *testing.T) {
+	cmd := &fakeCommander{respond: func(argv []string) (string, error) {
+		if strings.Contains(strings.Join(argv, " "), "find Load_Balancer name=pf-external") {
+			return "", nil
+		}
+		return healthyLabResponses(argv)
+	}}
+	ch, buf := newTestChurner(cmd)
+	act := churnActionNamed(t, defaultTestProfile(t), ch, "lb-vip-churn")
+
+	if err := act.inject(context.Background(), ch.lab, centralNode, 0); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if !cmd.called(`set load_balancer pf-external vips:"192.0.2.50:81"="192.168.10.10:8080"`) {
+		t.Fatalf("an empty vips column did not take the add branch: %v", cmd.lines())
+	}
+	churns := churnEventsIn(t, buf.String())
+	if len(churns) != 1 || churns[0].From != "absent" || churns[0].To != "present" {
+		t.Fatalf("the churn did not journal absent→present: %+v", churns)
 	}
 }
 

--- a/test/e2e/chaos/engine_test.go
+++ b/test/e2e/chaos/engine_test.go
@@ -434,8 +434,9 @@ func TestCancelDuringTheRestoreDoesNotKillIt(t *testing.T) {
 }
 
 // An action the runner cannot undo is worse than one it cannot inject:
-// the lab is left genuinely broken. The node is parked and the run fails.
-func TestFailedRestoreParksTheNodeAndFailsTheRun(t *testing.T) {
+// the lab is left genuinely broken. The node is parked and the run is
+// stamped a harness fault — the failing command was the runner's own.
+func TestFailedRestoreParksTheNodeAndFaultsTheHarness(t *testing.T) {
 	actions := noopActions("controller-restart")
 	actions[0].restore = func(context.Context, *lab, string) error {
 		return errBoom
@@ -443,8 +444,8 @@ func TestFailedRestoreParksTheNodeAndFailsTheRun(t *testing.T) {
 
 	journal, rec := runEngine(t, 42, 5*time.Minute, actions, nil)
 
-	if rec.Result != resultFail {
-		t.Fatalf("result = %q, want %q", rec.Result, resultFail)
+	if rec.Result != resultHarnessFault {
+		t.Fatalf("result = %q, want %q", rec.Result, resultHarnessFault)
 	}
 	if len(rec.Violations) == 0 || rec.Violations[0].Kind != violationActionFailed {
 		t.Fatalf("violations = %+v, want a %s", rec.Violations, violationActionFailed)
@@ -636,9 +637,9 @@ func parkedIn(t *testing.T, journal, gw string) bool {
 }
 
 // An action the runner cannot inject leaves the lab in a state it cannot
-// reason about: the node is parked, never targeted again, and the run
-// fails.
-func TestFailedInjectParksTheNodeAndFailsTheRun(t *testing.T) {
+// reason about: the node is parked, never targeted again, and the run is
+// stamped a harness fault.
+func TestFailedInjectParksTheNodeAndFaultsTheHarness(t *testing.T) {
 	actions := noopActions("controller-restart")
 	actions[0].inject = func(context.Context, *lab, string, int) error {
 		return errBoom
@@ -646,8 +647,8 @@ func TestFailedInjectParksTheNodeAndFailsTheRun(t *testing.T) {
 
 	_, rec := runEngine(t, 42, 5*time.Minute, actions, nil)
 
-	if rec.Result != resultFail {
-		t.Fatalf("result = %q, want %q", rec.Result, resultFail)
+	if rec.Result != resultHarnessFault {
+		t.Fatalf("result = %q, want %q", rec.Result, resultHarnessFault)
 	}
 	if len(rec.Violations) == 0 || rec.Violations[0].Kind != violationActionFailed {
 		t.Fatalf("violations = %+v, want a %s", rec.Violations, violationActionFailed)

--- a/test/e2e/chaos/journal.go
+++ b/test/e2e/chaos/journal.go
@@ -252,15 +252,30 @@ type runRecord struct {
 const (
 	resultPass = "pass"
 	resultFail = "fail"
+	// resultHarnessFault is a run whose only violations came from the
+	// runner's own inject or restore command failing — a defect in the
+	// harness, not in the agent. It still exits non-zero: the fault parks
+	// its node and aborts injection, so the run's fault coverage was cut
+	// short either way.
+	resultHarnessFault = "harness-fault"
 )
 
-// finalize stamps the result: any violation fails the run.
+// finalize stamps the result: no violation passes; violations that are all
+// action-failed — the only kind failAction produces, and both of its call
+// sites are the runner's own command failing — are a harness fault; any
+// other violation fails the run, because a product violation dominates.
 func (r *runRecord) finalize(endedAt time.Time) {
 	r.Schema = recordSchema
 	r.EndedAt = endedAt.UTC().Format(time.RFC3339Nano)
 	r.Result = resultPass
 	if len(r.Violations) > 0 {
-		r.Result = resultFail
+		r.Result = resultHarnessFault
+		for _, v := range r.Violations {
+			if v.Kind != violationActionFailed {
+				r.Result = resultFail
+				break
+			}
+		}
 	}
 	if r.ActionsByName == nil {
 		r.ActionsByName = map[string]int{}

--- a/test/e2e/chaos/journal_test.go
+++ b/test/e2e/chaos/journal_test.go
@@ -119,6 +119,28 @@ func TestSummaryFailsOnViolation(t *testing.T) {
 		t.Fatalf("schema = %q, want %q", dirty.Schema, recordSchema)
 	}
 
+	// A run whose only violations are the runner's own commands failing is
+	// a harness fault, not an agent regression — the verdict says which of
+	// the two a triager is looking at.
+	harness := &runRecord{Violations: []violationRecord{
+		{Kind: violationActionFailed, Detail: "remove the churn VIP entry"},
+		{Kind: violationActionFailed, Detail: "restore gateway-2"},
+	}}
+	harness.finalize(clock.now())
+	if harness.Result != resultHarnessFault {
+		t.Fatalf("result = %q, want %q", harness.Result, resultHarnessFault)
+	}
+
+	// A product violation dominates: a run that hit both is a failed run.
+	mixed := &runRecord{Violations: []violationRecord{
+		{Kind: violationActionFailed, Detail: "restore gateway-2"},
+		{Kind: violationRecoveryTimeout, Target: "gateway-2", Detail: "budget"},
+	}}
+	mixed.finalize(clock.now())
+	if mixed.Result != resultFail {
+		t.Fatalf("result = %q, want %q — a product violation dominates", mixed.Result, resultFail)
+	}
+
 	var buf bytes.Buffer
 	if err := dirty.write(&buf); err != nil {
 		t.Fatalf("write run record: %v", err)

--- a/test/e2e/chaos/main.go
+++ b/test/e2e/chaos/main.go
@@ -36,8 +36,11 @@
 //	make e2e-chaos CHAOS_FLAGS="-profile pf-only"
 //
 // Exit codes: 0 the run passed, 1 the run recorded a violation, 2 the
-// runner could not set the run up. On a non-zero exit the lab's existing
-// artifact collector is invoked into <out>/lab-state.
+// runner could not set the run up. A harness-fault run — every violation
+// is the runner's own inject or restore command failing — also exits 1,
+// because the fault parked a node and cut the run's coverage short. On a
+// non-zero exit the lab's existing artifact collector is invoked into
+// <out>/lab-state.
 package main
 
 import (
@@ -248,7 +251,7 @@ func run(cfg config) (int, error) {
 	if err := writeRecord(rec, filepath.Join(cfg.outDir, summaryFile)); err != nil {
 		return exitFatal, err
 	}
-	if rec.Result == resultFail && code == exitPass {
+	if rec.Result != resultPass && code == exitPass {
 		code = exitViolations
 	}
 	fmt.Fprintf(os.Stderr, "[chaos] %s: %d ticks, %d executed, %d skipped, %d violations (%s, %s)\n",

--- a/test/e2e/chaos/main_test.go
+++ b/test/e2e/chaos/main_test.go
@@ -327,8 +327,11 @@ func TestDriveRunsTheFinalSettle(t *testing.T) {
 		if code != exitPass {
 			t.Fatalf("exit code = %d, want %d", code, exitPass)
 		}
-		if rec.Result != resultFail {
-			t.Fatalf("result = %q, want %q — the run parked a node", rec.Result, resultFail)
+		// The violation is the runner's own restore failing, so the verdict
+		// names the harness — the run still parked a node and aborted.
+		if rec.Result != resultHarnessFault {
+			t.Fatalf("result = %q, want %q — the run parked a node on its own failed restore",
+				rec.Result, resultHarnessFault)
 		}
 		if len(rec.Settles) != 0 || settleStartsIn(t, buf.String()) != 0 {
 			t.Fatalf("an aborted run still settled: settles=%+v, journal=%s", rec.Settles, buf.String())

--- a/test/e2e/chaos/report_test.go
+++ b/test/e2e/chaos/report_test.go
@@ -95,6 +95,24 @@ func TestRenderReportCoversTheRecord(t *testing.T) {
 	}
 }
 
+// A run that failed on its own tooling renders its verdict verbatim, so
+// the headline alone tells a harness defect from an agent regression.
+func TestRenderReportNamesTheHarnessFault(t *testing.T) {
+	t.Parallel()
+	rec := reportRecord(t)
+	rec.Violations = []violationRecord{{
+		Kind: violationActionFailed, Tick: 3, Action: "lb-vip-churn", Target: centralNode,
+		Detail: "remove the churn VIP entry: exit status 1",
+	}}
+	rec.finalize(time.Date(2026, 7, 16, 19, 3, 30, 0, time.UTC))
+
+	out := renderToString(t, rec, nil)
+
+	if !strings.Contains(out, "## Chaos run — ❌ harness-fault") {
+		t.Fatalf("the harness fault did not reach the headline:\n%s", out)
+	}
+}
+
 func TestRenderReportNamesTheViolations(t *testing.T) {
 	t.Parallel()
 	rec := reportRecord(t)


### PR DESCRIPTION
Closes #229. Fixes three of the six red nightly chaos profiles (`everything-on`, `flat-dnat`, `heterogeneous`, run [30071226004](https://github.com/osism/ovn-network-agent/actions/runs/30071226004)) and makes the next harness bug of this class cheap to triage.

## What broke

`lbVIPChurn`'s remove branch passed the `vips` map key bare — `remove load_balancer pf-external vips 192.0.2.50:81`. `lab.nbctl` runs `docker exec` argv-style with no shell in between, so `ovn-nbctl` received the colon unquoted and rejected it: an OVSDB string atom holding a `:` only parses in its double-quoted form, which is exactly why the add branch's `vips:"192.0.2.50:81"=…` has always worked. The branch only runs when a session draws the action a second time; run 30071226004 was the first nightly to do so (tick 8 added, tick 11 removed), and the three profiles without the port-forward Load_Balancer stayed green because the action's `applicable` hook gates on `p.ovnLB`. Every oracle sweep passed and the API-VIP probes lost zero requests — the agent did nothing wrong, and nothing in `summary.json` said so.

## The fix

- **`churn.go`** — the remove branch passes the key as a quoted OVSDB string (`` `"`+churnLBVIP+`"` ``), so the command reads `remove load_balancer pf-external vips "192.0.2.50:81"`. The add branch is unchanged.
- **`journal.go`** — a third result value, `harness-fault`, beside `pass`/`fail`. `finalize` stamps it when the record holds at least one violation and every violation's kind is `action-failed`; a mix with any other kind still stamps `fail`, because a product violation dominates. `failAction` is that kind's only producer and both of its call sites are the runner's own inject or restore command failing, so the kind already marks the source — no new record field, `chaos-run-record/v1` unchanged, the renderer's schema gate untouched.
- **`main.go`** — the exit mapping becomes `rec.Result != resultPass`, so a harness-fault run still exits 1 and the CI job stays red: the fault parks its node and aborts injection, so the run's fault coverage was genuinely cut short. The verdict tells the two sources apart; the exit code keeps the run from being read as coverage it did not deliver.
- **Renderer** — no change needed. `renderReport` already prints `❌ ` plus the literal result, so the headline reads `## Chaos run — ❌ harness-fault` the moment `finalize` produces it; a test now pins that rather than leaving it to coincidence.
- **Docs** — `docs/contributing/e2e-tests.md` names the three `result` values and notes the harness-fault exit 1; the package doc in `main.go` says the same.

Setup failures (`profile-not-applied`, `start-state-not-green`, `oracle-setup`) keep `fail` and exit 2 — they already carry a distinct code and history shows they can be product defects (#223). Settle-window results stay binary pass/fail; they are per-window oracle verdicts, not run verdicts.

## Tests

- `TestLBVIPChurnTogglesTheVIPSEntry` — the remove assertion now expects the quoted key; the add assertion is unchanged.
- `TestLBVIPChurnReportsAFailedLookup` / `…AFailedRemove` — the `find` and `remove` error paths surface wrapped as `look up the port-forward Load_Balancer vips` and `remove the churn VIP entry`, the coverage the FIP churn's neighbours already had.
- `TestLBVIPChurnAddsWhenTheVIPSColumnIsEmpty` — an empty `vips` column takes the add branch and journals absent→present.
- `TestSummaryFailsOnViolation` — only-`action-failed` ⇒ `harness-fault`; `action-failed` + `recovery-timeout` ⇒ `fail`; the clean and dual-claim cases unchanged.
- `TestRenderReportNamesTheHarnessFault` — the `## Chaos run — ❌ harness-fault` headline.
- `TestFailedRestoreParksTheNodeAndFaultsTheHarness` / `TestFailedInjectParksTheNodeAndFaultsTheHarness` (renamed) and the aborted-run subtest in `main_test.go` now expect `harness-fault` — their only violation is the runner's own command failing. Their kind and park assertions, and `TestWriteRecordProducesTheRunSummary` (a `recovery-timeout`, still `fail`), are untouched.
- `go test ./test/e2e/chaos/...`, `go vet`, `gofmt`, `golangci-lint` — all green.

## Verification suggestion

After merge, dispatch `e2e-chaos.yml` with seed `30071226004` and profile `everything-on`: the run should pass with `lb-vip-churn` executing twice — the tick-8 add and the tick-11 remove both succeeding.

Prior `action-failed` root causes, both harness-side: #204 (stale netns) and #217 (restore racing a reincarnating container). This is the third, and the first whose report says so on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)