### PR TITLE
Gate the veth-leak plane on locally-owned routers

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -29,6 +29,14 @@ type Agent struct {
 	// from OVN Logical_Router_Port.Networks.
 	effectiveFilters []*net.IPNet
 
+	// leakNetworks holds the networks the veth-leak plane may claim this
+	// cycle: the locally-owned routers' networks, filtered by the manual
+	// config when one is set. Distinct from effectiveFilters on purpose — a
+	// leak route for a network whose chassisredirect port lives on another
+	// chassis steers that network's traffic into the local OVN, where
+	// nothing answers (#258).
+	leakNetworks []*net.IPNet
+
 	// consecutiveReAdds tracks how many reconcile cycles in a row the
 	// post-change verification had to re-add missing routes. A sustained
 	// non-zero value indicates persistent route instability (e.g. FRR
@@ -318,6 +326,7 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 
 	// Compute effective network filters for this cycle.
 	a.effectiveFilters = a.computeEffectiveNetworks(state.DiscoveredNetworks)
+	a.leakNetworks = a.computeLeakNetworks(state.DiscoveredNetworks)
 
 	// Everything the cycle needs to derive from OVN is a pure function of the
 	// snapshot plus the configured VIPs (see desired_state.go). Past this
@@ -420,7 +429,7 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 		}
 	default:
 		// No locally active routers — remove per-network veth leak and prefix-list entries.
