### PR TITLE
Repair bgpd's prefix-list copy when an FRR restart loses vtysh writes

### DIFF
--- a/docs/guides/frr-prefix-list.md
+++ b/docs/guides/frr-prefix-list.md
@@ -36,6 +36,16 @@ any network the gateway currently hosts, so a network entry cannot be relied
 on to cover it. Entries the agent no longer manages (removed networks,
 dormant VIPs) are removed during the next reconciliation.
 
+Each cycle also verifies the entries against bgpd's own copy of the list
+(`vtysh -d bgpd`), not just the merged view across all FRR daemons. The two
+can diverge: a vtysh write issued while FRR was restarting reaches only the
+daemons already accepting connections, and an entry that landed in zebra but
+missed bgpd silently blocks the network's announcements while looking present
+in `show running-config`. A line missing from bgpd's copy is re-applied with
+its existing sequence number, which repairs bgpd and is a no-op for the
+daemons that already have it. When bgpd itself is unreachable the check is
+skipped for that cycle and retried on the next one.
+
 The prefix list itself must already be referenced from your BGP configuration.
 There are two reference points, and a complete gateway config uses both:
 

--- a/routing.go
+++ b/routing.go
@@ -540,7 +540,15 @@ func (rm *RouteManager) ListFRRPrefixListEntries() ([]prefixListEntry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("vtysh show prefix-list %s: %w (output: %s)", rm.cfg.FRRPrefixList, err, strings.TrimSpace(string(output)))
 	}
+	return rm.parsePrefixListDocs(output)
+}
 
+// parsePrefixListDocs decodes the body of a `show ip prefix-list <name> json`
+// into the union of every answering daemon's entries. Shared by the
+// all-daemons listing above and the bgpd-only probe below — the union is the
+// right reading for stale removal and seq allocation, while bgpd's lone
+// document trivially unions to bgpd's own copy.
+func (rm *RouteManager) parsePrefixListDocs(output []byte) ([]prefixListEntry, error) {
 	// An empty body (or "{}") means the list does not exist — nothing to
 	// reconcile against, not an error.
 	trimmed := strings.TrimSpace(string(output))
@@ -555,8 +563,10 @@ func (rm *RouteManager) ListFRRPrefixListEntries() ([]prefixListEntry, error) {
 	// "invalid character '{' after top-level value". Each document nests the
 	// list under the daemon's own name: {"ZEBRA":{"<name>":{…}}}. Decode the
 	// documents in sequence and collect our list's entries from whichever
-	// daemons report it, deduplicating by sequence number since the daemons
-	// carry the same shared configuration.
+	// daemons report it, deduplicating by sequence number. The daemons hold
+	// the same configuration in steady state, but a write that raced an FRR
+	// restart can leave one daemon's copy short — which is why reconcile
+	// additionally checks bgpd's copy on its own (#256).
 	seen := make(map[int]bool)
 	var entries []prefixListEntry
 	dec := json.NewDecoder(strings.NewReader(trimmed))
@@ -597,6 +607,31 @@ func (rm *RouteManager) ListFRRPrefixListEntries() ([]prefixListEntry, error) {
 		}
 	}
 	return entries, nil
+}
+
+// listBGPDPrefixListEntries reads bgpd's own copy of the managed prefix-list
+// (`vtysh -d bgpd`). bgpd is the daemon whose copy gates announcements — the
+// neighbor outbound filter and the route-map on `redistribute connected` are
+// both evaluated there — so it is the copy reconcile verifies (#256).
+//
+// ok is false when the copy could not be read: bgpd not answering (down or
+// still starting) or an unparseable reply. Both mean "cannot verify this
+// cycle", not "the list is empty" — treating them as empty would re-apply
+// every entry against a daemon that cannot take the write. An empty body with
+// a clean exit is bgpd genuinely holding no such list, and is returned as
+// (nil, true) so every entry gets repaired.
+func (rm *RouteManager) listBGPDPrefixListEntries() ([]prefixListEntry, bool) {
+	output, err := rm.runVtysh("-d", "bgpd", "-c", fmt.Sprintf("show ip prefix-list %s json", rm.cfg.FRRPrefixList))
+	if err != nil {
+		slog.Warn("cannot read bgpd's prefix-list copy, skipping the per-daemon check this cycle", "name", rm.cfg.FRRPrefixList, "error", err, "output", strings.TrimSpace(string(output)))
+		return nil, false
+	}
+	entries, err := rm.parsePrefixListDocs(output)
+	if err != nil {
+		slog.Warn("cannot parse bgpd's prefix-list copy, skipping the per-daemon check this cycle", "name", rm.cfg.FRRPrefixList, "error", err)
+		return nil, false
+	}
+	return entries, true
 }
 
 // prefixListLine renders the config line body shared by add and remove:
