### PR TITLE
fix(agent): restore drained gateway priorities regardless of drain_on_shutdown

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -179,10 +179,16 @@ func (a *Agent) Run(ctx context.Context) error {
 		}
 		defer a.ovn.Close()
 
-		// Restore any gateway chassis priorities that were drained by a previous run.
-		if a.cfg.DrainOnShutdown {
-			a.ovn.RestoreDrainedGateways(ctx, a.ovn.GetState().LocalChassisName)
-		}
+		// Restore any gateway chassis priorities that were drained by a
+		// previous run. Unconditional on purpose: whether a priority-0
+		// residue exists is decided by the previous instance's config (the
+		// one that handled the SIGTERM), which this process cannot see. A
+		// restart that flips drain_on_shutdown off after a drain-enabled
+		// shutdown would otherwise strand the chassis at priority 0 —
+		// EnsureActivePriorityLead only boosts the active chassis, so
+		// nothing else ever lifts a standby off 0 (issue #254). Without
+		// local priority-0 rows the call is a no-op.
+		a.ovn.RestoreDrainedGateways(ctx, a.ovn.GetState().LocalChassisName)
 	}
 
 	// Initial reconciliation

--- a/docs/explanation/gateway-drain.md
+++ b/docs/explanation/gateway-drain.md
@@ -43,7 +43,11 @@ agent:
 On the **next startup**, before the first reconciliation, the agent detects
 drained entries (priority 0 on the local chassis) and **restores them to
 priority 1** (standby level). This re-adds the chassis to the HA group as a
-standby. The active chassis maintains a minimum priority of 2 via an
+standby. The restore runs regardless of the current `drain_on_shutdown`
+setting: the priority-0 residue was left by the previous instance's
+configuration, which the new process cannot see, so a restart that turns
+the flag off after a drain-enabled shutdown must still rejoin the HA
+group. The active chassis maintains a minimum priority of 2 via an
 automatic **priority lead boost** during reconciliation (see [Priority
 semantics](#priority-semantics)), which is strictly above the restore level
 of 1 — preventing reverse failover without requiring a priority tie to
@@ -104,7 +108,7 @@ already moved. The result is a hitless shutdown.
           │
           ▼
   ┌───────────────────────────────────────────────────────┐
-  │  RESTORE (if drain_on_shutdown=true)                  │
+  │  RESTORE (always, whatever drain_on_shutdown says)    │
   │                                                       │
   │  For each Gateway_Chassis on this node with           │
   │  priority == 0:                                       │

--- a/test/integration/scenario_failover_test.go
+++ b/test/integration/scenario_failover_test.go
@@ -470,3 +470,72 @@ func TestScenario_RestoreDrainedOnStartup(t *testing.T) {
 		t.Errorf("peer Gateway_Chassis %s disappeared", gcPeer)
 	}
 }
+
+// TestScenario_RestoreDrainedOnStartup_DrainDisabled (#254):
+//
+// NB Gateway_Chassis is already at priority 0 for this chassis — as a
+// previous drain-enabled shutdown leaves it — and the new instance runs
+// with drain_on_shutdown=false. This is the sequence a drain-disabling
+// restart produces (the chaos drain-toggle flip, or a config rollout that
+// turns the flag off): the old instance drains on SIGTERM, the new one
+// cannot know that it did. The startup restore must run regardless of the
+// current drain setting.
+//
+// Unlike TestScenario_RestoreDrainedOnStartup, the chassisredirect port is
+// bound to a peer chassis, so this node is a standby with no local routers —
+// the shape the drain leaves behind. That keeps EnsureActivePriorityLead
+// out of the picture (it returns early without local routers), so only the
+// startup restore can lift the row off 0: with the restore gated on
+// cfg.DrainOnShutdown the row stays at 0 forever and the chassis never
+// rejoins the HA group.
+func TestScenario_RestoreDrainedOnStartup_DrainDisabled(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	peerUUID := testenv.MakeChassis(t, ctx, sb, "restoreoff-peer")
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "restoreoff",
+		LRPNetworks: []string{"198.51.100.11/24"},
+		ChassisUUID: peerUUID,
+		GatewayChassis: []testenv.GatewayChassisEntry{
+			{ChassisName: testenv.LocalHostname(t), Priority: 0},
+			{ChassisName: "restoreoff-peer", Priority: 0},
+		},
+	})
+
+	gcLocal := "lrp-" + router.Name + "_" + testenv.LocalHostname(t)
+	gcPeer := "lrp-" + router.Name + "_restoreoff-peer"
+
+	cfg := testenv.Defaults()
+	off := false
+	cfg.DrainOnShutdown = &off
+	cfg.ReconcileInterval = "2s"
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	// The restore lifts the drained row to exactly 1 (standby level). No
+	// boost may follow: this chassis owns no chassisredirect port, and a
+	// standby re-entering above the restore level would risk reverse
+	// failover.
+	testenv.Eventually(t, func() bool {
+		gc, ok := testenv.FindGatewayChassis(t, ctx, nb, gcLocal)
+		return ok && gc.Priority == 1
+	}, 20*time.Second, 200*time.Millisecond,
+		"local Gateway_Chassis must be restored from 0 → 1 even with drain_on_shutdown=false (#254)")
+
+	// The restore itself ran (not some other writer raising the priority):
+	// the standby-restore log line is present.
+	if logs := a.LogTail(100000); !strings.Contains(logs, "restore-drain: gateway chassis priority restored to standby") {
+		t.Errorf("expected the restore-drain log line; tail:\n%s", a.LogTail(40))
+	}
+
+	// Peer entry must be untouched by RestoreDrainedGateways (different chassis).
+	if peer, ok := testenv.FindGatewayChassis(t, ctx, nb, gcPeer); ok {
+		if peer.Priority != 0 {
+			t.Errorf("peer Gateway_Chassis priority changed: got %d, want 0", peer.Priority)
+		}
+	} else {
+		t.Errorf("peer Gateway_Chassis %s disappeared", gcPeer)
+	}
+}