-		if err := a.routing.ReconcileVethLeakNetworks(nil); err != nil {
+		if err := a.routing.reconcileVethLeakNetworks(nil); err != nil {
 			slog.Error("failed to clean veth leak networks", "error", err)
 		}
 		if err := a.routing.ReconcileFRRPrefixList(nil, nil); err != nil {
@@ -514,8 +523,9 @@ func (a *Agent) reconcile(ctx context.Context, trigger string) {
 			slog.Error("failed to ensure active priority lead", "error", err)
 		}
 
-		// Reconcile per-network veth leak routes and policy rules.
-		if err := a.routing.ReconcileVethLeakNetworks(a.effectiveFilters); err != nil {
+		// Reconcile per-network veth leak routes and policy rules — for the
+		// locally-owned networks only, never for the raw filter list (#258).
+		if err := a.routing.reconcileVethLeakNetworks(a.leakNetworks); err != nil {
 			slog.Error("failed to reconcile veth leak networks", "error", err)
 		}
 	}
@@ -624,10 +634,11 @@ func (a *Agent) cleanupStaleChassis(ctx context.Context, allChassis map[string]b
 // computeEffectiveNetworks returns the network filters to use: manual config if
 // set, otherwise auto-discovered networks from OVN Logical_Router_Port. Only
 // IPv4 networks are returned — a.effectiveFilters feeds IPv4-only planes
-// (ReconcileVethLeakNetworks, ReconcileFRRPrefixList, and the "table ip"
-// provider-network rules in ReconcilePortForward), so a v6 network discovered
-// from a dual-stack LRP would otherwise abort those loops mid-way or fail the
-// whole nft ruleset load. Full IPv6 support is tracked in #85/#70.
+// (ReconcileFRRPrefixList and the "table ip" provider-network rules in
+// ReconcilePortForward), so a v6 network discovered from a dual-stack LRP
+// would otherwise abort those loops mid-way or fail the whole nft ruleset
+// load. The veth-leak plane feeds off computeLeakNetworks below instead
+// (#258). Full IPv6 support is tracked in #85/#70.
 func (a *Agent) computeEffectiveNetworks(discovered []*net.IPNet) []*net.IPNet {
 	eff := effectiveNetworkFilters(a.cfg.NetworkFilters, discovered)
 	v4 := make([]*net.IPNet, 0, len(eff))
@@ -637,6 +648,35 @@ func (a *Agent) computeEffectiveNetworks(discovered []*net.IPNet) []*net.IPNet {
 		}
 	}
 	return v4
+}
+
+// computeLeakNetworks returns the networks the veth-leak plane may claim: the
+// locally-owned routers' networks (discovered), filtered by the manual
+// network_cidr list when one is set. It never returns a network this chassis
+// does not host — a leak route for a network whose chassisredirect port lives
+// on another chassis is a trap: it beats the provider VRF's default route and
+// steers that network's traffic into the local OVN, where no NAT answers
+// (#258). Auto mode is unchanged (discovered already tracks ownership); the
+// manual list keeps its exclusion power but stops asserting local presence.
+//
+// Port-forward-only mode has no OVN and no ownership concept; there the manual
+// list stays the leak set, matching what SetupVethLeak seeded at startup.
+// Like computeEffectiveNetworks, the result is IPv4-only.
+func (a *Agent) computeLeakNetworks(discovered []*net.IPNet) []*net.IPNet {
+	if a.cfg.PortForwardOnly {
+		return a.computeEffectiveNetworks(nil)
+	}
+	leak := make([]*net.IPNet, 0, len(discovered))
+	for _, n := range discovered {
+		if n.IP.To4() == nil {
+			continue
+		}
+		if len(a.cfg.NetworkFilters) > 0 && !networkCoveredByAny(n, a.cfg.NetworkFilters) {
+			continue
+		}
+		leak = append(leak, n)
+	}
+	return leak
 }
 
 // vipRoutesAnnounceable reports whether the configured port-forward VIPs should
@@ -1215,7 +1255,7 @@ func (a *Agent) repairUnresolvableNexthop() {
 	a.lastNexthopRepair = time.Now()
 	recordNexthopRepair()
 
-	if err := a.routing.refreshVethNexthop(a.effectiveFilters); err != nil {
+	if err := a.routing.refreshVethNexthop(a.leakNetworks); err != nil {
 		slog.Error("failed to re-notify the kernel about the veth-provider address", "error", err)
 	}
 }

--- a/agent_test.go
+++ b/agent_test.go
@@ -79,6 +79,63 @@ func TestComputeEffectiveNetworks(t *testing.T) {
 	})
 }
 
+// TestComputeLeakNetworks pins the #258 gate: the leak plane claims only
+// locally-owned networks, with the manual list acting as a filter over them —
+// never as the set itself.
+func TestComputeLeakNetworks(t *testing.T) {
+	parse := func(cidrs ...string) []*net.IPNet {
+		var out []*net.IPNet
+		for _, s := range cidrs {
+			_, n, err := net.ParseCIDR(s)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out = append(out, n)
+		}
+		return out
+	}
+
+	tests := []struct {
+		name       string
+		cfg        Config
+		discovered []*net.IPNet
+		want       []string
+	}{
+		{"auto mode leaks the discovered set",
+			Config{}, parse("198.51.100.0/24"), []string{"198.51.100.0/24"}},
+		{"manual filter drops the un-owned networks",
+			Config{NetworkFilters: parse("192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24")},
+			parse("198.51.100.0/24"), []string{"198.51.100.0/24"}},
+		{"broader manual filter keeps the owned network",
+			Config{NetworkFilters: parse("198.51.0.0/16")},
+			parse("198.51.100.0/24"), []string{"198.51.100.0/24"}},
+		{"disjoint manual filter leaks nothing",
+			Config{NetworkFilters: parse("10.0.0.0/24")},
+			parse("198.51.100.0/24"), nil},
+		{"manual filter narrower than the owned network excludes it",
+			Config{NetworkFilters: parse("198.51.100.0/25")},
+			parse("198.51.100.0/24"), nil},
+		{"IPv6 networks are dropped",
+			Config{}, parse("198.51.100.0/24", "2001:db8::/64"), []string{"198.51.100.0/24"}},
+		{"port-forward-only leaks the manual list, ownership unknowable",
+			Config{PortForwardOnly: true, NetworkFilters: parse("192.0.2.0/24")},
+			nil, []string{"192.0.2.0/24"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Agent{cfg: tt.cfg}
+			got := netStrings(a.computeLeakNetworks(tt.discovered))
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("computeLeakNetworks = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTriggerReconcile(t *testing.T) {
 	a := &Agent{
 		reconcileCh: make(chan struct{}, 1),
@@ -212,6 +269,9 @@ func unresolvableNexthopAgent(t *testing.T, connected string) (*Agent, *[][]*net
 		cfg:              rm.cfg,
 		routing:          rm,
 		effectiveFilters: []*net.IPNet{cidr},
+		// In port-forward-only mode the leak set is the manual list, so the
+		// reconcile would compute the same value (computeLeakNetworks).
+		leakNetworks: []*net.IPNet{cidr},
 	}, &refreshed
 }
 
@@ -240,7 +300,7 @@ func TestVerifyRoutesRepairsUnresolvableNexthop(t *testing.T) {
 		t.Fatalf("repair ran %d times at the threshold, want 1", len(*refreshed))
 	}
 	if len((*refreshed)[0]) != 1 {
-		t.Errorf("repair got %d networks, want the agent's 1 effective filter", len((*refreshed)[0]))
+		t.Errorf("repair got %d networks, want the agent's 1 leak network", len((*refreshed)[0]))
 	}
 
 	// Still broken on the next cycle: the diagnosis repeats, the flap does not.
@@ -2222,6 +2282,69 @@ func TestReconcilePrefixListCarriesVIPOutsideHostedNetworks(t *testing.T) {
 	}
 	if !sawNetwork {
 		t.Errorf("the hosted network's ge/le entry must still be added; calls: %v", rec.calls)
+	}
+}
+
+// TestReconcileLeakPlaneClaimsOnlyOwnedNetworks pins #258: with a manual
+// network_cidr list, the veth-leak plane must claim only the networks whose
+// routers this chassis actually holds. Before the fix the reconcile handed the
+// leak plane the raw filter list, so a gateway holding only a VLAN router
+// programmed a leak route for the flat provider network too — and that route,
+// more specific than the provider VRF's default (#247), steered split-owner
+// port-forward replies into the local OVN where nothing answers.
+func TestReconcileLeakPlaneClaimsOnlyOwnedNetworks(t *testing.T) {
+	var manual []*net.IPNet
+	for _, s := range []string{"192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24"} {
+		_, n, err := net.ParseCIDR(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		manual = append(manual, n)
+	}
+
+	var leakCalls [][]*net.IPNet
+	rm := &RouteManager{
+		cfg:                  Config{BridgeDev: "br-ex", VRFName: "vrf-provider", VethNexthop: "169.254.0.1", NetworkFilters: manual},
+		execVtyshHook:        newVtyshRecorder().hook(),
+		execOVSHook:          newOVSRecorder().hook(),
+		listKernelRoutesHook: func() ([]kernelRouteEntry, error) { return nil, nil },
+		reconcileVethLeakHook: func(desired []*net.IPNet) error {
+			leakCalls = append(leakCalls, desired)
+			return nil
+		},
+	}
+
+	// The chassis holds only the VLAN router; the flat network's
+	// chassisredirect port lives on another gateway.
+	_, owned, _ := net.ParseCIDR("198.51.100.0/24")
+	c, _, _ := newOVNClientWithFakes(t, "host-a")
+	c.state.Replace(OVNState{
+		LocalRouters: []LocalRouterInfo{{
+			RouterName:  "router-vlan101",
+			LRPName:     "lrp-vlan101",
+			LRPMAC:      "aa:aa:aa:aa:aa:aa",
+			LRPNetworks: []string{"198.51.100.0/24"},
+		}},
+		HasLocalRouters:    true,
+		DiscoveredNetworks: []*net.IPNet{owned},
+	})
+	a := &Agent{
+		cfg:            rm.cfg,
+		ovn:            c,
+		routing:        rm,
+		reconcileCh:    make(chan struct{}, 1),
+		missingChassis: make(map[string]time.Time),
+	}
+
+	a.reconcile(context.Background(), "test")
+
+	if len(leakCalls) == 0 {
+		t.Fatal("reconcile never reached the veth-leak plane")
+	}
+	got := netStrings(leakCalls[len(leakCalls)-1])
+	want := []string{"198.51.100.0/24"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("leak plane got %v, want only the owned network %v", got, want)
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -35,10 +35,12 @@ func (s *StringOrSlice) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
-// containedInAny returns true if ip is contained in any of the given networks.
 // effectiveNetworkFilters returns manual config if non-empty, otherwise discovered networks.
 // This is the single source of truth for the "manual takes precedence" rule, used by
-// both NAT filtering (ovn.go) and veth-leak/prefix-list reconciliation (agent.go).
+// NAT filtering (ovn.go) and prefix-list reconciliation (agent.go). The veth-leak
+// plane deliberately does not consume it: a manual filter names networks that
+// may be announced, not networks hosted on this chassis, so the leak set is
+// gated on locally-owned routers instead (Agent.computeLeakNetworks, #258).
 func effectiveNetworkFilters(manual, discovered []*net.IPNet) []*net.IPNet {
 	if len(manual) > 0 {
 		return manual
@@ -46,9 +48,25 @@ func effectiveNetworkFilters(manual, discovered []*net.IPNet) []*net.IPNet {
 	return discovered
 }
 
+// containedInAny returns true if ip is contained in any of the given networks.
 func containedInAny(ip net.IP, nets []*net.IPNet) bool {
 	for _, n := range nets {
 		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// networkCoveredByAny returns true if network n is fully covered by one of the
+// filter networks: the filter contains n's base address and is no longer than
+// n's prefix. A filter equal to n covers it; a broader filter (a /16 over a
+// /24) covers it; a narrower or disjoint one does not.
+func networkCoveredByAny(n *net.IPNet, filters []*net.IPNet) bool {
+	nOnes, _ := n.Mask.Size()
+	for _, f := range filters {
+		fOnes, _ := f.Mask.Size()
+		if f.Contains(n.IP) && fOnes <= nOnes {
 			return true
 		}
 	}

--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -1539,13 +1539,14 @@ pass. If `-settle-timeout` expires first, the last evaluation's failures
 become violations, and any violation fails the run. Every poll recomputes
 the expectation, so a settle tracks a `config-flip` the instant it lands.
 
-**The eight verified planes.** For each gateway the oracle diffs the
+**The nine verified planes.** For each gateway the oracle diffs the
 live data plane against a per-gateway expectation recomputed from the OVN
 NB/SB snapshot and that gateway's own config:
 
 | Plane | What the oracle checks |
 | --- | --- |
 | Kernel routes | proto-44 `/32`s on their device (`br-ex`, or `br-ex.<tag>` for a VLAN segment) |
+| Veth-leak routes | proto-44 network routes in `vrf-provider`: exactly the locally-owned networks, filtered by `network_cidr` — never the raw manual list (#258) |
 | FRR statics | `/32` statics in `vrf-provider` via the veth nexthop |
 | VRF default | a default route in `vrf-provider`, on every gateway in every mode |
 | Prefix-list | the `ANNOUNCED-NETWORKS` entries |
@@ -1562,7 +1563,7 @@ or not it currently owns anything: without it, traffic bound for a
 destination the VRF does not host dies inside the chassis while every
 other plane still matches (issue #247).
 
-A ninth check reaches past the gateways to the upstream router: the BGP
+A tenth check reaches past the gateways to the upstream router: the BGP
 announcements `upstream` actually holds, bounded both ways — nothing
 stale (announced ⊆ desired) and nothing missing (every desired IP the
 mode requires must be announced). They are read from the upstream router

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -193,9 +193,16 @@ VRFs so that:
 
 The agent creates the veth pair and assigns link-local addresses at startup
 (`--veth-leak-enabled`, on by default). Per-network policy rules and routes
-are reconciled dynamically — networks are either auto-discovered from OVN
-`Logical_Router_Port.Networks` or taken from the static `network_cidr`
-configuration. On shutdown, all resources are cleaned up.
+are reconciled dynamically, and only for networks whose routers this chassis
+currently holds: the networks auto-discovered from the locally-active
+`Logical_Router_Port.Networks`, filtered by the `network_cidr` list when one
+is configured. The manual list restricts the leak set but never extends it —
+a leak route for a network whose chassisredirect port lives on another
+chassis would override the provider VRF's default route and pull that
+network's traffic into the local OVN, where no NAT answers (#258). In
+port-forward-only mode there is no OVN and no ownership, so the configured
+`network_cidr` list is leaked as-is. On shutdown, all resources are cleaned
+up.
 
 ### VLAN provider networks
 

--- a/docs/explanation/how-it-works.md
+++ b/docs/explanation/how-it-works.md
@@ -66,7 +66,10 @@ provider bridge).
      [Priority semantics](gateway-drain#priority-semantics).
    - Reconciles **per-network veth-leak routes and policy rules** in the
      veth leak table (default 200) so SNAT reply traffic on the provider
-     subnet crosses into `vrf-provider` for BGP delivery.
+     subnet crosses into `vrf-provider` for BGP delivery. Only networks
+     whose routers are locally active are leaked — a `network_cidr` list
+     filters that set but never extends it, so a network hosted on another
+     chassis keeps following the VRF's default route to its owner (#258).
    - If no routers are locally active: removes all managed routes (port
      forward VIPs still get kernel/FRR routes if any are configured).
 5. **Port forwarding (DNAT)** — optionally forwards traffic from anycast VIP

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -86,7 +86,11 @@ Substitute the values you configured for `vrf_name`, `frr_prefix_list`,
      excluding them, or OVN has not published them yet.
    - `effective_networks=0` — no provider networks are in effect (none
      configured via `network_cidr` and none auto-discovered from OVN). The
-     prefix-list and veth-leak reconciliation then have nothing to populate.
+     prefix-list reconciliation then has nothing to populate. The veth-leak
+     routes track the locally-owned routers' networks, not this count: with
+     a manual `network_cidr` list, `effective_networks` counts the full
+     list while the leak plane still only claims the networks whose routers
+     this chassis holds (#258).
 
 3. **Confirm the chassisredirect port is on this chassis.** A FIP is only
    announced from the node currently hosting the router's gateway:

--- a/routing.go
+++ b/routing.go
@@ -65,6 +65,11 @@ type RouteManager struct {
 	// which networks, without touching netlink.
 	refreshVethNexthopHook func(networks []*net.IPNet) error
 
+	// reconcileVethLeakHook, when non-nil, replaces ReconcileVethLeakNetworks
+	// in the agent's reconcile. Tests set this to observe which networks the
+	// leak plane is asked to claim, without touching netlink.
+	reconcileVethLeakHook func(desired []*net.IPNet) error
+
 	// wrapperStdinOK caches whether the configured OVS wrapper forwards
 	// stdin into the wrapped command, and ofctlBundleOK whether this
 	// ovs-ofctl speaks OpenFlow 1.4 bundles. Both are nil until probed and
@@ -160,6 +165,15 @@ func (rm *RouteManager) refreshVethNexthop(networks []*net.IPNet) error {
 		return rm.refreshVethNexthopHook(networks)
 	}
 	return rm.RefreshVethNexthop(networks)
+}
+
+// reconcileVethLeakNetworks dispatches to the platform
+// ReconcileVethLeakNetworks, or to the test hook when one is set.
+func (rm *RouteManager) reconcileVethLeakNetworks(desired []*net.IPNet) error {
+	if rm.reconcileVethLeakHook != nil {
+		return rm.reconcileVethLeakHook(desired)
+	}
+	return rm.ReconcileVethLeakNetworks(desired)
 }
 
 // validateIP checks that the given string is a valid IPv4 address. IPv6 is

--- a/routing_linux.go
+++ b/routing_linux.go
@@ -711,10 +711,13 @@ func (rm *RouteManager) SetupVethLeak() error {
 	}
 
 	// Per-network routes and policy rules are managed dynamically by
-	// ReconcileVethLeakNetworks() during each reconciliation cycle.
-	// If static network_cidr is configured, set up initial per-network
-	// routes now for backwards compatibility.
-	if len(rm.cfg.NetworkFilters) > 0 {
+	// ReconcileVethLeakNetworks() during each reconciliation cycle, gated on
+	// the locally-owned routers (#258). Ownership is unknown before the OVN
+	// connect, so full mode seeds nothing here — the first reconcile installs
+	// the owned set and prunes leftovers. Port-forward-only mode has no OVN
+	// and never reconciles the leak plane, so the manual network_cidr list is
+	// seeded now, as it always was.
+	if rm.cfg.PortForwardOnly && len(rm.cfg.NetworkFilters) > 0 {
 		if err := rm.ReconcileVethLeakNetworks(rm.cfg.NetworkFilters); err != nil {
 			return fmt.Errorf("initial veth leak network setup: %w", err)
 		}

--- a/test/e2e/chaos/expect.go
+++ b/test/e2e/chaos/expect.go
@@ -220,6 +220,16 @@ type gatewayExpectation struct {
 	// agent does removes it, so a false here is the lab or the fabric breaking
 	// under the agent, which is exactly the condition #247 left invisible.
 	VRFDefaultRoute bool
+
+	// LeakRoutes is the sorted set of per-network veth-leak routes expected in
+	// the provider VRF's table: the locally-owned routers' networks, filtered
+	// by the manual network_cidr when one is set — never the raw filter list.
+	// A leak route for a network whose chassisredirect port lives elsewhere
+	// beats the VRF default above and steers that network's traffic into the
+	// local OVN, where nothing answers (#258). Empty on a full-mode standby
+	// (the agent reconciles the plane to nil); in pf-only mode it is the
+	// manual list itself, matching SetupVethLeak's startup seeding.
+	LeakRoutes []string
 }
 
 // computeExpectation recomputes gw's expected data-plane state from the OVN
@@ -325,6 +335,11 @@ func computeExpectation(snap ovnSnapshot, gw string, doc map[string]any, mgmtIP 
 		}
 		exp.PrefixList = sortedUnique(entries)
 	}
+
+	// Rule 14 (#258) — veth-leak network routes: the owned networks filtered
+	// by the manual list. The raw network_cidr list must never be leaked —
+	// agent.go computeLeakNetworks is the mirror of this rule.
+	exp.LeakRoutes = leakNetworkStrings(doc, local, pfOnly, active)
 
 	// Rule 8 — hairpin flows: the hairpin targets when active, removed on
 	// standby, skipped in pf-only.
@@ -651,6 +666,50 @@ func effectiveNetworks(doc map[string]any, local []localRouter) []*net.IPNet {
 		discovered = append(discovered, lr.networks...)
 	}
 	return parseNetworks(discovered)
+}
+
+// leakNetworkStrings mirrors the agent's computeLeakNetworks (#258): the
+// veth-leak plane claims the locally-owned routers' networks, with the manual
+// network_cidr acting as a coverage filter over them — never as the set
+// itself. Port-forward-only mode has no ownership concept, so the manual list
+// stays the leak set there; a full-mode standby leaks nothing.
+func leakNetworkStrings(doc map[string]any, local []localRouter, pfOnly, active bool) []string {
+	manual := parseNetworks(stringsOf(doc["network_cidr"]))
+	if pfOnly {
+		return networkStrings(manual)
+	}
+	if !active {
+		return nil
+	}
+	var ownedCIDRs []string
+	for _, lr := range local {
+		ownedCIDRs = append(ownedCIDRs, lr.networks...)
+	}
+	owned := parseNetworks(ownedCIDRs)
+	if len(manual) == 0 {
+		return networkStrings(owned)
+	}
+	var leak []*net.IPNet
+	for _, n := range owned {
+		if networkCoveredByAny(n, manual) {
+			leak = append(leak, n)
+		}
+	}
+	return networkStrings(leak)
+}
+
+// networkCoveredByAny reports whether network n is fully covered by one of the
+// filter networks: the filter contains n's base address and is no longer than
+// n's prefix (config.go networkCoveredByAny).
+func networkCoveredByAny(n *net.IPNet, filters []*net.IPNet) bool {
+	nOnes, _ := n.Mask.Size()
+	for _, f := range filters {
+		fOnes, _ := f.Mask.Size()
+		if f.Contains(n.IP) && fOnes <= nOnes {
+			return true
+		}
+	}
+	return false
 }
 
 // parseNetworks parses CIDR strings into their networks, dropping malformed and

--- a/test/e2e/chaos/expect_test.go
+++ b/test/e2e/chaos/expect_test.go
@@ -67,6 +67,8 @@ func TestExpectationFollowsTheChassisredirectOwner(t *testing.T) {
 			t.Fatal("kernel plane must not be skipped on a full-mode gateway")
 		}
 		assertSet(t, "PrefixList", exp.PrefixList, []string{"192.0.2.0/24", "198.51.100.0/24"})
+		// Auto mode: the leak plane claims exactly the owned networks.
+		assertSet(t, "LeakRoutes", exp.LeakRoutes, []string{"192.0.2.0/24", "198.51.100.0/24"})
 		// Two segments (flat + VLAN-101), two MAC-tweak flows each.
 		if exp.MACTweakFlows != 4 {
 			t.Fatalf("MACTweakFlows = %d, want 4 (two per segment, two segments)", exp.MACTweakFlows)
@@ -100,6 +102,9 @@ func TestExpectationFollowsTheChassisredirectOwner(t *testing.T) {
 		}
 		if exp.PrefixList != nil {
 			t.Fatalf("PrefixList = %v, want it absent (nil) on a standby gateway", exp.PrefixList)
+		}
+		if len(exp.LeakRoutes) != 0 {
+			t.Fatalf("LeakRoutes = %v, want none on a standby gateway", exp.LeakRoutes)
 		}
 		// The agent does not clean MAC-tweak flows on standby, so the count is
 		// unknowable and the check is skipped.
@@ -152,6 +157,9 @@ func TestExpectationExcludesFIPsOutsideTheNetworkCIDRFilter(t *testing.T) {
 	}
 	// The manual filter is exactly the prefix-list.
 	assertSet(t, "PrefixList", exp.PrefixList, []string{"192.0.2.0/24"})
+	// The leak plane keeps only the owned networks the filter covers: the
+	// hosted 203.0.113.0/24 is excluded by the filter (#258).
+	assertSet(t, "LeakRoutes", exp.LeakRoutes, []string{"192.0.2.0/24"})
 	// The presence set keeps only the covered desired IPs.
 	assertSet(t, "MustAnnounce", exp.MustAnnounce, []string{"192.0.2.1", "192.0.2.10"})
 	if containsStr(exp.MustAnnounce, "203.0.113.1") || containsStr(exp.MustAnnounce, "203.0.113.10") {
@@ -159,6 +167,46 @@ func TestExpectationExcludesFIPsOutsideTheNetworkCIDRFilter(t *testing.T) {
 	}
 	// The staleness bound is exactly the desired set.
 	assertSet(t, "AnnounceBound", exp.AnnounceBound, exp.DesiredIPs)
+}
+
+// TestExpectationLeakPlaneClaimsOnlyOwnedNetworks pins #258 in the oracle: a
+// manual network_cidr listing networks whose routers live on another chassis
+// must not put those networks into the leak plane — that route beats the VRF
+// default and steers the peer's traffic into the local OVN. The prefix-list
+// keeps the full manual list; only the leak plane is ownership-gated.
+func TestExpectationLeakPlaneClaimsOnlyOwnedNetworks(t *testing.T) {
+	// gateway-1 owns only the VLAN-101 router; the flat router's CR port is
+	// on gateway-3 — the heterogeneous split after a failover.
+	snap := ovnSnapshot{
+		CRPortChassis: map[string]string{
+			"cr-lr0-public":        "gateway-3",
+			"cr-lr-vlan101-public": "gateway-1",
+		},
+		LRPs: map[string]lrpRow{
+			"lr0-public":        {Networks: []string{"192.0.2.1/24"}},
+			"lr-vlan101-public": {Networks: []string{"198.51.100.1/24"}},
+		},
+		LRPNameByUUID: map[string]string{
+			"uuid-lr0-public":        "lr0-public",
+			"uuid-lr-vlan101-public": "lr-vlan101-public",
+		},
+		Routers: map[string]routerRow{
+			"lr0":        {LRPUUIDs: []string{"uuid-lr0-public"}},
+			"lr-vlan101": {LRPUUIDs: []string{"uuid-lr-vlan101-public"}},
+		},
+		SegmentTagByLRP: map[string]int{"lr0-public": 0, "lr-vlan101-public": 101},
+	}
+	doc := fullModeDoc(t)
+	doc["network_cidr"] = anySlice([]string{"192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24"})
+
+	exp := computeExpectation(snap, "gateway-1", doc, "172.20.20.4")
+
+	if !exp.Active {
+		t.Fatal("gateway-1 owns the VLAN router's CR port, it must be active")
+	}
+	assertSet(t, "LeakRoutes", exp.LeakRoutes, []string{"198.51.100.0/24"})
+	assertSet(t, "PrefixList", exp.PrefixList,
+		[]string{"192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24"})
 }
 
 // Port-forward-only mode has no OVN view at all: every OVN-driven plane is
@@ -202,6 +250,9 @@ func TestExpectationPortForwardOnlySkipsEveryOVNPlane(t *testing.T) {
 	if exp.PrefixList != nil {
 		t.Fatalf("PrefixList = %v, want it untouched (nil) in pf-only", exp.PrefixList)
 	}
+	// pf-only has no ownership concept: the manual list stays the leak set,
+	// matching SetupVethLeak's startup seeding (#258).
+	assertSet(t, "LeakRoutes", exp.LeakRoutes, []string{"192.0.2.0/24"})
 	if exp.MACTweakFlows != -1 {
 		t.Fatalf("MACTweakFlows = %d, want -1 (skip) in pf-only", exp.MACTweakFlows)
 	}

--- a/test/e2e/chaos/fakes_test.go
+++ b/test/e2e/chaos/fakes_test.go
@@ -382,6 +382,8 @@ func (o *oracleLab) respond(argv []string) (string, error) {
 			return o.frr(gw), nil
 		case has("ip -j route show vrf vrf-provider default"):
 			return o.vrfDefault(gw), nil
+		case has("ip -j route show vrf vrf-provider proto 44"):
+			return o.leak(gw), nil
 		case has("show ip prefix-list ANNOUNCED-NETWORKS"):
 			return o.prefixList(gw), nil
 		case has("dump-flows br-ex cookie=0x998"):
@@ -515,6 +517,17 @@ func (o *oracleLab) frr(gw string) string {
 	}
 	b, _ := json.Marshal(doc)
 	return string(b)
+}
+
+// leak answers the observer's `ip -j route show vrf vrf-provider proto 44`:
+// the per-network veth-leak routes (#258). The fixture's docs run auto mode,
+// where the leak set is the owned network — present on the active gateway,
+// absent on a standby.
+func (o *oracleLab) leak(gw string) string {
+	if !o.active(gw) {
+		return "[]"
+	}
+	return `[{"dst":"192.0.2.0/24","gateway":"169.254.0.1","dev":"veth-provider"}]`
 }
 
 // vrfDefault answers the observer's `ip -j route show vrf vrf-provider

--- a/test/e2e/chaos/observe.go
+++ b/test/e2e/chaos/observe.go
@@ -369,6 +369,7 @@ func cellInt(raw json.RawMessage) int {
 // time.
 type observedGateway struct {
 	kernelRoutes     map[string]string // desired IP → kernel device
+	leakRoutes       map[string]bool   // per-network veth-leak routes in the VRF table
 	frrStatic        map[string]bool   // /32 IPs with an agent FRR static
 	prefixList       map[string]bool   // ANNOUNCED-NETWORKS CIDRs
 	prefixListAbsent bool              // the list does not exist at all
@@ -415,6 +416,7 @@ type gatewayMetrics struct {
 func observeGateway(ctx context.Context, l *lab, gw, portForwardDev string) (observedGateway, error) {
 	obs := observedGateway{
 		kernelRoutes: map[string]string{},
+		leakRoutes:   map[string]bool{},
 		frrStatic:    map[string]bool{},
 		prefixList:   map[string]bool{},
 		hairpin:      map[string]bool{},
@@ -422,6 +424,9 @@ func observeGateway(ctx context.Context, l *lab, gw, portForwardDev string) (obs
 		vips:         map[string]bool{},
 	}
 	if err := observeKernelRoutes(ctx, l, gw, &obs); err != nil {
+		return obs, err
+	}
+	if err := observeLeakRoutes(ctx, l, gw, &obs); err != nil {
 		return obs, err
 	}
 	if err := observeFRRStatic(ctx, l, gw, &obs); err != nil {
@@ -467,6 +472,31 @@ func observeKernelRoutes(ctx context.Context, l *lab, gw string, obs *observedGa
 	}
 	for _, r := range routes {
 		obs.kernelRoutes[strings.TrimSuffix(r.Dst, "/32")] = r.Dev
+	}
+	return nil
+}
+
+// observeLeakRoutes reads the agent's per-network veth-leak routes: proto-44
+// network routes in the provider VRF's table (#258). Distinct from
+// observeKernelRoutes, which reads the main table's /32 FIP routes — the same
+// protocol in a different table, invisible to that observer.
+func observeLeakRoutes(ctx context.Context, l *lab, gw string, obs *observedGateway) error {
+	out, err := l.exec(ctx, gw, "ip", "-j", "route", "show", "vrf", vrfProvider, "proto", "44")
+	if err != nil {
+		return fmt.Errorf("list proto-44 routes in %s on %s: %w", vrfProvider, gw, err)
+	}
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "" || trimmed == "[]" {
+		return nil
+	}
+	var routes []struct {
+		Dst string `json:"dst"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &routes); err != nil {
+		return fmt.Errorf("parse proto-44 routes in %s on %s: %w", vrfProvider, gw, err)
+	}
+	for _, r := range routes {
+		obs.leakRoutes[r.Dst] = true
 	}
 	return nil
 }

--- a/test/e2e/chaos/oracle.go
+++ b/test/e2e/chaos/oracle.go
@@ -302,6 +302,12 @@ func comparePlanes(gw string, exp gatewayExpectation, obs observedGateway, upstr
 	m, u := diffSet(exp.FRRStatic, obs.frrStatic)
 	add("frr", m, u)
 
+	// #258 — the leak plane must claim exactly the owned networks: an
+	// unexpected entry here is the route that hijacks another chassis's
+	// traffic into the local OVN.
+	m, u = diffSet(exp.LeakRoutes, obs.leakRoutes)
+	add("veth-leak", m, u)
+
 	if !exp.SkipPrefixList {
 		if exp.PrefixList == nil {
 			// A list expected gone but still present is the failure, whether or


### PR DESCRIPTION
Closes #258.

With a manual `network_cidr` list, the reconcile handed the veth-leak plane the raw filter, so a gateway programmed leak routes for networks whose chassisredirect port lives on another chassis. Such a route beats the provider VRF's default route (#247/#249) and steers split-owner port-forward replies into the local OVN, where nothing answers. Nightly chaos run 32097418440 (heterogeneous) blackholed `hairpin-vip` for 3 minutes exactly this way: a `cidr-toggle` config-flip put gateway-1 on the manual list while gateway-3 held `cr-lr0-public`, and gateway-1's new `192.0.2.0/24` leak route swallowed the replies. Ticks 6 to 8 of the same run prove the counterfactual: the identical ownership split with gateway-1 in auto mode stayed green.

The change set, one commit each:

1. **fix(agent): gate the veth-leak plane on locally-owned routers.** The leak set is now computed per cycle from the locally-owned routers' networks, with the manual list acting as a coverage filter over them (a broader filter keeps a covered network, a narrower or disjoint one drops it). Auto mode is unchanged, since discovery already tracks ownership. Port-forward-only mode keeps leaking the manual list: it has no OVN and no ownership concept, so `SetupVethLeak`'s startup seeding now applies to that mode alone, while full mode defers to the first reconcile. The nexthop repair (#214) restores the same gated set. The regression test fails before the fix (the leak plane received all three manual networks) and passes after; a table test covers the filter semantics including the pf-only case. `ReconcilePortForward` and the FRR prefix-list keep consuming the effective filters: both were verified benign (the former only widens an nftables accept set, the latter's network entry exports nothing without a covering local route).
2. **test/e2e/chaos: verify the veth-leak plane against router ownership.** The oracle never looked at this plane: its kernel-route observer reads the main table, and the leak routes live in the provider VRF's table, so every sweep passed while the probe was black. A ninth plane closes the gap: the expectation mirrors the agent's gate, the observer reads proto-44 routes in `vrf-provider`, and `comparePlanes` flags both missing and unexpected entries. `TestExpectationLeakPlaneClaimsOnlyOwnedNetworks` pins the exact run-32097418440 constellation.
3. **docs: the veth-leak plane follows router ownership, not the CIDR filter.** The architecture, reconcile-loop, and troubleshooting prose described the leak routes as fed by "discovered or configured" networks, which is the exact equivalence this PR removes.

Verification: `go test -count=1 ./...`, `go vet`, `gofmt -l`, and `golangci-lint run --new-from-rev=origin/main` are clean; total coverage is 86.7% against the 68% CI floor; `tools/docgen` produces no diff. The live proof is a post-merge dispatch replay of the failing night: `make e2e-chaos CHAOS_FLAGS="-seed 32097418440 -profile heterogeneous -duration 10m"` must converge tick 11 inside its 180 s budget instead of timing out on `hairpin-vip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1u8QCro9hTM8d6PJc8LnR
