### PR TITLE
ci: run the chaos nightly and dispatch on self-hosted runners

### DIFF
--- a/.github/actions/e2e-lab-setup/action.yml
+++ b/.github/actions/e2e-lab-setup/action.yml
@@ -23,7 +23,12 @@ runs:
     # modules must be loaded on the host before lab-up. The Azure kernel on
     # `ubuntu-latest` ships `openvswitch` in the base modules set but `vrf`
     # and `sch_netem` only in `linux-modules-extra-<uname>` — install it on
-    # demand. Without `vrf`, gwnode-entrypoint.sh crash-loops on
+    # demand. Each module is tried before any apt work runs, so a
+    # self-hosted runner whose kernel already ships them skips the install
+    # entirely; what such a runner does have to provide is passwordless
+    # sudo and the ability to load host kernel modules, which a
+    # containerised runner only has when it runs privileged. Without
+    # `vrf`, gwnode-entrypoint.sh crash-loops on
     # `ip link add vrf-provider type vrf table 100` with "Unknown device
     # type"; without `sch_netem` the impairment actions fail to add their
     # qdisc.

--- a/.github/workflows/e2e-chaos.yml
+++ b/.github/workflows/e2e-chaos.yml
@@ -24,6 +24,24 @@ name: E2E Chaos
 #     opts a single PR into a 3-minute seed-42 `everything-on` smoke,
 #     rather than adding chaos to every PR in the suite.
 #
+# The nightly and dispatch paths run on the org's self-hosted runners.
+# A chaos session is a 40-minute budget over a real containerlab lab,
+# and the pool has headroom the hosted runners do not. Two prerequisites
+# come with that. The runners need root on a real kernel — the
+# `e2e-lab-setup` action modprobes `openvswitch`, `vrf` and `sch_netem`
+# on the host — so a containerised runner has to be privileged. And the
+# lab name `ovn-e2e` is fixed in the topology, so two chaos jobs must
+# never share a machine: the pool is sized one job per host, and the
+# leftover-lab sweep below covers the case where a hard-killed job left
+# the previous lab behind.
+#
+# The PR smoke stays on `ubuntu-latest`. This repository is public, and
+# a `pull_request` run builds and runs the PR's own images with sudo; on
+# a throwaway VM that is contained, on a persistent org machine it would
+# not be. The `chaos-smoke` label gate is a cost gate, not a trust
+# boundary, so it is not what should be standing between a fork's
+# Dockerfile and the runner pool.
+#
 # Unlike the e2e.yml jobs there is no separate baseline gate here: the
 # runner refuses to start against a lab whose combined start state (a
 # superset of the baseline) never goes green, and reports that as exit
@@ -73,9 +91,11 @@ permissions:
   contents: read
 
 jobs:
-  # Resolve the three run inputs — the profile matrix, the seed and the
-  # duration — once, per trigger, so the chaos job below reads them the
-  # same way on every path. No checkout: the job only writes strings.
+  # Resolve the run inputs — the profile matrix, the seed, the duration
+  # and the runner label — once, per trigger, so the chaos job below
+  # reads them the same way on every path. No checkout: the job only
+  # writes strings, which is also why this job stays on `ubuntu-latest`
+  # rather than occupying a lab machine for a `case` statement.
   params:
     name: Resolve run inputs
     runs-on: ubuntu-latest
@@ -87,6 +107,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.label.name == 'chaos-smoke'
     outputs:
       profiles: ${{ steps.resolve.outputs.profiles }}
+      runner: ${{ steps.resolve.outputs.runner }}
       seed: ${{ steps.resolve.outputs.seed }}
       duration: ${{ steps.resolve.outputs.duration }}
     steps:
@@ -111,6 +132,7 @@ jobs:
             # Nightly: sweep every curated profile, seed = the run id so
             # each night is a different (recorded, replayable) sequence.
             profiles='["everything-on","flat-minimal","flat-dnat","vlan-no-dnat","pf-only","heterogeneous"]'
+            runner="self-hosted"
             seed="${GITHUB_RUN_ID}"
             duration="10m"
             ;;
@@ -118,12 +140,16 @@ jobs:
             # Replay/ad-hoc: a single chosen profile at the dispatched
             # seed and duration.
             profiles="[\"${INPUT_PROFILE}\"]"
+            runner="self-hosted"
             seed="${INPUT_SEED}"
             duration="${INPUT_DURATION}"
             ;;
           pull_request)
-            # PR smoke: one profile, a fixed seed, a short fault window.
+            # PR smoke: one profile, a fixed seed, a short fault window —
+            # and a throwaway hosted VM, because this is the one trigger
+            # that runs a fork's own code (see the header).
             profiles='["everything-on"]'
+            runner="ubuntu-latest"
             seed="42"
             duration="3m"
             ;;
@@ -132,12 +158,13 @@ jobs:
           # the dispatch path they are free-form inputs. Passing them
           # through env blocks shell injection but not GITHUB_OUTPUT
           # injection: a newline in the value opens a second `key=value`