### PR DESCRIPTION
Closes #254

`Agent.Run` gated the startup `RestoreDrainedGateways` call on the new process' `drain_on_shutdown`. Whether a priority-0 residue exists in NB is decided by the previous instance (the one that drained on SIGTERM), which the new process cannot see. A restart that flips the drain off — the chaos `drain-toggle`, or a config rollout — left the chassis' Gateway_Chassis rows at priority 0 forever: `EnsureActivePriorityLead` only boosts the active chassis, so a standby never rejoined the HA group. Nightly E2E Chaos run [31925597145](https://github.com/osism/ovn-network-agent/actions/runs/31925597145/job/95112562971) (profile `heterogeneous`) failed on exactly this via the oracle's `drain-while-disabled` invariant; the end-state dump shows `lr0-public-gateway-2` stuck at priority 0 against peers at 32/33.

## Commits

1. **84b35d4 — fix(agent): restore drained gateway priorities regardless of drain_on_shutdown.** Drops the `if a.cfg.DrainOnShutdown` gate so the restore runs on every startup after `Connect()`. Without local priority-0 rows the call is a no-op, and restoring to standby level 1 cannot cause reverse failover: the active chassis holds priority ≥ 2 via `EnsureActivePriorityLead`. Adds the regression scenario `TestScenario_RestoreDrainedOnStartup_DrainDisabled`: a drained row is seeded, the chassisredirect port is bound to a peer chassis so the node is a standby (the shape a drain leaves behind — with a locally bound CR port the priority boost would mask a skipped restore), and the agent starts with `drain_on_shutdown=false`. The row must come back to exactly 1, with the `restore-drain:` log line present and the peer row untouched.
2. **55efefc — docs: the startup drain restore is unconditional.** The gateway-drain explanation's startup diagram said `RESTORE (if drain_on_shutdown=true)`; the box and the prose now state the restore runs regardless of the current setting.

## Verification

- `make vet`, `make test`, `make docs-gen-check`, `GOOS=linux go vet -tags=integration ./test/integration/...` all pass locally; golangci-lint reports no findings beyond the four pre-existing on `main`.
- The integration scenario could not run on the development machine (Docker Desktop's LinuxKit kernel has no VRF support, which the suite requires) — the `integration` CI job on this PR is the executable proof. On `main` the scenario fails by construction: the gated restore never runs, and no other writer can lift a standby's row off 0.
- Remaining acceptance check from #254, after CI is green: replay the failing nightly seed against this branch — `gh workflow run e2e-chaos.yml --ref implement/issue-254-unconditional-drain-restore -f seed=31925597145 -f profile=heterogeneous -f duration=10m` — and confirm the `heterogeneous` session passes.
