### PR TITLE
fix: re-plumb the VIP routes even when the master never moved

### DIFF
--- a/test/e2e/chaos/engine.go
+++ b/test/e2e/chaos/engine.go
@@ -716,10 +716,16 @@ func bgpdAlive(ctx context.Context, l *lab) bool {
 }
 
 // followMaster keeps the port-forward VIP's hand-plumbed routes pointed
-// at whichever chassis currently owns cr-lr0-public. Re-election is the
-// whole point of the fault set, and the agent does not manage
-// Load_Balancer VIP routes — so without this the VIP probe would stay
-// red for the rest of the run after the first migration.
+// at whichever chassis currently owns cr-lr0-public. Re-election is one
+// half of the job; the other is the master coming back from a container
+// recycle with its claim intact: the scope-link route lives in the
+// container's netns, so a stop/start wipes it, and skipping the re-plumb
+// because the owner "never moved" leaves the VIP probe red for the rest
+// of the run. Run 30272920820 hit exactly that — double-failover on the
+// owner, whose priority put it straight back in charge before converge's
+// first poll, so the old owner-cache short-circuit never re-issued the
+// routes. Both routes are `ip route replace`, so re-plumbing on every
+// call is idempotent; the journal still only records actual movement.
 //
 // A profile without the port-forward layer has no Load_Balancer VIP at
 // all: there are no routes to re-point, and issuing them would plumb a
@@ -729,11 +735,14 @@ func (e *engine) followMaster(ctx context.Context) {
 		return
 	}
 	master := e.lab.currentMaster(ctx)
-	if master == "" || master == e.vipOwner {
+	if master == "" {
 		return
 	}
 	if err := e.lab.ensureVIPRouting(ctx, master); err != nil {
 		e.jrnl.emit(event{Event: evVIPRepoint, Target: master, Detail: err.Error()})
+		return
+	}
+	if master == e.vipOwner {
 		return
 	}
 	e.vipOwner = master

--- a/test/e2e/chaos/engine_test.go
+++ b/test/e2e/chaos/engine_test.go
@@ -556,10 +556,12 @@ func TestAParkedNodeStopsTheRun(t *testing.T) {
 	}
 }
 
-// The VIP's routes are re-pointed at whichever chassis owns
-// cr-lr0-public, and only when it moves — the agent does not manage them,
-// so without the re-point the VIP probe goes permanently red on the first
-// re-election and every later violation is noise.
+// The VIP's routes are re-plumbed at whichever chassis owns
+// cr-lr0-public on every call — the agent does not manage them, and the
+// master's scope-link route dies with its container netns, so an owner
+// that comes back from a recycle with an unchanged claim needs the routes
+// again just as much as a new owner does (run 30272920820). The journal
+// still only records actual movement.
 func TestFollowMasterRepointsTheVIPWhenTheMasterMoves(t *testing.T) {
 	master := "gateway-1"
 	var routesFail bool
@@ -589,12 +591,15 @@ func TestFollowMasterRepointsTheVIPWhenTheMasterMoves(t *testing.T) {
 			"the scope-link route on the master: %v", got, cmd.lines())
 	}
 
-	// The master has not moved: nothing is issued and nothing is
+	// The master has not moved: the routes are still re-issued — a
+	// recycled owner's netns came back without its scope-link route, and
+	// this call is the only thing that puts it back — but nothing is
 	// journaled, which is what keeps the journal readable.
 	e.followMaster(context.Background())
 
-	if got := cmd.count("ip route replace"); got != 2 {
-		t.Fatalf("re-pointed the VIP at a master that never moved: %v", cmd.lines())
+	if got := cmd.count("ip route replace"); got != 4 {
+		t.Fatalf("issued %d route commands after an unmoved master, want the re-plumb "+
+			"(a recycled owner has no scope-link route): %v", got, cmd.lines())
 	}
 
 	// Re-election, and the re-point fails: the owner must stay where the


### PR DESCRIPTION
## Problem

Replay #3 of seed `30243638392` ([run 30272920820](https://github.com/osism/ovn-network-agent/actions/runs/30272920820), everything-on, on 48051a2) is real progress: tick 1 `upstream-bgp-restart` now injects, restores and converges cleanly — both #232 and #233 hold in CI — and the run went on through five more ticks. It then failed genuinely differently:

```
tick 6  double-failover  gateway-1 (+gateway-2)
14:07:10  fip-vm1/vm2/vlan101/vlan102 back green
14:11:17  violation: not converged within 4m0s; red probes: pf-vip
```

The port-forward VIP `192.0.2.50` is an OVN Load_Balancer VIP the agent deliberately does not manage; the runner hand-plumbs its two routes (`ensureVIPRouting`): a forward route on the upstream and a **scope-link route on the master gateway**. That second route lives in the master's container netns — double-failover's stop/start of gateway-1 wiped it.

`followMaster` (called on every converge poll) exists to re-issue those routes, but only fired on a master *change*. Converge reaches it only after both gateways are `gatewayBack`, and by then gateway-1 (priority 30) had already reclaimed cr-lr0-public — so the owner cache said "nothing moved" on every poll for four minutes. The lab-state dump shows the healthy half perfectly: gateway-1 back as master, BGP config intact, all eight FIP /32s re-announced (`PfxRcd 8` at the upstream) — and `192.0.2.50` absent from every routing table.

Earlier runs survived owner recycles only by timing luck: lifecycle faults usually migrate the master (priority-flip then defends the new lead), so the change-detection fired and re-plumbed the fresh container as a side effect. An owner that comes back with its claim intact is the uncovered corner, and with double-failover it is deterministic.

## Fix

`followMaster` now calls `ensureVIPRouting(master)` on every invocation — both routes are `ip route replace`, idempotent — and journals `vip-repoint` only on actual movement, keeping the journal readable. A recycled-but-unmoved owner is healed within one converge poll interval.

## Verification

- `go test ./test/e2e/chaos/ -count=1`, `go vet`, `gofmt` — clean. `TestFollowMasterRepointsTheVIPWhenTheMasterMoves` now pins the new contract: the unmoved-master call must still issue both route commands and must journal nothing.
- Evidence from the run artifacts: journal (no `vip-repoint` after run start; pf-vip down 14:06:47 → abort), gateway-1 `ip route`/FRR dumps (FIP statics + kernel routes present, no trace of 192.0.2.50), upstream BGP summary (session 4m10s up, 8 prefixes from gateway-1).
- CI proof: re-dispatch seed `30243638392` (everything-on) — tick 6's converge should now go green and the run continue into its remaining fault window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)