### PR TITLE
fix: guard the upstream vtysh -b — the image has no integrated frr.conf

### DIFF
--- a/test/e2e/chaos/flaps.go
+++ b/test/e2e/chaos/flaps.go
@@ -145,14 +145,22 @@ func killUpstreamBGPD(ctx context.Context, l *lab) error {
 }
 
 // restoreUpstreamBGPD starts bgpd in place — never `frrinit.sh restart`,
-// never a docker restart — polls for it to register with watchfrr, then
-// reloads the write-memory'd config with `vtysh -b`, mirroring
-// start_upstream_bgpd in bootstrap.sh.
+// never a docker restart — and polls for it to register with watchfrr.
+// The restarted bgpd reloads its config itself: the upstream image's
+// vtysh has no integrated-config support ("this version of vtysh never
+// writes vtysh.conf"), so bootstrap's `write memory` persisted
+// /etc/frr/bgpd.conf — which bgpd reads at startup — and /etc/frr/frr.conf
+// never exists there. `vtysh -b` reads exactly that integrated file, so it
+// only runs when the file is present (a future image bump), the same guard
+// the image's own init applies ("/etc/frr/frr.conf does not exist;
+// skipping config apply"). Unconditional, it exited 11 on the missing file
+// in run 30261099950 and parked the node over a bgpd that was already
+// back up, configured and re-established.
 func restoreUpstreamBGPD(ctx context.Context, l *lab) error {
 	script := strings.Join([]string{
 		"pgrep -f '" + bgpdMatchPattern + "' >/dev/null 2>&1 || /usr/lib/frr/bgpd -d -A 127.0.0.1 -u frr -g frr",
 		bgpdReadyProbe,
-		"vtysh -b",
+		"[ ! -r /etc/frr/frr.conf ] || vtysh -b",
 	}, "; ")
 	if _, err := l.sh(ctx, upstreamNode, script); err != nil {
 		return fmt.Errorf("restart bgpd on %s: %w", upstreamNode, err)

--- a/test/e2e/chaos/flaps_test.go
+++ b/test/e2e/chaos/flaps_test.go
@@ -126,7 +126,12 @@ func TestUpstreamBGPRestartNeverRecyclesTheContainer(t *testing.T) {
 	for _, want := range []string{
 		"bgpd -d -A 127.0.0.1 -u frr -g frr",
 		"grep -qw bgpd",
-		"vtysh -b",
+		// The reload must stay guarded: the upstream image has no
+		// integrated /etc/frr/frr.conf (write memory persists per-daemon
+		// files), and an unguarded `vtysh -b` exits 11 on the missing
+		// file — run 30261099950 parked the node over it while bgpd was
+		// already back up and configured from /etc/frr/bgpd.conf.
+		"[ ! -r /etc/frr/frr.conf ] || vtysh -b",
 	} {
 		if !cmd.called(want) {
 			t.Fatalf("the restore did not start bgpd in place and reload: missing %q in %v", want, cmd.lines())


### PR DESCRIPTION
## Problem

The dispatch replay of seed `30243638392` ([run 30261099950](https://github.com/osism/ovn-network-agent/actions/runs/30261099950), everything-on) confirmed the #232 fix — and uncovered the next latent bug stacked on the same never-exercised restore path.

This time the inject really stopped bgpd (five probes went down, 15 packets lost on `fip-vlan101`), and the restore's first two steps worked: bgpd restarted in place and **reloaded its config on its own** from `/etc/frr/bgpd.conf`. The lab-state dump shows all three gateway sessions re-established with ~1 s uptime seconds after the abort.

The run still failed on the restore's final step:

```
vtysh -b: exit status 11:
% Can't open configuration file /etc/frr/frr.conf due to 'No such file or directory'.
```

The upstream image (Docker Hub `frrouting/frr`, FRR 8.4_git) has **no integrated-config support**: bootstrap's `write memory` prints `Note: this version of vtysh never writes vtysh.conf` and persists per-daemon files (`Configuration saved to /etc/frr/bgpd.conf`). `/etc/frr/frr.conf` never exists there, and `vtysh -b` reads exactly that file — so under `sh -euc` the whole restore script exited 11, the engine recorded `action-failed`, parked the upstream and ended the run as `harness-fault` over a bgpd that was already back up, configured and re-established.

Both this bug and the #232 one were latent since the action landed: `upstream-bgp-restart` (weight 1) had never been drawn before this seed, and in the nightly the pid-file-lock failure aborted the script before `vtysh -b` was ever reached.

## Fix

Run the reload only when an integrated `/etc/frr/frr.conf` is actually present (i.e. after a future image bump to an integrated-config build):

```sh
[ ! -r /etc/frr/frr.conf ] || vtysh -b
```

That is the same guard the image's own init applies at container start: `/etc/frr/frr.conf does not exist; skipping config apply`. Correctness of the restore stays asserted by the engine's converge gate (`bgpdAlive` + green probes), which is the check that actually proves the announcements returned.

## Verification

- `go test ./test/e2e/chaos/ -count=1`, `go vet`, `gofmt` — clean; the unit test now pins the guarded form so the reload cannot silently become unconditional again.
- Evidence from the run artifacts: journal violation `vtysh -b: exit status 11`, bootstrap log `Configuration saved to /etc/frr/bgpd.conf`, upstream `show bgp summary` with all three sessions Established (~1 s uptime) right after the abort.
- CI proof: re-dispatch seed `30243638392` (any profile) — with the reload guarded, the restore script exits 0 and the run must reach the converge gate and go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)