@@ -667,6 +702,44 @@ func (rm *RouteManager) ReconcileFRRPrefixList(networks []*net.IPNet, vips []str
 				return fmt.Errorf("add prefix-list entry %s seq %d: %w (output: %s)", key.network, maxSeq, err, strings.TrimSpace(string(output)))
 			}
 			slog.Info("FRR prefix-list entry added", "name", rm.cfg.FRRPrefixList, "network", key.network, "seq", maxSeq)
+		}
+	}
+
+	// Repair bgpd's copy where it diverges from the union view. vtysh config
+	// writes reach only the daemons whose sockets already accept connections,
+	// so a write issued while FRR was restarting can land in zebra but miss
+	// bgpd. The union above then reports the entry present although the one
+	// daemon whose copy gates announcements never saw it, permanently
+	// filtering the network's /32s out (#256). Re-applying the line with its
+	// existing seq is a no-op for the daemons that have it and repairs the
+	// one that lost it; a fresh seq would instead duplicate the entry there.
+	var verifyKeys []entryKey
+	for key := range desired {
+		if _, exists := currentByKey[key]; exists {
+			verifyKeys = append(verifyKeys, key)
+		}
+	}
+	if len(verifyKeys) > 0 {
+		if bgpdEntries, ok := rm.listBGPDPrefixListEntries(); ok {
+			bgpdByKey := make(map[entryKey]bool, len(bgpdEntries))
+			for _, e := range bgpdEntries {
+				bgpdByKey[entryKey{e.Network, e.Exact}] = true
+			}
+			for _, key := range verifyKeys {
+				if bgpdByKey[key] {
+					continue
+				}
+				seq := currentByKey[key]
+				output, err := rm.runVtysh(
+					"-c", "conf t",
+					"-c", rm.prefixListLine(seq, key.network, key.exact),
+					"-c", "end",
+				)
+				if err != nil {
+					return fmt.Errorf("repair prefix-list entry %s seq %d: %w (output: %s)", key.network, seq, err, strings.TrimSpace(string(output)))
+				}
+				slog.Info("FRR prefix-list entry repaired", "name", rm.cfg.FRRPrefixList, "network", key.network, "seq", seq)
+			}
 		}
 	}
 

--- a/routing_test.go
+++ b/routing_test.go
@@ -1266,6 +1266,14 @@ func TestReconcileFRRPrefixList_AddsMissingAndRemovesStale(t *testing.T) {
 		),
 		nil,
 	)
+	// bgpd's copy matches the union, so the per-daemon check repairs nothing.
+	rec.on(
+		[]string{"vtysh", "-d", "bgpd", "-c", "show ip prefix-list ANNOUNCED-NETWORKS json"},
+		frrPrefixListDoc("BGP", "ANNOUNCED-NETWORKS",
+			prefixListEntry{Seq: 10, Network: "198.51.100.0/24"},
+		),
+		nil,
+	)
 
 	rm := &RouteManager{cfg: Config{FRRPrefixList: "ANNOUNCED-NETWORKS"}, execVtyshHook: rec.hook()}
 
@@ -1275,9 +1283,9 @@ func TestReconcileFRRPrefixList_AddsMissingAndRemovesStale(t *testing.T) {
 		t.Fatalf("ReconcileFRRPrefixList: %v", err)
 	}
 