-          # line. Since profiles= is written before seed=, an injected
-          # `profiles=[...]` line lands after the constrained one, wins as
-          # the last value for the key, and fans the matrix out to
-          # attacker-chosen values. Reject anything but a bare non-negative
-          # integer seed, and forbid a newline in duration. The schedule
-          # and PR paths set literals that pass unchanged.
+          # line. Since profiles= and runner= are written before seed=, an
+          # injected `profiles=[...]` or `runner=...` line lands after the
+          # constrained one, wins as the last value for the key, and either
+          # fans the matrix out to attacker-chosen values or picks the
+          # machine the chaos job lands on. Reject anything but a bare
+          # non-negative integer seed, and forbid a newline in duration.
+          # The schedule and PR paths set literals that pass unchanged.
           case "${seed}" in
           ''|*[!0-9]*)
             echo "seed must be a non-negative integer, got: ${seed}" >&2
@@ -152,20 +179,26 @@ jobs:
           esac
           # Echoing to the run log is what records the resolved nightly
           # seed there; the runner also records it in the uploaded
-          # summary.json and journal.jsonl. Writing the same three values
-          # to GITHUB_OUTPUT is what the matrix and the chaos job read.
+          # summary.json and journal.jsonl. Writing the same four values
+          # to GITHUB_OUTPUT is what the matrix, the chaos job's runs-on
+          # and the chaos job's run step read.
           echo "profiles: ${profiles}"
+          echo "runner: ${runner}"
           echo "seed: ${seed}"
           echo "duration: ${duration}"
           {
             echo "profiles=${profiles}"
+            echo "runner=${runner}"
             echo "seed=${seed}"
             echo "duration=${duration}"
           } >> "${GITHUB_OUTPUT}"
 
   chaos:
     name: Seeded chaos session (${{ matrix.profile }})
-    runs-on: ubuntu-latest
+    # Resolved per trigger by `params`: `self-hosted` for the nightly and
+    # dispatch paths, `ubuntu-latest` for the PR smoke. The header
+    # explains why the PR path is the one that stays hosted.
+    runs-on: ${{ needs.params.outputs.runner }}
     needs: params
     # fail-fast: false keeps one profile's failure from cancelling the
     # other five nightly jobs — each profile's run is worth its own
@@ -201,6 +234,18 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
+
+      # A hosted runner hands every job a fresh VM; a self-hosted one
+      # hands it whatever the last job left behind. A chaos job that died
+      # outside its own teardown — runner restart, OOM, a cancellation
+      # that outran the grace period — leaves `clab-ovn-e2e-*` containers
+      # and the topology's docker networks in place, and `containerlab
+      # deploy` will not deploy over them. Without this sweep that machine
+      # stays red every night until someone logs in. `|| true` because
+      # having nothing to destroy is the normal case, and always the case
+      # on the hosted PR path.
+      - name: Destroy a lab left behind by an earlier run
+        run: make e2e-down || true
 
       - name: Bring the lab up
         run: make e2e-up
@@ -259,8 +304,11 @@ jobs:
           retention-days: 7
 
       # Always tear the lab down so a partial-failure run does not leak
-      # docker networks/containers on a self-hosted runner. `if:
-      # always()` runs this step even when an earlier step failed.
+      # docker networks/containers on the self-hosted machine. `if:
+      # always()` runs this step even when an earlier step failed — and
+      # even on cancellation, which is why it, not the pre-run sweep
+      # above, is the primary cleanup. The sweep only has to cover the
+      # deaths that skip this step entirely.
       - name: Tear the lab down
         if: always()
         run: make e2e-down

--- a/docs/contributing/ci.md
+++ b/docs/contributing/ci.md
@@ -154,9 +154,33 @@ recorded by the runner in the uploaded `summary.json` and
 `e2e-chaos.yml` with the seed, profile and duration read back from that
 job's artifacts and the run reproduces exactly.
 
+Both the nightly and the dispatch path run on the org's **self-hosted
+runners** (`runs-on: self-hosted`), which is where a 40-minute session
+over a real containerlab lab has the headroom it wants. The runner
+label is resolved per trigger by the workflow's `params` job, not
+hard-coded on the chaos job, so the PR smoke below can stay hosted. A
+runner joining that pool has to satisfy two things the hosted images
+gave for free:
+
+- **Root on a real kernel.** The `e2e-lab-setup` action modprobes
+  `openvswitch`, `vrf` and `sch_netem` on the host, because the gwnode
+  containers only get `CAP_NET_ADMIN`. A containerised runner therefore
+  has to run privileged.
+- **One chaos job per machine.** The lab name `ovn-e2e` is fixed in the
+  topology, so two concurrent chaos jobs on one host collide at
+  `containerlab deploy`. The pool is sized one runner process per
+  machine; the nightly's six-profile fan-out relies on that. A job that
+  dies outside its own teardown still leaves a lab behind, which the
+  workflow's pre-run `make e2e-down || true` sweep clears before
+  deploying.
+
 A pull request opts into a short chaos smoke by carrying the
 `chaos-smoke` label, which keeps chaos off the default PR gate;
