### PR TITLE
fix: match the upstream bgpd by path — BusyBox pgrep/pkill never saw it

### DIFF
--- a/test/e2e/bootstrap.sh
+++ b/test/e2e/bootstrap.sh
@@ -493,8 +493,12 @@ start_upstream_bgpd() {
 if grep -q "^bgpd=no" /etc/frr/daemons 2>/dev/null; then
     sed -i "s/^bgpd=no/bgpd=yes/" /etc/frr/daemons
 fi
+# The upstream image's pgrep/pkill are BusyBox applets that match against
+# argv[0] — the full path — never the comm name, so `-x bgpd` finds
+# nothing even while bgpd runs. Anchor the full path under -f (same
+# reading on BusyBox and procps).
 start_out=""
-if ! pgrep -x bgpd >/dev/null; then
+if ! pgrep -f '^/usr/lib/frr/bgpd' >/dev/null; then
     if start_out=$(/usr/lib/frr/bgpd -d -A 127.0.0.1 -u frr -g frr 2>&1); then
         :
     else
@@ -530,7 +534,7 @@ configure_upstream_frr() {
             break
         fi
         log "bgpd start attempt ${attempt}/${BGPD_START_ATTEMPTS} failed on ${UPSTREAM_NODE}"
-        docker exec "${UPSTREAM_NODE}" pkill -x bgpd || true
+        docker exec "${UPSTREAM_NODE}" pkill -f '^/usr/lib/frr/bgpd' || true
         if [ "${attempt}" -eq "${BGPD_START_ATTEMPTS}" ]; then
             dump_upstream_frr_state
             echo "bgpd did not come up on ${UPSTREAM_NODE} after ${BGPD_START_ATTEMPTS} attempts" >&2

--- a/test/e2e/chaos/engine.go
+++ b/test/e2e/chaos/engine.go
@@ -711,7 +711,7 @@ func (e *engine) nodeConverged(ctx context.Context, d decision, node string) boo
 // still in place; any other failure is a question that could not be asked,
 // and reads here as "not yet back" so convergence keeps polling.
 func bgpdAlive(ctx context.Context, l *lab) bool {
-	out, err := l.exec(ctx, upstreamNode, "pgrep", "-x", "bgpd")
+	out, err := l.exec(ctx, upstreamNode, "pgrep", "-f", bgpdMatchPattern)
 	return err == nil && strings.TrimSpace(out) != ""
 }
 

--- a/test/e2e/chaos/engine_test.go
+++ b/test/e2e/chaos/engine_test.go
@@ -1105,7 +1105,7 @@ func TestConvergenceDispatchesPerNodeKind(t *testing.T) {
 			name:  "upstream action never converges while bgpd is down",
 			scope: scopeUpstream,
 			respond: func(argv []string) (string, error) {
-				if strings.Contains(strings.Join(argv, " "), "pgrep -x bgpd") {
+				if strings.Contains(strings.Join(argv, " "), "pgrep -f "+bgpdMatchPattern) {
 					return "", errExit(t, 1)
 				}
 				return healthyLabResponses(argv)

--- a/test/e2e/chaos/fakes_test.go
+++ b/test/e2e/chaos/fakes_test.go
@@ -128,7 +128,7 @@ func healthyLabResponses(argv []string) (string, error) {
 		return "", nil
 	case strings.Contains(line, "pgrep -f /usr/local/bin/ovn-network-agent"):
 		return "1\n", nil
-	case strings.Contains(line, "pgrep -x bgpd"):
+	case strings.Contains(line, "pgrep -f") && strings.Contains(line, bgpdMatchPattern):
 		return "1\n", nil // a healthy upstream runs bgpd
 	case strings.Contains(line, "find Chassis name="):
 		return strings.TrimPrefix(argv[len(argv)-1], "name=") + "\n", nil

--- a/test/e2e/chaos/flaps.go
+++ b/test/e2e/chaos/flaps.go
@@ -20,6 +20,17 @@ import (
 const bgpdReadyProbe = "for _ in $(seq 1 30); do " +
 	"if vtysh -c 'show daemons' 2>/dev/null | grep -qw bgpd; then break; fi; sleep 1; done"
 
+// bgpdMatchPattern selects the upstream bgpd for pgrep/pkill. The upstream
+// runs the Alpine FRR image, whose pgrep/pkill are BusyBox applets that
+// match the pattern against argv[0] — the full path `/usr/lib/frr/bgpd` —
+// never the comm name, so `-x bgpd` matches nothing there: run 30243638392
+// no-op'd the kill (exit 1, read as "already down"), the restore's guard
+// then saw no bgpd and its second bgpd died on the pid-file lock the live
+// one still held. The anchored path under -f reads the same for BusyBox
+// (argv0) and procps (full cmdline), and cannot match the `sh -euc`
+// wrapper that carries the pattern on its own command line.
+const bgpdMatchPattern = "^/usr/lib/frr/bgpd"
+
 // frrRestartDoneMarker is touched inside a gateway container as the last
 // step of the backgrounded FRR recycle. It is the only signal that tells
 // the restore the new FRR is the one answering vtysh rather than the old
@@ -123,7 +134,7 @@ func restoreGatewayFRR(ctx context.Context, l *lab, gw string) error {
 // pkill that matches nothing means bgpd was already down — which is the
 // fault in place — so its exit 1 is not an error.
 func killUpstreamBGPD(ctx context.Context, l *lab) error {
-	if _, err := l.exec(ctx, upstreamNode, "pkill", "-x", "bgpd"); err != nil {
+	if _, err := l.exec(ctx, upstreamNode, "pkill", "-f", bgpdMatchPattern); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
 			return nil
@@ -139,7 +150,7 @@ func killUpstreamBGPD(ctx context.Context, l *lab) error {
 // start_upstream_bgpd in bootstrap.sh.
 func restoreUpstreamBGPD(ctx context.Context, l *lab) error {
 	script := strings.Join([]string{
-		"pgrep -x bgpd >/dev/null 2>&1 || /usr/lib/frr/bgpd -d -A 127.0.0.1 -u frr -g frr",
+		"pgrep -f '" + bgpdMatchPattern + "' >/dev/null 2>&1 || /usr/lib/frr/bgpd -d -A 127.0.0.1 -u frr -g frr",
 		bgpdReadyProbe,
 		"vtysh -b",
 	}, "; ")

--- a/test/e2e/chaos/flaps_test.go
+++ b/test/e2e/chaos/flaps_test.go
@@ -116,7 +116,7 @@ func TestUpstreamBGPRestartNeverRecyclesTheContainer(t *testing.T) {
 	if err := act.inject(context.Background(), l, upstreamNode, 0); err != nil {
 		t.Fatalf("inject: %v", err)
 	}
-	if !cmd.called("exec clab-ovn-e2e-upstream pkill -x bgpd") {
+	if !cmd.called("exec clab-ovn-e2e-upstream pkill -f " + bgpdMatchPattern) {
 		t.Fatalf("the inject did not stop bgpd on the upstream: %v", cmd.lines())
 	}
 
@@ -146,7 +146,7 @@ func TestUpstreamBGPRestartNeverRecyclesTheContainer(t *testing.T) {
 // fault in place — not a failure. Any other pkill failure must surface.
 func TestKillUpstreamBGPDToleratesNoMatchButNotRealFailure(t *testing.T) {
 	noMatch := &fakeCommander{respond: func(argv []string) (string, error) {
-		if strings.Contains(strings.Join(argv, " "), "pkill -x bgpd") {
+		if strings.Contains(strings.Join(argv, " "), "pkill -f "+bgpdMatchPattern) {
 			return "", errExit(t, 1)
 		}
 		return healthyLabResponses(argv)
@@ -156,7 +156,7 @@ func TestKillUpstreamBGPDToleratesNoMatchButNotRealFailure(t *testing.T) {
 	}
 
 	broken := &fakeCommander{respond: func(argv []string) (string, error) {
-		if strings.Contains(strings.Join(argv, " "), "pkill -x bgpd") {
+		if strings.Contains(strings.Join(argv, " "), "pkill -f "+bgpdMatchPattern) {
 			return "", errBoom
 		}
 		return healthyLabResponses(argv)


### PR DESCRIPTION
## Problem

Nightly E2E Chaos run [30243638392](https://github.com/osism/ovn-network-agent/actions/runs/30243638392) went red in **all six profiles** with the identical tick-1 violation: the shared seed (= run id) drew `upstream-bgp-restart` everywhere, and that action is deterministically broken — this was simply the first nightly whose seed ever drew it (every green run since 6a9d9cf shows `actions_by_name.upstream-bgp-restart: 0`).

The upstream node is the Alpine FRR image, whose `pgrep`/`pkill` are **BusyBox applets that match the pattern against argv[0]** — the full `/usr/lib/frr/bgpd` path — never the comm name. In sequence:

1. **Inject:** `pkill -x bgpd` matched nothing; its exit 1 was read as "bgpd already down", so the fault was never injected. The collected upstream `show bgp summary` proves it: all three session uptimes span the inject, and the probes saw 0 loss.
2. **Restore (16 s later):** the `pgrep -x bgpd` guard saw no bgpd either and started a *second* one, which died on the pid-file lock the live bgpd still held (`Could not lock pid_file … Resource temporarily unavailable`) → `action-failed` → node parked → `run-aborted` → `harness-fault`.
3. `bgpdAlive` (the upstream convergence signal) shared the blind spot — a genuinely killed bgpd could never have converged.
4. `bootstrap.sh` carried the same latent pattern, harmless only because its first start has nothing to match and success gates on `show daemons`.

## Fix

New `bgpdMatchPattern = "^/usr/lib/frr/bgpd"` constant, used with `-f` at all five call sites (kill, restore guard, `bgpdAlive`, and both bootstrap.sh sites). The anchored full path under `-f` reads identically on BusyBox (argv0) and procps (full cmdline) — the same idiom as the gwnode healthcheck from #205 — and the `^` anchor keeps the `sh -euc` wrapper (whose own cmdline carries the pattern) from self-matching. `killUpstreamBGPD`'s exit-1-means-already-down contract is preserved: `pkill -f` still exits 1 on no match.

## Verification

- All five semantics validated natively in alpine:3.16, which ships the image's exact BusyBox 1.35.0: anchored `-f` matches a running `/usr/lib/frr/bgpd`, misses the wrapper, and exits 1 when nothing runs.
- Caveat for local testing: Docker Desktop's qemu emulation rewrites argv[0], making the old form falsely work and the new form falsely fail — test the applet natively, not through the emulated image.
- `go test ./test/e2e/chaos/` green, `go vet`/`gofmt`/shellcheck clean.
- **CI proof:** a dispatch replay of seed `30243638392` must go green (any profile — all six failed identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)