-	// Expect: 1 list call + 1 add (203.0.113.0/24) + 1 remove (10.0.0.0/24).
-	if len(rec.calls) != 3 {
-		t.Fatalf("expected 3 vtysh calls (list+add+remove), got %d: %v", len(rec.calls), rec.calls)
+	// Expect: 1 list + 1 add (203.0.113.0/24) + 1 bgpd list + 1 remove (10.0.0.0/24).
+	if len(rec.calls) != 4 {
+		t.Fatalf("expected 4 vtysh calls (list+add+bgpd-list+remove), got %d: %v", len(rec.calls), rec.calls)
 	}
 
 	var sawAdd, sawRemove bool
@@ -1344,6 +1352,15 @@ func TestReconcileFRRPrefixList_VIPEntries(t *testing.T) {
 		),
 		nil,
 	)
+	// bgpd's copy matches the union, so the per-daemon check repairs nothing.
+	rec.on(
+		[]string{"vtysh", "-d", "bgpd", "-c", "show ip prefix-list ANNOUNCED-NETWORKS json"},
+		frrPrefixListDoc("BGP", "ANNOUNCED-NETWORKS",
+			prefixListEntry{Seq: 10, Network: "198.51.100.0/24"},
+			prefixListEntry{Seq: 15, Network: "192.0.2.80/32", Exact: true},
+		),
+		nil,
+	)
 
 	rm := &RouteManager{cfg: Config{FRRPrefixList: "ANNOUNCED-NETWORKS"}, execVtyshHook: rec.hook()}
 
@@ -1352,9 +1369,9 @@ func TestReconcileFRRPrefixList_VIPEntries(t *testing.T) {
 		t.Fatalf("ReconcileFRRPrefixList: %v", err)
 	}
 
