### PR TITLE
test/e2e: dispatch ad-hoc chaos runs with a random seed and profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION   ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "d
 LDFLAGS   := -s -w -X main.version=$(VERSION)
 GOFLAGS   := -trimpath
 
-.PHONY: all build build-static build-integration clean fmt vet test test-integration install docs-gen docs-gen-check models-gen models-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-failover-strict e2e-hairpin e2e-hairpin-churn e2e-multi-vlan e2e-pf-external e2e-pf-hairpin e2e-pf-split-owner e2e-stale-chassis e2e-drain-hitless e2e-chaos e2e-chaos-report
+.PHONY: all build build-static build-integration clean fmt vet test test-integration install docs-gen docs-gen-check models-gen models-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-failover-strict e2e-hairpin e2e-hairpin-churn e2e-multi-vlan e2e-pf-external e2e-pf-hairpin e2e-pf-split-owner e2e-stale-chassis e2e-drain-hitless e2e-chaos e2e-chaos-report e2e-chaos-random
 
 # Containerlab E2E harness. See test/e2e/README.md for the topology and
 # acceptance criteria (issue #44).
@@ -20,6 +20,7 @@ E2E_PF_SPLIT_OWNER := test/e2e/scenarios/pf-split-owner.sh
 E2E_STALE       := test/e2e/scenarios/stale-chassis.sh
 E2E_DRAIN       := test/e2e/scenarios/drain-hitless.sh
 E2E_CHAOS       := go run ./test/e2e/chaos
+E2E_CHAOS_RANDOM := test/e2e/chaos-random.sh
 E2E_GWNODE_TAG  := ovn-network-agent/gwnode:e2e
 E2E_CENTRAL_TAG := ovn-network-agent/central:e2e
 
@@ -361,3 +362,20 @@ e2e-chaos:
 CHAOS_RUN ?= chaos-artifacts
 e2e-chaos-report:
 	$(E2E_CHAOS) -report $(CHAOS_RUN)
+
+# Dispatch an ad-hoc chaos run in CI with a random seed and a random
+# profile, always at the nightly 10-minute window. Unlike every other
+# e2e target this one runs no lab locally — it needs `gh`, authenticated,
+# and dispatches .github/workflows/e2e-chaos.yml against the current
+# branch (which must be pushed). The point is the draw: a hand-dispatched
+# run defaults to seed 42 / everything-on and re-walks a sequence the
+# nightly already covers, while this explores a fresh one and prints the
+# seed and profile it drew, so a red run replays in CI or locally.
+#
+#   make e2e-chaos-random
+#   make e2e-chaos-random CHAOS_RANDOM_FLAGS="-n 3"
+#   make e2e-chaos-random CHAOS_RANDOM_FLAGS="--watch"
+#   make e2e-chaos-random CHAOS_RANDOM_FLAGS="--dry-run"
+CHAOS_RANDOM_FLAGS ?=
+e2e-chaos-random:
+	$(E2E_CHAOS_RANDOM) $(CHAOS_RANDOM_FLAGS)

