### PR TITLE
fix(ovs): reconcile the hairpin and MAC-tweak flow planes differentially

### DIFF
--- a/config.go
+++ b/config.go
@@ -136,7 +136,7 @@ type Config struct {
 	GatewayPort       string
 	RouteTableID      int
 	BridgeIP          string // IP to add to br-ex for ARP resolution (default: 169.254.169.254)
-	OVSWrapper        string // e.g. "docker exec openvswitch_vswitchd" — prepended to ovs-vsctl/ovs-ofctl calls
+	OVSWrapper        string // e.g. "docker exec -i openvswitch_vswitchd" — prepended to ovs-vsctl/ovs-ofctl calls; must forward stdin, or flow adds fall back to one exec per flow
 	ReconcileInterval time.Duration
 	LogLevel          string
 	DryRun            bool
@@ -445,7 +445,7 @@ func configOptions() []configOption {
 			func(c *Config) *int { return &c.RouteTableID }),
 		stringOpt("bridge-ip", "169.254.169.254", "IP to add to bridge device for ARP resolution (default: 169.254.169.254)",
 			func(c *Config) *string { return &c.BridgeIP }),
-		stringOpt("ovs-wrapper", "", "Command prefix for ovs-vsctl/ovs-ofctl (e.g. 'docker exec openvswitch_vswitchd')",
+		stringOpt("ovs-wrapper", "", "Command prefix for ovs-vsctl/ovs-ofctl, must forward stdin for batched flow programming (e.g. 'docker exec -i openvswitch_vswitchd')",
 			func(c *Config) *string { return &c.OVSWrapper }),
 		durationOpt("reconcile-interval", 60*time.Second, "Full reconciliation interval (e.g. 60s, 5m)",
 			func(c *Config) *time.Duration { return &c.ReconcileInterval }),

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -27,7 +27,7 @@ regenerate it with `go generate ./...`.
 | `--gateway-port` |  | Chassisredirect port filter; empty = track all routers automatically |
 | `--route-table-id` | `0` | Routing table ID for FIP routes (1-252); 0 = main table |
 | `--bridge-ip` | `169.254.169.254` | IP to add to bridge device for ARP resolution (default: 169.254.169.254) |
-| `--ovs-wrapper` |  | Command prefix for ovs-vsctl/ovs-ofctl (e.g. 'docker exec openvswitch_vswitchd') |
+| `--ovs-wrapper` |  | Command prefix for ovs-vsctl/ovs-ofctl, must forward stdin for batched flow programming (e.g. 'docker exec -i openvswitch_vswitchd') |
 | `--reconcile-interval` | `60s` | Full reconciliation interval (e.g. 60s, 5m) |
 | `--log-level` | `info` | Log level (debug, info, warn, error) |
 | `--dry-run` | `false` | Dry-run mode: connect and reconcile but only log what would be done |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -33,7 +33,7 @@ regenerate this page with `go generate ./...`.
 | `--gateway-port` | `OVN_NETWORK_GATEWAY_PORT` | `gateway_port` |  | Chassisredirect port filter; empty = track all routers automatically |
 | `--route-table-id` | `OVN_NETWORK_ROUTE_TABLE_ID` | `route_table_id` | `0` | Routing table ID for FIP routes (1-252); 0 = main table |
 | `--bridge-ip` | `OVN_NETWORK_BRIDGE_IP` | `bridge_ip` | `169.254.169.254` | IP to add to bridge device for ARP resolution (default: 169.254.169.254) |
-| `--ovs-wrapper` | `OVN_NETWORK_OVS_WRAPPER` | `ovs_wrapper` |  | Command prefix for ovs-vsctl/ovs-ofctl (e.g. 'docker exec openvswitch_vswitchd') |
+| `--ovs-wrapper` | `OVN_NETWORK_OVS_WRAPPER` | `ovs_wrapper` |  | Command prefix for ovs-vsctl/ovs-ofctl, must forward stdin for batched flow programming (e.g. 'docker exec -i openvswitch_vswitchd') |
 | `--reconcile-interval` | `OVN_NETWORK_RECONCILE_INTERVAL` | `reconcile_interval` | `60s` | Full reconciliation interval (e.g. 60s, 5m) |
 | `--log-level` | `OVN_NETWORK_LOG_LEVEL` | `log_level` | `info` | Log level (debug, info, warn, error) |
 | `--dry-run` | `OVN_NETWORK_DRY_RUN` | `dry_run` | `false` | Dry-run mode: connect and reconcile but only log what would be done |

--- a/ovn-network-agent.yaml.sample
+++ b/ovn-network-agent.yaml.sample
@@ -72,7 +72,10 @@ ovn_nb_remote: "tcp:10.10.0.1:6641,tcp:10.10.0.2:6641,tcp:10.10.0.3:6641"
 
 # Command prefix for ovs-vsctl/ovs-ofctl when OVS runs in a container.
 # Set this if ovs-vsctl is not in PATH (e.g. containerized OVS in OSISM/Kolla).
-# ovs_wrapper: "docker exec openvswitch_vswitchd"
+# The wrapper must forward stdin (docker exec needs -i): flow programming is
+# batched through "ovs-ofctl add-flows <bridge> -", and a wrapper that drops
+# stdin falls back to one exec per flow.
+# ovs_wrapper: "docker exec -i openvswitch_vswitchd"
 
 # Chassisredirect port filter (default: empty = track all routers)
 # When empty, the agent automatically discovers all chassisredirect port bindings

--- a/ovs.go
+++ b/ovs.go
@@ -1,17 +1,30 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
 	"os/exec"
 	"sort"
+	"strconv"
 	"strings"
+	"unicode"
 )
 
 const (
 	ovsCookieMACTweak = "0x999"
 	ovsCookieHairpin  = "0x998"
+)
+
+// Priorities of the two agent-managed flow planes. Hairpin fires first so
+// locally-managed IPs are reflected into OVN while everything else falls
+// through to the MAC-tweak flow. The constants feed both the rendered flow
+// spec and the diff key, so the two can never disagree.
+const (
+	macTweakFlowPriority = 900
+	hairpinFlowPriority  = 910
 )
 
 // ovsLocalnetPortKey is the external_ids key ovn-controller sets on the
@@ -53,8 +66,8 @@ func MACTweakFlow(cookie, ofport, mac string, ipv6 bool) string {
 	if ipv6 {
 		proto = "ipv6"
 	}
-	return fmt.Sprintf("cookie=%s,priority=900,%s,in_port=%s,actions=mod_dl_dst:%s,NORMAL",
-		cookie, proto, ofport, mac)
+	return fmt.Sprintf("cookie=%s,priority=%d,%s,in_port=%s,actions=mod_dl_dst:%s,NORMAL",
+		cookie, macTweakFlowPriority, proto, ofport, mac)
 }
 
 // ovsCmd builds an exec.Cmd for an OVS command, prepending the configured
@@ -72,6 +85,18 @@ func (rm *RouteManager) ovsCmd(binary string, args ...string) *exec.Cmd {
 // command is dispatched through it instead of being executed.
 func (rm *RouteManager) runOVS(binary string, args ...string) ([]byte, error) {
 	cmd := rm.ovsCmd(binary, args...)
+	if rm.execOVSHook != nil {
+		return rm.execOVSHook(cmd)
+	}
+	return cmd.CombinedOutput()
+}
+
+// runOVSStdin runs an OVS command with input on its stdin. It mirrors runOVS,
+// including the execOVSHook seam, so tests read a batch back off the captured
+// command.
+func (rm *RouteManager) runOVSStdin(input []byte, binary string, args ...string) ([]byte, error) {
+	cmd := rm.ovsCmd(binary, args...)
+	cmd.Stdin = bytes.NewReader(input)
 	if rm.execOVSHook != nil {
 		return rm.execOVSHook(cmd)
 	}
@@ -109,14 +134,19 @@ func (rm *RouteManager) EnsureSegments(desired []DesiredSegment) error {
 		slog.Warn("failed to prune stale segment interfaces", "error", err)
 	}
 
-	// Delete existing agent-managed flows (idempotent replace).
-	if out, err := rm.runOVS("ovs-ofctl", "del-flows", rm.cfg.BridgeDev,
-		fmt.Sprintf("cookie=%s/-1", ovsCookieMACTweak)); err != nil {
-		slog.Warn("failed to delete old OVS flows", "error", err, "output", strings.TrimSpace(string(out)))
+	if err := rm.reconcileFlowPlane(ovsCookieMACTweak, rm.desiredMACTweakFlows()); err != nil {
+		return err
 	}
 
-	// Add IPv4 and IPv6 MAC-tweak flows per patch port. Several segments
-	// may share one binding (fallback), so dedup by ofport.
+	slog.Debug("OVS MAC-tweak flows ensured", "dev", rm.cfg.BridgeDev, "segments", len(rm.segments))
+	return nil
+}
+
+// desiredMACTweakFlows renders the MAC-tweak plane the current segment
+// bindings ask for: an IPv4 and an IPv6 flow per patch port. Several segments
+// may share one binding (the legacy fallback), so the ofports are deduplicated.
+func (rm *RouteManager) desiredMACTweakFlows() []desiredFlow {
+	desired := make([]desiredFlow, 0, 2*len(rm.segments))
 	seenOfports := make(map[string]bool, len(rm.segments))
 	for _, key := range sortedSegmentKeys(rm.segments) {
 		b := rm.segments[key]
@@ -125,25 +155,16 @@ func (rm *RouteManager) EnsureSegments(desired []DesiredSegment) error {
 		}
 		seenOfports[b.ofport] = true
 
-		// Install both flows best-effort: the up-front del-flows already
-		// swept every segment's old flows, so a failed re-add on one patch
-		// port must not abort the loop and leave the remaining segments
-		// without any MAC-tweak flow at all. Log and move on.
-		ipv4Flow := MACTweakFlow(ovsCookieMACTweak, b.ofport, b.kernelMAC, false)
-		if err := rm.addOVSFlow(ipv4Flow); err != nil {
-			slog.Warn("failed to add IPv4 MAC-tweak flow, skipping",
-				"patch_port", b.patchPort, "ofport", b.ofport, "error", err)
-		}
-
-		ipv6Flow := MACTweakFlow(ovsCookieMACTweak, b.ofport, b.kernelMAC, true)
-		if err := rm.addOVSFlow(ipv6Flow); err != nil {
-			slog.Warn("failed to add IPv6 MAC-tweak flow, skipping",
-				"patch_port", b.patchPort, "ofport", b.ofport, "error", err)
+		for _, ipv6 := range []bool{false, true} {
+			spec := MACTweakFlow(ovsCookieMACTweak, b.ofport, b.kernelMAC, ipv6)
+			desired = append(desired, desiredFlow{
+				key:     flowKey{priority: macTweakFlowPriority, ipv6: ipv6, inPort: b.ofport},
+				actions: normalizeActions(flowActions(spec)),
+				spec:    spec,
+			})
 		}
 	}
-
-	slog.Debug("OVS MAC-tweak flows ensured", "dev", rm.cfg.BridgeDev, "segments", len(rm.segments))
-	return nil
+	return desired
 }
 
 // sortedSegmentKeys returns the segment map keys in deterministic order.
@@ -398,11 +419,11 @@ func (rm *RouteManager) SegmentMAC(localnetPort string) string {
 // physical network normally.
 func HairpinFlow(cookie, ofport, ip, bridgeMAC, routerMAC string, ipv6 bool) string {
 	if ipv6 {
-		return fmt.Sprintf("cookie=%s,priority=910,ipv6,in_port=%s,ipv6_dst=%s/128,actions=mod_dl_src:%s,mod_dl_dst:%s,output:in_port",
-			cookie, ofport, ip, bridgeMAC, routerMAC)
+		return fmt.Sprintf("cookie=%s,priority=%d,ipv6,in_port=%s,ipv6_dst=%s/128,actions=mod_dl_src:%s,mod_dl_dst:%s,output:in_port",
+			cookie, hairpinFlowPriority, ofport, ip, bridgeMAC, routerMAC)
 	}
-	return fmt.Sprintf("cookie=%s,priority=910,ip,in_port=%s,ip_dst=%s/32,actions=mod_dl_src:%s,mod_dl_dst:%s,output:in_port",
-		cookie, ofport, ip, bridgeMAC, routerMAC)
+	return fmt.Sprintf("cookie=%s,priority=%d,ip,in_port=%s,ip_dst=%s/32,actions=mod_dl_src:%s,mod_dl_dst:%s,output:in_port",
+		cookie, hairpinFlowPriority, ofport, ip, bridgeMAC, routerMAC)
 }
 
 // ReconcileOVSHairpinFlows installs per-IP hairpin flows on the bridge device.
@@ -426,29 +447,35 @@ func HairpinFlow(cookie, ofport, ip, bridgeMAC, routerMAC string, ipv6 bool) str
 // Pass nil or an empty map to remove all hairpin flows (e.g. when no
 // locally-active routers remain).
 //
-// The up-front del-flows sweep is a hard precondition: if it fails the method
-// returns without touching the plane. Per-flow failures thereafter (an invalid
-// IP or a failed add-flow) are logged and skipped so one bad row never leaves
-// the hairpin plane empty for every other FIP — the delete-then-abort behaviour
-// this replaces.
+// The plane is never blanked: reconcileFlowPlane adds what is missing before
+// it deletes what is stale, so a flow that is already correct is not touched
+// at all. A row the agent cannot render (an invalid IP, a segment with no
+// binding) is warned about and left out of the desired set, which retires its
+// flow like any other flow that is no longer wanted.
 func (rm *RouteManager) ReconcileOVSHairpinFlows(targets map[string]HairpinTarget) error {
 	if rm.cfg.DryRun {
 		slog.Info("[dry-run] would reconcile OVS hairpin flows", "count", len(targets))
 		return nil
 	}
 	if len(rm.segments) == 0 {
-		// Segments not yet discovered; EnsureSegments must run first.
+		// Segments not yet discovered; EnsureSegments must run first. The
+		// existing flows stay installed until it does.
 		slog.Warn("skipping OVS hairpin flow reconcile: segment bindings not yet discovered")
 		return nil
 	}
 
-	// Full replace: delete all current hairpin flows then reinstall.
-	// The replacement window is sub-millisecond and tolerable.
-	if out, err := rm.runOVS("ovs-ofctl", "del-flows", rm.cfg.BridgeDev,
-		fmt.Sprintf("cookie=%s/-1", ovsCookieHairpin)); err != nil {
-		return fmt.Errorf("del hairpin OVS flows on %s: %w (output: %s)", rm.cfg.BridgeDev, err, strings.TrimSpace(string(out)))
+	if err := rm.reconcileFlowPlane(ovsCookieHairpin, rm.desiredHairpinFlows(targets)); err != nil {
+		return err
 	}
 
+	slog.Debug("OVS hairpin flows reconciled", "count", len(targets))
+	return nil
+}
+
+// desiredHairpinFlows renders the hairpin plane the given targets ask for,
+// one flow per target IP bound to its own segment's patch port.
+func (rm *RouteManager) desiredHairpinFlows(targets map[string]HairpinTarget) []desiredFlow {
+	desired := make([]desiredFlow, 0, len(targets))
 	for ip, target := range targets {
 		parsed := net.ParseIP(ip)
 		if parsed == nil {
@@ -462,16 +489,14 @@ func (rm *RouteManager) ReconcileOVSHairpinFlows(targets map[string]HairpinTarge
 			continue
 		}
 		isIPv6 := parsed.To4() == nil
-		flow := HairpinFlow(ovsCookieHairpin, b.ofport, ip, b.kernelMAC, target.RouterMAC, isIPv6)
-		if err := rm.addOVSFlow(flow); err != nil {
-			slog.Warn("failed to add hairpin flow, skipping",
-				"ip", ip, "segment", target.Segment, "error", err)
-			continue
-		}
+		spec := HairpinFlow(ovsCookieHairpin, b.ofport, ip, b.kernelMAC, target.RouterMAC, isIPv6)
+		desired = append(desired, desiredFlow{
+			key:     flowKey{priority: hairpinFlowPriority, ipv6: isIPv6, inPort: b.ofport, dst: parsed.String()},
+			actions: normalizeActions(flowActions(spec)),
+			spec:    spec,
+		})
 	}
-
-	slog.Debug("OVS hairpin flows reconciled", "count", len(targets))
-	return nil
+	return desired
 }
 
 // RemoveOVSFlows removes all agent-managed OVS flows from the bridge device.
@@ -538,4 +563,346 @@ func (rm *RouteManager) addOVSFlow(flow string) error {
 		return fmt.Errorf("ovs-ofctl add-flow %s %q: %w (output: %s)", rm.cfg.BridgeDev, flow, err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// flowKey identifies one agent-managed flow by everything OpenFlow uses to
+// tell two entries apart: the priority and the match. Two flows with the same
+// key are the same entry, so adding a flow whose key is already installed
+// replaces it in place instead of opening a window where neither is there.
+type flowKey struct {
+	priority int
+	ipv6     bool
+	inPort   string
+	dst      string // canonical destination IP; "" for MAC-tweak flows
+}
+
+// desiredFlow is one flow the agent wants installed: its identity, its
+// normalized actions for comparison against a dump, and the exact add-flow
+// spec handed to ovs-ofctl.
+type desiredFlow struct {
+	key     flowKey
+	actions string
+	spec    string
+}
+
+// parsedFlow is one flow read back from ovs-ofctl dump-flows.
+type parsedFlow struct {
+	key     flowKey
+	actions string
+}
+
+// deleteMatch renders the --strict del-flows match that removes exactly this
+// entry: the agent cookie, the priority, and the full match. Strict deletion
+// keys on the priority as well as the match, so it can never take out a
+// neighbouring flow that happens to share the in_port.
+func (k flowKey) deleteMatch(cookie string) string {
+	proto, dstField := "ip", "nw_dst"
+	if k.ipv6 {
+		proto, dstField = "ipv6", "ipv6_dst"
+	}
+	match := fmt.Sprintf("cookie=%s/-1,priority=%d,%s,in_port=%s", cookie, k.priority, proto, k.inPort)
+	if k.dst != "" {
+		match += fmt.Sprintf(",%s=%s", dstField, k.dst)
+	}
+	return match
+}
+
+// canonicalIP renders an IP the way ovs-ofctl dumps it, so a desired address
+// and the same address read back compare equal. OVS canonicalizes IPv6
+// (lowercase, :: compressed) exactly as net.IP.String does; without this an
+// expanded or uppercase address would diff unequal on every cycle and rewrite
+// its own flow forever. Returns "" for an address that does not parse.
+func canonicalIP(s string) string {
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
+}
+
+// flowActions returns the action list of an add-flow spec, so a desired
+// flow's comparison actions are always derived from the spec that is actually
+// installed rather than spelled out a second time.
+func flowActions(spec string) string {
+	_, actions, _ := strings.Cut(spec, ",actions=")
+	return actions
+}
+
+// normalizeActions renders an action list in one spelling, so a desired flow
+// and its dumped counterpart compare equal. ovs-ofctl echoes back what it
+// canonicalized: output:in_port comes back as IN_PORT, a MAC rewrite may come
+// back in OXM set_field form, and MACs come back lowercase.
+func normalizeActions(actions string) string {
+	parts := strings.Split(strings.ToLower(actions), ",")
+	for i, p := range parts {
+		p = strings.TrimSpace(p)
+		switch {
+		case p == "in_port":
+			p = "output:in_port"
+		case strings.HasPrefix(p, "set_field:") && strings.HasSuffix(p, "->eth_src"):
+			p = "mod_dl_src:" + strings.TrimSuffix(strings.TrimPrefix(p, "set_field:"), "->eth_src")
+		case strings.HasPrefix(p, "set_field:") && strings.HasSuffix(p, "->eth_dst"):
+			p = "mod_dl_dst:" + strings.TrimSuffix(strings.TrimPrefix(p, "set_field:"), "->eth_dst")
+		}
+		parts[i] = p
+	}
+	return strings.Join(parts, ",")
+}
+
+// parseFlowDump turns ovs-ofctl dump-flows output into the flows currently
+// installed. Only lines carrying a cookie are flows; the "NXST_FLOW reply"
+// header is not.
+//
+// A line the agent cannot key — no priority, no protocol keyword, or a
+// non-numeric in_port — is logged and dropped rather than guessed at.
+// Dropping it can only cause a harmless re-add of a flow that is already
+// installed, while a wrong key would synthesize a delete for an entry that
+// does not exist. Port names in place of numbers do not occur here: runOVS
+// captures output through a pipe and ovs-ofctl prints names only on a
+// terminal.
+func parseFlowDump(out []byte) []parsedFlow {
+	var flows []parsedFlow
+	for _, line := range strings.Split(string(out), "\n") {
+		if !strings.Contains(line, "cookie=") {
+			continue
+		}
+		match, actions, ok := strings.Cut(line, " actions=")
+		if !ok {
+			slog.Warn("ignoring OVS flow dump line without actions", "line", strings.TrimSpace(line))
+			continue
+		}
+
+		var (
+			key           flowKey
+			havePriority  bool
+			haveProto     bool
+			haveInPort    bool
+			malformedPort bool
+			malformedDst  bool
+		)
+		fields := strings.FieldsFunc(match, func(r rune) bool {
+			return r == ',' || unicode.IsSpace(r)
+		})
+		for _, f := range fields {
+			switch {
+			case f == "ip":
+				haveProto = true
+			case f == "ipv6":
+				haveProto, key.ipv6 = true, true
+			case strings.HasPrefix(f, "priority="):
+				p, err := strconv.Atoi(strings.TrimPrefix(f, "priority="))
+				if err != nil {
+					continue
+				}
+				key.priority, havePriority = p, true
+			case strings.HasPrefix(f, "in_port="):
+				port := strings.TrimPrefix(f, "in_port=")
+				if _, err := strconv.Atoi(port); err != nil {
+					malformedPort = true
+					continue
+				}
+				key.inPort, haveInPort = port, true
+			case strings.HasPrefix(f, "nw_dst="), strings.HasPrefix(f, "ip_dst="), strings.HasPrefix(f, "ipv6_dst="):
+				_, value, _ := strings.Cut(f, "=")
+				addr, _, _ := strings.Cut(value, "/") // the host mask is elided in some dumps, present in others
+				key.dst = canonicalIP(addr)
+				if key.dst == "" {
+					malformedDst = true
+				}
+			}
+		}
+		if !havePriority || !haveProto || !haveInPort || malformedPort || malformedDst {
+			slog.Warn("ignoring unparseable OVS flow dump line", "line", strings.TrimSpace(line))
+			continue
+		}
+
+		flows = append(flows, parsedFlow{key: key, actions: normalizeActions(actions)})
+	}
+	return flows
+}
+
+// reconcileFlowPlane brings one agent-managed flow plane — the flows carrying
+// the given cookie — to the desired set without ever blanking it.
+//
+// The plane is dumped once, diffed, and only the difference is applied: adds
+// first, then the deletes of what is no longer wanted. A flow whose actions
+// changed is re-added under the identical match and priority, which OpenFlow
+// replaces in place, so no packet ever sees a gap. When desired and installed
+// agree, the dump is the only command that runs and the cycle costs one exec.
+//
+// A failed add returns before the delete phase: a plane whose grow failed must
+// never be shrunk on top of that.
+func (rm *RouteManager) reconcileFlowPlane(cookie string, desired []desiredFlow) error {
+	out, err := rm.runOVS("ovs-ofctl", "--no-stats", "dump-flows", rm.cfg.BridgeDev,
+		fmt.Sprintf("cookie=%s/-1", cookie))
+	if err != nil {
+		return fmt.Errorf("dump cookie=%s flows on %s: %w (output: %s)",
+			cookie, rm.cfg.BridgeDev, err, strings.TrimSpace(string(out)))
+	}
+
+	current := make(map[flowKey]string)
+	for _, f := range parseFlowDump(out) {
+		current[f.key] = f.actions
+	}
+
+	wanted := make(map[flowKey]bool, len(desired))
+	var adds []desiredFlow
+	for _, d := range desired {
+		wanted[d.key] = true
+		if actions, ok := current[d.key]; ok && actions == d.actions {
+			continue
+		}
+		adds = append(adds, d)
+	}
+	var dels []flowKey
+	for k := range current {
+		if !wanted[k] {
+			dels = append(dels, k)
+		}
+	}
+	if len(adds) == 0 && len(dels) == 0 {
+		slog.Debug("OVS flow plane already in sync", "cookie", cookie, "flows", len(desired))
+		return nil
+	}
+
+	// Deterministic order, so a batch and a test read the same both times.
+	sort.Slice(adds, func(i, j int) bool { return adds[i].spec < adds[j].spec })
+	sort.Slice(dels, func(i, j int) bool { return dels[i].deleteMatch(cookie) < dels[j].deleteMatch(cookie) })
+
+	if err := rm.applyFlowAdds(adds); err != nil {
+		return err
+	}
+
+	var delErrs []error
+	for _, k := range dels {
+		match := k.deleteMatch(cookie)
+		if out, err := rm.runOVS("ovs-ofctl", "--strict", "del-flows", rm.cfg.BridgeDev, match); err != nil {
+			// Keep going: a stale flow matches nothing the agent wants, so
+			// retrying it on the next cycle costs nothing, while stopping
+			// here would leave the later stale flows in place as well.
+			slog.Warn("failed to delete stale OVS flow", "cookie", cookie, "match", match,
+				"error", err, "output", strings.TrimSpace(string(out)))
+			delErrs = append(delErrs, fmt.Errorf("ovs-ofctl --strict del-flows %s %q: %w",
+				rm.cfg.BridgeDev, match, err))
+		}
+	}
+
+	slog.Debug("OVS flow plane reconciled", "cookie", cookie,
+		"added", len(adds), "deleted", len(dels), "desired", len(desired))
+	return errors.Join(delErrs...)
+}
+
+// applyFlowAdds installs the given flows, preferring one exec for the whole
+// batch: the specs go to `ovs-ofctl add-flows <bridge> -` on stdin, inside an
+// OpenFlow 1.4 bundle where both the wrapper and ovs-ofctl support one.
+//
+// Falls back to one add-flow exec per spec where stdin does not reach
+// ovs-ofctl. Every spec is attempted in that mode and the failures are
+// returned together, so a bad flow never hides the ones behind it.
+func (rm *RouteManager) applyFlowAdds(adds []desiredFlow) error {
+	if len(adds) == 0 {
+		return nil
+	}
+
+	if !rm.stdinForwardingOK() {
+		var errs []error
+		for _, a := range adds {
+			if err := rm.addOVSFlow(a.spec); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		return errors.Join(errs...)
+	}
+
+	var input bytes.Buffer
+	for _, a := range adds {
+		input.WriteString(a.spec)
+		input.WriteByte('\n')
+	}
+
+	bundle := rm.bundleSupported()
+	args := []string{"add-flows", rm.cfg.BridgeDev, "-"}
+	if bundle {
+		args = append([]string{"--bundle"}, args...)
+	}
+	out, err := rm.runOVSStdin(input.Bytes(), "ovs-ofctl", args...)
+	if err != nil {
+		if bundle {
+			// The cached verdict may be wrong or stale (an OVS downgrade, a
+			// probe that passed on an empty bundle where a real one cannot).
+			// Drop it so the next cycle re-probes and can fall back, instead
+			// of failing every apply from here on.
+			rm.ofctlBundleOK = nil
+		}
+		return fmt.Errorf("ovs-ofctl %s (%d flows): %w (output: %s)",
+			strings.Join(args, " "), len(adds), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// ovsStdinProbe is the payload the wrapper stdin probe echoes through `cat`.
+const ovsStdinProbe = "ovn-network-agent-stdin-probe"
+
+// stdinForwardingOK reports whether the configured OVS wrapper forwards stdin
+// into the wrapped command, which decides whether a batch of flow adds can be
+// piped in at all.
+//
+// The documented wrapper `docker exec <container>` does not: without -i the
+// wrapped command reads EOF immediately, so a batch would install nothing and
+// still exit 0. No string inspection can tell — a wrapper is an arbitrary
+// command — so the check runs `cat` through the wrapper and looks for its own
+// payload coming back.
+func (rm *RouteManager) stdinForwardingOK() bool {
+	if len(rm.ovsWrapper) == 0 {
+		return true
+	}
+	if rm.wrapperStdinOK != nil {
+		return *rm.wrapperStdinOK
+	}
+
+	out, err := rm.runOVSStdin([]byte(ovsStdinProbe+"\n"), "cat")
+	if err != nil {
+		// The wrapper itself could not run (container gone, daemon down).
+		// That says nothing about stdin, so cache nothing and probe again on
+		// the next apply; the per-flow adds below will report the real error.
+		slog.Warn("OVS wrapper stdin probe could not run, adding flows one by one this cycle",
+			"wrapper", rm.cfg.OVSWrapper, "error", err, "output", strings.TrimSpace(string(out)))
+		return false
+	}
+
+	ok := strings.Contains(string(out), ovsStdinProbe)
+	rm.wrapperStdinOK = &ok
+	if !ok && !rm.warnedWrapperStdin {
+		rm.warnedWrapperStdin = true
+		slog.Warn("OVS wrapper does not forward stdin, falling back to one exec per flow; add -i to it (e.g. \"docker exec -i openvswitch_vswitchd\") to batch flow programming",
+			"wrapper", rm.cfg.OVSWrapper)
+	}
+	return ok
+}
+
+// bundleSupported reports whether this ovs-ofctl can apply a batch as an
+// OpenFlow 1.4 bundle, which makes the adds land as one transaction.
+//
+// The probe sends an empty bundle: it installs nothing and exercises only the
+// protocol negotiation the real batch depends on. A negative verdict is never
+// cached, so a one-cycle ovs-ofctl outage cannot degrade every later apply to
+// the non-transactional path.
+func (rm *RouteManager) bundleSupported() bool {
+	if rm.ofctlBundleOK != nil {
+		return *rm.ofctlBundleOK
+	}
+
+	out, err := rm.runOVSStdin(nil, "ovs-ofctl", "--bundle", "add-flows", rm.cfg.BridgeDev, "-")
+	if err != nil {
+		if !rm.warnedOfctlBundle {
+			rm.warnedOfctlBundle = true
+			slog.Warn("ovs-ofctl --bundle unavailable, applying flow adds without a bundle",
+				"error", err, "output", strings.TrimSpace(string(out)))
+		}
+		return false
+	}
+
+	ok := true
+	rm.ofctlBundleOK = &ok
+	return true
 }

--- a/ovs_test.go
+++ b/ovs_test.go
@@ -3,18 +3,20 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os/exec"
 	"reflect"
-	"sort"
 	"strings"
 	"testing"
 )
 
-// ovsRecorder captures calls to RouteManager.runOVS for assertion. It returns
-// canned responses keyed by the full joined command line and falls back to
-// (nil, nil) — i.e. empty output, no error — for unmatched commands.
+// ovsRecorder captures calls to RouteManager.runOVS and runOVSStdin for
+// assertion. It returns canned responses keyed by the full joined command line
+// and falls back to (nil, nil) — i.e. empty output, no error — for unmatched
+// commands.
 type ovsRecorder struct {
 	calls     [][]string
+	stdins    []string
 	responses map[string]ovsResponse
 }
 
@@ -32,26 +34,109 @@ func (r *ovsRecorder) on(args []string, out string, err error) {
 	r.responses[strings.Join(args, " ")] = ovsResponse{out: []byte(out), err: err}
 }
 
+// onStdin registers a canned response for a command identified by its Args
+// *and* the exact bytes on its stdin. The bundle probe and a real bundled add
+// share the argv "ovs-ofctl --bundle add-flows <br> -" and differ only in what
+// they pipe in, so a test that fails one without the other needs this key.
+func (r *ovsRecorder) onStdin(args []string, stdin, out string, err error) {
+	r.responses[stdinKey(args, stdin)] = ovsResponse{out: []byte(out), err: err}
+}
+
+// onDump registers the dump a plane's reconcile reads back.
+func (r *ovsRecorder) onDump(bridge, cookie, out string) {
+	r.on([]string{"ovs-ofctl", "--no-stats", "dump-flows", bridge, "cookie=" + cookie + "/-1"}, out, nil)
+}
+
+func stdinKey(args []string, stdin string) string {
+	return strings.Join(args, " ") + "\x00" + stdin
+}
+
 func (r *ovsRecorder) hook() ovsExecFunc {
 	return func(cmd *exec.Cmd) ([]byte, error) {
 		args := append([]string{}, cmd.Args...)
+		stdin := ""
+		if cmd.Stdin != nil {
+			b, err := io.ReadAll(cmd.Stdin)
+			if err != nil {
+				return nil, err
+			}
+			stdin = string(b)
+		}
 		r.calls = append(r.calls, args)
-		if resp, ok := r.responses[strings.Join(cmd.Args, " ")]; ok {
+		r.stdins = append(r.stdins, stdin)
+		if resp, ok := r.responses[stdinKey(args, stdin)]; ok {
+			return resp.out, resp.err
+		}
+		if resp, ok := r.responses[strings.Join(args, " ")]; ok {
 			return resp.out, resp.err
 		}
 		return nil, nil
 	}
 }
 
+// ofctlArgs returns a recorded call from its "ovs-ofctl" token onwards, or nil
+// when the call is not an ovs-ofctl one. It exists so the helpers below read
+// the same whether or not an OVS wrapper prefixes the argv.
+func ofctlArgs(call []string) []string {
+	for i, a := range call {
+		if a == "ovs-ofctl" {
+			return call[i:]
+		}
+	}
+	return nil
+}
+
 // findAddFlows returns just the flow strings from "ovs-ofctl add-flow <br> <flow>" calls.
 func (r *ovsRecorder) findAddFlows() []string {
 	var flows []string
 	for _, c := range r.calls {
-		if len(c) >= 4 && c[0] == "ovs-ofctl" && c[1] == "add-flow" {
-			flows = append(flows, c[3])
+		if a := ofctlArgs(c); len(a) >= 4 && a[1] == "add-flow" {
+			flows = append(flows, a[3])
 		}
 	}
 	return flows
+}
+
+// findBatchedFlows returns the flow specs piped into "ovs-ofctl add-flows
+// <br> -" calls, in the order they were written. The empty-stdin bundle probe
+// contributes nothing.
+func (r *ovsRecorder) findBatchedFlows() []string {
+	var flows []string
+	for i, c := range r.calls {
+		if ofctlArgs(c) == nil || !strings.Contains(strings.Join(c, " "), " add-flows ") {
+			continue
+		}
+		for _, line := range strings.Split(strings.TrimSpace(r.stdins[i]), "\n") {
+			if line != "" {
+				flows = append(flows, line)
+			}
+		}
+	}
+	return flows
+}
+
+// findOfctl returns the recorded ovs-ofctl calls (wrapper prefix stripped),
+// which is what the exec-count and ordering assertions compare against.
+func (r *ovsRecorder) findOfctl() [][]string {
+	var calls [][]string
+	for _, c := range r.calls {
+		if a := ofctlArgs(c); a != nil {
+			calls = append(calls, a)
+		}
+	}
+	return calls
+}
+
+// findStrictDeletes returns the match strings of "ovs-ofctl --strict del-flows
+// <br> <match>" calls.
+func (r *ovsRecorder) findStrictDeletes() []string {
+	var matches []string
+	for _, c := range r.calls {
+		if a := ofctlArgs(c); len(a) >= 5 && a[1] == "--strict" && a[2] == "del-flows" {
+			matches = append(matches, a[4])
+		}
+	}
+	return matches
 }
 
 // containsFlow reports whether want is one of the recorded flow strings.
@@ -148,6 +233,193 @@ func TestMACTweakFlow(t *testing.T) {
 	}
 }
 
+// TestParseFlowDump pins the dump spellings the differential apply has to
+// read back. The tolerances mirror the ones the integration suite and the E2E
+// scenario already observed empirically: nw_dst= (classic) or ip_dst= (OXM),
+// the host mask elided or spelled out, ",ip,"/",ipv6," as the protocol
+// keyword, IN_PORT for output:in_port, and set_field:…->eth_src/eth_dst for
+// the MAC rewrites (test/integration/scenario_fip_test.go,
+// test/e2e/scenarios/hairpin.sh).
+func TestParseFlowDump(t *testing.T) {
+	const (
+		hairpinActions = "mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:6f:a1:64,output:in_port"
+		tweakActions   = "mod_dl_dst:aa:bb:cc:dd:ee:ff,normal"
+	)
+	tests := []struct {
+		name string
+		dump string
+		want []parsedFlow
+	}{
+		{
+			name: "reply header carries no flow",
+			dump: " NXST_FLOW reply (xid=0x4):\n",
+		},
+		{
+			name: "v4 hairpin flow with nw_dst and elided mask",
+			dump: " cookie=0x998, table=0, priority=910,ip,in_port=42,nw_dst=5.182.234.199 actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:6f:a1:64,IN_PORT\n",
+			want: []parsedFlow{{
+				key:     flowKey{priority: 910, inPort: "42", dst: "5.182.234.199"},
+				actions: hairpinActions,
+			}},
+		},
+		{
+			name: "v4 hairpin flow with ip_dst and explicit /32",
+			dump: " cookie=0x998, table=0, priority=910,ip,in_port=42,ip_dst=5.182.234.199/32 actions=mod_dl_src:AA:BB:CC:DD:EE:FF,mod_dl_dst:FA:16:3E:6F:A1:64,output:in_port\n",
+			want: []parsedFlow{{
+				key:     flowKey{priority: 910, inPort: "42", dst: "5.182.234.199"},
+				actions: hairpinActions,
+			}},
+		},
+		{
+			name: "v6 hairpin flow, OXM action spellings and an expanded address",
+			dump: " cookie=0x998, table=0, priority=910,ipv6,in_port=7,ipv6_dst=2001:0db8:0000:0000:0000:0000:0000:0001/128 actions=set_field:aa:bb:cc:dd:ee:ff->eth_src,set_field:fa:16:3e:6f:a1:64->eth_dst,IN_PORT\n",
+			want: []parsedFlow{{
+				key:     flowKey{priority: 910, ipv6: true, inPort: "7", dst: "2001:db8::1"},
+				actions: hairpinActions,
+			}},
+		},
+		{
+			name: "MAC-tweak pair has no destination",
+			dump: " cookie=0x999, table=0, priority=900,ip,in_port=42 actions=mod_dl_dst:aa:bb:cc:dd:ee:ff,NORMAL\n" +
+				" cookie=0x999, table=0, priority=900,ipv6,in_port=42 actions=mod_dl_dst:aa:bb:cc:dd:ee:ff,NORMAL\n",
+			want: []parsedFlow{
+				{key: flowKey{priority: 900, inPort: "42"}, actions: tweakActions},
+				{key: flowKey{priority: 900, ipv6: true, inPort: "42"}, actions: tweakActions},
+			},
+		},
+		{
+			name: "stats fields are ignored",
+			dump: " cookie=0x999, duration=1234.567s, table=0, n_packets=17, n_bytes=1462, idle_age=3, priority=900,ip,in_port=42 actions=mod_dl_dst:aa:bb:cc:dd:ee:ff,NORMAL\n",
+			want: []parsedFlow{{key: flowKey{priority: 900, inPort: "42"}, actions: tweakActions}},
+		},
+		{
+			name: "line without a priority is dropped",
+			dump: " cookie=0x999, table=0, ip,in_port=42 actions=mod_dl_dst:aa:bb:cc:dd:ee:ff,NORMAL\n",
+		},
+		{
+			name: "line with a named in_port is dropped",
+			dump: " cookie=0x999, table=0, priority=900,ip,in_port=patch-provnet-0 actions=mod_dl_dst:aa:bb:cc:dd:ee:ff,NORMAL\n",
+		},
+		{
+			name: "line without a protocol keyword is dropped",
+			dump: " cookie=0x999, table=0, priority=900,in_port=42 actions=mod_dl_dst:aa:bb:cc:dd:ee:ff,NORMAL\n",
+		},
+		{
+			name: "line without actions is dropped",
+			dump: " cookie=0x999, table=0, priority=900,ip,in_port=42\n",
+		},
+		{
+			name: "line with an unparseable destination is dropped",
+			dump: " cookie=0x998, table=0, priority=910,ip,in_port=42,nw_dst=not-an-ip actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:6f:a1:64,IN_PORT\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseFlowDump([]byte(tt.dump))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseFlowDump() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseFlowDumpMatchesDesiredKeys is the property the diff rests on: a
+// flow the agent renders and then reads back out of a dump must produce the
+// same key and the same normalized actions, or every cycle would delete and
+// re-add it.
+func TestParseFlowDumpMatchesDesiredKeys(t *testing.T) {
+	hairpin := HairpinFlow(ovsCookieHairpin, "42", "2001:DB8:0:0::1", "aa:bb:cc:dd:ee:ff", "FA:16:3E:6F:A1:64", true)
+	tweak := MACTweakFlow(ovsCookieMACTweak, "42", "aa:bb:cc:dd:ee:ff", false)
+
+	dump := " NXST_FLOW reply (xid=0x4):\n" +
+		" cookie=0x998, table=0, priority=910,ipv6,in_port=42,ipv6_dst=2001:db8::1 actions=set_field:aa:bb:cc:dd:ee:ff->eth_src,set_field:fa:16:3e:6f:a1:64->eth_dst,IN_PORT\n" +
+		" cookie=0x999, table=0, priority=900,ip,in_port=42 actions=mod_dl_dst:aa:bb:cc:dd:ee:ff,NORMAL\n"
+
+	want := []parsedFlow{
+		{
+			key:     flowKey{priority: hairpinFlowPriority, ipv6: true, inPort: "42", dst: "2001:db8::1"},
+			actions: normalizeActions(flowActions(hairpin)),
+		},
+		{
+			key:     flowKey{priority: macTweakFlowPriority, inPort: "42"},
+			actions: normalizeActions(flowActions(tweak)),
+		},
+	}
+	if got := parseFlowDump([]byte(dump)); !reflect.DeepEqual(got, want) {
+		t.Errorf("parseFlowDump() = %+v, want %+v", got, want)
+	}
+}
+
+func TestNormalizeActions(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"IN_PORT is the dumped form of output:in_port", "IN_PORT", "output:in_port"},
+		{"output:in_port is left alone", "output:in_port", "output:in_port"},
+		{"OXM eth_src write", "set_field:AA:BB:CC:DD:EE:FF->eth_src", "mod_dl_src:aa:bb:cc:dd:ee:ff"},
+		{"OXM eth_dst write", "set_field:fa:16:3e:6f:a1:64->eth_dst", "mod_dl_dst:fa:16:3e:6f:a1:64"},
+		{"mixed-case MAC lowercased", "mod_dl_dst:FA:16:3E:6F:A1:64,NORMAL", "mod_dl_dst:fa:16:3e:6f:a1:64,normal"},
+		{
+			"full hairpin action list in dumped spelling",
+			"set_field:aa:bb:cc:dd:ee:ff->eth_src,set_field:FA:16:3E:6F:A1:64->eth_dst,IN_PORT",
+			"mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:6f:a1:64,output:in_port",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeActions(tt.in); got != tt.want {
+				t.Errorf("normalizeActions(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlowKeyDeleteMatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		key    flowKey
+		cookie string
+		want   string
+	}{
+		{
+			"v4 hairpin flow",
+			flowKey{priority: 910, inPort: "42", dst: "5.182.234.199"},
+			ovsCookieHairpin,
+			"cookie=0x998/-1,priority=910,ip,in_port=42,nw_dst=5.182.234.199",
+		},
+		{
+			"v6 hairpin flow",
+			flowKey{priority: 910, ipv6: true, inPort: "7", dst: "2001:db8::1"},
+			ovsCookieHairpin,
+			"cookie=0x998/-1,priority=910,ipv6,in_port=7,ipv6_dst=2001:db8::1",
+		},
+		{
+			"v4 MAC-tweak flow has no destination",
+			flowKey{priority: 900, inPort: "42"},
+			ovsCookieMACTweak,
+			"cookie=0x999/-1,priority=900,ip,in_port=42",
+		},
+		{
+			"v6 MAC-tweak flow has no destination",
+			flowKey{priority: 900, ipv6: true, inPort: "42"},
+			ovsCookieMACTweak,
+			"cookie=0x999/-1,priority=900,ipv6,in_port=42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.key.deleteMatch(tt.cookie); got != tt.want {
+				t.Errorf("deleteMatch() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestOVSCmdWrapperPrepended(t *testing.T) {
 	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, ovsWrapper: []string{"docker", "exec", "openvswitch_vswitchd"}}
 
@@ -179,9 +451,9 @@ func fallbackSegments(patchPort, ofport, mac string) map[string]*segmentBinding 
 
 // TestEnsureSegmentsWithCachedFallbackKeepsFlatFlowSet locks the flat
 // single-network behavior: with a cached fallback binding that still
-// resolves to its ofport, EnsureSegments issues exactly the pre-segment
-// command sequence — one ofport validation, one cookie sweep, and the
-// IPv4+IPv6 MAC-tweak pair for the single patch port and bridge MAC.
+// resolves to its ofport and an empty plane, EnsureSegments validates the
+// ofport, dumps the plane once, probes for bundle support, and installs the
+// IPv4+IPv6 MAC-tweak pair in one batched exec. Nothing is ever deleted.
 func TestEnsureSegmentsWithCachedFallbackKeepsFlatFlowSet(t *testing.T) {
 	rec := newOVSRecorder()
 	// EnsureSegments re-validates every cached binding on each call; here
@@ -190,13 +462,14 @@ func TestEnsureSegmentsWithCachedFallbackKeepsFlatFlowSet(t *testing.T) {
 		[]string{"ovs-vsctl", "get", "Interface", "patch-provnet-0", "ofport"},
 		"42\n", nil,
 	)
+	rec.onDump("br-ex", ovsCookieMACTweak, " NXST_FLOW reply (xid=0x4):\n")
 	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, segments: fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"), execOVSHook: rec.hook()}
 
 	if err := rm.EnsureSegments([]DesiredSegment{{LocalnetPort: ""}}); err != nil {
 		t.Fatalf("EnsureSegments() error: %v", err)
 	}
 
-	// Expect: 1 ofport validation + 1 del-flows + 2 add-flows (IPv4 + IPv6).
+	// Expect: 1 ofport validation + dump + bundle probe + batched add.
 	if len(rec.calls) != 4 {
 		t.Fatalf("expected 4 OVS commands, got %d: %v", len(rec.calls), rec.calls)
 	}
@@ -205,18 +478,49 @@ func TestEnsureSegmentsWithCachedFallbackKeepsFlatFlowSet(t *testing.T) {
 	if !reflect.DeepEqual(rec.calls[0], wantValidate) {
 		t.Errorf("first call = %v, want %v", rec.calls[0], wantValidate)
 	}
-	wantDel := []string{"ovs-ofctl", "del-flows", "br-ex", "cookie=0x999/-1"}
-	if !reflect.DeepEqual(rec.calls[1], wantDel) {
-		t.Errorf("second call = %v, want %v", rec.calls[1], wantDel)
+	wantOfctl := [][]string{
+		{"ovs-ofctl", "--no-stats", "dump-flows", "br-ex", "cookie=0x999/-1"},
+		{"ovs-ofctl", "--bundle", "add-flows", "br-ex", "-"},
+		{"ovs-ofctl", "--bundle", "add-flows", "br-ex", "-"},
+	}
+	if got := rec.findOfctl(); !reflect.DeepEqual(got, wantOfctl) {
+		t.Errorf("ovs-ofctl calls = %v, want %v", got, wantOfctl)
 	}
 
-	flows := rec.findAddFlows()
+	flows := rec.findBatchedFlows()
 	wantFlows := []string{
 		"cookie=0x999,priority=900,ip,in_port=42,actions=mod_dl_dst:aa:bb:cc:dd:ee:ff,NORMAL",
 		"cookie=0x999,priority=900,ipv6,in_port=42,actions=mod_dl_dst:aa:bb:cc:dd:ee:ff,NORMAL",
 	}
 	if !reflect.DeepEqual(flows, wantFlows) {
-		t.Errorf("add-flow flows = %v, want %v", flows, wantFlows)
+		t.Errorf("batched flows = %v, want %v", flows, wantFlows)
+	}
+}
+
+// TestEnsureSegmentsUnchangedPlaneIsReadOnly is the headline property of the
+// differential apply on the MAC-tweak plane: when the installed flows already
+// match the desired set, the reconcile issues the dump and nothing else. The
+// dump is spelled the way OVS renders it, including the IN_PORT-era
+// canonicalizations, so the comparison exercises the normalizer too.
+func TestEnsureSegmentsUnchangedPlaneIsReadOnly(t *testing.T) {
+	rec := newOVSRecorder()
+	rec.on(
+		[]string{"ovs-vsctl", "get", "Interface", "patch-provnet-0", "ofport"},
+		"42\n", nil,
+	)
+	rec.onDump("br-ex", ovsCookieMACTweak,
+		" NXST_FLOW reply (xid=0x4):\n"+
+			" cookie=0x999, table=0, priority=900,ip,in_port=42 actions=mod_dl_dst:AA:BB:CC:DD:EE:FF,NORMAL\n"+
+			" cookie=0x999, table=0, priority=900,ipv6,in_port=42 actions=set_field:aa:bb:cc:dd:ee:ff->eth_dst,NORMAL\n")
+	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, segments: fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"), execOVSHook: rec.hook()}
+
+	if err := rm.EnsureSegments([]DesiredSegment{{LocalnetPort: ""}}); err != nil {
+		t.Fatalf("EnsureSegments() error: %v", err)
+	}
+
+	wantOfctl := [][]string{{"ovs-ofctl", "--no-stats", "dump-flows", "br-ex", "cookie=0x999/-1"}}
+	if got := rec.findOfctl(); !reflect.DeepEqual(got, wantOfctl) {
+		t.Errorf("steady-state cycle must issue only the dump, got %v", got)
 	}
 }
 
@@ -224,8 +528,8 @@ func TestEnsureSegmentsWithCachedFallbackKeepsFlatFlowSet(t *testing.T) {
 // two localnet segments resolve to their own patch ports (via the
 // external_ids ovn-controller stamps on the Port rows) and their own kernel
 // interfaces (via the segment-interface hook), and the MAC-tweak flows are
-// installed per patch port with the per-segment MACs after a single
-// bridge-wide cookie sweep.
+// installed per patch port with the per-segment MACs, in one batch and
+// without deleting anything.
 func TestEnsureSegmentsInstallsFlowsPerPatchPort(t *testing.T) {
 	rec := newOVSRecorder()
 	rec.on(
@@ -265,26 +569,22 @@ func TestEnsureSegmentsInstallsFlowsPerPatchPort(t *testing.T) {
 		t.Fatalf("EnsureSegments() error: %v", err)
 	}
 
-	flows := rec.findAddFlows()
+	flows := rec.findBatchedFlows()
 	wantFlows := []string{
 		"cookie=0x999,priority=900,ip,in_port=5,actions=mod_dl_dst:aa:bb:cc:dd:ee:65,NORMAL",
-		"cookie=0x999,priority=900,ipv6,in_port=5,actions=mod_dl_dst:aa:bb:cc:dd:ee:65,NORMAL",
 		"cookie=0x999,priority=900,ip,in_port=6,actions=mod_dl_dst:aa:bb:cc:dd:ee:66,NORMAL",
+		"cookie=0x999,priority=900,ipv6,in_port=5,actions=mod_dl_dst:aa:bb:cc:dd:ee:65,NORMAL",
 		"cookie=0x999,priority=900,ipv6,in_port=6,actions=mod_dl_dst:aa:bb:cc:dd:ee:66,NORMAL",
 	}
 	if !reflect.DeepEqual(flows, wantFlows) {
-		t.Errorf("add-flow flows = %v, want %v", flows, wantFlows)
+		t.Errorf("batched flows = %v, want %v", flows, wantFlows)
 	}
 
-	// Exactly one cookie sweep, bridge-wide.
-	dels := 0
+	// Nothing is deleted: the plane was empty, so the diff is adds only.
 	for _, c := range rec.calls {
-		if len(c) >= 4 && c[1] == "del-flows" && c[3] == "cookie=0x999/-1" {
-			dels++
+		if a := ofctlArgs(c); a != nil && strings.Contains(strings.Join(a, " "), "del-flows") {
+			t.Errorf("unexpected delete on an empty plane: %v", a)
 		}
-	}
-	if dels != 1 {
-		t.Errorf("expected 1 del-flows sweep, got %d", dels)
 	}
 
 	// The kernel devices are recorded per segment for the routing side.
@@ -338,7 +638,7 @@ func TestEnsureSegmentsSkipsSegmentWhenIfaceFails(t *testing.T) {
 		t.Fatalf("EnsureSegments() error: %v", err)
 	}
 
-	flows := rec.findAddFlows()
+	flows := rec.findBatchedFlows()
 	if len(flows) != 2 {
 		t.Fatalf("expected 2 flows (healthy segment only), got %v", flows)
 	}
@@ -399,86 +699,125 @@ func TestEnsureSegmentsFallbackDiscoveryWhenUncached(t *testing.T) {
 	}
 }
 
-func TestEnsureSegmentsTolersDelFailure(t *testing.T) {
-	// del-flows is treated as best-effort; a failure must not abort the
-	// subsequent add-flow calls.
+// TestEnsureSegmentsDumpFailureIsSurfaced covers the read that opens the
+// apply: without a dump there is no diff, so the reconcile reports the
+// wrapped error and touches nothing. The previously installed flows keep
+// forwarding in the meantime.
+func TestEnsureSegmentsDumpFailureIsSurfaced(t *testing.T) {
 	rec := newOVSRecorder()
 	rec.on(
 		[]string{"ovs-vsctl", "get", "Interface", "patch-provnet-0", "ofport"},
 		"42\n", nil,
 	)
 	rec.on(
-		[]string{"ovs-ofctl", "del-flows", "br-ex", "cookie=0x999/-1"},
+		[]string{"ovs-ofctl", "--no-stats", "dump-flows", "br-ex", "cookie=0x999/-1"},
 		"some output", errors.New("transient ofctl error"),
 	)
 	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, segments: fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"), execOVSHook: rec.hook()}
 
-	if err := rm.EnsureSegments([]DesiredSegment{{LocalnetPort: ""}}); err != nil {
-		t.Fatalf("EnsureSegments() should swallow del-flows error, got: %v", err)
+	err := rm.EnsureSegments([]DesiredSegment{{LocalnetPort: ""}})
+	if err == nil || !strings.Contains(err.Error(), "dump cookie=0x999 flows on br-ex") {
+		t.Fatalf("expected the wrapped dump error, got: %v", err)
 	}
-
-	if got := len(rec.findAddFlows()); got != 2 {
-		t.Errorf("expected 2 add-flow calls after del failure, got %d", got)
+	if got := rec.findOfctl(); len(got) != 1 {
+		t.Errorf("a failed dump must mutate nothing, got %v", got)
 	}
 }
 
-// TestEnsureSegmentsAddFailureDoesNotStarveOthers verifies that a per-segment
-// add-flow failure is logged and skipped rather than aborting the whole loop.
-// All flows are deleted up front, so returning on the first failure would
-// leave every later segment with no MAC-tweak flow at all. Here the first
-// segment's IPv4 add-flow fails; the second segment's flows must still be
-// installed and EnsureSegments must not report a hard error.
+// TestEnsureSegmentsBatchedAddFailureIsSurfaced covers the failure of the
+// batched add on the MAC-tweak plane: the bundle applied nothing, so the
+// previously installed flows are still forwarding, and the error reaches the
+// caller instead of being swallowed the way the per-flow re-adds were.
+func TestEnsureSegmentsBatchedAddFailureIsSurfaced(t *testing.T) {
+	rec := newOVSRecorder()
+	rec.on(
+		[]string{"ovs-vsctl", "get", "Interface", "patch-provnet-0", "ofport"},
+		"42\n", nil,
+	)
+	rec.onDump("br-ex", ovsCookieMACTweak, " NXST_FLOW reply (xid=0x4):\n")
+	batch := "cookie=0x999,priority=900,ip,in_port=42,actions=mod_dl_dst:aa:bb:cc:dd:ee:ff,NORMAL\n" +
+		"cookie=0x999,priority=900,ipv6,in_port=42,actions=mod_dl_dst:aa:bb:cc:dd:ee:ff,NORMAL\n"
+	rec.onStdin([]string{"ovs-ofctl", "--bundle", "add-flows", "br-ex", "-"}, batch,
+		"bundle failed", errors.New("ofctl exit 1"))
+	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, segments: fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"), execOVSHook: rec.hook()}
+
+	err := rm.EnsureSegments([]DesiredSegment{{LocalnetPort: ""}})
+	if err == nil || !strings.Contains(err.Error(), "ofctl exit 1") {
+		t.Fatalf("expected the batched add failure to surface, got: %v", err)
+	}
+}
+
+// TestEnsureSegmentsAddFailureDoesNotStarveOthers verifies the per-flow
+// fallback mode, taken when the configured wrapper does not forward stdin
+// (`docker exec` without -i: the probe's `cat` echoes nothing back). Every
+// flow gets its own add-flow exec, a failure on one does not stop the rest,
+// and the collected failures are returned naming the flow that broke — never
+// a silent skip.
 func TestEnsureSegmentsAddFailureDoesNotStarveOthers(t *testing.T) {
 	rec := newOVSRecorder()
 	rec.on(
-		[]string{"ovs-vsctl", "list-ports", "br-ex"},
+		[]string{"docker", "exec", "ovs", "ovs-vsctl", "list-ports", "br-ex"},
 		"patch-seg101\npatch-seg102\n", nil,
 	)
 	rec.on(
-		[]string{"ovs-vsctl", "--if-exists", "get", "Port", "patch-seg101", "external_ids:ovn-localnet-port"},
+		[]string{"docker", "exec", "ovs", "ovs-vsctl", "--if-exists", "get", "Port", "patch-seg101", "external_ids:ovn-localnet-port"},
 		"\"seg-101\"\n", nil,
 	)
 	rec.on(
-		[]string{"ovs-vsctl", "--if-exists", "get", "Port", "patch-seg102", "external_ids:ovn-localnet-port"},
+		[]string{"docker", "exec", "ovs", "ovs-vsctl", "--if-exists", "get", "Port", "patch-seg102", "external_ids:ovn-localnet-port"},
 		"\"seg-102\"\n", nil,
 	)
 	rec.on(
-		[]string{"ovs-vsctl", "get", "Interface", "patch-seg101", "ofport"},
+		[]string{"docker", "exec", "ovs", "ovs-vsctl", "get", "Interface", "patch-seg101", "ofport"},
 		"5\n", nil,
 	)
 	rec.on(
-		[]string{"ovs-vsctl", "get", "Interface", "patch-seg102", "ofport"},
+		[]string{"docker", "exec", "ovs", "ovs-vsctl", "get", "Interface", "patch-seg102", "ofport"},
 		"6\n", nil,
 	)
+	// The wrapper swallows stdin: `cat` sees EOF, prints nothing, exits 0.
+	rec.on([]string{"docker", "exec", "ovs", "cat"}, "", nil)
 	// The first segment's IPv4 add-flow fails.
 	rec.on(
-		[]string{"ovs-ofctl", "add-flow", "br-ex",
+		[]string{"docker", "exec", "ovs", "ovs-ofctl", "add-flow", "br-ex",
 			"cookie=0x999,priority=900,ip,in_port=5,actions=mod_dl_dst:aa:bb:cc:dd:ee:65,NORMAL"},
 		"add-flow failed", errors.New("bad flow"),
 	)
-	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, execOVSHook: rec.hook(), segmentIfaceHook: func(tag int) (string, string, error) {
-		return fmt.Sprintf("br-ex.%d", tag), fmt.Sprintf("aa:bb:cc:dd:ee:%02x", tag), nil
-	}}
+	rm := &RouteManager{
+		cfg:         Config{BridgeDev: "br-ex", OVSWrapper: "docker exec ovs"},
+		ovsWrapper:  []string{"docker", "exec", "ovs"},
+		execOVSHook: rec.hook(),
+		segmentIfaceHook: func(tag int) (string, string, error) {
+			return fmt.Sprintf("br-ex.%d", tag), fmt.Sprintf("aa:bb:cc:dd:ee:%02x", tag), nil
+		},
+	}
 
 	tag101, tag102 := 101, 102
 	desired := []DesiredSegment{
 		{LocalnetPort: "seg-101", VLANTag: &tag101},
 		{LocalnetPort: "seg-102", VLANTag: &tag102},
 	}
-	if err := rm.EnsureSegments(desired); err != nil {
-		t.Fatalf("EnsureSegments() should tolerate a per-segment add-flow failure, got: %v", err)
+	err := rm.EnsureSegments(desired)
+	if err == nil || !strings.Contains(err.Error(), "bad flow") {
+		t.Fatalf("expected the failed flow to be reported, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "in_port=5") {
+		t.Errorf("error must name the failed flow, got: %v", err)
 	}
 
-	// The healthy second segment's flows must still have been installed.
-	flows := rec.findAddFlows()
-	wantSurviving := []string{
+	// Every flow is attempted, including the healthy segment's pair behind
+	// the failure.
+	wantAttempted := []string{
+		"cookie=0x999,priority=900,ip,in_port=5,actions=mod_dl_dst:aa:bb:cc:dd:ee:65,NORMAL",
 		"cookie=0x999,priority=900,ip,in_port=6,actions=mod_dl_dst:aa:bb:cc:dd:ee:66,NORMAL",
+		"cookie=0x999,priority=900,ipv6,in_port=5,actions=mod_dl_dst:aa:bb:cc:dd:ee:65,NORMAL",
 		"cookie=0x999,priority=900,ipv6,in_port=6,actions=mod_dl_dst:aa:bb:cc:dd:ee:66,NORMAL",
 	}
-	for _, want := range wantSurviving {
-		if !containsFlow(flows, want) {
-			t.Errorf("healthy segment flow %q not installed after earlier failure; got %v", want, flows)
-		}
+	if got := rec.findAddFlows(); !reflect.DeepEqual(got, wantAttempted) {
+		t.Errorf("per-flow adds = %v, want every flow attempted: %v", got, wantAttempted)
+	}
+	if got := rec.findBatchedFlows(); len(got) != 0 {
+		t.Errorf("no batch may be piped into a wrapper that eats stdin, got %v", got)
 	}
 }
 
@@ -554,6 +893,7 @@ func TestEnsureSegmentsRediscoversWhenSegmentSetChanges(t *testing.T) {
 
 func TestReconcileOVSHairpinFlowsInstallsExpectedFlows(t *testing.T) {
 	rec := newOVSRecorder()
+	rec.onDump("br-ex", ovsCookieHairpin, " NXST_FLOW reply (xid=0x4):\n")
 	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, segments: fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"), execOVSHook: rec.hook()}
 
 	targets := map[string]HairpinTarget{
@@ -565,23 +905,157 @@ func TestReconcileOVSHairpinFlowsInstallsExpectedFlows(t *testing.T) {
 		t.Fatalf("ReconcileOVSHairpinFlows() error: %v", err)
 	}
 
-	// First call should be del-flows for the hairpin cookie.
-	wantDel := []string{"ovs-ofctl", "del-flows", "br-ex", "cookie=0x998/-1"}
-	if !reflect.DeepEqual(rec.calls[0], wantDel) {
-		t.Errorf("first call = %v, want %v", rec.calls[0], wantDel)
+	// The plane is read before it is written, and nothing is deleted.
+	wantOfctl := [][]string{
+		{"ovs-ofctl", "--no-stats", "dump-flows", "br-ex", "cookie=0x998/-1"},
+		{"ovs-ofctl", "--bundle", "add-flows", "br-ex", "-"},
+		{"ovs-ofctl", "--bundle", "add-flows", "br-ex", "-"},
+	}
+	if got := rec.findOfctl(); !reflect.DeepEqual(got, wantOfctl) {
+		t.Errorf("ovs-ofctl calls = %v, want %v", got, wantOfctl)
 	}
 
-	// Two add-flows expected, one per IP. Order is map-iteration-dependent,
-	// so compare as sets.
-	got := rec.findAddFlows()
-	sort.Strings(got)
+	// One spec per IP, batched through stdin in sorted order — map
+	// iteration order must not reach ovs-ofctl.
+	got := rec.findBatchedFlows()
 	want := []string{
 		"cookie=0x998,priority=910,ip,in_port=42,ip_dst=5.182.234.199/32,actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:6f:a1:64,output:in_port",
 		"cookie=0x998,priority=910,ipv6,in_port=42,ipv6_dst=2001:db8::1/128,actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:00:00:01,output:in_port",
 	}
-	sort.Strings(want)
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("add-flow flows = %v, want %v", got, want)
+		t.Errorf("batched flows = %v, want %v", got, want)
+	}
+}
+
+// TestReconcileOVSHairpinFlowsUnchangedPlaneIsReadOnly is the headline
+// property of this change: a cycle whose desired set already matches the
+// installed flows issues the dump and nothing else, so the flows — and their
+// packet counters — are never interrupted. The dump is spelled the way OVS
+// renders it back (nw_dst without the /32, IN_PORT for output:in_port).
+func TestReconcileOVSHairpinFlowsUnchangedPlaneIsReadOnly(t *testing.T) {
+	rec := newOVSRecorder()
+	rec.onDump("br-ex", ovsCookieHairpin,
+		" NXST_FLOW reply (xid=0x4):\n"+
+			" cookie=0x998, table=0, priority=910,ip,in_port=42,nw_dst=5.182.234.199 actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:6f:a1:64,IN_PORT\n"+
+			" cookie=0x998, table=0, priority=910,ipv6,in_port=42,ipv6_dst=2001:db8::1 actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:00:00:01,IN_PORT\n")
+	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, segments: fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"), execOVSHook: rec.hook()}
+
+	targets := map[string]HairpinTarget{
+		"5.182.234.199": {RouterMAC: "fa:16:3e:6f:a1:64"},
+		"2001:db8::1":   {RouterMAC: "FA:16:3E:00:00:01"},
+	}
+	if err := rm.ReconcileOVSHairpinFlows(targets); err != nil {
+		t.Fatalf("ReconcileOVSHairpinFlows() error: %v", err)
+	}
+
+	wantOfctl := [][]string{{"ovs-ofctl", "--no-stats", "dump-flows", "br-ex", "cookie=0x998/-1"}}
+	if got := rec.findOfctl(); !reflect.DeepEqual(got, wantOfctl) {
+		t.Errorf("steady-state cycle must issue only the dump, got %v", got)
+	}
+}
+
+// TestReconcileOVSHairpinFlowsChangedActionsReplaceInPlace covers a FIP that
+// moved to another router: same match, new mod_dl_dst. The flow is re-added
+// under the identical match and priority — which OpenFlow replaces atomically
+// — and is never deleted first, so the destination is reachable throughout.
+func TestReconcileOVSHairpinFlowsChangedActionsReplaceInPlace(t *testing.T) {
+	rec := newOVSRecorder()
+	rec.onDump("br-ex", ovsCookieHairpin,
+		" cookie=0x998, table=0, priority=910,ip,in_port=42,nw_dst=5.182.234.199 actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:00:00:aa,IN_PORT\n")
+	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, segments: fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"), execOVSHook: rec.hook()}
+
+	targets := map[string]HairpinTarget{"5.182.234.199": {RouterMAC: "fa:16:3e:6f:a1:64"}}
+	if err := rm.ReconcileOVSHairpinFlows(targets); err != nil {
+		t.Fatalf("ReconcileOVSHairpinFlows() error: %v", err)
+	}
+
+	want := []string{"cookie=0x998,priority=910,ip,in_port=42,ip_dst=5.182.234.199/32,actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:6f:a1:64,output:in_port"}
+	if got := rec.findBatchedFlows(); !reflect.DeepEqual(got, want) {
+		t.Errorf("batched flows = %v, want the re-add %v", got, want)
+	}
+	if got := rec.findStrictDeletes(); len(got) != 0 {
+		t.Errorf("a changed flow must be replaced, not deleted first; got deletes %v", got)
+	}
+}
+
+// TestReconcileOVSHairpinFlowsDeletesStaleAfterAdds pins the order the whole
+// change rests on: the new flow is installed before the retired one is
+// removed, and the removal is strict and fully qualified so it can only match
+// the one entry.
+func TestReconcileOVSHairpinFlowsDeletesStaleAfterAdds(t *testing.T) {
+	rec := newOVSRecorder()
+	rec.onDump("br-ex", ovsCookieHairpin,
+		" cookie=0x998, table=0, priority=910,ip,in_port=42,nw_dst=203.0.113.50 actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:00:01:02,IN_PORT\n"+
+			" cookie=0x998, table=0, priority=910,ipv6,in_port=42,ipv6_dst=2001:db8::99 actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:00:00:99,IN_PORT\n")
+	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, segments: fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"), execOVSHook: rec.hook()}
+
+	// The v4 FIP is gone, a new one took its place; the v6 one is gone too.
+	targets := map[string]HairpinTarget{"5.182.234.199": {RouterMAC: "fa:16:3e:6f:a1:64"}}
+	if err := rm.ReconcileOVSHairpinFlows(targets); err != nil {
+		t.Fatalf("ReconcileOVSHairpinFlows() error: %v", err)
+	}
+
+	wantOfctl := [][]string{
+		{"ovs-ofctl", "--no-stats", "dump-flows", "br-ex", "cookie=0x998/-1"},
+		{"ovs-ofctl", "--bundle", "add-flows", "br-ex", "-"},
+		{"ovs-ofctl", "--bundle", "add-flows", "br-ex", "-"},
+		{"ovs-ofctl", "--strict", "del-flows", "br-ex", "cookie=0x998/-1,priority=910,ip,in_port=42,nw_dst=203.0.113.50"},
+		{"ovs-ofctl", "--strict", "del-flows", "br-ex", "cookie=0x998/-1,priority=910,ipv6,in_port=42,ipv6_dst=2001:db8::99"},
+	}
+	if got := rec.findOfctl(); !reflect.DeepEqual(got, wantOfctl) {
+		t.Errorf("ovs-ofctl calls = %v, want adds before deletes: %v", got, wantOfctl)
+	}
+}
+
+// TestReconcileOVSHairpinFlowsIgnoresUnparseableDumpLine proves a dump line
+// the agent cannot key is dropped rather than guessed at: it produces no
+// delete, and the desired flow it partly resembles is simply (re-)added.
+func TestReconcileOVSHairpinFlowsIgnoresUnparseableDumpLine(t *testing.T) {
+	logs := captureSlog(t)
+	rec := newOVSRecorder()
+	rec.onDump("br-ex", ovsCookieHairpin,
+		" cookie=0x998, table=0, priority=910,ip,in_port=patch-provnet-0,nw_dst=5.182.234.199 actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:6f:a1:64,IN_PORT\n")
+	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, segments: fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"), execOVSHook: rec.hook()}
+
+	targets := map[string]HairpinTarget{"5.182.234.199": {RouterMAC: "fa:16:3e:6f:a1:64"}}
+	if err := rm.ReconcileOVSHairpinFlows(targets); err != nil {
+		t.Fatalf("ReconcileOVSHairpinFlows() error: %v", err)
+	}
+
+	if got := rec.findStrictDeletes(); len(got) != 0 {
+		t.Errorf("an unkeyable dump line must not synthesize a delete, got %v", got)
+	}
+	if got := len(rec.findBatchedFlows()); got != 1 {
+		t.Errorf("expected the desired flow to be (re-)added, got %d batched flows", got)
+	}
+	if !strings.Contains(logs.String(), "ignoring unparseable OVS flow dump line") {
+		t.Errorf("expected a warning about the dropped line; log:\n%s", logs.String())
+	}
+}
+
+// TestReconcileOVSHairpinFlowsDeleteFailureDoesNotStopOthers verifies that one
+// failing strict delete neither hides the remaining stale flows nor the error
+// itself.
+func TestReconcileOVSHairpinFlowsDeleteFailureDoesNotStopOthers(t *testing.T) {
+	rec := newOVSRecorder()
+	rec.onDump("br-ex", ovsCookieHairpin,
+		" cookie=0x998, table=0, priority=910,ip,in_port=42,nw_dst=203.0.113.50 actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:00:01:02,IN_PORT\n"+
+			" cookie=0x998, table=0, priority=910,ip,in_port=42,nw_dst=203.0.113.51 actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:00:01:03,IN_PORT\n")
+	rec.on([]string{"ovs-ofctl", "--strict", "del-flows", "br-ex",
+		"cookie=0x998/-1,priority=910,ip,in_port=42,nw_dst=203.0.113.50"},
+		"del failed", errors.New("ofctl exit 1"))
+	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, segments: fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"), execOVSHook: rec.hook()}
+
+	err := rm.ReconcileOVSHairpinFlows(nil)
+	if err == nil || !strings.Contains(err.Error(), "ofctl exit 1") {
+		t.Fatalf("expected the failed delete to be reported, got: %v", err)
+	}
+	want := []string{
+		"cookie=0x998/-1,priority=910,ip,in_port=42,nw_dst=203.0.113.50",
+		"cookie=0x998/-1,priority=910,ip,in_port=42,nw_dst=203.0.113.51",
+	}
+	if got := rec.findStrictDeletes(); !reflect.DeepEqual(got, want) {
+		t.Errorf("strict deletes = %v, want both attempted: %v", got, want)
 	}
 }
 
@@ -609,30 +1083,54 @@ func TestReconcileOVSHairpinFlowsPerSegment(t *testing.T) {
 		t.Fatalf("ReconcileOVSHairpinFlows() error: %v", err)
 	}
 
-	got := rec.findAddFlows()
-	sort.Strings(got)
+	got := rec.findBatchedFlows()
 	want := []string{
 		"cookie=0x998,priority=910,ip,in_port=5,ip_dst=198.51.100.50/32,actions=mod_dl_src:aa:bb:cc:dd:ee:65,mod_dl_dst:fa:16:3e:00:01:01,output:in_port",
 		"cookie=0x998,priority=910,ip,in_port=6,ip_dst=203.0.113.50/32,actions=mod_dl_src:aa:bb:cc:dd:ee:66,mod_dl_dst:fa:16:3e:00:01:02,output:in_port",
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("add-flow flows = %v, want %v", got, want)
+		t.Errorf("batched flows = %v, want %v", got, want)
 	}
 }
 
+// TestReconcileOVSHairpinFlowsEmptyMapClearsAll covers the plane going empty
+// (no locally-active routers left): every installed flow is retired with its
+// own strict delete, and nothing is added.
 func TestReconcileOVSHairpinFlowsEmptyMapClearsAll(t *testing.T) {
 	rec := newOVSRecorder()
+	rec.onDump("br-ex", ovsCookieHairpin,
+		" cookie=0x998, table=0, priority=910,ip,in_port=42,nw_dst=5.182.234.199 actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:6f:a1:64,IN_PORT\n"+
+			" cookie=0x998, table=0, priority=910,ipv6,in_port=42,ipv6_dst=2001:db8::1 actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:00:00:01,IN_PORT\n")
 	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, segments: fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"), execOVSHook: rec.hook()}
 
 	if err := rm.ReconcileOVSHairpinFlows(nil); err != nil {
 		t.Fatalf("ReconcileOVSHairpinFlows(nil) error: %v", err)
 	}
 
-	if len(rec.calls) != 1 {
-		t.Fatalf("expected only del-flows call, got %d: %v", len(rec.calls), rec.calls)
+	wantOfctl := [][]string{
+		{"ovs-ofctl", "--no-stats", "dump-flows", "br-ex", "cookie=0x998/-1"},
+		{"ovs-ofctl", "--strict", "del-flows", "br-ex", "cookie=0x998/-1,priority=910,ip,in_port=42,nw_dst=5.182.234.199"},
+		{"ovs-ofctl", "--strict", "del-flows", "br-ex", "cookie=0x998/-1,priority=910,ipv6,in_port=42,ipv6_dst=2001:db8::1"},
 	}
-	if rec.calls[0][1] != "del-flows" {
-		t.Errorf("expected del-flows, got %v", rec.calls[0])
+	if got := rec.findOfctl(); !reflect.DeepEqual(got, wantOfctl) {
+		t.Errorf("ovs-ofctl calls = %v, want %v", got, wantOfctl)
+	}
+}
+
+// TestReconcileOVSHairpinFlowsEmptyMapEmptyPlaneOnlyDumps covers the other
+// empty case: nothing desired and nothing installed costs exactly one read.
+func TestReconcileOVSHairpinFlowsEmptyMapEmptyPlaneOnlyDumps(t *testing.T) {
+	rec := newOVSRecorder()
+	rec.onDump("br-ex", ovsCookieHairpin, " NXST_FLOW reply (xid=0x4):\n")
+	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, segments: fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"), execOVSHook: rec.hook()}
+
+	if err := rm.ReconcileOVSHairpinFlows(nil); err != nil {
+		t.Fatalf("ReconcileOVSHairpinFlows(nil) error: %v", err)
+	}
+
+	wantOfctl := [][]string{{"ovs-ofctl", "--no-stats", "dump-flows", "br-ex", "cookie=0x998/-1"}}
+	if got := rec.findOfctl(); !reflect.DeepEqual(got, wantOfctl) {
+		t.Errorf("ovs-ofctl calls = %v, want only the dump", got)
 	}
 }
 
@@ -652,12 +1150,15 @@ func TestReconcileOVSHairpinFlowsNoBindingsIsNoOp(t *testing.T) {
 	}
 }
 
-// TestReconcileOVSHairpinFlowsSkipsInvalidIP proves an invalid IP is skipped
-// with no error and does not prevent the healthy flow from installing (issue
-// #158 test b, hairpin half). The old behaviour deleted every flow up front
-// then aborted on the first invalid IP, leaving the plane permanently empty.
+// TestReconcileOVSHairpinFlowsSkipsInvalidIP proves a row the agent cannot
+// render — an unparseable IP, or a segment with no binding — is left out of
+// the desired set with a warning and does not prevent the healthy flow from
+// installing (issue #158 test b, hairpin half). Whatever stale flow such a row
+// left behind is retired like any other flow that is no longer wanted.
 func TestReconcileOVSHairpinFlowsSkipsInvalidIP(t *testing.T) {
 	rec := newOVSRecorder()
+	rec.onDump("br-ex", ovsCookieHairpin,
+		" cookie=0x998, table=0, priority=910,ip,in_port=42,nw_dst=192.0.2.7 actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:aa:aa:aa:aa:aa:aa,IN_PORT\n")
 	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, segments: fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"), execOVSHook: rec.hook()}
 
 	targets := map[string]HairpinTarget{
@@ -668,33 +1169,72 @@ func TestReconcileOVSHairpinFlowsSkipsInvalidIP(t *testing.T) {
 		t.Fatalf("ReconcileOVSHairpinFlows() must skip the invalid IP, got: %v", err)
 	}
 
-	wantHealthy := "cookie=0x998,priority=910,ip,in_port=42,ip_dst=5.182.234.199/32,actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:6f:a1:64,output:in_port"
-	if !containsFlow(rec.findAddFlows(), wantHealthy) {
-		t.Errorf("healthy flow not installed despite the invalid sibling; got %v", rec.findAddFlows())
+	wantHealthy := []string{"cookie=0x998,priority=910,ip,in_port=42,ip_dst=5.182.234.199/32,actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:6f:a1:64,output:in_port"}
+	if got := rec.findBatchedFlows(); !reflect.DeepEqual(got, wantHealthy) {
+		t.Errorf("batched flows = %v, want only the healthy one: %v", got, wantHealthy)
+	}
+	wantDeletes := []string{"cookie=0x998/-1,priority=910,ip,in_port=42,nw_dst=192.0.2.7"}
+	if got := rec.findStrictDeletes(); !reflect.DeepEqual(got, wantDeletes) {
+		t.Errorf("strict deletes = %v, want the stale flow retired: %v", got, wantDeletes)
 	}
 }
 
-// TestReconcileOVSHairpinFlowsAddFailureDoesNotStarveOthers proves a failed
-// add-flow for one FIP does not abort the loop: the other FIP's flow still
-// installs and the call returns nil (issue #158 test b). Mirrors
-// TestEnsureSegmentsAddFailureDoesNotStarveOthers.
-func TestReconcileOVSHairpinFlowsAddFailureDoesNotStarveOthers(t *testing.T) {
+// TestReconcileOVSHairpinFlowsBatchedAddFailureSkipsDeletes proves a failed
+// batch stops the apply before the delete phase: the bundle installed nothing,
+// so shrinking the plane on top of that would take out flows that are still
+// the only ones forwarding. The error reaches the caller.
+func TestReconcileOVSHairpinFlowsBatchedAddFailureSkipsDeletes(t *testing.T) {
 	rec := newOVSRecorder()
-	// The flow for the first FIP fails to install.
-	const failingFlow = "cookie=0x998,priority=910,ip,in_port=42,ip_dst=5.182.234.199/32,actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:6f:a1:64,output:in_port"
-	rec.on([]string{"ovs-ofctl", "add-flow", "br-ex", failingFlow}, "add-flow failed", errors.New("bad flow"))
-
+	rec.onDump("br-ex", ovsCookieHairpin,
+		" cookie=0x998, table=0, priority=910,ip,in_port=42,nw_dst=203.0.113.50 actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:00:01:02,IN_PORT\n")
+	batch := "cookie=0x998,priority=910,ip,in_port=42,ip_dst=5.182.234.199/32,actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:6f:a1:64,output:in_port\n"
+	rec.onStdin([]string{"ovs-ofctl", "--bundle", "add-flows", "br-ex", "-"}, batch,
+		"bundle failed", errors.New("bad flow"))
 	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, segments: fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"), execOVSHook: rec.hook()}
+
+	targets := map[string]HairpinTarget{"5.182.234.199": {RouterMAC: "fa:16:3e:6f:a1:64"}}
+	err := rm.ReconcileOVSHairpinFlows(targets)
+	if err == nil || !strings.Contains(err.Error(), "bad flow") {
+		t.Fatalf("expected the batch failure to surface, got: %v", err)
+	}
+	if got := rec.findStrictDeletes(); len(got) != 0 {
+		t.Errorf("a failed grow must not be followed by a shrink, got deletes %v", got)
+	}
+	if rm.ofctlBundleOK != nil {
+		t.Error("a bundle-mode failure must drop the cached verdict so the next cycle re-probes")
+	}
+}
+
+// TestReconcileOVSHairpinFlowsPerFlowFallbackJoinsFailures covers the same
+// failure in the per-flow mode a stdin-less wrapper forces: every remaining
+// flow is still attempted and the failures come back together, each naming its
+// own flow.
+func TestReconcileOVSHairpinFlowsPerFlowFallbackJoinsFailures(t *testing.T) {
+	rec := newOVSRecorder()
+	rec.on([]string{"docker", "exec", "ovs", "ovs-ofctl", "--no-stats", "dump-flows", "br-ex", "cookie=0x998/-1"},
+		" NXST_FLOW reply (xid=0x4):\n", nil)
+	// The wrapper swallows stdin, so `cat` echoes nothing back.
+	rec.on([]string{"docker", "exec", "ovs", "cat"}, "", nil)
+	const failingFlow = "cookie=0x998,priority=910,ip,in_port=42,ip_dst=203.0.113.50/32,actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:00:01:02,output:in_port"
+	rec.on([]string{"docker", "exec", "ovs", "ovs-ofctl", "add-flow", "br-ex", failingFlow},
+		"add-flow failed", errors.New("bad flow"))
+	rm := &RouteManager{
+		cfg:         Config{BridgeDev: "br-ex", OVSWrapper: "docker exec ovs"},
+		ovsWrapper:  []string{"docker", "exec", "ovs"},
+		segments:    fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"),
+		execOVSHook: rec.hook(),
+	}
 
 	targets := map[string]HairpinTarget{
 		"5.182.234.199": {RouterMAC: "fa:16:3e:6f:a1:64"},
 		"203.0.113.50":  {RouterMAC: "fa:16:3e:00:01:02"},
 	}
-	if err := rm.ReconcileOVSHairpinFlows(targets); err != nil {
-		t.Fatalf("ReconcileOVSHairpinFlows() must tolerate a per-flow add failure, got: %v", err)
+	err := rm.ReconcileOVSHairpinFlows(targets)
+	if err == nil || !strings.Contains(err.Error(), "ip_dst=203.0.113.50/32") {
+		t.Fatalf("expected the failed flow to be named in the error, got: %v", err)
 	}
 
-	wantSurviving := "cookie=0x998,priority=910,ip,in_port=42,ip_dst=203.0.113.50/32,actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:00:01:02,output:in_port"
+	wantSurviving := "cookie=0x998,priority=910,ip,in_port=42,ip_dst=5.182.234.199/32,actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:6f:a1:64,output:in_port"
 	if !containsFlow(rec.findAddFlows(), wantSurviving) {
 		t.Errorf("healthy flow not installed after the sibling's add-flow failure; got %v", rec.findAddFlows())
 	}
@@ -709,6 +1249,213 @@ func TestReconcileOVSHairpinFlowsDryRun(t *testing.T) {
 	}
 	if len(rec.calls) != 0 {
 		t.Errorf("dry-run should issue no commands, got: %v", rec.calls)
+	}
+}
+
+// wrapperRM returns a RouteManager wired to the given recorder with a
+// containerized OVS wrapper configured, which is what makes the stdin probe
+// run at all.
+func wrapperRM(rec *ovsRecorder) *RouteManager {
+	return &RouteManager{
+		cfg:         Config{BridgeDev: "br-ex", OVSWrapper: "docker exec ovs"},
+		ovsWrapper:  []string{"docker", "exec", "ovs"},
+		segments:    fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"),
+		execOVSHook: rec.hook(),
+	}
+}
+
+// countCalls returns how many recorded calls contain the given joined
+// substring.
+func (r *ovsRecorder) countCalls(substr string) int {
+	n := 0
+	for _, c := range r.calls {
+		if strings.Contains(strings.Join(c, " "), substr) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestStdinProbeSkippedWithoutWrapper: with ovs-ofctl on PATH there is no
+// wrapper that could eat stdin, so no probe is worth an exec.
+func TestStdinProbeSkippedWithoutWrapper(t *testing.T) {
+	rec := newOVSRecorder()
+	rec.onDump("br-ex", ovsCookieHairpin, "")
+	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, segments: fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"), execOVSHook: rec.hook()}
+
+	if err := rm.ReconcileOVSHairpinFlows(map[string]HairpinTarget{"5.182.234.199": {RouterMAC: "fa:16:3e:6f:a1:64"}}); err != nil {
+		t.Fatalf("ReconcileOVSHairpinFlows() error: %v", err)
+	}
+	if n := rec.countCalls("cat"); n != 0 {
+		t.Errorf("expected no stdin probe without a wrapper, got %d", n)
+	}
+	if rm.wrapperStdinOK != nil {
+		t.Error("no wrapper means no verdict to cache")
+	}
+}
+
+// TestProbesOnlyRunOnANonEmptyDiff: a steady-state cycle applies nothing, so
+// neither probe has anything to decide.
+func TestProbesOnlyRunOnANonEmptyDiff(t *testing.T) {
+	rec := newOVSRecorder()
+	rec.on([]string{"docker", "exec", "ovs", "ovs-ofctl", "--no-stats", "dump-flows", "br-ex", "cookie=0x998/-1"},
+		" cookie=0x998, table=0, priority=910,ip,in_port=42,nw_dst=5.182.234.199 actions=mod_dl_src:aa:bb:cc:dd:ee:ff,mod_dl_dst:fa:16:3e:6f:a1:64,IN_PORT\n", nil)
+	rm := wrapperRM(rec)
+
+	if err := rm.ReconcileOVSHairpinFlows(map[string]HairpinTarget{"5.182.234.199": {RouterMAC: "fa:16:3e:6f:a1:64"}}); err != nil {
+		t.Fatalf("ReconcileOVSHairpinFlows() error: %v", err)
+	}
+	if len(rec.calls) != 1 {
+		t.Errorf("expected the dump alone, got %v", rec.calls)
+	}
+	if rm.wrapperStdinOK != nil || rm.ofctlBundleOK != nil {
+		t.Error("probes must not run on a cycle that applies nothing")
+	}
+}
+
+// TestStdinProbeCachesEchoedVerdict: a wrapper that echoes the probe payload
+// back forwards stdin, and the verdict is cached — the second apply pipes its
+// batch without probing again.
+func TestStdinProbeCachesEchoedVerdict(t *testing.T) {
+	rec := newOVSRecorder()
+	rec.on([]string{"docker", "exec", "ovs", "cat"}, ovsStdinProbe+"\n", nil)
+	rec.on([]string{"docker", "exec", "ovs", "ovs-ofctl", "--no-stats", "dump-flows", "br-ex", "cookie=0x998/-1"}, "", nil)
+	rm := wrapperRM(rec)
+
+	for i := 0; i < 2; i++ {
+		targets := map[string]HairpinTarget{"5.182.234.199": {RouterMAC: fmt.Sprintf("fa:16:3e:00:00:%02d", i)}}
+		if err := rm.ReconcileOVSHairpinFlows(targets); err != nil {
+			t.Fatalf("cycle %d: %v", i, err)
+		}
+	}
+
+	if n := rec.countCalls(" cat"); n != 1 {
+		t.Errorf("expected exactly 1 stdin probe across two applies, got %d", n)
+	}
+	if rm.wrapperStdinOK == nil || !*rm.wrapperStdinOK {
+		t.Errorf("expected a cached positive stdin verdict, got %v", rm.wrapperStdinOK)
+	}
+	if got := len(rec.findBatchedFlows()); got != 2 {
+		t.Errorf("expected both cycles to batch their add, got %d batched flows", got)
+	}
+}
+
+// TestStdinProbeCachesNegativeVerdictAndWarnsOnce covers `docker exec` without
+// -i: `cat` reads EOF, prints nothing and exits 0. The apply degrades to one
+// exec per flow and says so once, naming the fix.
+func TestStdinProbeCachesNegativeVerdictAndWarnsOnce(t *testing.T) {
+	logs := captureSlog(t)
+	rec := newOVSRecorder()
+	rec.on([]string{"docker", "exec", "ovs", "cat"}, "", nil)
+	rec.on([]string{"docker", "exec", "ovs", "ovs-ofctl", "--no-stats", "dump-flows", "br-ex", "cookie=0x998/-1"}, "", nil)
+	rm := wrapperRM(rec)
+
+	for i := 0; i < 2; i++ {
+		targets := map[string]HairpinTarget{"5.182.234.199": {RouterMAC: fmt.Sprintf("fa:16:3e:00:00:%02d", i)}}
+		if err := rm.ReconcileOVSHairpinFlows(targets); err != nil {
+			t.Fatalf("cycle %d: %v", i, err)
+		}
+	}
+
+	if n := rec.countCalls(" cat"); n != 1 {
+		t.Errorf("expected the negative verdict to be cached after 1 probe, got %d probes", n)
+	}
+	if rm.wrapperStdinOK == nil || *rm.wrapperStdinOK {
+		t.Errorf("expected a cached negative stdin verdict, got %v", rm.wrapperStdinOK)
+	}
+	if got := len(rec.findAddFlows()); got != 2 {
+		t.Errorf("expected one per-flow add per cycle, got %d", got)
+	}
+	if n := strings.Count(logs.String(), "does not forward stdin"); n != 1 {
+		t.Errorf("expected exactly 1 stdin warning, got %d; log:\n%s", n, logs.String())
+	}
+	if !strings.Contains(logs.String(), "docker exec -i") {
+		t.Errorf("the warning must name the fix; log:\n%s", logs.String())
+	}
+}
+
+// TestStdinProbeCachesNothingOnExecError: a probe that could not run says
+// nothing about stdin, so the next apply probes again instead of degrading for
+// the rest of the agent's life.
+func TestStdinProbeCachesNothingOnExecError(t *testing.T) {
+	rec := newOVSRecorder()
+	rec.on([]string{"docker", "exec", "ovs", "cat"}, "no such container", errors.New("exit 125"))
+	rec.on([]string{"docker", "exec", "ovs", "ovs-ofctl", "--no-stats", "dump-flows", "br-ex", "cookie=0x998/-1"}, "", nil)
+	rm := wrapperRM(rec)
+
+	for i := 0; i < 2; i++ {
+		targets := map[string]HairpinTarget{"5.182.234.199": {RouterMAC: fmt.Sprintf("fa:16:3e:00:00:%02d", i)}}
+		if err := rm.ReconcileOVSHairpinFlows(targets); err != nil {
+			t.Fatalf("cycle %d: %v", i, err)
+		}
+	}
+
+	if rm.wrapperStdinOK != nil {
+		t.Errorf("a failed probe must cache no verdict, got %v", *rm.wrapperStdinOK)
+	}
+	if n := rec.countCalls(" cat"); n != 2 {
+		t.Errorf("expected the probe to be retried on the next apply, got %d probes", n)
+	}
+}
+
+// TestBundleProbeCachesSuccess: the empty-bundle probe runs once and its
+// positive verdict is reused.
+func TestBundleProbeCachesSuccess(t *testing.T) {
+	rec := newOVSRecorder()
+	rec.onDump("br-ex", ovsCookieHairpin, "")
+	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, segments: fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"), execOVSHook: rec.hook()}
+
+	for i := 0; i < 2; i++ {
+		targets := map[string]HairpinTarget{"5.182.234.199": {RouterMAC: fmt.Sprintf("fa:16:3e:00:00:%02d", i)}}
+		if err := rm.ReconcileOVSHairpinFlows(targets); err != nil {
+			t.Fatalf("cycle %d: %v", i, err)
+		}
+	}
+
+	if rm.ofctlBundleOK == nil || !*rm.ofctlBundleOK {
+		t.Errorf("expected a cached positive bundle verdict, got %v", rm.ofctlBundleOK)
+	}
+	// 2 dumps + 1 probe + 2 batched adds.
+	if len(rec.calls) != 5 {
+		t.Errorf("expected the probe to run once across two applies, got %v", rec.calls)
+	}
+}
+
+// TestBundleProbeNeverCachesFailure mirrors the ovs-ofctl failure-injection
+// scenario: every call fails for one cycle. The apply falls back to a plain
+// add-flows batch and warns once, and because the negative verdict is not
+// cached the next cycle probes again and recovers the atomic path.
+func TestBundleProbeNeverCachesFailure(t *testing.T) {
+	logs := captureSlog(t)
+	rec := newOVSRecorder()
+	rec.onDump("br-ex", ovsCookieHairpin, "")
+	rec.onStdin([]string{"ovs-ofctl", "--bundle", "add-flows", "br-ex", "-"}, "",
+		"version negotiation failed", errors.New("exit 1"))
+	rm := &RouteManager{cfg: Config{BridgeDev: "br-ex"}, segments: fallbackSegments("patch-provnet-0", "42", "aa:bb:cc:dd:ee:ff"), execOVSHook: rec.hook()}
+
+	targets := map[string]HairpinTarget{"5.182.234.199": {RouterMAC: "fa:16:3e:6f:a1:64"}}
+	if err := rm.ReconcileOVSHairpinFlows(targets); err != nil {
+		t.Fatalf("a failed bundle probe must not fail the apply, got: %v", err)
+	}
+	if rm.ofctlBundleOK != nil {
+		t.Errorf("a negative bundle verdict must not be cached, got %v", *rm.ofctlBundleOK)
+	}
+	wantPlain := []string{"ovs-ofctl", "add-flows", "br-ex", "-"}
+	if got := rec.findOfctl(); !reflect.DeepEqual(got[len(got)-1], wantPlain) {
+		t.Errorf("expected the batch to fall back to a plain add-flows, got %v", got)
+	}
+
+	// Second cycle: the probe succeeds again and the bundle is back.
+	delete(rec.responses, stdinKey([]string{"ovs-ofctl", "--bundle", "add-flows", "br-ex", "-"}, ""))
+	targets["5.182.234.199"] = HairpinTarget{RouterMAC: "fa:16:3e:6f:a1:65"}
+	if err := rm.ReconcileOVSHairpinFlows(targets); err != nil {
+		t.Fatalf("second cycle: %v", err)
+	}
+	if rm.ofctlBundleOK == nil || !*rm.ofctlBundleOK {
+		t.Errorf("expected the re-probe to restore the bundle mode, got %v", rm.ofctlBundleOK)
+	}
+	if n := strings.Count(logs.String(), "--bundle unavailable"); n != 1 {
+		t.Errorf("expected exactly 1 bundle warning, got %d; log:\n%s", n, logs.String())
 	}
 }
 
@@ -845,6 +1592,21 @@ func TestRunOVSWithoutHookCallsCombinedOutput(t *testing.T) {
 	}
 }
 
+func TestRunOVSStdinWithoutHookPipesInput(t *testing.T) {
+	// Sanity check that runOVSStdin without a hook really hands its input to
+	// the process — the wrapper stdin probe and the batched add are only
+	// worth anything if it does.
+	rm := &RouteManager{}
+	out, err := rm.runOVSStdin([]byte("probe\n"), "cat")
+	if err != nil {
+		// Some hermetic CI environments lack /bin/cat; treat as skip.
+		t.Skipf("`cat` binary unavailable in test env: %v (output: %s)", err, out)
+	}
+	if strings.TrimSpace(string(out)) != "probe" {
+		t.Errorf("runOVSStdin() = %q, want the piped input echoed back", string(out))
+	}
+}
+
 // Ensure the recorder's own behavior is correct so test failures don't
 // stem from a buggy harness.
 func TestOVSRecorderRecordsAndResponds(t *testing.T) {
@@ -866,6 +1628,23 @@ func TestOVSRecorderRecordsAndResponds(t *testing.T) {
 	want := []string{"ovs-vsctl", "list-ports", "br-ex"}
 	if !reflect.DeepEqual(rec.calls[0], want) {
 		t.Errorf("recorded call = %v, want %v", rec.calls[0], want)
+	}
+
+	// Commands carrying stdin are recorded with it, and a response may be
+	// keyed on the pair — which is how a bundle probe and a real bundled add
+	// are told apart.
+	rec.onStdin([]string{"ovs-ofctl", "--bundle", "add-flows", "br-ex", "-"}, "flow\n", "applied", nil)
+	batch := exec.Command("ovs-ofctl", "--bundle", "add-flows", "br-ex", "-")
+	batch.Stdin = strings.NewReader("flow\n")
+	out, err = hook(batch)
+	if err != nil || string(out) != "applied" {
+		t.Fatalf("stdin-keyed response = (%q, %v), want (\"applied\", nil)", string(out), err)
+	}
+	if rec.stdins[1] != "flow\n" {
+		t.Errorf("recorded stdin = %q, want %q", rec.stdins[1], "flow\n")
+	}
+	if got := rec.findBatchedFlows(); !reflect.DeepEqual(got, []string{"flow"}) {
+		t.Errorf("findBatchedFlows() = %v, want [flow]", got)
 	}
 }
 

--- a/routing.go
+++ b/routing.go
@@ -65,6 +65,25 @@ type RouteManager struct {
 	// which networks, without touching netlink.
 	refreshVethNexthopHook func(networks []*net.IPNet) error
 
+	// wrapperStdinOK caches whether the configured OVS wrapper forwards
+	// stdin into the wrapped command, and ofctlBundleOK whether this
+	// ovs-ofctl speaks OpenFlow 1.4 bundles. Both are nil until probed and
+	// decide how a batch of flow adds is applied (see applyFlowAdds). Only
+	// verdicts the agent actually observed are cached: a probe that could
+	// not run leaves the field nil so the next apply probes again.
+	//
+	// Plain fields are safe for the same reason frrRouteCache below is: the
+	// reconcile loop is single-goroutine.
+	wrapperStdinOK *bool
+	ofctlBundleOK  *bool
+
+	// warnedWrapperStdin and warnedOfctlBundle keep the two degradation
+	// warnings to one line per agent lifetime. Without them the bundle
+	// warning would repeat on every apply, since a negative bundle verdict
+	// is deliberately never cached.
+	warnedWrapperStdin bool
+	warnedOfctlBundle  bool
+
 	// frrRouteCache memoizes FRR's static-route document for the current
 	// reconcile cycle. ListFRRRoutes and InactiveFRRRoutes now issue the
 	// identical `show ip route ... static json` query, so without this a

--- a/test/integration/scenario_failure_injection_test.go
+++ b/test/integration/scenario_failure_injection_test.go
@@ -183,10 +183,12 @@ func TestScenario_FailureInjection_OvsOfctlFailsOnce(t *testing.T) {
 	const fipA = "198.51.100.55"
 	testenv.AddFIP(t, ctx, nb, router, fipA, "10.0.0.55")
 
-	// failCount must exceed the ovs-ofctl call count in a single reconcile
-	// (del-flows MAC-tweak + add-flow v4 + add-flow v6 + del-flows hairpin
-	// + add-flow hairpin = 5). Setting it to 10 leaves headroom for any
-	// future call added inside the same cycle.
+	// failCount must exceed the ovs-ofctl call count in a single reconcile.
+	// Since #241 a cycle costs at most a dump, a bundle probe and one
+	// batched add per plane (2 planes × 3 = 6); a cycle whose dump already
+	// fails costs just the two dumps, so an armed shim is consumed over
+	// several cycles rather than one. Setting failCount to 10 keeps the
+	// window above a single healthy cycle either way.
 	shim := testenv.WithFailingTool(t, "ovs-ofctl", 10)
 	cfg := testenv.FastDefaults()
 	cfg.ExtraEnv = append(cfg.ExtraEnv, shim.Env())

--- a/test/integration/scenario_fip_test.go
+++ b/test/integration/scenario_fip_test.go
@@ -3,6 +3,8 @@
 package integration
 
 import (
+	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -154,4 +156,98 @@ func TestScenario_MultiRouterOnOneChassis(t *testing.T) {
 		func(line string) bool {
 			return strings.Contains(line, "nw_dst="+fipB) && strings.Contains(line, "mod_dl_dst:"+r2.LRPMAC)
 		}, 15*time.Second, "hairpin flow for FIP B → router B MAC")
+}
+
+// TestScenario_HairpinFlowSelfHeal (#241):
+//
+// The differential apply has to be self-healing in one direction and
+// completely still in the other. Both halves are checked here against real
+// OVS:
+//
+//   - A flow that disappears out-of-band (someone runs del-flows, or OVS
+//     restarts) is missing from the dump the next reconcile takes, lands in
+//     that reconcile's add set, and is back within one interval.
+//   - A flow that is already correct is never touched. The reconciles that
+//     follow leave the installed entry alone, which shows up as a duration=
+//     counter that keeps running instead of resetting to zero. The old
+//     sweep-and-re-add reconcile reset it on every cycle, and with it the
+//     packet counters this flow's traffic is debugged by.
+func TestScenario_HairpinFlowSelfHeal(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "healr1",
+		LRPMAC:      "fa:16:3e:cc:00:01",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	// A 2s reconcile interval, so the repair and the two quiet cycles after
+	// it fit into a test without a long wait.
+	const reconcileInterval = 2 * time.Second
+	cfg := testenv.FastDefaults()
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	const fip = "198.51.100.77"
+	testenv.AddFIP(t, ctx, nb, router, fip, "10.0.0.77")
+
+	isFlow := func(line string) bool {
+		return strings.Contains(line, "nw_dst="+fip) && strings.Contains(line, "mod_dl_dst:"+router.LRPMAC)
+	}
+	testenv.AssertOVSFlowMatches(t, "0x998", isFlow, 15*time.Second, "hairpin flow for the FIP")
+
+	// Blow the plane away behind the agent's back.
+	if out, err := exec.Command("ovs-ofctl", "del-flows", testenv.DefaultBridgeDev, "cookie=0x998/-1").CombinedOutput(); err != nil {
+		t.Fatalf("out-of-band del-flows: %v (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+
+	// The next reconcile sees the flow missing and re-adds it.
+	testenv.AssertOVSFlowMatches(t, "0x998", isFlow, 5*reconcileInterval, "hairpin flow repaired after an out-of-band delete")
+	repaired := time.Now()
+
+	// Now let two further reconciles pass with nothing changing in OVN. The
+	// entry must survive them: its duration counts from the repair, so it
+	// exceeds two intervals only if no reconcile replaced it in between.
+	quiet := 3 * reconcileInterval
+	time.Sleep(quiet)
+
+	out, err := exec.Command("ovs-ofctl", "dump-flows", testenv.DefaultBridgeDev, "cookie=0x998/-1").CombinedOutput()
+	if err != nil {
+		t.Fatalf("dump-flows: %v (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	var duration time.Duration
+	for _, line := range strings.Split(string(out), "\n") {
+		if !isFlow(line) {
+			continue
+		}
+		duration = flowDuration(t, line)
+	}
+	if duration == 0 {
+		t.Fatalf("hairpin flow for %s gone after %s of quiet reconciles; dump:\n%s", fip, quiet, strings.TrimSpace(string(out)))
+	}
+	if duration < 2*reconcileInterval {
+		t.Errorf("hairpin flow duration = %s after %s (installed at %s), want more than two reconcile intervals: the flow was rewritten instead of left alone",
+			duration, quiet, repaired.Format(time.TimeOnly))
+	}
+}
+
+// flowDuration reads the duration= field ovs-ofctl reports for a flow, e.g.
+// "duration=7.481s". It is how long the entry has been installed, so a
+// reconcile that replaces the flow resets it.
+func flowDuration(t *testing.T, line string) time.Duration {
+	t.Helper()
+	for _, field := range strings.Fields(strings.ReplaceAll(line, ",", " ")) {
+		value, ok := strings.CutPrefix(field, "duration=")
+		if !ok {
+			continue
+		}
+		seconds, err := strconv.ParseFloat(strings.TrimSuffix(value, "s"), 64)
+		if err != nil {
+			t.Fatalf("unparseable duration %q in flow line %q: %v", value, line, err)
+		}
+		return time.Duration(seconds * float64(time.Second))
+	}
+	t.Fatalf("no duration= field in flow line %q", line)
+	return 0
 }


### PR DESCRIPTION
Both agent-managed OVS flow planes were rewritten from scratch on every
reconcile: a cookie-wide `del-flows` sweep followed by one `add-flow` exec per
flow. Between the two the plane is empty, so same-node FIP-to-FIP traffic falls
into the kernel path #16 documents as broken, and every OVN-to-kernel provider
packet on the node is dropped. Reconciles fire on a timer and after every
debounced NB `NAT` change cloud-wide, so the window repeats many times a minute.

This replaces both rewrites with one differential apply. A steady-state cycle is
now a single read-only dump.

## The commits

**`fix(ovs): reconcile the hairpin and MAC-tweak planes differentially`**

Adds the flow model (`flowKey`, `desiredFlow`, `parsedFlow`, `parseFlowDump`,
`normalizeActions`) and the shared apply `reconcileFlowPlane`, and moves
`ReconcileOVSHairpinFlows` and `EnsureSegments` onto it.

- Dump once with `--no-stats`, diff against the desired set, add what is missing
  or changed, then delete what is stale. A flow whose actions changed is
  re-added under the identical match and priority, which OpenFlow replaces in
  place, so no packet sees a gap.
- The adds go in as one batch on stdin, inside an OpenFlow 1.4 bundle where both
  the wrapper and `ovs-ofctl` support one. Deletes are `--strict` and fully
  qualified, one per stale flow.
- Two runtime probes decide the mode. The documented `docker exec <container>`
  wrapper does not forward stdin without `-i`, and a batch through it would read
  EOF, install nothing and still exit 0; a wrapper that fails the `cat` probe
  degrades to one exec per flow with a warning. Neither probe caches a verdict
  it did not observe, so a one-cycle `ovs-ofctl` outage cannot permanently
  degrade the mode.
- Add failures are surfaced instead of logged and skipped: a failed batch
  returns before the delete phase, so a plane whose grow failed is never shrunk
  on top of that, and the per-flow fallback attempts every flow and joins the
  failures.
- The parser tolerates both dump spellings the integration suite and
  `test/e2e/scenarios/hairpin.sh` already observed: `nw_dst=` or `ip_dst=`, the
  host mask elided or spelled out, `IN_PORT` for `output:in_port`, and OXM
  `set_field:…->eth_src`/`eth_dst` for the MAC rewrites. A line it cannot key is
  dropped with a warning and never used to synthesize a delete.
- `RemoveOVSFlows` keeps its blanket sweeps, which are correct at shutdown and
  standby cleanup.

**`docs(config): the OVS wrapper has to forward stdin`**

The `ovs_wrapper` example becomes `docker exec -i openvswitch_vswitchd` in
config.go and in the sample config, both stating the stdin requirement and the
per-flow fallback. `go generate ./...` regenerates
`docs/reference/configuration.md` and `docs/reference/cli.md`, which render the
same flag usage string.

**`test(integration): cover hairpin flow self-heal and stillness`**

`TestScenario_HairpinFlowSelfHeal` checks both directions against real OVS: a
flow deleted out-of-band is back within one reconcile interval, and a flow that
is already correct survives two further quiet reconciles with its `duration=`
counter still running, which the sweep-and-re-add reconcile reset every cycle.
The `ovs-ofctl` call inventory in
`TestScenario_FailureInjection_OvsOfctlFailsOnce` is updated to the new
per-cycle call set.

## Verification

`go build ./...`, `go vet ./...`, `GOOS=linux go build ./...`,
`go test -race ./...`, `gofmt -l`, `golangci-lint run` (no new findings), and
`go generate ./... && git diff --exit-code -- docs/reference/` all pass on a
macOS checkout. Every unit acceptance criterion of #241 has a test in
`ovs_test.go`.

The integration suite, the new `TestScenario_HairpinFlowSelfHeal`, and
`make e2e-hairpin` / `make e2e-pf-hairpin` need Linux with root and real OVS (the
E2E pair additionally a containerlab lab), so they could not run in that
checkout. Both integration files compile and vet there with
`go vet -tags integration ./test/integration/...`; CI runs them here.

Closes #241
