### PR TITLE
fix(routing): bypass veth-leak policy for locally hosted FIPs

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -883,6 +883,14 @@ func (a *Agent) ensureRoutes(desiredIPs, frrStaticIPs []string, ipDev map[string
 				slog.Error("failed to add kernel route", "ip", ip, "dev", dev, "error", err)
 				kernelOK = false
 			}
+		} else if manageKernel && !skipKernelRoute[ip] {
+			// The /32 already exists, but its companion destination policy rule
+			// may have been absent in an older release or deleted out of band.
+			// Repair it on every reconcile without touching the healthy route.
+			if err := a.routing.EnsureKernelRouteRule(ip); err != nil {
+				slog.Error("failed to ensure kernel route ip rule", "ip", ip, "error", err)
+				kernelOK = false
+			}
 		}
 		if needsFRR {
 			addFRR = append(addFRR, ip)

--- a/config.go
+++ b/config.go
@@ -471,7 +471,7 @@ func configOptions() []configOption {
 			func(c *Config) *string { return &c.VethProviderIP }),
 		intOpt("veth-leak-table-id", 200, "Routing table ID for veth leak default route (1-252)",
 			func(c *Config) *int { return &c.VethLeakTableID }),
-		intOpt("veth-leak-rule-priority", 2000, "Policy rule priority for veth leak rules",
+		intOpt("veth-leak-rule-priority", 2000, "Policy rule priority for veth leak rules (must be at least 2)",
 			func(c *Config) *int { return &c.VethLeakRulePriority }),
 		stringOpt("metrics-listen", "", "Address for the Prometheus /metrics endpoint (e.g. 127.0.0.1:9273); empty = disabled",
 			func(c *Config) *string { return &c.MetricsListen }),
@@ -824,6 +824,9 @@ func validateConfig(cfg *Config) error {
 	if cfg.VethLeakEnabled {
 		if cfg.VethLeakTableID < 1 || cfg.VethLeakTableID > 252 {
 			return fmt.Errorf("invalid veth-leak-table-id: %d (must be 1-252)", cfg.VethLeakTableID)
+		}
+		if cfg.VethLeakRulePriority < 2 {
+			return fmt.Errorf("invalid veth-leak-rule-priority: %d (must be at least 2)", cfg.VethLeakRulePriority)
 		}
 		// RouteTableID 0 means "main table" and cannot conflict with an explicit leak table.
 		if cfg.VethLeakTableID == cfg.RouteTableID && cfg.RouteTableID != 0 {

--- a/config_test.go
+++ b/config_test.go
@@ -1166,6 +1166,23 @@ func TestLoadConfigVethLeakTableIDInvalid(t *testing.T) {
 	}
 }
 
+func TestLoadConfigVethLeakRulePriorityTooLow(t *testing.T) {
+	for _, priority := range []string{"0", "1"} {
+		t.Run(priority, func(t *testing.T) {
+			_, err := loadConfig(fullModeArgs(
+				"--veth-leak-rule-priority", priority,
+				"--network-cidr", "10.0.0.0/24",
+			))
+			if err == nil {
+				t.Fatal("expected error for veth-leak-rule-priority below 2")
+			}
+			if !strings.Contains(err.Error(), "veth-leak-rule-priority") {
+				t.Errorf("error = %v, want veth-leak-rule-priority validation", err)
+			}
+		})
+	}
+}
+
 func TestApplyEnvConfigVethLeak(t *testing.T) {
 	cfg := Config{VethLeakEnabled: true}
 	t.Setenv("OVN_NETWORK_VETH_LEAK_ENABLED", "false")
@@ -1534,13 +1551,14 @@ port_forwards:
 func TestPortForwardValidation(t *testing.T) {
 	base := func() Config {
 		return Config{
-			VethNexthop:        "169.254.0.1",
-			ReconcileInterval:  60 * time.Second,
-			VethLeakEnabled:    true,
-			VethLeakTableID:    200,
-			PortForwardDev:     "loopback1",
-			PortForwardTableID: 201,
-			PortForwardCTZone:  64000,
+			VethNexthop:          "169.254.0.1",
+			ReconcileInterval:    60 * time.Second,
+			VethLeakEnabled:      true,
+			VethLeakTableID:      200,
+			VethLeakRulePriority: 2000,
+			PortForwardDev:       "loopback1",
+			PortForwardTableID:   201,
+			PortForwardCTZone:    64000,
 			PortForwards: []PortForwardVIP{
 				{
 					VIP: "198.51.100.10",
@@ -1878,13 +1896,14 @@ func TestDestAddrsHelper(t *testing.T) {
 func TestPortForwardMultiBackendValidation(t *testing.T) {
 	base := func() Config {
 		return Config{
-			VethNexthop:        "169.254.0.1",
-			ReconcileInterval:  60 * time.Second,
-			VethLeakEnabled:    true,
-			VethLeakTableID:    200,
-			PortForwardDev:     "loopback1",
-			PortForwardTableID: 201,
-			PortForwardCTZone:  64000,
+			VethNexthop:          "169.254.0.1",
+			ReconcileInterval:    60 * time.Second,
+			VethLeakEnabled:      true,
+			VethLeakTableID:      200,
+			VethLeakRulePriority: 2000,
+			PortForwardDev:       "loopback1",
+			PortForwardTableID:   201,
+			PortForwardCTZone:    64000,
 			PortForwards: []PortForwardVIP{
 				{
 					VIP: "198.51.100.10",
@@ -2003,10 +2022,11 @@ port_forwards:
 // VethProviderIP) trips this test instead of silently changing the contract.
 func TestVethProviderIPAutoComputeWrapsAt255_255_255_255(t *testing.T) {
 	cfg := Config{
-		VethNexthop:       "255.255.255.255",
-		ReconcileInterval: 60 * time.Second,
-		VethLeakEnabled:   true,
-		VethLeakTableID:   200,
+		VethNexthop:          "255.255.255.255",
+		ReconcileInterval:    60 * time.Second,
+		VethLeakEnabled:      true,
+		VethLeakTableID:      200,
+		VethLeakRulePriority: 2000,
 		// VethProviderIP intentionally unset — triggers auto-compute.
 	}
 

--- a/routing_linux.go
+++ b/routing_linux.go
@@ -357,13 +357,13 @@ func (rm *RouteManager) AddKernelRoute(ip, dev string) error {
 		return fmt.Errorf("add kernel route %s/32 dev %s: %w", ip, dev, err)
 	}
 
-	// Add ip rule when using a dedicated routing table.
-	// If the rule fails, remove the route to avoid an orphaned route without a matching rule.
-	if rm.cfg.RouteTableID > 0 {
-		if err := rm.ensureIPRule(dst); err != nil {
-			_ = netlink.RouteDel(route)
-			return fmt.Errorf("add ip rule for %s (route rolled back): %w", ip, err)
-		}
+	// Add the per-IP destination rule after the route is present. In the main
+	// table this bypasses the veth-leak source rule for locally-hosted FIPs;
+	// with a dedicated table it selects that table as before. If the rule
+	// fails, remove the route to avoid advertising an unreachable IP.
+	if err := rm.EnsureKernelRouteRule(ip); err != nil {
+		_ = netlink.RouteDel(route)
+		return fmt.Errorf("add ip rule for %s (route rolled back): %w", ip, err)
 	}
 
 	slog.Info("kernel route ensured", "ip", ip, "dev", dev, "table", rm.cfg.RouteTableID)
@@ -388,10 +388,9 @@ func (rm *RouteManager) DelKernelRoute(ip, dev string) error {
 		return fmt.Errorf("invalid IP: %s", ip)
 	}
 
-	// Remove ip rule first (stop steering traffic before removing route).
-	if rm.cfg.RouteTableID > 0 {
-		rm.removeIPRule(dst)
-	}
+	// Remove the destination exception first so traffic is not steered to a
+	// route that no longer exists.
+	rm.removeIPRule(dst)
 
 	route := &netlink.Route{
 		LinkIndex: link.Attrs().Index,
@@ -511,12 +510,49 @@ func (rm *RouteManager) segmentCandidateLinks() ([]netlink.Link, error) {
 // IP rule helpers (policy routing)
 // =============================================================================
 
-// ensureIPRule adds an ip rule: "to <dst> lookup <table>" if not already present.
+// localIPRuleSpec describes the destination rule accompanying an agent-owned
+// kernel /32. A dedicated route table keeps its long-standing priority-1000
+// selector. When routes are in main, the veth-leak source policy rule would
+// otherwise capture cross-node FIP traffic, so install a selector immediately
+// before it that explicitly looks up main.
+func (rm *RouteManager) localIPRuleSpec() (table, priority int, enabled bool) {
+	if rm.cfg.RouteTableID > 0 {
+		return rm.cfg.RouteTableID, 1000, true
+	}
+	if rm.cfg.VethLeakEnabled {
+		return rtTableMain, rm.cfg.VethLeakRulePriority - 1, true
+	}
+	return 0, 0, false
+}
+
+// EnsureKernelRouteRule repairs the destination rule for an already-present
+// agent-owned kernel route. Reconciliation calls it for existing routes so an
+// upgrade or an out-of-band deletion converges without replacing the route.
+func (rm *RouteManager) EnsureKernelRouteRule(ip string) error {
+	if rm.cfg.DryRun {
+		return nil
+	}
+	dst := &net.IPNet{IP: net.ParseIP(ip), Mask: net.CIDRMask(32, 32)}
+	if dst.IP == nil || dst.IP.To4() == nil {
+		return fmt.Errorf("invalid IPv4 address: %s", ip)
+	}
+	if err := rm.ensureIPRule(dst); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ensureIPRule adds the configured ip rule: "to <dst> lookup <table>" if not
+// already present.
 func (rm *RouteManager) ensureIPRule(dst *net.IPNet) error {
+	table, priority, enabled := rm.localIPRuleSpec()
+	if !enabled {
+		return nil
+	}
 	rule := netlink.NewRule()
 	rule.Dst = dst
-	rule.Table = rm.cfg.RouteTableID
-	rule.Priority = 1000
+	rule.Table = table
+	rule.Priority = priority
 
 	if err := netlink.RuleAdd(rule); err != nil {
 		// Ignore "already exists".
@@ -529,10 +565,14 @@ func (rm *RouteManager) ensureIPRule(dst *net.IPNet) error {
 
 // removeIPRule removes the ip rule for <dst>.
 func (rm *RouteManager) removeIPRule(dst *net.IPNet) {
+	table, priority, enabled := rm.localIPRuleSpec()
+	if !enabled {
+		return
+	}
 	rule := netlink.NewRule()
 	rule.Dst = dst
-	rule.Table = rm.cfg.RouteTableID
-	rule.Priority = 1000
+	rule.Table = table
+	rule.Priority = priority
 
 	if err := netlink.RuleDel(rule); err != nil {
 		slog.Debug("ip rule already absent or failed to remove", "dst", dst, "error", err)

--- a/routing_linux_test.go
+++ b/routing_linux_test.go
@@ -165,6 +165,46 @@ func TestAddKernelRouteRejectsInvalidIP(t *testing.T) {
 	t.Skip("validation happens after link lookup; covered by callers")
 }
 
+func TestLocalIPRuleSpec(t *testing.T) {
+	tests := []struct {
+		name                    string
+		cfg                     Config
+		wantTable, wantPriority int
+		wantEnabled             bool
+	}{
+		{
+			name:         "dedicated route table keeps existing selector",
+			cfg:          Config{RouteTableID: 123, VethLeakEnabled: true, VethLeakRulePriority: 2000},
+			wantTable:    123,
+			wantPriority: 1000,
+			wantEnabled:  true,
+		},
+		{
+			name:         "main table with veth leak bypasses source policy",
+			cfg:          Config{VethLeakEnabled: true, VethLeakRulePriority: 2000},
+			wantTable:    rtTableMain,
+			wantPriority: 1999,
+			wantEnabled:  true,
+		},
+		{
+			name:        "main table without veth leak needs no selector",
+			cfg:         Config{},
+			wantEnabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rm := &RouteManager{cfg: tt.cfg}
+			table, priority, enabled := rm.localIPRuleSpec()
+			if table != tt.wantTable || priority != tt.wantPriority || enabled != tt.wantEnabled {
+				t.Errorf("localIPRuleSpec() = (%d, %d, %t), want (%d, %d, %t)",
+					table, priority, enabled, tt.wantTable, tt.wantPriority, tt.wantEnabled)
+			}
+		})
+	}
+}
+
 func TestDelKernelRouteWrapsLinkLookupError(t *testing.T) {
 	rm := &RouteManager{cfg: Config{BridgeDev: nonexistentBridge}}
 	err := rm.DelKernelRoute("10.0.0.1", nonexistentBridge)

--- a/routing_notlinux.go
+++ b/routing_notlinux.go
@@ -80,6 +80,13 @@ func (rm *RouteManager) DelKernelRoute(ip, dev string) error {
 	return fmt.Errorf("kernel route management is only supported on Linux")
 }
 
+func (rm *RouteManager) EnsureKernelRouteRule(ip string) error {
+	// Non-Linux builds cannot own kernel routes, but unit tests use their
+	// listKernelRoutes hook to model already-present routes. Treat policy-rule
+	// repair as a no-op there so that model remains usable.
+	return nil
+}
+
 func (rm *RouteManager) ListKernelRoutes() ([]kernelRouteEntry, error) {
 	if rm.cfg.DryRun {
 		return nil, nil

--- a/test/integration/scenario_fip_test.go
+++ b/test/integration/scenario_fip_test.go
@@ -52,6 +52,45 @@ func TestScenario_FIPAddRemove(t *testing.T) {
 	}
 }
 
+// TestScenario_FIPMainTableVethLeakException exercises the policy-routing
+// exception needed when the FIP /32 lives in main. The destination rule is
+// one priority ahead of the source-based veth-leak rule, so cross-node FIP
+// traffic for a locally-hosted FIP stays in main instead of looping through
+// veth-default. It must also self-heal and be removed with the FIP.
+func TestScenario_FIPMainTableVethLeakException(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "fipmainrule",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+
+	cfg := testenv.FastDefaults()
+	cfg.RouteTableID = intPtr(0) // Explicitly exercise the main-table path.
+	a := readyAgent(t, cfg)
+	defer a.Stop(15 * time.Second)
+
+	const fip = "198.51.100.43"
+	const rulePriority = testenv.DefaultVethLeakRulePriority - 1
+	natUUID := testenv.AddFIP(t, ctx, nb, router, fip, "10.0.0.43")
+
+	testenv.AssertKernelRoute(t, fip, 10*time.Second)
+	testenv.AssertIPRuleToPriorityTable(t, rulePriority, fip+"/32", 254, 10*time.Second)
+	testenv.AssertIPRuleAtPriority(t, testenv.DefaultVethLeakRulePriority, "198.51.100.0/24", 10*time.Second)
+
+	// Remove only the rule while retaining the /32 route. The periodic
+	// reconcile must repair this exact upgrade/drift state without replacing
+	// the healthy kernel route.
+	testenv.DeleteIPRuleTo(t, rulePriority, fip+"/32")
+	testenv.AssertNoIPRuleToPriority(t, rulePriority, fip+"/32", time.Second)
+	testenv.AssertIPRuleToPriorityTable(t, rulePriority, fip+"/32", 254, 8*time.Second)
+
+	testenv.RemoveFIP(t, ctx, nb, router, natUUID)
+	testenv.AssertNoKernelRoute(t, fip, 15*time.Second)
+	testenv.AssertNoIPRuleToPriority(t, rulePriority, fip+"/32", 15*time.Second)
+}
+
 // TestScenario_GatewaylessVirtualGateway (#42 scenario 2):
 //
 // A provider net without a real gateway (no pre-existing default route in NB)

--- a/test/integration/testenv/vethleak.go
+++ b/test/integration/testenv/vethleak.go
@@ -87,6 +87,10 @@ type ruleInfo struct {
 	Priority int             `json:"priority"`
 	Src      string          `json:"src,omitempty"`
 	Srclen   int             `json:"srclen,omitempty"`
+	Dst      string          `json:"dst,omitempty"`
+	To       string          `json:"to,omitempty"`
+	Dstlen   int             `json:"dstlen,omitempty"`
+	DstLen   int             `json:"dst_len,omitempty"`
 	Table    json.RawMessage `json:"table,omitempty"`
 }
 
@@ -98,6 +102,26 @@ func (r ruleInfo) srcCIDR() string {
 		return ""
 	}
 	return r.Src + "/" + strconv.Itoa(r.Srclen)
+}
+
+// dstCIDR rebuilds the rule's destination CIDR from dst + dst_len. iproute2
+// uses "all" for an unqualified destination, just as it does for source.
+func (r ruleInfo) dstCIDR() string {
+	dst := r.Dst
+	if dst == "" {
+		dst = r.To
+	}
+	if dst == "" || dst == "all" {
+		return ""
+	}
+	if strings.Contains(dst, "/") {
+		return dst
+	}
+	prefixLen := r.Dstlen
+	if prefixLen == 0 {
+		prefixLen = r.DstLen
+	}
+	return dst + "/" + strconv.Itoa(prefixLen)
 }
 
 // readLink invokes `ip -j -d link show <name>` and decodes the first entry.
@@ -374,6 +398,80 @@ func DeleteIPRule(t *testing.T, priority int, src string) {
 	}
 }
 
+// AssertIPRuleToPriorityTable waits for a destination policy rule at priority
+// that points at tableID. This is used for the local-FIP exception placed just
+// before the veth-leak source policy rule.
+func AssertIPRuleToPriorityTable(t *testing.T, priority int, dst string, tableID int, timeout time.Duration) {
+	t.Helper()
+	if _, _, err := net.ParseCIDR(dst); err != nil {
+		t.Fatalf("AssertIPRuleToPriorityTable: invalid CIDR %q: %v", dst, err)
+	}
+	deadline := time.Now().Add(timeout)
+	var lastOut string
+	for {
+		out, err := exec.Command("ip", "-j", "rule", "show").CombinedOutput()
+		lastOut = string(out)
+		if err == nil {
+			var rules []ruleInfo
+			if err := json.Unmarshal(out, &rules); err == nil {
+				for _, r := range rules {
+					if r.Priority == priority && r.dstCIDR() == dst && tableMatches(r.Table, tableID) {
+						return
+					}
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("ip rule priority %d to %s table %d not present after %s (last: %q)",
+				priority, dst, tableID, timeout, strings.TrimSpace(lastOut))
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+}
+
+// AssertNoIPRuleToPriority waits until no matching destination policy rule
+// remains. It verifies FIP cleanup and that drift was actually injected.
+func AssertNoIPRuleToPriority(t *testing.T, priority int, dst string, timeout time.Duration) {
+	t.Helper()
+	if _, _, err := net.ParseCIDR(dst); err != nil {
+		t.Fatalf("AssertNoIPRuleToPriority: invalid CIDR %q: %v", dst, err)
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := exec.Command("ip", "-j", "rule", "show").CombinedOutput()
+		if err == nil {
+			var rules []ruleInfo
+			if err := json.Unmarshal(out, &rules); err == nil {
+				present := false
+				for _, r := range rules {
+					if r.Priority == priority && r.dstCIDR() == dst {
+						present = true
+						break
+					}
+				}
+				if !present {
+					return
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("ip rule priority %d to %s still present after %s (out: %q)",
+				priority, dst, timeout, strings.TrimSpace(string(out)))
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+}
+
+// DeleteIPRuleTo removes a destination policy rule from the main table. It
+// simulates an upgraded host or an out-of-band deletion for reconciliation.
+func DeleteIPRuleTo(t *testing.T, priority int, dst string) {
+	t.Helper()
+	out, err := exec.Command("ip", "rule", "del", "priority", strconv.Itoa(priority), "to", dst, "lookup", "main").CombinedOutput()
+	if err != nil {
+		t.Fatalf("ip rule del priority %d to %s lookup main: %v (%s)", priority, dst, err, strings.TrimSpace(string(out)))
+	}
+}
+
 // hasFlag reports whether flag appears in flags. Used to fall back to UP
 // detection when iproute2 omits operstate (rare, but seen on some kernels
 // with veth devices that have no carrier).
@@ -444,24 +542,26 @@ func scrubVethLeakState(t *testing.T) {
 	t.Helper()
 
 	// Drop policy rules we might have planted at the agent's priorities.
-	// Both default and any custom priority a future test may inject get
-	// flushed; missing rules cause `ip rule del` to exit non-zero with
-	// "RTNETLINK answers: No such file or directory" — ignore.
+	// This includes both the veth-leak source rule and the local-FIP
+	// destination exception immediately before it. Missing rules cause `ip
+	// rule del` to exit non-zero with "RTNETLINK answers: No such file or
+	// directory" — ignore.
 	if out, err := exec.Command("ip", "-j", "rule", "show").CombinedOutput(); err == nil {
 		var rules []ruleInfo
 		if err := json.Unmarshal(out, &rules); err == nil {
 			for _, r := range rules {
-				if r.Priority != DefaultVethLeakRulePriority {
-					continue
+				switch {
+				case r.Priority == DefaultVethLeakRulePriority && r.srcCIDR() != "":
+					_ = exec.Command("ip", "rule", "del",
+						"priority", strconv.Itoa(r.Priority),
+						"from", r.srcCIDR(),
+					).Run()
+				case r.Priority == DefaultVethLeakRulePriority-1 && r.dstCIDR() != "":
+					_ = exec.Command("ip", "rule", "del",
+						"priority", strconv.Itoa(r.Priority),
+						"to", r.dstCIDR(), "lookup", "main",
+					).Run()
 				}
-				cidr := r.srcCIDR()
-				if cidr == "" {
-					continue
-				}
-				_ = exec.Command("ip", "rule", "del",
-					"priority", strconv.Itoa(r.Priority),
-					"from", cidr,
-				).Run()
 			}
 		}
 	}


### PR DESCRIPTION
When FIP routes live in the main table, veth-leak’s source-based policy rule can override the local /32 route for cross-chassis FIP-to-FIP traffic and cause a veth loop. 

Add a per-IP destination rule into main immediately before the veth-leak rule, reconcile it continuously, and clean it up with the associated kernel route.

Co-Authored by: Claude