--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -44,6 +44,7 @@ test/e2e/
     stale-chassis.sh        — stale chassis cleanup scenario, hard kill (issue #111)
     drain-hitless.sh        — graceful drain vs hard kill, hitless comparison (issue #113)
     collect-artifacts.sh    — dump lab state for offline triage
+  chaos-random.sh           — dispatch an ad-hoc CI chaos run with a random seed and profile
   chaos/                    — seeded chaos runner, `make e2e-chaos` (issue #176)
     main.go                 — flags, wiring, exit codes, artifact collection
     engine.go               — the seeded tick loop: draw, guardrails, execute, converge
@@ -1755,6 +1756,31 @@ each assert one fault and leave the lab baseline-green, while a chaos
 run is a randomized sequence that deliberately leaves the master
 wherever the last election put it. Dispatch it from the Actions tab
 when you touch the agent's failover, drain or chassis-cleanup paths.
+
+**Ad-hoc exploration.**
+[`chaos-random.sh`](https://github.com/osism/ovn-network-agent/blob/main/test/e2e/chaos-random.sh)
+dispatches that workflow from a checkout with a **random seed and a
+random profile**, always at the nightly 10-minute window:
+
+```sh
+make e2e-chaos-random                                # one run against the current branch
+make e2e-chaos-random CHAOS_RANDOM_FLAGS="-n 3"      # three independent draws at once
+make e2e-chaos-random CHAOS_RANDOM_FLAGS="--watch"   # wait, then render each run's report
+make e2e-chaos-random CHAOS_RANDOM_FLAGS="--dry-run" # print the dispatch, send nothing
+```
+
+It exists because dispatching by hand is dispatching seed 42 on
+`everything-on` — the workflow's defaults — which re-walks a sequence the
+nightly matrix already covers, so the ad-hoc run buys no exploration. The
+draw comes from `/dev/urandom`, and the profile list is read out of the
+workflow's own dispatch `choice` options rather than duplicated, so a
+profile added to the registry becomes reachable here as soon as
+`TestChaosWorkflowSweepsEveryProfile` passes. Each dispatch prints the
+seed and profile it drew, the run URL, and the CI and local replay lines
+for it; `--seed` and `--profile` pin either half. It needs `gh`
+authenticated, and it dispatches against the current branch, which must
+exist on the remote (`--ref` overrides). Unlike every other `e2e-*`
+target it runs no lab locally.
 
 ### Manual setup for triage
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -18,5 +18,6 @@ make e2e-failover        # run the HA failover scenario (master chassis loss)
 make e2e-failover-strict # run the failover scenario with the strict ~2s outage budget
 make e2e-hairpin-churn   # hold zero loss on the same-chassis hairpin path under reconcile churn
 make e2e-chaos           # run a seeded 10-minute chaos session
+make e2e-chaos-random    # dispatch an ad-hoc CI chaos run, random seed + profile
 make e2e-down            # destroy the lab
 ```

--- a/test/e2e/chaos-random.sh
+++ b/test/e2e/chaos-random.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# Dispatch an ad-hoc E2E Chaos run with a random seed and a random
+# profile, on demand, from a checkout.
+#
+# Why this exists: the chaos runner's exploration budget is the nightly
+# matrix — six profiles, seeded from the run id, once a day. Touching the
+# failover, drain or chassis-cleanup paths means wanting that exploration
+# *now*, and the only ad-hoc path is the Actions tab, where a human picks
+# the seed and the profile by hand. Picking either by hand is the problem:
+# a hand-picked seed is almost always 42 (the dispatch default) and a
+# hand-picked profile almost always `everything-on`, so the ad-hoc runs
+# re-walk a sequence the nightly already covers. This draws both from
+# /dev/urandom instead, and prints what it drew.
+#
+# It does not weaken the replay contract — it only makes what there is to
+# replay worth replaying. The seed and profile are echoed here, recorded
+# in the run's `run-start` journal event and in `summary.json`, and
+# printed as a copy-pasteable replay line for CI and for a local lab, so
+# a run that goes red is reproducible either way.
+#
+# The duration is fixed at 10 minutes: the nightly window, the length
+# every recovery budget and every recorded comparison baseline was
+# calibrated against, and comfortably inside the workflow's 40-minute job
+# timeout.
+#
+# The profile list is not duplicated here. It is read out of the dispatch
+# input's `choice` options in .github/workflows/e2e-chaos.yml — the list
+# `TestChaosWorkflowSweepsEveryProfile` (test/e2e/chaos/profiles_test.go)
+# already guards against drift from the registry in
+# test/e2e/chaos/profiles.go — so a profile added to the registry becomes
+# reachable here as soon as that test passes.
+#
+# Usage:
+#   test/e2e/chaos-random.sh                    # one run, random seed, random profile
+#   test/e2e/chaos-random.sh -n 3               # three independent runs at once
+#   test/e2e/chaos-random.sh --profile pf-only  # pin the profile, keep the random seed
+#   test/e2e/chaos-random.sh --seed 12345       # pin the seed, keep the random profile
+#   test/e2e/chaos-random.sh --ref my-branch    # dispatch against a pushed branch
+#   test/e2e/chaos-random.sh --watch            # wait for the run, then render its report
+#   test/e2e/chaos-random.sh --dry-run          # draw and print, dispatch nothing
+#
+# Requires `gh`, authenticated (`gh auth status`). `--watch` waits for
+# every dispatched run and renders it through
+# `go run ./test/e2e/chaos -report`, exiting non-zero if any run did; with
+# no Go toolchain on PATH it prints the report command instead.
+#
+# Environment overrides:
+#   WORKFLOW     workflow file to dispatch (default e2e-chaos.yml)
+#   DURATION     fault-injection window (default 10m)
+#   REMOTE       git remote the ref must exist on (default origin)
+#   RUN_TIMEOUT  seconds to wait for a dispatched run to appear (default 60)
+
+set -euo pipefail
+
+WORKFLOW="${WORKFLOW:-e2e-chaos.yml}"
+DURATION="${DURATION:-10m}"
+REMOTE="${REMOTE:-origin}"
+RUN_TIMEOUT="${RUN_TIMEOUT:-60}"
+
+RUNS=1
+REF=""
+PIN_SEED=""
+PIN_PROFILE=""
+WATCH=0
+DRY_RUN=0
+
+REPO=""
+PROFILES=()
+DISPATCHED=()
+
+log() { printf '[chaos-random] %s\n' "$*" >&2; }
+die() { log "$*"; exit 1; }
+
+usage() {
+    cat >&2 <<'EOF'
+Dispatch an E2E Chaos run with a random seed and a random profile.
+
+  test/e2e/chaos-random.sh [options]
+
+  -n, --runs N        dispatch N runs, each with its own draw (default 1)
+      --profile NAME  pin the profile instead of drawing one
+      --seed N        pin the seed instead of drawing one
+      --ref REF       branch to dispatch against (default: current branch)
+      --watch         wait for each run and render its report
+      --dry-run       draw and print the dispatch command, dispatch nothing
+  -h, --help          this text
+
+The duration is always 10m. See the file header for the rationale.
+EOF
+}
+
+parse_args() {
+    while (( $# )); do
+        case "$1" in
+        -n|--runs) RUNS="${2:-}"; shift 2 ;;
+        --profile) PIN_PROFILE="${2:-}"; shift 2 ;;
+        --seed)    PIN_SEED="${2:-}"; shift 2 ;;
+        --ref)     REF="${2:-}"; shift 2 ;;
+        --watch)   WATCH=1; shift ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *)         log "unknown argument: $1"; usage; exit 1 ;;
+        esac
+    done
+
+    case "${RUNS}" in
+    ''|*[!0-9]*) die "-n takes a positive integer, got: ${RUNS}" ;;
+    esac
+    (( RUNS >= 1 )) || die "-n takes a positive integer, got: ${RUNS}"
+
+    # The workflow rejects anything but a bare non-negative integer seed
+    # (it fans one out through GITHUB_OUTPUT into a matrix). Fail here
+    # rather than burn a dispatch on a value it will reject.
+    if [ -n "${PIN_SEED}" ]; then
+        case "${PIN_SEED}" in
+        *[!0-9]*) die "--seed takes a non-negative integer, got: ${PIN_SEED}" ;;
+        esac
+    fi
+}
+
+# The dispatch input's choice options, in registry order. Read from the
+# workflow rather than hard-coded, so this script can never become the
+# place a new profile is missing from. Anchored on the `profile:` input
+# key rather than on the first `options:` block, so a second choice input
+# added to the workflow later cannot silently redirect the scan; the
+# matrix's `profile: ${{ … }}` has a value on the same line and does not
+# match.
+workflow_profiles() {
+    awk '
+        /^[[:space:]]*profile:[[:space:]]*$/ { inprofile = 1; next }
+        inprofile && /^[[:space:]]*options:[[:space:]]*$/ { inblock = 1; next }
+        inblock && /^[[:space:]]*-[[:space:]]/ {
+            sub(/^[[:space:]]*-[[:space:]]*/, "")
+            gsub(/["'"'"']/, "")
+            sub(/[[:space:]]*(#.*)?$/, "")
+            if (length($0)) print
+            next
+        }
+        inblock { exit }
+    ' "$1"
+}
+
+# A 32-bit draw from /dev/urandom. $RANDOM is 15 bits and seeded per
+# shell, which makes two invocations in the same second collide often
+# enough to matter when a fresh sequence is the entire point.
+random_uint32() {
+    od -An -N4 -tu4 < /dev/urandom | tr -d '[:space:]'
+}
+
+# The modulo bias of 2^32 over a handful of profiles is far below the
+# noise of a randomized fault sequence.
+random_profile() {
+    local index
+    index=$(( $(random_uint32) % ${#PROFILES[@]} ))
+    printf '%s\n' "${PROFILES[${index}]}"
+}
+
+preflight() {
+    command -v gh >/dev/null 2>&1 || die "gh is not installed — see https://cli.github.com"
+    gh auth status >/dev/null 2>&1 || die "gh is not authenticated — run: gh auth login"
+
+    REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+    [ -n "${REPO}" ] || die "could not resolve the repository — run gh repo set-default"
+
+    # A ref that exists only locally produces an opaque 422 from the
+    # dispatch API, so check it here and say what to do about it.
+    if ! git ls-remote --exit-code --heads "${REMOTE}" "${REF}" >/dev/null 2>&1; then
+        die "branch ${REF} does not exist on ${REMOTE} — push it first, or pass --ref main"
+    fi
+}
+
+newest_run_id() {
+    gh run list -R "${REPO}" --workflow "${WORKFLOW}" --event workflow_dispatch \
+        --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true
+}
+
+# Poll for the run the dispatch just created: `gh workflow run` returns no
+# id, so the newest dispatch run whose id differs from the one seen just
+# before is ours. Runs appear within a second or two; the deadline only
+# bounds the wait when the API lags.
+resolve_run_id() {
+    local before="$1" deadline newest
+    deadline=$(( $(date +%s) + RUN_TIMEOUT ))
+    while (( $(date +%s) < deadline )); do
+        newest="$(newest_run_id)"
+        if [ -n "${newest}" ] && [ "${newest}" != "${before}" ]; then
+            printf '%s\n' "${newest}"
+            return 0
+        fi
+        sleep 2
+    done
+    return 1
+}
+
+dispatch_one() {
+    local seed profile before run_id
+    seed="${PIN_SEED:-$(random_uint32)}"
+    profile="${PIN_PROFILE:-$(random_profile)}"
+
+    log "seed=${seed} profile=${profile} duration=${DURATION} ref=${REF}"
+
+    if (( DRY_RUN )); then
+        printf 'gh workflow run %s --ref %s -f seed=%s -f profile=%s -f duration=%s\n' \
+            "${WORKFLOW}" "${REF}" "${seed}" "${profile}" "${DURATION}"
+        return 0
+    fi
+
+    before="$(newest_run_id)"
+    gh workflow run "${WORKFLOW}" -R "${REPO}" --ref "${REF}" \
+        -f "seed=${seed}" \
+        -f "profile=${profile}" \
+        -f "duration=${DURATION}" >/dev/null
+
+    if ! run_id="$(resolve_run_id "${before}")"; then
+        log "dispatched, but the run did not appear within ${RUN_TIMEOUT}s — find it with:"
+        log "  gh run list -R ${REPO} --workflow ${WORKFLOW} --event workflow_dispatch"
+        DISPATCHED+=("?:${seed}:${profile}")
+        return 0
+    fi
+
+    log "run ${run_id}: https://github.com/${REPO}/actions/runs/${run_id}"
+    DISPATCHED+=("${run_id}:${seed}:${profile}")
+}
+
+summarize() {
+    local entry run_id seed profile
+    log "dispatched ${#DISPATCHED[@]} run(s); replay any of them with:"
+    for entry in "${DISPATCHED[@]}"; do
+        IFS=: read -r run_id seed profile <<<"${entry}"
+        log "  CI:    gh workflow run ${WORKFLOW} --ref ${REF} -f seed=${seed} -f profile=${profile} -f duration=${DURATION}"
+        log "  local: make e2e-up && make e2e-chaos CHAOS_FLAGS=\"-seed ${seed} -profile ${profile} -duration ${DURATION}\""
+    done
+}
+
+# Wait for each dispatched run and render its record — the verdict, the
+# recovery durations, the loss windows attributed to their faults — the
+# same way each job renders its own summary. It reads the uploaded
+# artifacts, so a red run reports too; only a run that died before the
+# runner wrote a record has nothing to show.
+watch_and_report() {
+    local entry run_id seed profile url status=0
+    for entry in "${DISPATCHED[@]}"; do
+        IFS=: read -r run_id seed profile <<<"${entry}"
+        [ "${run_id}" != "?" ] || continue
+
+        log "waiting for run ${run_id} (seed ${seed}, profile ${profile})"
+        gh run watch "${run_id}" -R "${REPO}" --exit-status >/dev/null || status=1
+
+        url="https://github.com/${REPO}/actions/runs/${run_id}"
+        if command -v go >/dev/null 2>&1; then
+            go run ./test/e2e/chaos -report "${url}" ||
+                log "the report could not be rendered for run ${run_id}"
+        else
+            log "no Go toolchain on PATH — render the report with:"
+            log "  make e2e-chaos-report CHAOS_RUN=${url}"
+        fi
+    done
+    return "${status}"
+}
+
+main() {
+    parse_args "$@"
+
+    command -v git >/dev/null 2>&1 || die "git is not installed"
+    local repo_root workflow_file profile known
+    repo_root="$(git rev-parse --show-toplevel)"
+    # `--watch` renders the report with `go run ./test/e2e/chaos`, which
+    # is a repo-relative package path, so run from the root regardless of
+    # where the script was invoked.
+    cd "${repo_root}"
+    workflow_file="${repo_root}/.github/workflows/${WORKFLOW}"
+    [ -f "${workflow_file}" ] || die "no such workflow: ${workflow_file}"
+
+    # `+=` rather than mapfile: /bin/bash on macOS is 3.2, where mapfile
+    # does not exist and expanding an empty array under `set -u` is an
+    # error.
+    while IFS= read -r profile; do
+        PROFILES+=("${profile}")
+    done < <(workflow_profiles "${workflow_file}")
+    (( ${#PROFILES[@]} )) || die "no profiles in ${workflow_file} — has the dispatch input changed?"
+
+    if [ -n "${PIN_PROFILE}" ]; then
+        known=0
+        for profile in "${PROFILES[@]}"; do
+            [ "${profile}" != "${PIN_PROFILE}" ] || known=1
+        done
+        (( known )) || die "unknown profile: ${PIN_PROFILE} (known: ${PROFILES[*]})"
+    fi
+
+    if [ -z "${REF}" ]; then
+        REF="$(git rev-parse --abbrev-ref HEAD)"
+        [ "${REF}" != "HEAD" ] || die "detached HEAD — pass an explicit --ref"
+    fi
+
+    log "profiles: ${PROFILES[*]}"
+    (( DRY_RUN )) || preflight
+
+    local i
+    for (( i = 0; i < RUNS; i++ )); do
+        dispatch_one
+    done
+
+    if (( DRY_RUN )); then
+        return 0
+    fi
+
+    summarize
+
+    # The exit code carries the runs' verdict only when we waited for it;
+    # a plain dispatch is done the moment the runs exist.
+    if (( WATCH )); then
+        watch_and_report
+        return $?
+    fi
+    return 0
+}
+
+main "$@"


### PR DESCRIPTION
The chaos runner's exploration budget is the nightly matrix: six profiles, seeded from the run id, once a day. Wanting that exploration *now* — after touching failover, drain or chassis cleanup — means dispatching `e2e-chaos.yml` from the Actions tab, where the seed and the profile are picked by hand.

That is what this closes. A hand-picked seed is the dispatch default `42` and a hand-picked profile is `everything-on`, so the ad-hoc run re-walks a sequence the nightly already covered and buys no coverage at all.

```sh
make e2e-chaos-random                                # one run against the current branch
make e2e-chaos-random CHAOS_RANDOM_FLAGS="-n 3"      # three independent draws at once
make e2e-chaos-random CHAOS_RANDOM_FLAGS="--watch"   # wait, then render each run's report
make e2e-chaos-random CHAOS_RANDOM_FLAGS="--dry-run" # print the dispatch, send nothing
```

Duration is fixed at `10m` — the nightly window, and the length every recovery budget and every recorded comparison baseline was calibrated against.

## The draw

Seed and profile come from `/dev/urandom`. `$RANDOM` would not do: 15 bits, seeded per shell, so two invocations in the same second collide often enough to matter when a fresh sequence is the entire point.

The replay contract is untouched — this only makes what there is to replay worth replaying. Every dispatch echoes its seed and profile, the run URL, and both replay lines:

```
[chaos-random] seed=2899487889 profile=flat-dnat duration=10m ref=main
[chaos-random] run 31810281882: https://github.com/osism/ovn-network-agent/actions/runs/31810281882
[chaos-random] dispatched 1 run(s); replay any of them with:
[chaos-random]   CI:    gh workflow run e2e-chaos.yml --ref main -f seed=2899487889 -f profile=flat-dnat -f duration=10m
[chaos-random]   local: make e2e-up && make e2e-chaos CHAOS_FLAGS="-seed 2899487889 -profile flat-dnat -duration 10m"
```

The runner records the same pair in `run-start` and in `summary.json`, so a red run replays from its own artifacts as before. `--seed` and `--profile` pin either half.

## The profile list is not duplicated

It is read out of the workflow's own `profile:` choice options — the list `TestChaosWorkflowSweepsEveryProfile` already guards against drift from the registry in `profiles.go`. A profile added to the registry becomes reachable here as soon as that test passes, and this script can never become the third place one is missing from.

The scan is anchored on the input key rather than on the first `options:` block, so a choice input added to the workflow later cannot silently redirect it. (The matrix's `profile: \${{ … }}` carries a value on the same line and does not match.)

## Two preflights

Both failures are otherwise opaque:

- A branch that exists only locally is rejected here, not as a 422 from the dispatch API.
- A non-integer seed is rejected here, not by the workflow's own `GITHUB_OUTPUT` guard after a dispatch is already spent.

## Notes

- Unlike every other `e2e-*` target this one runs no lab. It needs `gh` authenticated, not containerlab.
- Bash 3.2 holds (no `mapfile`, no empty-array expansion under `set -u`), so it runs against `/bin/bash` on macOS — where a developer dispatching CI is likely to be sitting. shellcheck-clean.
- Verified: profile parsing (six profiles, uniform over 300 draws), every argument-validation path, invocation from a subdirectory, the `make` target, and `gh repo view` / `gh run list` / `git ls-remote` read-only. No live dispatch was fired from the branch before opening this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)