### PR TITLE
chore: add the chaos-analysis skill for E2E smoothness triage

### DIFF
--- a/.claude/skills/chaos-analysis/SKILL.md
+++ b/.claude/skills/chaos-analysis/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: chaos-analysis
+description: Analyze recent E2E Chaos runs for packet loss and downtime, attribute both to fault actions, compare nights, and derive concrete smoothness measures. Use when asked to analyze chaos/E2E runs, investigate packet loss or failover downtime, or check whether a change made the agent smoother.
+---
+
+# Chaos run smoothness analysis
+
+Aggregate the chaos-run records of several E2E Chaos runs, attribute
+packet loss and downtime to fault actions, and turn the worst offenders
+into concrete, issue-ready measures.
+
+## 1. Collect the runs
+
+```sh
+gh run list --workflow "E2E Chaos" --limit 10 \
+  --json databaseId,conclusion,createdAt,event
+```
+
+Pick the runs to compare (default: the last 4 with artifacts — artifact
+retention is 7 days). Download each into its own directory:
+
+```sh
+for run in <id...>; do
+  gh run download "$run" --repo osism/ovn-network-agent --dir e2e-runs/"$run" &
+done; wait
+```
+
+Nightly runs hold one artifact per profile (6); a dispatch run holds one.
+
+## 2. Aggregate
+
+```sh
+python3 .claude/skills/chaos-analysis/analyze.py e2e-runs/* > report.md      # all runs pooled
+python3 .claude/skills/chaos-analysis/analyze.py e2e-runs/<one-run>          # one night alone
+```
+
+`--format json` emits the same aggregation for scripted drill-downs.
+Always ALSO run the per-night breakdown for each run: the pooled table
+mixes seeds, and a fix shows up as one night improving, not as the pool
+improving. Correlate nights with `git log` — nightlies run ~06:00 UTC,
+so a fix merged in the evening first shows in the next morning's run.
+
+## 3. Read the numbers — semantics that matter
+
+- Per recovery event, `from_inject_ms` (per probe) is downtime measured
+  from fault injection; `from_restore_ms` is the part after the fault was
+  lifted. The hold (`hold_ms` on the `decision` journal event, 0–45 s
+  by action) is the fault window itself.
+- **Downtime ≈ hold + ~1–3 s, per probe** means that traffic class never
+  failed over and waited for the node to come back. That is the smell to
+  chase: with three gateways, loss should end at failover (a few
+  seconds), not at restore.
+- **`from_restore_ms` (residual)** is the tail the recovery path owns —
+  the agent's reaction plus BGP re-establishment after the node returns.
+- Probe classes: `fip-vm*` = FIPs on the flat (Geneve-backed) provider
+  network, `fip-vlan10*` = FIPs on VLAN provider networks, `pf-vip` =
+  DNAT port-forward VIP, `api-vip` = LB VIP. Which classes go dark in an
+  event tells you which networks' CR ports the target chassis owned.
+- `check-error` events with `ovn-sbctl --timeout=5` during `sb-pause`
+  holds are harness-side sweep noise, not agent regressions.
+- Actions whose median worst downtime is 0 with occasional small `after`
+  loss windows (route drops, churn, pauses) are healthy.
+
+## 4. Known-good baseline (2026-07-30, runs 30288259170..30518214683)
+
+- Overall probe loss 5.13 % pooled; best night 0.4–1.9 % per profile.
+- Fast and fine: all pause/churn/drop actions converge in ~100–300 ms
+  with no downtime.
+- Standing offenders (each ends ~1–3 s after restore, i.e. no failover):
+  `gateway-kill`/`double-failover` up to 42 s on VLAN+PF probes,
+  `controller-restart` ~15 s, `agent-terminate` ~19 s,
+  `upstream-bgp-restart` ~15–19 s on every probe,
+  `config-flip`/`gateway-restart` 6–14 s.
+- A consistent ~2.4–3.2 s residual follows nearly every restore.
+
+Regressions are deviations from this shape, not from zero.
+
+## 5. Derive measures and file issues
+
+For each offender, name the mechanism before proposing a fix: replay it
+first (`make e2e-chaos CHAOS_FLAGS="-seed <seed> -profile <profile>
+-duration 10m"` — seed and profile are in the report/summary.json) when
+the mechanism is unclear. Then propose one measure per root cause, each
+with: the measured cost (seconds of downtime × frequency), the affected
+probe classes, the suspected code/config surface, and the replay line.
+
+File issues per the user's convention: a few independent, fully-detailed
+issues (not one plan), `gh issue create` with measured evidence and
+acceptance criteria phrased against these metrics (e.g. "worst-probe
+downtime for gateway-kill on the owner drops below 5 s").

--- a/.claude/skills/chaos-analysis/analyze.py
+++ b/.claude/skills/chaos-analysis/analyze.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Aggregate chaos-run records across runs into a smoothness report.
+
+Reads every summary.json (+ journal.jsonl next to it, when present) under
+the given directories — the layout `gh run download` produces — and
+answers the question the per-run report cannot: which fault actions cost
+the most packet loss and downtime *across* runs, and where the recovery
+budget headroom is thinnest.
+
+Usage:
+    analyze.py DIR [DIR ...] [--format md|json] [--top N]
+
+Each DIR may be a single artifact directory (holding summary.json) or a
+parent holding one subdirectory per profile/run. Output goes to stdout.
+"""
+
+import argparse
+import json
+import statistics
+import sys
+from datetime import datetime
+from pathlib import Path
+
+RECORD_SCHEMA = "chaos-run-record/v1"
+
+
+def parse_ts(s):
+    # RFC3339Nano; Python handles up to microseconds, so trim the tail.
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    if "." in s:
+        head, rest = s.split(".", 1)
+        frac = rest[: rest.index("+")] if "+" in rest else rest
+        tz = rest[len(frac):]
+        s = f"{head}.{frac[:6].ljust(6, '0')}{tz}"
+    return datetime.fromisoformat(s)
+
+
+def find_records(roots):
+    seen = set()
+    for root in roots:
+        root = Path(root)
+        candidates = [root / "summary.json"] if (root / "summary.json").exists() else sorted(root.rglob("summary.json"))
+        for path in candidates:
+            if path in seen:
+                continue
+            seen.add(path)
+            yield path
+
+
+def load_record(path):
+    rec = json.loads(path.read_text())
+    if rec.get("schema") != RECORD_SCHEMA:
+        print(f"skip {path}: schema {rec.get('schema')!r}", file=sys.stderr)
+        return None, []
+    events = []
+    journal = path.parent / "journal.jsonl"
+    if journal.exists():
+        for line in journal.read_text().splitlines():
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue  # an interrupted run truncates its last line
+    return rec, events
+
+
+def loss_windows(events, run_end):
+    """Pair probe-transition events into down windows, attributed to the
+    fault whose inject→converged span they overlap (the report renderer's
+    duringFaults logic, reduced to the primary attribution)."""
+    faults, by_tick = [], {}
+    for ev in events:
+        if ev.get("event") == "inject":
+            by_tick[ev["tick"]] = len(faults)
+            faults.append({"tick": ev["tick"], "action": ev["action"], "target": ev.get("target", ""),
+                           "inject": parse_ts(ev["ts"]), "end": None})
+        elif ev.get("event") == "converged" and ev.get("tick") in by_tick:
+            faults[by_tick[ev["tick"]]]["end"] = parse_ts(ev["ts"])
+    for f in faults:
+        if f["end"] is None:
+            f["end"] = run_end
+
+    open_at, windows = {}, []
+    for ev in events:
+        if ev.get("event") != "probe-transition":
+            continue
+        ts = parse_ts(ev["ts"])
+        if not ev["up"]:
+            open_at.setdefault(ev["probe"], ts)
+        elif ev["probe"] in open_at:
+            windows.append({"probe": ev["probe"], "start": open_at.pop(ev["probe"]), "end": ts})
+    for probe, start in open_at.items():
+        windows.append({"probe": probe, "start": start, "end": run_end})
+
+    for w in windows:
+        w["ms"] = (w["end"] - w["start"]).total_seconds() * 1000
+        hits = [f for f in faults if w["start"] < f["end"] and w["end"] > f["inject"]]
+        if hits:
+            w["action"], w["attribution"] = hits[0]["action"], "during"
+        else:
+            before = [f for f in faults if f["inject"] < w["start"]]
+            w["action"] = before[-1]["action"] if before else "(none)"
+            w["attribution"] = "after"
+    return windows
+
+
+def analyze(roots):
+    runs, per_action, per_probe, windows_by_action = [], {}, {}, {}
+    for path in find_records(roots):
+        rec, events = load_record(path)
+        if rec is None:
+            continue
+        start, end = parse_ts(rec["started_at"]), parse_ts(rec["ended_at"])
+        label = path.parent.name or str(path)
+        run = {
+            "label": label,
+            "profile": rec["inputs"]["profile"],
+            "seed": rec["inputs"]["seed"],
+            "result": rec["result"],
+            "started_at": rec["started_at"],
+            "wall_s": (end - start).total_seconds(),
+            "ticks": rec["ticks"],
+            "executed": rec["decisions"]["executed"],
+            "check_errors": rec.get("checks", {}).get("errors", 0),
+            "violations": len(rec.get("violations", [])),
+            "sent": sum(p["sent"] for p in rec["probes"].values()),
+            "lost": sum(p["lost"] for p in rec["probes"].values()),
+        }
+        runs.append(run)
+
+        for name, p in rec["probes"].items():
+            agg = per_probe.setdefault(name, {"sent": 0, "lost": 0, "transitions": 0, "target": p["target"]})
+            agg["sent"] += p["sent"]
+            agg["lost"] += p["lost"]
+            agg["transitions"] += p["transitions"]
+
+        for r in rec.get("recoveries", []):
+            agg = per_action.setdefault(r["action"], {
+                "events": 0, "converged_ms": [], "budget_ms": r["budget_ms"],
+                "worst_downtime_ms": [], "downtime_events": 0,
+                "downtime_sum_s": 0.0, "residual_sum_s": 0.0, "worst": None})
+            agg["events"] += 1
+            agg["converged_ms"].append(r["converged_ms"])
+            worst = max(r.get("from_inject_ms", {}).values(), default=0)
+            agg["worst_downtime_ms"].append(worst)
+            if worst > 0:
+                agg["downtime_events"] += 1
+            agg["downtime_sum_s"] += sum(r.get("from_inject_ms", {}).values()) / 1000
+            agg["residual_sum_s"] += sum(r.get("from_restore_ms", {}).values()) / 1000
+            if agg["worst"] is None or worst > agg["worst"]["worst_ms"]:
+                agg["worst"] = {"worst_ms": worst, "run": label, "tick": r["tick"],
+                                "target": r.get("target", ""), "converged_ms": r["converged_ms"],
+                                "probes": {k: v for k, v in r.get("from_inject_ms", {}).items() if v > 0}}
+
+        for w in loss_windows(events, end):
+            key = (w["action"], w["attribution"])
+            agg = windows_by_action.setdefault(key, {"count": 0, "total_ms": 0.0, "max_ms": 0.0})
+            agg["count"] += 1
+            agg["total_ms"] += w["ms"]
+            agg["max_ms"] = max(agg["max_ms"], w["ms"])
+
+    return runs, per_action, per_probe, windows_by_action
+
+
+def fmt_ms(ms):
+    return f"{ms / 1000:.1f} s" if ms >= 1000 else f"{ms:.0f} ms"
+
+
+def render_md(runs, per_action, per_probe, windows_by_action, top):
+    out = []
+    total_sent = sum(r["sent"] for r in runs)
+    total_lost = sum(r["lost"] for r in runs)
+    out.append(f"# Chaos smoothness report — {len(runs)} run records\n")
+    out.append(f"Overall probe loss: **{total_lost}/{total_sent}** "
+               f"(**{100 * total_lost / max(total_sent, 1):.2f}%**) · "
+               f"results: {', '.join(sorted({r['result'] for r in runs}))}\n")
+
+    out.append("## Runs\n")
+    out.append("| record | profile | seed | result | loss | check errors | violations |")
+    out.append("| --- | --- | --- | --- | --- | --- | --- |")
+    for r in sorted(runs, key=lambda r: (r["started_at"], r["profile"])):
+        out.append(f"| {r['label']} | {r['profile']} | {r['seed']} | {r['result']} "
+                   f"| {r['lost']}/{r['sent']} ({100 * r['lost'] / max(r['sent'], 1):.1f}%) "
+                   f"| {r['check_errors']} | {r['violations']} |")
+    out.append("")
+
+    out.append("## Downtime by fault action — worst probe, from inject\n")
+    out.append("Sorted by total probe-downtime seconds across all runs. `residual` is downtime "
+               "*after* the fault was restored — the part the agent's reaction time owns.\n")
+    out.append("| action | events | with downtime | median worst | max worst | total probe-down | residual | median converged | budget |")
+    out.append("| --- | --- | --- | --- | --- | --- | --- | --- | --- |")
+    for name, a in sorted(per_action.items(), key=lambda kv: -kv[1]["downtime_sum_s"]):
+        out.append(f"| {name} | {a['events']} | {a['downtime_events']} "
+                   f"| {fmt_ms(statistics.median(a['worst_downtime_ms']))} "
+                   f"| {fmt_ms(max(a['worst_downtime_ms']))} "
+                   f"| {a['downtime_sum_s']:.1f} s | {a['residual_sum_s']:.1f} s "
+                   f"| {fmt_ms(statistics.median(a['converged_ms']))} | {fmt_ms(a['budget_ms'])} |")
+    out.append("")
+
+    out.append(f"## Worst single events — top {top}\n")
+    out.append("| action | run record | tick | target | worst probe downtime | probes hit |")
+    out.append("| --- | --- | --- | --- | --- | --- |")
+    worsts = [(name, a["worst"]) for name, a in per_action.items() if a["worst"] and a["worst"]["worst_ms"] > 0]
+    for name, w in sorted(worsts, key=lambda kv: -kv[1]["worst_ms"])[:top]:
+        probes = ", ".join(f"{k} {fmt_ms(v)}" for k, v in sorted(w["probes"].items(), key=lambda kv: -kv[1]))
+        out.append(f"| {name} | {w['run']} | {w['tick']} | {w['target']} | {fmt_ms(w['worst_ms'])} | {probes} |")
+    out.append("")
+
+    out.append("## Loss windows by fault action (journal)\n")
+    out.append("`after` rows are loss that surfaced only after the engine declared convergence — "
+               "the smoothness gap the budgets never see.\n")
+    out.append("| action | attribution | windows | total down | max down |")
+    out.append("| --- | --- | --- | --- | --- |")
+    for (action, attribution), a in sorted(windows_by_action.items(), key=lambda kv: -kv[1]["total_ms"]):
+        out.append(f"| {action} | {attribution} | {a['count']} | {fmt_ms(a['total_ms'])} | {fmt_ms(a['max_ms'])} |")
+    out.append("")
+
+    out.append("## Loss by probe\n")
+    out.append("| probe | target | sent | lost | loss | transitions |")
+    out.append("| --- | --- | --- | --- | --- | --- |")
+    for name, p in sorted(per_probe.items(), key=lambda kv: -kv[1]["lost"]):
+        out.append(f"| {name} | {p['target']} | {p['sent']} | {p['lost']} "
+                   f"| {100 * p['lost'] / max(p['sent'], 1):.2f}% | {p['transitions']} |")
+    out.append("")
+    return "\n".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("dirs", nargs="+", help="artifact directories (each holding summary.json, or parents of such)")
+    ap.add_argument("--format", choices=["md", "json"], default="md")
+    ap.add_argument("--top", type=int, default=15, help="rows in the worst-events table")
+    args = ap.parse_args()
+
+    runs, per_action, per_probe, windows_by_action = analyze(args.dirs)
+    if not runs:
+        print("no chaos run records found", file=sys.stderr)
+        return 1
+    if args.format == "json":
+        for a in per_action.values():
+            a["median_converged_ms"] = statistics.median(a["converged_ms"])
+            a["median_worst_downtime_ms"] = statistics.median(a["worst_downtime_ms"])
+            a["max_worst_downtime_ms"] = max(a["worst_downtime_ms"])
+            del a["converged_ms"], a["worst_downtime_ms"]
+        print(json.dumps({
+            "runs": runs,
+            "actions": per_action,
+            "probes": per_probe,
+            "loss_windows": [
+                {"action": k[0], "attribution": k[1], **v} for k, v in windows_by_action.items()],
+        }, indent=2))
+    else:
+        print(render_md(runs, per_action, per_probe, windows_by_action, args.top))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds a Claude Code project skill (`.claude/skills/chaos-analysis/`) that automates the cross-run smoothness analysis of the E2E Chaos artifacts:

- **`analyze.py`** pools every `summary.json` (+ `journal.jsonl`) under the given directories — the layout `gh run download` produces — and renders one Markdown report: loss per run and probe, downtime per fault action split into from-inject and the residual after restore, worst single events, and journal loss windows attributed to the faults they overlapped. `--format json` emits the same aggregation for scripted drill-downs.
- **`SKILL.md`** documents the workflow (collect the last N runs, aggregate, compare nights against `git log`) and the semantics that make the numbers readable: downtime ≈ hold + 1–3 s means a traffic class never failed over and waited for the node to come back; `from_restore_ms` is the tail the recovery path owns; `check-error`s inside `sb-pause` holds are sweep noise. It also records the 2026-07-30 baseline the next analysis compares against.

## Why

The nightly runs answer pass/fail per run and `-report` renders one run for a triager, but the smoothness question — which fault actions cost how much packet loss and downtime, and whether a fix moved the numbers — needs aggregation across runs and nights. The first pass with this skill (runs 30288259170..30518214683) produced #235, #236, #237, #238 and #239.

## Notes

- No agent/runner code is touched; the skill only reads the artifacts the chaos workflow already uploads.
- `analyze.py` is stdlib-only Python 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015caYwVonNqTThSL5ku3vo4