-applying the label needs triage permission. The label is not created
+applying the label needs triage permission. That smoke stays on
+`ubuntu-latest`. This repository is public and a `pull_request` run
+builds and runs the PR's own images with sudo, so the label is a cost
+gate, not a trust boundary — it is not what should stand between a
+fork's Dockerfile and a persistent org machine. The label is not created
 automatically — as a one-time repository-admin action (like applying
 the rulesets above), create it once with:
 

--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -1744,9 +1744,13 @@ runner records it, replayable — fault sequence. `workflow_dispatch`
 takes `seed`/`duration`/`profile` inputs (defaulting to 42 / 10m /
 `everything-on`), so replaying a failing nightly combination is just
 dispatching it with the seed, profile and duration read back from that
-job's artifacts. A pull request opts into a short smoke (3 minutes,
-seed 42, `everything-on`) by carrying the `chaos-smoke` label, rather
-than chaos running on every PR. Each profile's journal and summary
+job's artifacts. Both of those paths run on the org's self-hosted
+runners; the requirements a runner has to meet to join that pool are in
+[CI pipeline](./ci.md#scheduled-and-push-runs). A pull request opts into
+a short smoke (3 minutes, seed 42, `everything-on`) by carrying the
+`chaos-smoke` label, rather than chaos running on every PR — and that
+smoke stays on `ubuntu-latest`, because it is the one trigger that
+builds and runs a fork's own code. Each profile's journal and summary
 upload on every outcome, with the lab-state dump added on failure —
 and each job renders its own `-report` into the Actions job summary,
 so the verdict, the recovery durations and the loss windows are


### PR DESCRIPTION
A chaos session is a 40-minute budget over a real containerlab lab, and the nightly spends six of them at once. That is the workload the org's self-hosted pool exists for, so the nightly and the dispatch path move onto it.

## The PR smoke does not move

The label is not hard-coded on the chaos job. It is a fourth output of the `params` job, resolved in the same `case` that already resolves the profile matrix, the seed and the duration:

| Trigger | `runs-on` |
| --- | --- |
| `schedule` (nightly, six profiles) | `self-hosted` |
| `workflow_dispatch` (replay, ad-hoc) | `self-hosted` |
| `pull_request` (`chaos-smoke` label) | `ubuntu-latest` |

This repository is public and `pull_request` builds and runs the PR's own images with sudo. On a throwaway VM that is contained; on a persistent org machine it is not. The `chaos-smoke` label gate was written as a cost gate and is documented as one — and a cost gate is not what should stand between a fork's Dockerfile and the runner pool.

`params` itself stays on `ubuntu-latest`: no checkout, pure string work, no reason to occupy a lab machine for a `case` statement.

## `runner=` is written before the free-form values

Same ordering that already protects `profiles=`. An injected line from a newline in `seed` or `duration` lands *after* it and wins as the last value for the key — and the key it would be winning here is the machine the job lands on. The existing guards (integer-only seed, no newline in duration) close that; the comment now names what else is behind them.

## The pre-run sweep is what the move actually costs

```yaml
- name: Destroy a lab left behind by an earlier run
  run: make e2e-down || true
```

A hosted runner hands every job a fresh VM; a self-hosted one hands it whatever the last job left. The existing teardown step covers failure and cancellation, but not a runner restart or an OOM — and a lab that survives one of those leaves `clab-ovn-e2e-*` containers behind that `containerlab deploy` will not deploy over, so that machine stays red every night until someone logs in. The sweep only has to cover the deaths that skip the teardown; on the hosted PR path it is a no-op.

## Two prerequisites that live outside this repository

Documented in `docs/contributing/ci.md`, not enforceable here. **Both must hold before the first nightly on the new pool.**

- **Root on a real kernel.** `e2e-lab-setup` modprobes `openvswitch`, `vrf` and `sch_netem` on the host, because the gwnode containers only get `CAP_NET_ADMIN`. A containerised runner has to run privileged. (Each module is tried before any apt work, so a kernel that already ships them skips the install entirely.)
- **One chaos job per machine.** The lab name `ovn-e2e` is fixed in the topology, so two concurrent chaos jobs on one host collide at deploy time. The six-profile fan-out relies on the pool running one runner process per machine.

Separately, the runner group needs **Allow public repositories** — off by default per the `osism/infrastructure` runner README — or every job on the new label queues forever.

## Verification

- `actionlint -shellcheck=shellcheck` clean over all workflows.
- `go test ./test/e2e/chaos/` green, including `TestChaosWorkflowSweepsEveryProfile`, which parses this workflow's YAML — the new `runner=` assignments sit inside the `case` arms its nightly-profile regex spans.
- `npm run docs:build` clean, which is the repo's dead-link gate for the two doc changes.
- No chaos run was dispatched from this branch. The self-hosted path is exercised for the first time by the nightly (or by a dispatch) once the pool prerequisites above are in place; applying `chaos-smoke` to this PR exercises only the `ubuntu-latest` path, which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkJqSq992gYthMTNxL3MF2