-	// Expect: 1 list call + 1 add (192.0.2.81/32) + 1 remove (192.0.2.99/32).
-	if len(rec.calls) != 3 {
-		t.Fatalf("expected 3 vtysh calls (list+add+remove), got %d: %v", len(rec.calls), rec.calls)
+	// Expect: 1 list + 1 add (192.0.2.81/32) + 1 bgpd list + 1 remove (192.0.2.99/32).
+	if len(rec.calls) != 4 {
+		t.Fatalf("expected 4 vtysh calls (list+add+bgpd-list+remove), got %d: %v", len(rec.calls), rec.calls)
 	}
 
 	var sawAdd, sawRemove bool
@@ -1429,6 +1446,127 @@ func TestReconcileFRRPrefixList_AddFailureBailsOut(t *testing.T) {
 	_, n, _ := net.ParseCIDR("198.51.100.0/24")
 	if err := rm.ReconcileFRRPrefixList([]*net.IPNet{n}, nil); err == nil {
 		t.Fatal("expected error when add command fails, got nil")
+	}
+}
+
+// TestReconcileFRRPrefixList_RepairsBGPDDivergence is the regression test for
+// #256: vtysh config writes issued while FRR was still starting land only in
+// the daemons already accepting connections, so an entry can exist in zebra's
+// copy of the list but be missing from bgpd's. The union view reports it
+// present, while bgpd's outbound filter silently blocks the network forever.
+// Reconcile must check bgpd's own copy and re-apply the missing line with its
+// existing seq — not a fresh one, which would duplicate the entry in zebra.
+func TestReconcileFRRPrefixList_RepairsBGPDDivergence(t *testing.T) {
+	kept := prefixListEntry{Seq: 5, Network: "198.51.100.0/24"}
+	lost := prefixListEntry{Seq: 10, Network: "203.0.113.0/24"}
+	rec := newVtyshRecorder()
+	// The incident shape: zebra carries both entries, bgpd's document in the
+	// concatenated reply is missing one — the union still reports both.
+	rec.on(
+		[]string{"vtysh", "-c", "show ip prefix-list ANNOUNCED-NETWORKS json"},
+		frrPrefixListDoc("ZEBRA", "ANNOUNCED-NETWORKS", kept, lost)+
+			frrPrefixListDoc("BGP", "ANNOUNCED-NETWORKS", kept),
+		nil,
+	)
+	rec.on(
+		[]string{"vtysh", "-d", "bgpd", "-c", "show ip prefix-list ANNOUNCED-NETWORKS json"},
+		frrPrefixListDoc("BGP", "ANNOUNCED-NETWORKS", kept),
+		nil,
+	)
+
+	rm := &RouteManager{cfg: Config{FRRPrefixList: "ANNOUNCED-NETWORKS"}, execVtyshHook: rec.hook()}
+	_, n1, _ := net.ParseCIDR("198.51.100.0/24")
+	_, n2, _ := net.ParseCIDR("203.0.113.0/24")
+	if err := rm.ReconcileFRRPrefixList([]*net.IPNet{n1, n2}, nil); err != nil {
+		t.Fatalf("ReconcileFRRPrefixList: %v", err)
+	}
+
+	// Expect: union list + bgpd list + exactly one repair, nothing else — no
+	// new-seq add (both entries exist in the union) and no remove.
+	if len(rec.calls) != 3 {
+		t.Fatalf("expected 3 vtysh calls (list+bgpd-list+repair), got %d: %v", len(rec.calls), rec.calls)
+	}
+	repair := strings.Join(rec.calls[2], " ")
+	want := "ip prefix-list ANNOUNCED-NETWORKS seq 10 permit 203.0.113.0/24 ge 32 le 32"
+	if !strings.Contains(repair, want) || strings.Contains(repair, "no ip prefix-list") {
+		t.Errorf("expected a repair call re-applying %q, got: %v", want, rec.calls)
+	}
+}
+
+// TestReconcileFRRPrefixList_BGPDUnreachableSkipsRepair pins the degraded
+// path: when bgpd does not answer (vtysh -d bgpd fails), there is no copy to
+// verify and nothing a write could reach, so reconcile keeps the union
+// behavior, issues no repair, and does not fail the cycle — the next cycle
+// after bgpd returns performs the check.
+func TestReconcileFRRPrefixList_BGPDUnreachableSkipsRepair(t *testing.T) {
+	entry := prefixListEntry{Seq: 5, Network: "198.51.100.0/24"}
+	rec := newVtyshRecorder()
+	rec.on(
+		[]string{"vtysh", "-c", "show ip prefix-list ANNOUNCED-NETWORKS json"},
+		frrPrefixListJSON("ANNOUNCED-NETWORKS", entry),
+		nil,
+	)
+	rec.on(
+		[]string{"vtysh", "-d", "bgpd", "-c", "show ip prefix-list ANNOUNCED-NETWORKS json"},
+		"Exiting: failed to connect to daemon bgpd", errors.New("exit status 1"),
+	)
+
+	rm := &RouteManager{cfg: Config{FRRPrefixList: "ANNOUNCED-NETWORKS"}, execVtyshHook: rec.hook()}
+	_, n, _ := net.ParseCIDR("198.51.100.0/24")
+	if err := rm.ReconcileFRRPrefixList([]*net.IPNet{n}, nil); err != nil {
+		t.Fatalf("ReconcileFRRPrefixList must not fail on an unreachable bgpd: %v", err)
+	}
+	// A failed probe must not be mistaken for an empty bgpd list: exactly the
+	// union list and the probe ran, no repair writes followed.
+	if len(rec.calls) != 2 {
+		t.Fatalf("expected 2 vtysh calls (list+bgpd-list), got %d: %v", len(rec.calls), rec.calls)
+	}
+}
+
+// TestReconcileFRRPrefixList_BGPDListAbsentRepairsAll covers bgpd holding no
+// copy of the list at all (a restart with a stale frr.conf): every desired
+// entry the union carries is re-applied, each in the shape and with the seq it
+// already has — the network ge/le form and the exact VIP form both.
+func TestReconcileFRRPrefixList_BGPDListAbsentRepairsAll(t *testing.T) {
+	network := prefixListEntry{Seq: 5, Network: "198.51.100.0/24"}
+	vip := prefixListEntry{Seq: 10, Network: "192.0.2.80/32", Exact: true}
+	rec := newVtyshRecorder()
+	rec.on(
+		[]string{"vtysh", "-c", "show ip prefix-list ANNOUNCED-NETWORKS json"},
+		frrPrefixListJSON("ANNOUNCED-NETWORKS", network, vip),
+		nil,
+	)
+	// A daemon without the list contributes an empty body.
+	rec.on(
+		[]string{"vtysh", "-d", "bgpd", "-c", "show ip prefix-list ANNOUNCED-NETWORKS json"},
+		"", nil,
+	)
+
+	rm := &RouteManager{cfg: Config{FRRPrefixList: "ANNOUNCED-NETWORKS"}, execVtyshHook: rec.hook()}
+	_, n, _ := net.ParseCIDR("198.51.100.0/24")
+	if err := rm.ReconcileFRRPrefixList([]*net.IPNet{n}, []string{"192.0.2.80"}); err != nil {
+		t.Fatalf("ReconcileFRRPrefixList: %v", err)
+	}
+
+	// Expect: union list + bgpd list + one repair per entry.
+	if len(rec.calls) != 4 {
+		t.Fatalf("expected 4 vtysh calls (list+bgpd-list+2 repairs), got %d: %v", len(rec.calls), rec.calls)
+	}
+	var sawNetworkRepair, sawVIPRepair bool
+	for _, c := range rec.calls[2:] {
+		j := strings.Join(c, " ")
+		if strings.Contains(j, "ip prefix-list ANNOUNCED-NETWORKS seq 5 permit 198.51.100.0/24 ge 32 le 32") {
+			sawNetworkRepair = true
+		}
+		if strings.HasSuffix(j, "ip prefix-list ANNOUNCED-NETWORKS seq 10 permit 192.0.2.80/32 -c end") {
+			sawVIPRepair = true
+		}
+	}
+	if !sawNetworkRepair {
+		t.Errorf("expected a ge/le-form repair for 198.51.100.0/24 seq 5, got: %v", rec.calls)
+	}
+	if !sawVIPRepair {
+		t.Errorf("expected an exact-form repair for 192.0.2.80/32 seq 10, got: %v", rec.calls)
 	}
 }
 


### PR DESCRIPTION
Closes #256.

Chaos run [32007447033](https://github.com/osism/ovn-network-agent/actions/runs/32007447033) (profile `vlan-no-dnat`, seed 2230961235) failed with a recovery-timeout: after `frr-restart` on the gateway owning all CR ports, the `203.0.113.0/24` prefix-list entry survived only in zebra's copy, not in bgpd's, and the agent never repaired it because `ListFRRPrefixListEntries` reads the union of all daemon replies. bgpd's outbound filter blocked the network's /32s until teardown. This pull request implements measure 2 from the issue: verification against bgpd's own copy.

## Commits

1. `fix(routing): repair bgpd's prefix-list copy when a restart loses vtysh writes`. `ReconcileFRRPrefixList` now reads bgpd's copy of the managed list through `vtysh -d bgpd` after the add pass and re-applies every desired entry missing from it, using the entry's existing sequence number: a no-op for the daemons that already hold the line, a repair for the one that lost it (a fresh seq would duplicate the entry in zebra). An unreachable bgpd, or an unparseable reply, skips the check for that cycle with a warning instead of being mistaken for an empty list. The union view keeps its role for stale removal and seq allocation. The regression test `TestReconcileFRRPrefixList_RepairsBGPDDivergence` reproduces the incident shape (union reports the entry, bgpd's document lacks it) and failed before the fix; `TestReconcileFRRPrefixList_BGPDUnreachableSkipsRepair` and `TestReconcileFRRPrefixList_BGPDListAbsentRepairsAll` pin the degraded paths.
2. `docs: note the per-daemon prefix-list verification`. The frr-prefix-list guide documents the new check and why the daemon copies can diverge.

## Acceptance criteria

- Divergent-daemon repair within one reconcile interval, with unit coverage: delivered, see the three tests above.
- Replay converges with 0 violations, and frr-restart downtime returns to the baseline shape: verified against the live lab by dispatching the recorded seed on this branch: `gh workflow run e2e-chaos.yml --ref implement/issue-256-bgpd-prefixlist-verify -f seed=2230961235 -f profile=vlan-no-dnat -f duration=10m`. Result to be posted here once the run finishes.
- The upstream received-prefix assertion in the chaos harness is not part of this pull request, per the author's decision to deliver measure 2 only.

## Verification

- `go build ./...`, `make vet`, `make test` (full suite including the chaos harness package) and `make docs-gen-check` pass locally; `golangci-lint run ./...` reports only the four findings pre-existing on `main`.
- The regression test was run before the fix and failed ("expected 3 vtysh calls, got 1"), then passed after it.
