### PR TITLE
fix(routing): read a default route by its prefix, not by a nil Dst

### DIFF
--- a/routing_linux.go
+++ b/routing_linux.go
@@ -1091,14 +1091,22 @@ func (rm *RouteManager) VRFDefaultRoutePresent() (bool, error) {
 
 // hasDefaultRoute reports whether any route in the list is 0.0.0.0/0.
 //
-// netlink encodes a default route as a nil Dst rather than a zero-length
-// prefix — the same encoding SetupVethLeak writes one with — so that is the
-// whole test. Split out from VRFDefaultRoutePresent because the netlink call
-// around it needs root and a real VRF device, while this is the part worth
-// pinning.
+// Both encodings count, because the two directions of the netlink API do not
+// agree. Writing a default route means leaving Dst unset — that is how
+// SetupVethLeak installs the leak-table default — but reading one back yields
+// an explicit 0.0.0.0/0 with a zero-length mask, since the deserializer fills
+// Dst in from the message's prefix length rather than from an RTA_DST
+// attribute the kernel never sends for a default. Testing only for a nil Dst
+// reads every real routing table as having no default at all.
+//
+// Split out from VRFDefaultRoutePresent because the netlink call around it
+// needs root and a real VRF device, while this is the part worth pinning.
 func hasDefaultRoute(routes []netlink.Route) bool {
 	for _, r := range routes {
 		if r.Dst == nil {
+			return true
+		}
+		if ones, _ := r.Dst.Mask.Size(); ones == 0 {
 			return true
 		}
 	}

--- a/routing_linux_test.go
+++ b/routing_linux_test.go
@@ -54,6 +54,11 @@ func TestVRFDefaultRoutePresentWrapsVRFLookupError(t *testing.T) {
 // A VRF that routes several networks but has no way out of them is the state
 // the whole check exists to name: the table is full, and every destination
 // outside it is still dropped.
+//
+// The cases below carry the encoding RouteListFiltered actually returns, not
+// the one the write side accepts. Those differ, and an earlier version of this
+// test asserted the write-side shape only — so it passed while the check read
+// every real routing table as empty of defaults.
 func TestHasDefaultRoute(t *testing.T) {
 	_, provider, err := net.ParseCIDR("192.0.2.0/24")
 	if err != nil {
@@ -62,6 +67,13 @@ func TestHasDefaultRoute(t *testing.T) {
 	_, fip, err := net.ParseCIDR("192.0.2.10/32")
 	if err != nil {
 		t.Fatalf("parse FIP CIDR: %v", err)
+	}
+	// What the deserializer hands back for `default via …`: an explicit
+	// 0.0.0.0/0 with a zero-length mask, verified against netlink v1.3.1
+	// reading a real table 100.
+	_, defaultDst, err := net.ParseCIDR("0.0.0.0/0")
+	if err != nil {
+		t.Fatalf("parse default CIDR: %v", err)
 	}
 
 	tests := []struct {
@@ -75,16 +87,26 @@ func TestHasDefaultRoute(t *testing.T) {
 			routes: []netlink.Route{{Dst: provider}, {Dst: fip}},
 		},
 		{
-			// netlink gives a default route a nil Dst whatever installed it,
-			// so the protocol is not part of the question. 186 is RTPROT_BGP,
-			// which the syscall package does not name.
-			name:   "a BGP-learned default",
-			routes: []netlink.Route{{Dst: provider}, {Dst: nil, Protocol: netlink.RouteProtocol(186)}},
-			want:   true,
+			// 186 is RTPROT_BGP, which the syscall package does not name. The
+			// protocol is not part of the question — only the prefix is.
+			name: "a BGP-learned default, as netlink returns it",
+			routes: []netlink.Route{
+				{Dst: provider},
+				{Dst: defaultDst, Protocol: netlink.RouteProtocol(186)},
+			},
+			want: true,
 		},
 		{
 			name:   "a statically configured default counts too",
-			routes: []netlink.Route{{Dst: nil, Protocol: netlink.RouteProtocol(syscall.RTPROT_STATIC)}},
+			routes: []netlink.Route{{Dst: defaultDst, Protocol: netlink.RouteProtocol(syscall.RTPROT_STATIC)}},
+			want:   true,
+		},
+		{
+			// The write-side shape, which SetupVethLeak uses for the leak
+			// table. Kept so the check survives a library that normalises the
+			// other way.
+			name:   "a default with Dst left unset",
+			routes: []netlink.Route{{Dst: nil}},
 			want:   true,
 		},
 	}


### PR DESCRIPTION
`VRFDefaultRoutePresent` reported every provider VRF as having no default route, on every gateway, for a whole chaos run — while the kernel had the route the entire time.

Found by the replay of seed `31771823085` on `heterogeneous` ([run 31782620754](https://github.com/osism/ovn-network-agent/actions/runs/31782620754)), which failed with nine `expected-state` violations, all of them `vrf-default: the agent reports vrf_default_route_present=0`, on all three gateways at two separate settles.

## The bug

`hasDefaultRoute` tested for a nil `Dst`. That is how a default route is *written* — `SetupVethLeak` installs the leak-table default by leaving `Dst` unset, and the kernel infers `0.0.0.0/0` from the zero prefix length — but it is not how one is *read back*. The deserializer fills `Dst` in from the message's prefix length rather than from an `RTA_DST` attribute the kernel never sends for a default, so `RouteListFiltered` returns an explicit `0.0.0.0/0` with a zero-length mask and the nil test never matched.

Verified against netlink v1.3.1 reading a real table 100, in both the plain form and the nexthop-group form zebra installs BGP routes with:

```
### CASE A — plain default route in table 100
    dst=0.0.0.0/0  table=100  gw=100.64.1.1  oif=12 proto=3
  AGENT hasDefaultRoute=false        <-- before
  AGENT hasDefaultRoute=true         <-- after

### CASE B — default via a nexthop group, the form zebra installs
    dst=0.0.0.0/0  table=100  gw=100.64.1.1  oif=12 proto=186
  AGENT hasDefaultRoute=false        <-- before
  AGENT hasDefaultRoute=true         <-- after
```

The check now accepts either shape.

## Why the tests did not catch it

`TestHasDefaultRoute` built its routes by hand with a nil `Dst`, so it asserted my assumption about the library rather than the library's behaviour, and passed while the code was wrong. It now carries the encoding `RouteListFiltered` actually returns, and keeps the write-side shape alongside it so the check survives a library that normalises the other way. The test fails before this change and passes after.

## Impact, and what was not affected

While this was live, an agent on a healthy fleet logged an outage that was not happening, held `ovn_network_agent_vrf_default_route_present` at 0, and would have kept `OVNNetworkAgentVRFDefaultRouteMissing` firing permanently. The chaos oracle failed every profile.

The data-plane fix the detector was added for (#247) is unaffected and demonstrably works. Same seed, same profile, against the nightly it was filed from:

| | nightly `31771823085` | replay after #247 |
|---|---|---|
| `hairpin-vip` loss | 335/839 = 39.9% | 40/777 = 5.15% |
| tick 11 `chassis-delete` | owner parked on gateway-3, 55 s dark | worst downtime 1.3 s |
| verdict | `recovery-timeout` on `hairpin-vip` | no recovery-timeout |

`hairpin-vip` now loses exactly the 40 packets every other probe loses, i.e. only the tick-7 `gateway-kill`, which is a documented standing offender unrelated to #247.

That replay aborted at tick 11 on the violations this PR fixes, so it never reached tick 18's `double-failover` — the case the original nightly failed on. Re-dispatching the same seed after this merges is what closes that out.

## A note on the oracle

The kernel-plane check passed throughout while the gauge check failed. That disagreement is the redundancy `metricsGate` was given deliberately — the plane check catches the route going away, the gauge catches the agent failing to notice — and it caught a broken detector on its first real run.

Refs #247
