### PR TITLE
fix(routing): exempt veth-default ingress from the veth-leak source rule

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -207,6 +207,56 @@ jobs:
         if: always()
         run: make e2e-down
 
+  cross-chassis-fip:
+    name: Cross-chassis FIP-to-FIP (routers on different gateways)
+    runs-on: ubuntu-latest
+    # Gates on baseline like hairpin: the scenario adds one bootstrap, the
+    # baseline gate, the second router's convergence wait (≤60s) and two
+    # 5-packet probes, well inside the 15-minute budget. It measures the
+    # one path no other scenario enters — provider-sourced ingress through
+    # a second gateway's veth pair (issue #265).
+    needs: baseline
+    timeout-minutes: 15
+
+    env:
+      E2E_TOPOLOGY: test/e2e/topology.clab.yml
+      LAB: ovn-e2e
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # See the baseline job / e2e-lab-setup action for the rationale.
+      - uses: ./.github/actions/e2e-lab-setup
+
+      - name: Bring the lab up
+        run: make e2e-up
+
+      - name: Run cross-chassis FIP-to-FIP scenario
+        # On failure the scenario dumps both gateways' rule, veth-counter
+        # and route state into ARTIFACTS_DIR; collect-artifacts.sh and the
+        # uploader pick it up from the same root.
+        env:
+          ARTIFACTS_DIR: ${{ runner.temp }}/e2e-artifacts/cross-chassis-fip
+        run: ./test/e2e/scenarios/cross-chassis-fip.sh
+
+      - name: Collect failure artifacts
+        if: failure()
+        run: |
+          ./test/e2e/scenarios/collect-artifacts.sh "${RUNNER_TEMP}/e2e-artifacts"
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: e2e-artifacts-cross-chassis-fip-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/e2e-artifacts
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Tear the lab down
+        if: always()
+        run: make e2e-down
+
   hairpin-churn:
     name: Same-chassis hairpin under reconcile churn
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION   ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "d
 LDFLAGS   := -s -w -X main.version=$(VERSION)
 GOFLAGS   := -trimpath
 
-.PHONY: all build build-static build-integration clean fmt vet test test-integration install docs-gen docs-gen-check models-gen models-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-failover-strict e2e-hairpin e2e-hairpin-churn e2e-multi-vlan e2e-pf-external e2e-pf-hairpin e2e-pf-split-owner e2e-stale-chassis e2e-drain-hitless e2e-chaos e2e-chaos-report e2e-chaos-random
+.PHONY: all build build-static build-integration clean fmt vet test test-integration install docs-gen docs-gen-check models-gen models-gen-check e2e-images e2e-up e2e-down e2e-install-tools e2e-baseline e2e-failover e2e-failover-strict e2e-hairpin e2e-hairpin-churn e2e-cross-chassis-fip e2e-multi-vlan e2e-pf-external e2e-pf-hairpin e2e-pf-split-owner e2e-stale-chassis e2e-drain-hitless e2e-chaos e2e-chaos-report e2e-chaos-random
 
 # Containerlab E2E harness. See test/e2e/README.md for the topology and
 # acceptance criteria (issue #44).
@@ -13,6 +13,7 @@ E2E_BASELINE    := test/e2e/scenarios/baseline.sh
 E2E_FAILOVER    := test/e2e/scenarios/failover.sh
 E2E_HAIRPIN     := test/e2e/scenarios/hairpin.sh
 E2E_HAIRPIN_CHURN := test/e2e/scenarios/hairpin-churn.sh
+E2E_CROSS_CHASSIS := test/e2e/scenarios/cross-chassis-fip.sh
 E2E_MULTI_VLAN  := test/e2e/scenarios/multi-vlan.sh
 E2E_PF_EXTERNAL := test/e2e/scenarios/pf-external.sh
 E2E_PF_HAIRPIN  := test/e2e/scenarios/pf-hairpin.sh
@@ -239,6 +240,20 @@ e2e-hairpin:
 # lab down.
 e2e-hairpin-churn:
 	$(E2E_HAIRPIN_CHURN)
+
+# Run the cross-chassis FIP-to-FIP scenario (issue #265) against a lab
+# that is already up. Adds a second flat router lr1 on the shared
+# provider switch, pinned to gateway-2 as its only candidate, with a FIP
+# (192.0.2.20) and a vm3 responder on gateway-3; asserts cr-lr1-public
+# and cr-lr0-public sit on different chassis and both gateways carry the
+# veth-default ingress exception rule; then pings each FIP from the
+# workload behind the other and requires zero loss, plus a growing
+# veth-default packet counter on gateway-2 proving the traffic crossed
+# the kernel path. The EXIT trap removes the router, switch, FIP and
+# responder so a subsequent `make e2e-baseline` works without tearing
+# the lab down.
+e2e-cross-chassis-fip:
+	$(E2E_CROSS_CHASSIS)
 
 # Run the multi-VLAN provider-network scenario (issue #147) against a
 # lab that is already up. Adds two VLAN provider networks (tags 101/102

--- a/config.go
+++ b/config.go
@@ -471,7 +471,7 @@ func configOptions() []configOption {
 			func(c *Config) *string { return &c.VethProviderIP }),
 		intOpt("veth-leak-table-id", 200, "Routing table ID for veth leak default route (1-252)",
 			func(c *Config) *int { return &c.VethLeakTableID }),
-		intOpt("veth-leak-rule-priority", 2000, "Policy rule priority for veth leak rules",
+		intOpt("veth-leak-rule-priority", 2000, "Policy rule priority for veth leak rules; the veth-default ingress rule uses this priority minus one (must be at least 2)",
 			func(c *Config) *int { return &c.VethLeakRulePriority }),
 		stringOpt("metrics-listen", "", "Address for the Prometheus /metrics endpoint (e.g. 127.0.0.1:9273); empty = disabled",
 			func(c *Config) *string { return &c.MetricsListen }),
@@ -824,6 +824,11 @@ func validateConfig(cfg *Config) error {
 	if cfg.VethLeakEnabled {
 		if cfg.VethLeakTableID < 1 || cfg.VethLeakTableID > 252 {
 			return fmt.Errorf("invalid veth-leak-table-id: %d (must be 1-252)", cfg.VethLeakTableID)
+		}
+		// The veth-default ingress rule sits one priority below the leak
+		// rules; priority 1 would put it on the kernel's priority-0 local rule.
+		if cfg.VethLeakRulePriority < 2 {
+			return fmt.Errorf("invalid veth-leak-rule-priority: %d (must be at least 2)", cfg.VethLeakRulePriority)
 		}
 		// RouteTableID 0 means "main table" and cannot conflict with an explicit leak table.
 		if cfg.VethLeakTableID == cfg.RouteTableID && cfg.RouteTableID != 0 {

--- a/config_test.go
+++ b/config_test.go
@@ -1166,6 +1166,39 @@ func TestLoadConfigVethLeakTableIDInvalid(t *testing.T) {
 	}
 }
 
+// TestLoadConfigVethLeakRulePriorityTooLow pins the floor for
+// veth-leak-rule-priority (#265): the veth-default ingress rule is installed
+// one priority below the leak rules, so 0 and 1 are rejected and 2 (ingress
+// rule at 1) is the smallest value that loads.
+func TestLoadConfigVethLeakRulePriorityTooLow(t *testing.T) {
+	for _, priority := range []string{"0", "1"} {
+		t.Run(priority, func(t *testing.T) {
+			_, err := loadConfig(fullModeArgs(
+				"--veth-leak-rule-priority", priority,
+				"--network-cidr", "10.0.0.0/24",
+			))
+			if err == nil {
+				t.Fatal("expected error for veth-leak-rule-priority below 2")
+			}
+			if !strings.Contains(err.Error(), "veth-leak-rule-priority") {
+				t.Errorf("error = %v, want veth-leak-rule-priority validation", err)
+			}
+		})
+	}
+	t.Run("2", func(t *testing.T) {
+		cfg, err := loadConfig(fullModeArgs(
+			"--veth-leak-rule-priority", "2",
+			"--network-cidr", "10.0.0.0/24",
+		))
+		if err != nil {
+			t.Fatalf("veth-leak-rule-priority 2 should load, got: %v", err)
+		}
+		if cfg.VethLeakRulePriority != 2 {
+			t.Errorf("VethLeakRulePriority = %d, want 2", cfg.VethLeakRulePriority)
+		}
+	})
+}
+
 func TestApplyEnvConfigVethLeak(t *testing.T) {
 	cfg := Config{VethLeakEnabled: true}
 	t.Setenv("OVN_NETWORK_VETH_LEAK_ENABLED", "false")
@@ -1534,13 +1567,14 @@ port_forwards:
 func TestPortForwardValidation(t *testing.T) {
 	base := func() Config {
 		return Config{
-			VethNexthop:        "169.254.0.1",
-			ReconcileInterval:  60 * time.Second,
-			VethLeakEnabled:    true,
-			VethLeakTableID:    200,
-			PortForwardDev:     "loopback1",
-			PortForwardTableID: 201,
-			PortForwardCTZone:  64000,
+			VethNexthop:          "169.254.0.1",
+			ReconcileInterval:    60 * time.Second,
+			VethLeakEnabled:      true,
+			VethLeakTableID:      200,
+			VethLeakRulePriority: 2000,
+			PortForwardDev:       "loopback1",
+			PortForwardTableID:   201,
+			PortForwardCTZone:    64000,
 			PortForwards: []PortForwardVIP{
 				{
 					VIP: "198.51.100.10",
@@ -1878,13 +1912,14 @@ func TestDestAddrsHelper(t *testing.T) {
 func TestPortForwardMultiBackendValidation(t *testing.T) {
 	base := func() Config {
 		return Config{
-			VethNexthop:        "169.254.0.1",
-			ReconcileInterval:  60 * time.Second,
-			VethLeakEnabled:    true,
-			VethLeakTableID:    200,
-			PortForwardDev:     "loopback1",
-			PortForwardTableID: 201,
-			PortForwardCTZone:  64000,
+			VethNexthop:          "169.254.0.1",
+			ReconcileInterval:    60 * time.Second,
+			VethLeakEnabled:      true,
+			VethLeakTableID:      200,
+			VethLeakRulePriority: 2000,
+			PortForwardDev:       "loopback1",
+			PortForwardTableID:   201,
+			PortForwardCTZone:    64000,
 			PortForwards: []PortForwardVIP{
 				{
 					VIP: "198.51.100.10",
@@ -2003,10 +2038,11 @@ port_forwards:
 // VethProviderIP) trips this test instead of silently changing the contract.
 func TestVethProviderIPAutoComputeWrapsAt255_255_255_255(t *testing.T) {
 	cfg := Config{
-		VethNexthop:       "255.255.255.255",
-		ReconcileInterval: 60 * time.Second,
-		VethLeakEnabled:   true,
-		VethLeakTableID:   200,
+		VethNexthop:          "255.255.255.255",
+		ReconcileInterval:    60 * time.Second,
+		VethLeakEnabled:      true,
+		VethLeakTableID:      200,
+		VethLeakRulePriority: 2000,
 		// VethProviderIP intentionally unset — triggers auto-compute.
 	}
 

--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -1162,12 +1162,13 @@ the physical network and keeps working while the hairpin plane is broken,
 so a run without an internal vantage records no loss for exactly the
 traffic class the hairpin flows exist for.
 
-Two targets use it, both from `vm1`'s namespace on `gateway-3`:
+Three targets use it, all from workload namespaces on `gateway-3`:
 
 | Target | Kind | Address | What it rides |
 | --- | --- | --- | --- |
-| `hairpin-fip` | ping | `192.0.2.12` | the `cookie=0x998` reflect path on whichever chassis holds `cr-lr0-public` |
-| `hairpin-vip` | TCP | `198.18.0.50:8080` | OVN egress SNAT → `br-ex` → the chassis kernel's nftables DNAT → the API VIP's own backend, and the reply steered back into OVN |
+| `hairpin-fip` | ping | `192.0.2.12` | from `vm1`: the `cookie=0x998` reflect path on whichever chassis holds `cr-lr0-public` |
+| `hairpin-vip` | TCP | `198.18.0.50:8080` | from `vm1`: OVN egress SNAT → `br-ex` → the chassis kernel's nftables DNAT → the API VIP's own backend, and the reply steered back into OVN |
+| `cross-fip` | ping | `192.0.2.10` | from `vm3`: OVN egress on the chassis holding `cr-lr1-public` (`gateway-2`), its kernel veth path into `vrf-provider`, BGP to the chassis holding `cr-lr0-public`, and that kernel's `iif veth-default` ingress into `br-ex` (issue #265) |
 
 The third probe kind, TCP, is a handshake through bash's `/dev/tcp`
 redirect: the gateway image carries no curl, and `pf-hairpin.sh` probes
@@ -1243,8 +1244,10 @@ sequences reproducible.
 the bootstrap baseline, so one run can exercise all of them at once:
 `hairpin.sh`'s second FIP (`192.0.2.12` with a `vm2` responder),
 `multi-vlan.sh`'s two VLAN provider networks (tags 101/102, routers
-pinned to `gateway-1`), and `pf-external.sh`'s `Load_Balancer` VIP
-(`192.0.2.50:80` in front of the `vm1` backend). Which of them a run puts
+pinned to `gateway-1`), `pf-external.sh`'s `Load_Balancer` VIP
+(`192.0.2.50:80` in front of the `vm1` backend), and
+`cross-chassis-fip.sh`'s second flat router `lr1` (pinned to `gateway-2`,
+FIP `192.0.2.20` with a `vm3` responder). Which of them a run puts
 up is the profile's call. The layering is idempotent, which is what makes
 it reusable as the post-fault restore path. If the start state is not
 green within 120 s the run aborts with exit code 2 — a fault injected
@@ -1265,6 +1268,7 @@ up has no responder and would be red for the whole run:
 | `fip-vlan102` | `ping 203.0.113.10` | the VLAN layers |
 | `pf-vip` | `curl http://192.0.2.50:80/` | the port-forward layer (an OVN `Load_Balancer`) |
 | `api-vip` | `curl http://192.0.2.80:8080/` | the **agent's own** DNAT (`port_forwards`), on the gateways a profile configures it on |
+| `cross-fip` | `ping 192.0.2.10` from `vm3` | the cross-chassis layer |
 
 The baseline lab's second FIP, `192.0.2.11`, is deliberately **not**
 probed: `bootstrap.sh` seeds its NAT row but nothing answers behind
@@ -1286,12 +1290,12 @@ The set is curated, not combinatorial:
 
 | `-profile` | Start topology | Agent configuration | Probes |
 | --- | --- | --- | --- |
-| `everything-on` (default) | hairpin + VLAN + port-forward | the baked lab config, unchanged | the four FIPs + `pf-vip` + `hairpin-fip` |
+| `everything-on` (default) | hairpin + VLAN + port-forward + cross-chassis | the baked lab config, unchanged | the four FIPs + `pf-vip` + `hairpin-fip` + `cross-fip` |
 | `flat-minimal` | baseline only | `cleanup_on_shutdown: true` | `fip-vm1` |
-| `flat-dnat` | hairpin + port-forward | the API VIP and the hairpin VIP (`port_forwards` + `port_forward_l3mdev_accept`) | `fip-vm1`, `fip-vm2`, `pf-vip`, `api-vip`, `hairpin-fip`, `hairpin-vip` |
-| `vlan-no-dnat` | hairpin + VLAN | the baked lab config, unchanged | `fip-vm1`, `fip-vm2`, both VLAN FIPs, `hairpin-fip` |
+| `flat-dnat` | hairpin + port-forward + cross-chassis | the API VIP and the hairpin VIP (`port_forwards` + `port_forward_l3mdev_accept`) | `fip-vm1`, `fip-vm2`, `pf-vip`, `api-vip`, `hairpin-fip`, `hairpin-vip`, `cross-fip` |
+| `vlan-no-dnat` | hairpin + VLAN + cross-chassis | the baked lab config, unchanged | `fip-vm1`, `fip-vm2`, both VLAN FIPs, `hairpin-fip`, `cross-fip` |
 | `pf-only` | baseline only | **no OVN remotes** + the API VIP + `network_cidr` | `api-vip` |
-| `heterogeneous` | hairpin + VLAN + port-forward | `gateway-1` API + hairpin VIP, `gateway-2` the same + drain, `gateway-3` manual `network_cidr` + 15 s cadence + cleanup | the four FIPs + `pf-vip` + `api-vip` + `hairpin-fip` + `hairpin-vip` |
+| `heterogeneous` | hairpin + VLAN + port-forward + cross-chassis | `gateway-1` API + hairpin VIP, `gateway-2` the same + drain, `gateway-3` manual `network_cidr` + 15 s cadence + cleanup | the four FIPs + `pf-vip` + `api-vip` + `hairpin-fip` + `hairpin-vip` + `cross-fip` |
 
 `pf-only` and `flat-minimal` carry neither same-node target: `pf-only`
 has no OVN connection, so the agent manages no FIP path at all, and

--- a/docs/contributing/e2e-tests.md
+++ b/docs/contributing/e2e-tests.md
@@ -37,6 +37,7 @@ test/e2e/
     hairpin.sh              — same-chassis hairpin scenario, two FIPs on master (issue #108)
     hairpin-churn.sh        — zero loss on the hairpin path under reconcile churn (issue #243)
     lib/hairpin-topology.sh — the FIP_B topology both hairpin scenarios source
+    cross-chassis-fip.sh    — cross-chassis FIP-to-FIP through both gateways' veth paths (issue #265)
     multi-vlan.sh           — multi-VLAN provider networks, two segments on master (issue #147)
     pf-external.sh          — port-forward / DNAT scenario, source IP preserved (issue #109)
     pf-hairpin.sh           — port-forward hairpin masquerade scenario (issue #110)
@@ -215,18 +216,26 @@ diagnostics and retries.
   `eth3 = 100.64.3.1/30`), `10.0.0.1/24` on `eth4` (towards
   `client-1`), IPv4 forwarding enabled, FRR with `bgpd` enabled and
   one eBGP neighbor per gateway.
+- the gateways all share AS 65000, so on its own the upstream's
+  re-advertisement of one gateway's prefixes to another would be
+  dropped by AS-path loop prevention. The upstream therefore sets
+  `neighbor <gateway> as-override`, rewriting the gateways' ASN to
+  its own in the AS_PATH it sends, so every gateway's `vrf-provider`
+  learns the other gateways' FIP `/32`s — what a fabric carrying host
+  `/32`s does. Cross-chassis FIP-to-FIP on a shared provider network
+  depends on it: the agent's per-network leak route in
+  `vrf-provider` (`<net> via 169.254.0.1`) is more specific than a
+  default and would otherwise catch traffic for a FIP hosted on
+  another gateway (issue #265).
 - the upstream also originates a default route to every gateway
   (`neighbor <gateway> default-originate`), so each `vrf-provider`
   learns `default via 100.64.N.1`. That default is what carries
-  traffic to anything the chassis does not host itself — a
-  port-forward VIP another gateway announces, or the reply to a
-  client behind a FIP that has moved. The gateways all share
-  AS 65000, so BGP delivers no such route on its own: the upstream's
-  re-advertisement is dropped by AS-path loop prevention. The
-  gateways do not pass the default on either, because they export
-  only through `redistribute connected` filtered by
-  `ANNOUNCE-CONNECTED` and their outbound
-  `prefix-list ANNOUNCED-NETWORKS out` permits `/32`s only.
+  traffic to anything no gateway announces at all — a port-forward
+  VIP another gateway announces before its `/32` has propagated, or
+  the reply to a client behind a FIP that has moved. The gateways do
+  not pass the default on, because they export only through
+  `redistribute connected` filtered by `ANNOUNCE-CONNECTED` and their
+  outbound `prefix-list ANNOUNCED-NETWORKS out` permits `/32`s only.
 - each gateway's FRR (in `vrf-provider`): eBGP against its specific
   upstream `/30` endpoint, redistributing the FIP `/32` static
   routes that the agent installs in `vrf-provider`. The placeholder
@@ -267,6 +276,7 @@ Between bring-up and teardown, each scenario is its own `make` target:
 | --- | --- | --- | --- |
 | [Baseline](#baseline) | `e2e-baseline` | An external client reaches a FIP once the agent reconciles. | [#45](https://github.com/osism/ovn-network-agent/issues/45) |
 | [Chaos runner](#chaos-runner) | `e2e-chaos` | Under a seeded, randomized fault sequence — in any of six agent [configuration profiles](#configuration-profiles) — the agents stay alive, reachability recovers within budget, no gateway port is claimed twice, and the lab converges to its config-aware expected state in settle windows. | [#176](https://github.com/osism/ovn-network-agent/issues/176), [#177](https://github.com/osism/ovn-network-agent/issues/177), [#179](https://github.com/osism/ovn-network-agent/issues/179) |
+| [Cross-chassis FIP-to-FIP](#cross-chassis-fip-to-fip) | `e2e-cross-chassis-fip` | A FIP behind a router on one gateway reaches a FIP behind a router on another gateway through both kernels' veth paths. | [#265](https://github.com/osism/ovn-network-agent/issues/265) |
 | [Drain-hitless](#drain-hitless) | `e2e-drain-hitless` | A graceful `SIGTERM` drain loses fewer packets than a hard `docker kill` of the same chassis. | [#113](https://github.com/osism/ovn-network-agent/issues/113) |
 | [Failover](#failover) | `e2e-failover` | `cr-lr0-public` re-elects to a surviving chassis after the master is lost. | [#105](https://github.com/osism/ovn-network-agent/issues/105) |
 | [Failover (strict)](#failover) | `e2e-failover-strict` | The data-plane outage across the re-election stays within a ~2s budget. | [#131](https://github.com/osism/ovn-network-agent/issues/131) |
@@ -507,6 +517,67 @@ FIP_B, restores the baseline config, restarts the master and waits for
 **Overrides for triage:** `PROBE_DURATION`, `PROBE_INTERVAL`,
 `CHURN_INTERVAL`, `CHURN_RECONCILE`, `METRICS_INTERVALS`, `MASTER`,
 `SANITY_GATE`.
+
+### Cross-chassis FIP-to-FIP
+
+```sh
+make e2e-cross-chassis-fip
+```
+
+[`cross-chassis-fip.sh`](https://github.com/osism/ovn-network-agent/blob/main/test/e2e/scenarios/cross-chassis-fip.sh)
+measures the one path no other scenario enters: provider-sourced traffic
+arriving through a *second* gateway's veth pair. With FIP routes in the
+main table (the lab's default), the destination gateway's veth-leak
+source rule used to catch such a packet before the main table was
+consulted and send it straight back into `vrf-provider`, where the FRR
+static for the `/32` pointed at `veth-default` again; the packet bounced
+between the veth ends until its TTL expired (issue #265). The agent now
+keeps an ingress exception rule, `iif veth-default lookup main`, one
+priority below the leak rules.
+
+The scenario:
+
+1. Runs the baseline first as a sanity gate.
+2. Adds — scenario-locally — a second flat router `lr1` on the shared
+   provider switch `ls-public` (`lr1-public` `192.0.2.2/24`, pinned to
+   `gateway-2` as its only candidate), a tenant switch `ls1`
+   (`192.168.20.0/24`), the FIP `192.0.2.20` → `192.168.20.10`, and a
+   `vm3` netns + veth on `gateway-3` behind it. No default route and no
+   `Static_MAC_Binding` are seeded for `lr1`; the agent on `gateway-2`
+   programs both, as it does for `lr0`.
+3. Waits until `cr-lr1-public` is bound to `gateway-2` and asserts that
+   `cr-lr0-public` sits on a different chassis (a shared chassis fails the
+   run naming it: it would be measuring the hairpin path); then waits for
+   `192.0.2.20/32` on `gateway-2` and for the ingress rule at priority
+   `1999` on both gateways.
+4. Records `gateway-2`'s `veth-default` packet counters, pings `192.0.2.10`
+   from `vm3` and `192.0.2.20` from `vm1` (`ping -c 5 -W 2`, zero loss
+   required in both directions), and requires the counters to have grown
+   by at least the ping count — proof that the traffic crossed the kernel
+   path on the router's chassis rather than staying inside OVN.
+
+On failure the scenario writes `ip rule show`, `ip -s link show
+veth-default`, `ip route show table 200` and `ip route show` from both
+gateways into `ARTIFACTS_DIR`. The EXIT trap removes the router, its
+ports, the switch, the FIP, the MAC binding the agent programmed for it,
+and the `vm3` responder, returning the lab to baseline. The CI workflow
+runs this scenario as its own `cross-chassis-fip` job gating on
+`baseline`.
+
+::: details Expected packet flow on a green run
+`vm3` (`192.168.20.10` on `gateway-3`) → geneve → `cr-lr1-public` on
+`gateway-2` (egress SNAT to `192.0.2.20`) → `ls-public` localnet →
+`br-ex` on `gateway-2` → kernel: `from 192.0.2.0/24 lookup 200` →
+`veth-default` → `vrf-provider` → BGP → `upstream` → `gateway-1`'s
+`vrf-provider` → FRR static `192.0.2.10/32` via the veth pair →
+`veth-default` on `gateway-1` → `iif veth-default lookup main` →
+`192.0.2.10/32 dev br-ex` → OVN → DNAT → `vm1`. The reply takes the
+mirror image through both kernels.
+:::
+
+**Overrides for triage:** `MASTER`, `PEER`, `WORKLOAD_HOST`, `FIP_A`,
+`FIP_C`, `FIP_C_INTERNAL`, `INGRESS_RULE_PRIORITY`, `PING_COUNT`,
+`PING_TIMEOUT`, `RECONCILE_TIMEOUT`, `SANITY_GATE`.
 
 ### Multi-VLAN
 

--- a/docs/contributing/integration-tests.md
+++ b/docs/contributing/integration-tests.md
@@ -23,7 +23,7 @@ test/integration/
   scenario_port_forward_test.go               — DNAT, sticky multi-backend, VIP mgmt, masquerade, hairpin
   scenario_prefix_list_test.go                — ReconcileFRRPrefixList lifecycle on real FRR (#58)
   scenario_bridge_ip_test.go                  — cold-start bridge IP + proxy_arp housekeeping (#63)
-  scenario_vethleak_test.go                   — SetupVethLeak / ReconcileVethLeakNetworks / TeardownVethLeak (#56)
+  scenario_vethleak_test.go                   — SetupVethLeak / ReconcileVethLeakNetworks / TeardownVethLeak (#56) + veth-default ingress exception rule (#265)
   scenario_ipv6_test.go                       — IPv6-capable OVS flow plumbing on br-ex (#54; kernel/FRR paths are v4-only today)
   scenario_metrics_test.go                    — Prometheus /metrics scrapes (reconcile counter, drain outcome, stale-chassis, desired-state gauges)
   scenario_multi_segment_test.go              — multi-VLAN localnet segments: per-segment interfaces/routes/flows, failover isolation, same-segment hairpin, restart re-adoption (#147)

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -126,6 +126,7 @@ pair managed by the agent (`--veth-leak-enabled`) bridges the two VRFs.
  │  │   ┌─────────────────┐                                                          │  │
  │  │   │  veth-default   │    ip rule: from <provider-net> → lookup table 200       │  │
  │  │   │  169.254.0.1/30 │    table 200: default via 169.254.0.2                    │  │
+ │  │   │                 │    ip rule: iif veth-default → lookup main (one below)   │  │
  │  │   └────────┬────────┘                                                          │  │
  │  └────────────┼───────────────────────────────────────────────────────────────────┘  │
  │          veth pair                                                                   │
@@ -191,11 +192,26 @@ VRFs so that:
   `192.0.2.0/24 via 169.254.0.1`) send return traffic back through the veth
   pair into the default VRF for normal kernel delivery.
 
+Traffic arriving on `veth-default` is exempt from the source rule: one
+priority below the per-network rules the agent keeps `iif veth-default
+lookup main` (`veth_leak_rule_priority - 1`, 1999 by default). A packet
+that enters the default VRF through the veth pair has already left
+`vrf-provider`; without the exemption a source inside a leaked provider
+network (a FIP behind a router on another gateway, or an external host on
+the provider subnet) would match the source rule, be sent back into
+`vrf-provider`, and loop between the veth ends until its TTL expires,
+because the FRR static for the `/32` points at `veth-default` again. With
+the exemption the main-table `/32` delivers it to `br-ex`. One rule covers
+every hosted IP, so it does not depend on `route_table_id` or on the FIP
+count.
+
 The agent creates the veth pair and assigns link-local addresses at startup
 (`--veth-leak-enabled`, on by default). Per-network policy rules and routes
 are reconciled dynamically — networks are either auto-discovered from OVN
 `Logical_Router_Port.Networks` or taken from the static `network_cidr`
-configuration. On shutdown, all resources are cleaned up.
+configuration. The ingress exemption is installed with the pair, repaired
+on every reconcile, and removed with the pair. On shutdown, all resources
+are cleaned up.
 
 ### VLAN provider networks
 

--- a/docs/explanation/how-it-works.md
+++ b/docs/explanation/how-it-works.md
@@ -66,7 +66,10 @@ provider bridge).
      [Priority semantics](gateway-drain#priority-semantics).
    - Reconciles **per-network veth-leak routes and policy rules** in the
      veth leak table (default 200) so SNAT reply traffic on the provider
-     subnet crosses into `vrf-provider` for BGP delivery.
+     subnet crosses into `vrf-provider` for BGP delivery, and keeps the
+     `veth-default` ingress exception rule (`iif veth-default lookup main`)
+     in front of them so traffic that already left `vrf-provider` is never
+     sent back into it.
    - If no routers are locally active: removes all managed routes (port
      forward VIPs still get kernel/FRR routes if any are configured).
 5. **Port forwarding (DNAT)** — optionally forwards traffic from anycast VIP

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -124,13 +124,20 @@ Substitute the values you configured for `vrf_name`, `frr_prefix_list`,
    ip route show <fip>/32
    ip route show table 200
    ip route show table 201
+   ip rule show
    ```
 
    Table `200` holds the veth-leak default route (owned by
    `veth_leak_table_id`); table `201` holds the DNAT return route (owned by
    `port_forward_table_id`). The FIP `/32` lives in the main table unless
    `route_table_id` is set to a non-zero table, in which case query that table
-   instead.
+   instead. In the rule listing, `iif veth-default lookup main` must sit one
+   priority below the `from <network> lookup 200` rules (1999 and 2000 by
+   default). If it is missing, traffic between FIPs whose routers live on
+   different gateways is lost while external clients keep working, and the
+   packet counters of `veth-default` (`ip -s link show veth-default`) climb
+   far above the offered load: each packet loops through the veth pair until
+   its TTL expires.
 
 7. **Check the nftables table.** Note the family is `ip`, not `inet`:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -40,7 +40,7 @@ regenerate it with `go generate ./...`.
 | `--veth-leak-enabled` | `true` | Enable veth VRF route leaking |
 | `--veth-provider-ip` |  | IP of the veth-provider side (default: veth-nexthop + 1) |
 | `--veth-leak-table-id` | `200` | Routing table ID for veth leak default route (1-252) |
-| `--veth-leak-rule-priority` | `2000` | Policy rule priority for veth leak rules |
+| `--veth-leak-rule-priority` | `2000` | Policy rule priority for veth leak rules; the veth-default ingress rule uses this priority minus one (must be at least 2) |
 | `--metrics-listen` |  | Address for the Prometheus /metrics endpoint (e.g. 127.0.0.1:9273); empty = disabled |
 | `--port-forward-dev` | `loopback1` | Loopback device for VIP addresses in VRF (default: loopback1) |
 | `--port-forward-table-id` | `201` | Routing table ID for DNAT return traffic (1-252) |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -46,7 +46,7 @@ regenerate this page with `go generate ./...`.
 | `--veth-leak-enabled` | `OVN_NETWORK_VETH_LEAK_ENABLED` | `veth_leak_enabled` | `true` | Enable veth VRF route leaking |
 | `--veth-provider-ip` | `OVN_NETWORK_VETH_PROVIDER_IP` | `veth_provider_ip` |  | IP of the veth-provider side (default: veth-nexthop + 1) |
 | `--veth-leak-table-id` | `OVN_NETWORK_VETH_LEAK_TABLE_ID` | `veth_leak_table_id` | `200` | Routing table ID for veth leak default route (1-252) |
-| `--veth-leak-rule-priority` | `OVN_NETWORK_VETH_LEAK_RULE_PRIORITY` | `veth_leak_rule_priority` | `2000` | Policy rule priority for veth leak rules |
+| `--veth-leak-rule-priority` | `OVN_NETWORK_VETH_LEAK_RULE_PRIORITY` | `veth_leak_rule_priority` | `2000` | Policy rule priority for veth leak rules; the veth-default ingress rule uses this priority minus one (must be at least 2) |
 | `--metrics-listen` | `OVN_NETWORK_METRICS_LISTEN` | `metrics_listen` |  | Address for the Prometheus /metrics endpoint (e.g. 127.0.0.1:9273); empty = disabled |
 | `--port-forward-dev` | `OVN_NETWORK_PORT_FORWARD_DEV` | `port_forward_dev` | `loopback1` | Loopback device for VIP addresses in VRF (default: loopback1) |
 | `--port-forward-table-id` | `OVN_NETWORK_PORT_FORWARD_TABLE_ID` | `port_forward_table_id` | `201` | Routing table ID for DNAT return traffic (1-252) |

--- a/ovn-network-agent.default
+++ b/ovn-network-agent.default
@@ -119,7 +119,8 @@ OVN_NETWORK_OVN_NB_REMOTE=tcp:10.10.0.1:6641,tcp:10.10.0.2:6641,tcp:10.10.0.3:66
 # Routing table ID for the leak default route (1-252, must differ from ROUTE_TABLE_ID)
 #OVN_NETWORK_VETH_LEAK_TABLE_ID=200
 
-# Policy rule priority for veth leak rules
+# Policy rule priority for veth leak rules (must be at least 2; the
+# veth-default ingress rule uses this priority minus one)
 #OVN_NETWORK_VETH_LEAK_RULE_PRIORITY=2000
 
 # =============================================================================

--- a/ovn-network-agent.yaml.sample
+++ b/ovn-network-agent.yaml.sample
@@ -154,7 +154,9 @@ ovn_nb_remote: "tcp:10.10.0.1:6641,tcp:10.10.0.2:6641,tcp:10.10.0.3:6641"
 # Must differ from route_table_id.
 # veth_leak_table_id: 200
 
-# Policy rule priority for veth leak rules (default: 2000)
+# Policy rule priority for veth leak rules (default: 2000, must be at least 2).
+# The veth-default ingress rule (iif veth-default lookup main) uses this
+# priority minus one.
 # veth_leak_rule_priority: 2000
 
 # =============================================================================

--- a/routing.go
+++ b/routing.go
@@ -162,6 +162,15 @@ func (rm *RouteManager) refreshVethNexthop(networks []*net.IPNet) error {
 	return rm.RefreshVethNexthop(networks)
 }
 
+// vethIngressRulePriority is the priority of the veth-default ingress
+// exception rule (`iif veth-default lookup main`): one below the per-network
+// leak rules, so the kernel consults it first. validateConfig keeps
+// VethLeakRulePriority at 2 or above, which keeps this rule off the kernel's
+// priority-0 local rule.
+func (rm *RouteManager) vethIngressRulePriority() int {
+	return rm.cfg.VethLeakRulePriority - 1
+}
+
 // validateIP checks that the given string is a valid IPv4 address. IPv6 is
 // rejected: the FRR and kernel route paths that call this are IPv4-only (vtysh
 // "ip route .../32", net.CIDRMask(32, 32)), so a v6 address would produce an

--- a/routing_linux.go
+++ b/routing_linux.go
@@ -604,6 +604,7 @@ func (rm *RouteManager) SetupVethLeak() error {
 			"provider_ip", rm.cfg.VethProviderIP,
 			"table", rm.cfg.VethLeakTableID,
 			"priority", rm.cfg.VethLeakRulePriority,
+			"ingress_rule_priority", rm.vethIngressRulePriority(),
 			"networks", rm.cfg.NetworkFilters,
 		)
 		return nil
@@ -708,6 +709,17 @@ func (rm *RouteManager) SetupVethLeak() error {
 		Table:     rm.cfg.VethLeakTableID,
 	}); err != nil {
 		return fmt.Errorf("add default route in table %d: %w", rm.cfg.VethLeakTableID, err)
+	}
+
+	// 7. Ingress exception ahead of the per-network source rules. A packet
+	// arriving on veth-default has already left vrf-provider; without this
+	// rule the source rule would send provider-sourced ingress (cross-chassis
+	// FIP-to-FIP on a shared provider network) straight back into the VRF,
+	// where the FRR static for the /32 points at veth-default again, and the
+	// packet loops until its TTL expires (#265). Installed before the first
+	// per-network rule can exist.
+	if err := rm.ensureVethIngressRule(); err != nil {
+		return fmt.Errorf("veth ingress rule: %w", err)
 	}
 
 	// Per-network routes and policy rules are managed dynamically by
@@ -833,6 +845,9 @@ func (rm *RouteManager) TeardownVethLeak() error {
 			}
 		}
 	}
+	// The ingress exception belongs to the veth pair, not to a network, so it
+	// goes with the leak rules rather than with the per-network sweep.
+	rm.removeVethIngressRules()
 
 	// 2. Remove default route from leak table
 	vethDefault, err := netlink.LinkByName(vethDefaultName)
@@ -888,6 +903,79 @@ func (rm *RouteManager) TeardownVethLeak() error {
 	return nil
 }
 
+// ensureVethIngressRule installs the policy rule that exempts veth-default
+// ingress from the per-network source rules:
+//
+//	iif veth-default lookup main   priority <veth_leak_rule_priority - 1>
+//
+// Everything that arrives on veth-default came out of vrf-provider, and for
+// all of it the right next step is the main-table lookup that delivers to
+// the bridge /32. One rule covers every hosted IP, so the exception is
+// independent of route_table_id and of the FIP count.
+//
+// A rule with the veth-default selector at any other priority or table is a
+// leftover (a changed veth_leak_rule_priority) and is removed first, so that
+// exactly one such rule remains. A concurrent add of the same rule is not an
+// error (EEXIST); a stale rule that vanished underneath is not one either.
+func (rm *RouteManager) ensureVethIngressRule() error {
+	wantPrio := rm.vethIngressRulePriority()
+	rules, err := netlink.RuleList(netlink.FAMILY_V4)
+	if err != nil {
+		return fmt.Errorf("list policy rules: %w", err)
+	}
+	present := false
+	for _, r := range rules {
+		if r.IifName != vethDefaultName {
+			continue
+		}
+		if r.Priority == wantPrio && r.Table == rtTableMain {
+			present = true
+			continue
+		}
+		if err := netlink.RuleDel(&r); err != nil && !isNoSuchRule(err) {
+			slog.Warn("failed to remove stale veth ingress rule",
+				"priority", r.Priority, "table", r.Table, "error", err)
+		}
+	}
+	if present {
+		return nil
+	}
+	rule := netlink.NewRule()
+	rule.IifName = vethDefaultName
+	rule.Table = rtTableMain
+	rule.Priority = wantPrio
+	rule.Family = netlink.FAMILY_V4
+	if err := netlink.RuleAdd(rule); err != nil && !isFileExists(err) {
+		return fmt.Errorf("add veth ingress rule: %w", err)
+	}
+	slog.Info("veth ingress rule added", "iif", vethDefaultName, "priority", wantPrio)
+	return nil
+}
+
+// removeVethIngressRules deletes every policy rule carrying the veth-default
+// ingress selector, whatever its priority or table. Best effort, like the
+// rest of TeardownVethLeak: a rule that is already gone is not an error,
+// anything else is logged.
+func (rm *RouteManager) removeVethIngressRules() {
+	rules, err := netlink.RuleList(netlink.FAMILY_V4)
+	if err != nil {
+		slog.Warn("failed to list policy rules for veth ingress rule removal", "error", err)
+		return
+	}
+	for _, r := range rules {
+		if r.IifName != vethDefaultName {
+			continue
+		}
+		if err := netlink.RuleDel(&r); err != nil {
+			if !isNoSuchRule(err) {
+				slog.Warn("failed to remove veth ingress rule", "priority", r.Priority, "error", err)
+			}
+			continue
+		}
+		slog.Debug("removed veth ingress rule", "priority", r.Priority)
+	}
+}
+
 // ReconcileVethLeakNetworks ensures per-network VRF routes and policy rules
 // match the desired set of networks. Pass nil to remove all per-network state.
 func (rm *RouteManager) ReconcileVethLeakNetworks(desired []*net.IPNet) error {
@@ -904,6 +992,13 @@ func (rm *RouteManager) ReconcileVethLeakNetworks(desired []*net.IPNet) error {
 	vethProvider, err := netlink.LinkByName(vethProviderName)
 	if err != nil {
 		return fmt.Errorf("find %s: %w", vethProviderName, err)
+	}
+
+	// The ingress exception belongs to the veth pair, not to a network, so
+	// it is repaired on every cycle, the standby path's nil call included,
+	// and before any per-network rule is (re)added below.
+	if err := rm.ensureVethIngressRule(); err != nil {
+		return fmt.Errorf("veth ingress rule: %w", err)
 	}
 
 	vrfTableID, err := rm.getVRFTableID()

--- a/routing_test.go
+++ b/routing_test.go
@@ -414,6 +414,18 @@ func TestDisabledVethLeak(t *testing.T) {
 	}
 }
 
+// TestVethIngressRulePriority pins the derivation of the veth-default ingress
+// rule's priority (#265): always one below the leak rules, so the config
+// floor of 2 lands the exception at 1, above the kernel's local rule.
+func TestVethIngressRulePriority(t *testing.T) {
+	for _, tt := range []struct{ leak, want int }{{2000, 1999}, {2, 1}} {
+		rm := &RouteManager{cfg: Config{VethLeakRulePriority: tt.leak}}
+		if got := rm.vethIngressRulePriority(); got != tt.want {
+			t.Errorf("vethIngressRulePriority() with leak priority %d = %d, want %d", tt.leak, got, tt.want)
+		}
+	}
+}
+
 // frrConnectedRoutesJSON renders an FRR `show ip route vrf <vrf> connected json`
 // document for the given prefixes, each directly connected via veth-provider.
 func frrConnectedRoutesJSON(prefixes ...string) string {

--- a/test/e2e/bootstrap.sh
+++ b/test/e2e/bootstrap.sh
@@ -45,7 +45,9 @@
 #          eth4 = 10.0.0.1/24 (client side), IPv4 forwarding enabled.
 #        * FRR with bgpd enabled and one eBGP neighbor per gateway,
 #          redistributing connected so the gateways learn the
-#          10.0.0.0/24 return path.
+#          10.0.0.0/24 return path, originating a default to every
+#          gateway, and re-advertising each gateway's /32s to the
+#          others with as-override (see configure_upstream_frr).
 #   4. Each gateway FRR
 #        * eBGP from vrf-provider against its specific upstream /30
 #          endpoint (replaces the placeholder neighbor pushed by the
@@ -556,21 +558,35 @@ configure_upstream_frr() {
     # ignored. The result was an upstream FRR with no BGP instance and
     # gateway sessions permanently stuck in "Active".
     #
-    # default-originate is what gives each gateway's vrf-provider a route to
-    # everything it does not host itself. The gateways all share
-    # BGP_ASN_GATEWAYS, so the upstream's re-advertisement of one gateway's
-    # prefixes to another is dropped by AS-path loop prevention, and
+    # The gateways all share BGP_ASN_GATEWAYS, so on its own the upstream's
+    # re-advertisement of one gateway's prefixes to another is dropped by
+    # AS-path loop prevention. Two things put a route for "elsewhere" into
+    # every gateway's vrf-provider:
+    #
+    #   * as-override on each neighbor rewrites the gateways' ASN to the
+    #     upstream's own in the AS_PATH it sends, so a sibling gateway's
+    #     FIP /32s are accepted. That is what a fabric carrying host /32s
+    #     does, and cross-chassis FIP-to-FIP on a shared provider network
+    #     depends on it: the agent's per-network leak route in vrf-provider
+    #     (<net> via 169.254.0.1, the return path for the network it hosts)
+    #     is more specific than a default, so without the sibling's /32 it
+    #     would catch traffic for a FIP hosted elsewhere and hand it to a
+    #     default VRF that has no route for it (issue #265).
+    #   * default-originate covers everything no gateway announces at all.
+    #     Without it, a chassis that owns cr-lr0-public but carries no
+    #     port_forwards has no route for a peer's VIP and drops the traffic
+    #     inside the VRF (issue #247). default-originate is unconditional
+    #     in FRR — the upstream advertises 0.0.0.0/0 whether or not it holds
+    #     one — and the gateways never pass it on: they export via
+    #     `redistribute connected` through ANNOUNCE-CONNECTED and filter
+    #     outbound with `prefix-list ANNOUNCED-NETWORKS out`, which permits
+    #     /32s only.
+    #
     # `redistribute connected` below only exports the upstream's own
-    # networks. Without a default, a chassis that owns cr-lr0-public but
-    # carries no port_forwards has no route for a peer's VIP and drops the
-    # traffic inside the VRF (issue #247). default-originate is
-    # unconditional in FRR — the upstream advertises 0.0.0.0/0 whether or
-    # not it holds one — and the gateways never pass it on: they export via
-    # `redistribute connected` through ANNOUNCE-CONNECTED and filter
-    # outbound with `prefix-list ANNOUNCED-NETWORKS out`, which permits
-    # /32s only.
+    # networks.
     local neighbors_remote_as=""
     local neighbors_activate=""
+    local neighbors_as_override=""
     local neighbors_default_originate=""
     for entry in "${UNDERLAY_LINKS[@]}"; do
         local _gw gw_cidr _upstream_iface _upstream_cidr
@@ -578,6 +594,7 @@ configure_upstream_frr() {
         local gw_ip="${gw_cidr%/*}"
         neighbors_remote_as+=" neighbor ${gw_ip} remote-as ${BGP_ASN_GATEWAYS}"$'\n'
         neighbors_activate+="  neighbor ${gw_ip} activate"$'\n'
+        neighbors_as_override+="  neighbor ${gw_ip} as-override"$'\n'
         neighbors_default_originate+="  neighbor ${gw_ip} default-originate"$'\n'
     done
     docker exec -i "${UPSTREAM_NODE}" vtysh <<EOF
@@ -588,7 +605,7 @@ router bgp ${BGP_ASN_UPSTREAM}
  no bgp ebgp-requires-policy
 ${neighbors_remote_as} address-family ipv4 unicast
   redistribute connected
-${neighbors_activate}${neighbors_default_originate} exit-address-family
+${neighbors_activate}${neighbors_as_override}${neighbors_default_originate} exit-address-family
 end
 write memory
 EOF

--- a/test/e2e/chaos/actions_test.go
+++ b/test/e2e/chaos/actions_test.go
@@ -351,6 +351,15 @@ func TestVLANLayerReportsANBFailure(t *testing.T) {
 	}
 }
 
+func TestCrossChassisLayerReportsANBFailure(t *testing.T) {
+	cmd := &fakeCommander{respond: func([]string) (string, error) { return "", errBoom }}
+	l := newTestLab(cmd, newFakeClock())
+
+	if err := applyCrossChassisLayer(context.Background(), l); err == nil {
+		t.Fatal("a failed ovn-nbctl call was swallowed")
+	}
+}
+
 // 192.0.2.11 is seeded by bootstrap.sh as a NAT row with nothing behind
 // it. Probing it would be red for the whole run and every recovery gate
 // would time out, so it must stay out of the probe set.
@@ -360,8 +369,8 @@ func TestProbeTargetsExcludeTheBackendlessFIP(t *testing.T) {
 			t.Fatalf("probe target %q has no responder behind it", target.name)
 		}
 	}
-	if len(defaultProbes) != 6 {
-		t.Fatalf("probe set = %v, want the four FIPs, the port-forward VIP and the same-node hairpin FIP", defaultProbes)
+	if len(defaultProbes) != 7 {
+		t.Fatalf("probe set = %v, want the four FIPs, the port-forward VIP, the same-node hairpin FIP and the cross-chassis FIP", defaultProbes)
 	}
 }
 

--- a/test/e2e/chaos/profiles.go
+++ b/test/e2e/chaos/profiles.go
@@ -93,16 +93,30 @@ var (
 		name: "hairpin-vip", kind: probeTCP, addr: hairpinVIPHostPort,
 		node: workloadHost, netns: "vm1",
 	}
+
+	// The cross-chassis vantage (#265): vm3 sits behind lr1, whose
+	// chassisredirect port is pinned to gateway-2, and pings the FIP behind
+	// lr0. The packet leaves OVN on gateway-2, crosses that kernel's veth
+	// path into vrf-provider, rides BGP to whichever chassis holds
+	// cr-lr0-public and enters that kernel on veth-default — the one
+	// ingress no other probe exercises, and the one the veth-leak source
+	// rule used to loop.
+	probeCrossFIP = probeTarget{
+		name: "cross-fip", kind: probePing, addr: "192.0.2.10",
+		node: workloadHost, netns: "vm3",
+	}
 )
 
 // defaultProbes is what a full-topology run measures: the four FIPs, the
-// OVN Load_Balancer VIP, and the same-node hairpin FIP.
+// OVN Load_Balancer VIP, the same-node hairpin FIP, and the cross-chassis
+// FIP.
 //
 // The baseline lab's second FIP, 192.0.2.11, is deliberately absent:
 // bootstrap.sh seeds its NAT row but nothing answers behind
 // 192.168.10.11, so probing it would be red for the whole run.
 var defaultProbes = []probeTarget{
 	probeVM1, probeVM2, probeVLAN101, probeVLAN102, probeLBVIP, probeHairpinFIP,
+	probeCrossFIP,
 }
 
 // gwConfig is a profile's agent-configuration overlay for one gateway,
@@ -153,9 +167,10 @@ type profile struct {
 	// The start-state layers. Everything the bootstrap baseline itself
 	// seeds (the HA router, FIP 192.0.2.10, the vm1 workload) is always
 	// there — a profile only decides what is layered on top.
-	hairpin bool // hairpin.sh's second FIP and its vm2 responder
-	vlans   bool // multi-vlan.sh's two VLAN provider networks
-	ovnLB   bool // pf-external.sh's OVN Load_Balancer VIP
+	hairpin      bool // hairpin.sh's second FIP and its vm2 responder
+	vlans        bool // multi-vlan.sh's two VLAN provider networks
+	ovnLB        bool // pf-external.sh's OVN Load_Balancer VIP
+	crossChassis bool // cross-chassis-fip.sh's second flat router on gateway-2 and its vm3 responder
 
 	// gateways carries the per-gateway agent-config overlay. A gateway
 	// absent from the map runs the baked lab config unchanged.
@@ -213,12 +228,13 @@ func everyGateway(c gwConfig) map[string]gwConfig {
 func profiles() []*profile {
 	return []*profile{
 		{
-			name:        defaultProfileName,
-			description: "every topology layer, every gateway on the baked lab config",
-			hairpin:     true,
-			vlans:       true,
-			ovnLB:       true,
-			probes:      defaultProbes,
+			name:         defaultProfileName,
+			description:  "every topology layer, every gateway on the baked lab config",
+			hairpin:      true,
+			vlans:        true,
+			ovnLB:        true,
+			crossChassis: true,
+			probes:       defaultProbes,
 		},
 		{
 			name:        "flat-minimal",
@@ -227,23 +243,26 @@ func profiles() []*profile {
 			probes:      []probeTarget{probeVM1},
 		},
 		{
-			name:        "flat-dnat",
-			description: "no VLAN; the agent's own DNAT on an API VIP, alongside the OVN Load_Balancer VIP",
-			hairpin:     true,
-			ovnLB:       true,
-			gateways:    everyGateway(gwConfig{apiVIP: true, hairpinVIP: true}),
+			name:         "flat-dnat",
+			description:  "no VLAN; the agent's own DNAT on an API VIP, alongside the OVN Load_Balancer VIP",
+			hairpin:      true,
+			ovnLB:        true,
+			crossChassis: true,
+			gateways:     everyGateway(gwConfig{apiVIP: true, hairpinVIP: true}),
 			probes: []probeTarget{
 				probeVM1, probeVM2, probeLBVIP, probeAPIVIP,
-				probeHairpinFIP, probeHairpinVIP,
+				probeHairpinFIP, probeHairpinVIP, probeCrossFIP,
 			},
 		},
 		{
-			name:        "vlan-no-dnat",
-			description: "VLAN provider networks, no DNAT of any kind",
-			hairpin:     true,
-			vlans:       true,
+			name:         "vlan-no-dnat",
+			description:  "VLAN provider networks, no DNAT of any kind",
+			hairpin:      true,
+			vlans:        true,
+			crossChassis: true,
 			probes: []probeTarget{
 				probeVM1, probeVM2, probeVLAN101, probeVLAN102, probeHairpinFIP,
+				probeCrossFIP,
 			},
 		},
 		{
@@ -274,11 +293,12 @@ func profiles() []*profile {
 			// Carried by both, the active chassis announces it from the
 			// start, and losing gateway-1 hands lr0 — and with it the
 			// announce — to gateway-2.
-			name:        "heterogeneous",
-			description: "each gateway on a different configuration, as mid-rollout",
-			hairpin:     true,
-			vlans:       true,
-			ovnLB:       true,
+			name:         "heterogeneous",
+			description:  "each gateway on a different configuration, as mid-rollout",
+			hairpin:      true,
+			vlans:        true,
+			ovnLB:        true,
+			crossChassis: true,
 			gateways: map[string]gwConfig{
 				"gateway-1": {apiVIP: true, hairpinVIP: true},
 				"gateway-2": {apiVIP: true, hairpinVIP: true, drainOnShutdown: true},

--- a/test/e2e/chaos/profiles_test.go
+++ b/test/e2e/chaos/profiles_test.go
@@ -245,6 +245,12 @@ func TestSameNodeProbesAreWiredToTheRightProfiles(t *testing.T) {
 		"vlan-no-dnat": true, "heterogeneous": true,
 	}
 	wantVIP := map[string]bool{"flat-dnat": true, "heterogeneous": true}
+	// The cross-chassis probe rides every profile that puts the hairpin
+	// layer up: both need OVN and a second router beside lr0 (#265).
+	wantCross := map[string]bool{
+		"everything-on": true, "flat-dnat": true,
+		"vlan-no-dnat": true, "heterogeneous": true,
+	}
 
 	for _, p := range profiles() {
 		if got := hasProbe(p.probes, probeHairpinFIP.name); got != wantFIP[p.name] {
@@ -252,6 +258,9 @@ func TestSameNodeProbesAreWiredToTheRightProfiles(t *testing.T) {
 		}
 		if got := hasProbe(p.probes, probeHairpinVIP.name); got != wantVIP[p.name] {
 			t.Errorf("%s probes hairpin-vip = %v, want %v", p.name, got, wantVIP[p.name])
+		}
+		if got := hasProbe(p.probes, probeCrossFIP.name); got != wantCross[p.name] {
+			t.Errorf("%s probes cross-fip = %v, want %v", p.name, got, wantCross[p.name])
 		}
 		// Both ride vm1's namespace on the workload host, and both need
 		// the hairpin layer's FIP_B or the VIP behind them.
@@ -265,10 +274,22 @@ func TestSameNodeProbesAreWiredToTheRightProfiles(t *testing.T) {
 				if !anyGatewayHasHairpinVIP(p) {
 					t.Errorf("%s probes the hairpin VIP but no gateway is configured with it", p.name)
 				}
+			case probeCrossFIP.name:
+				if !p.crossChassis {
+					t.Errorf("%s probes the cross-chassis FIP without the cross-chassis layer", p.name)
+				}
 			}
 			if target.name == probeHairpinFIP.name || target.name == probeHairpinVIP.name {
 				if target.node != workloadHost || target.netns != "vm1" {
 					t.Errorf("%s: %s probes from %q/%q, want the workload host's vm1",
+						p.name, target.name, target.node, target.netns)
+				}
+			}
+			// The cross-chassis probe must leave OVN on gateway-2, which
+			// only a workload behind lr1 does: vm3 on the workload host.
+			if target.name == probeCrossFIP.name {
+				if target.node != workloadHost || target.netns != "vm3" {
+					t.Errorf("%s: %s probes from %q/%q, want the workload host's vm3",
 						p.name, target.name, target.node, target.netns)
 				}
 			}
@@ -335,6 +356,10 @@ func TestProfileProbesOnlyWhatItsLayersPutUp(t *testing.T) {
 			case probeAPIVIP.name:
 				if len(p.apiVIPGateways()) == 0 {
 					t.Fatalf("%s probes the API VIP but no gateway is configured with it", p.name)
+				}
+			case probeCrossFIP.name:
+				if !p.crossChassis {
+					t.Fatalf("%s probes the cross-chassis FIP without the cross-chassis layer", p.name)
 				}
 			}
 		}

--- a/test/e2e/chaos/state.go
+++ b/test/e2e/chaos/state.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-// The start state layers the setups of three existing scenarios on top of
+// The start state layers the setups of four existing scenarios on top of
 // the bootstrap baseline, so one chaos run can exercise all of them at
 // once:
 //
@@ -19,6 +19,9 @@ import (
 //     with a router pinned to gateway-1 and a FIP behind a responder.
 //   - pf-external.sh  — a Load_Balancer VIP (192.0.2.50:80) in front of
 //     the vm1 backend, plus the two routes the agent does not manage.
+//   - cross-chassis-fip.sh — a second flat router lr1 on the shared
+//     provider switch, pinned to gateway-2, with FIP 192.0.2.20 behind a
+//     vm3 responder, so a probe can enter another chassis' veth pair.
 //
 // Which of them a run puts up is the profile's call (profiles.go): a
 // profile that configures its gateways without OVN has no use for a
@@ -100,6 +103,10 @@ func responders(p *profile) []netns {
 			})
 		}
 	}
+	if p.crossChassis {
+		// cross-chassis-fip.sh:ensure_responder
+		all = append(all, netns{"vm3", "ls1-vm3", "02:00:00:00:14:0a", "192.168.20.10/24", "192.168.20.1"})
+	}
 	return all
 }
 
@@ -116,6 +123,11 @@ func applyStartState(ctx context.Context, l *lab, p *profile) error {
 			if err := applyVLANLayer(ctx, l, n); err != nil {
 				return err
 			}
+		}
+	}
+	if p.crossChassis {
+		if err := applyCrossChassisLayer(ctx, l); err != nil {
+			return err
 		}
 	}
 	if err := ensureResponders(ctx, l, p); err != nil {
@@ -198,6 +210,47 @@ func applyVLANLayer(ctx context.Context, l *lab, n vlanNetwork) error {
 	for _, args := range steps {
 		if _, err := l.nbctl(ctx, args...); err != nil {
 			return fmt.Errorf("vlan %s layer: %w", n.tag, err)
+		}
+	}
+	return nil
+}
+
+// applyCrossChassisLayer mirrors ensure_router in cross-chassis-fip.sh: a
+// second flat router lr1 on the shared provider switch ls-public, its
+// chassisredirect port pinned to gateway-2 as the only candidate, a tenant
+// switch, a FIP and a backing LSP. The vm3 responder itself is created by
+// ensureResponders. No default route and no Static_MAC_Binding are seeded;
+// the agent on gateway-2 programs both, as it does for lr0.
+//
+// The single candidate is deliberate, like the VLAN routers' pin to
+// gateway-1: a fault on gateway-2 legitimately darkens cross-fip until the
+// node is back, and the action's recovery budget covers it.
+func applyCrossChassisLayer(ctx context.Context, l *lab) error {
+	steps := [][]string{
+		{"--may-exist", "ls-add", "ls1"},
+		{"--may-exist", "lr-add", "lr1"},
+
+		{"--may-exist", "lrp-add", "lr1", "lr1-ls1", "02:00:00:00:14:01", "192.168.20.1/24"},
+		{"--may-exist", "lsp-add", "ls1", "ls1-lr1"},
+		{"lsp-set-type", "ls1-lr1", "router"},
+		{"lsp-set-addresses", "ls1-lr1", "router"},
+		{"lsp-set-options", "ls1-lr1", "router-port=lr1-ls1"},
+
+		{"--may-exist", "lrp-add", "lr1", "lr1-public", "02:00:00:00:14:02", "192.0.2.2/24"},
+		{"--may-exist", "lsp-add", "ls-public", "ls-public-lr1"},
+		{"lsp-set-type", "ls-public-lr1", "router"},
+		{"lsp-set-addresses", "ls-public-lr1", "router"},
+		{"lsp-set-options", "ls-public-lr1", "router-port=lr1-public"},
+
+		{"lrp-set-gateway-chassis", "lr1-public", "gateway-2", "30"},
+
+		{"--may-exist", "lr-nat-add", "lr1", "dnat_and_snat", "192.0.2.20", "192.168.20.10"},
+		{"--may-exist", "lsp-add", "ls1", "ls1-vm3"},
+		{"lsp-set-addresses", "ls1-vm3", "02:00:00:00:14:0a 192.168.20.10"},
+	}
+	for _, args := range steps {
+		if _, err := l.nbctl(ctx, args...); err != nil {
+			return fmt.Errorf("cross-chassis layer: %w", err)
 		}
 	}
 	return nil

--- a/test/e2e/chaos/state_test.go
+++ b/test/e2e/chaos/state_test.go
@@ -30,10 +30,15 @@ func TestApplyStartStateLayersEveryScenarioSetup(t *testing.T) {
 		"lr-lb-add lr0 pf-external",
 		"ip route replace 192.0.2.50/32 via 100.64.1.2",
 		"ip route replace 192.0.2.50/32 dev br-ex scope link",
+		// cross-chassis-fip.sh: the second router pinned to gateway-2 and
+		// its FIP.
+		"lrp-set-gateway-chassis lr1-public gateway-2 30",
+		"lr-nat-add lr1 dnat_and_snat 192.0.2.20 192.168.20.10",
 		// Every responder behind a probed FIP.
 		"external_ids:iface-id=ls0-vm2",
 		"external_ids:iface-id=vm101",
 		"external_ids:iface-id=vm102",
+		"external_ids:iface-id=ls1-vm3",
 	} {
 		if !cmd.called(want) {
 			t.Fatalf("the start state did not issue %q", want)
@@ -201,7 +206,7 @@ func TestEveryProbedFIPHasARestoredResponder(t *testing.T) {
 	for _, n := range responders(defaultTestProfile(t)) {
 		lsps[n.lsp] = true
 	}
-	for _, want := range []string{"ls0-vm1", "ls0-vm2", "vm101", "vm102"} {
+	for _, want := range []string{"ls0-vm1", "ls0-vm2", "vm101", "vm102", "ls1-vm3"} {
 		if !lsps[want] {
 			t.Fatalf("responder for %s is not rebuilt after its host is recycled", want)
 		}
@@ -256,7 +261,9 @@ func TestApplyStartStateOnlyLayersTheProfilesOwnScenarios(t *testing.T) {
 		"ln-vlan101", // multi-vlan.sh
 		"lr-nat-add lr0 dnat_and_snat 192.0.2.12", // hairpin.sh
 		"lb-add pf-external",                      // pf-external.sh
+		"lr-nat-add lr1",                          // cross-chassis-fip.sh
 		"external_ids:iface-id=ls0-vm2",
+		"external_ids:iface-id=ls1-vm3",
 		"/usr/local/bin/pf-backend",
 	} {
 		if cmd.called(unwanted) {

--- a/test/e2e/scenarios/cross-chassis-fip.sh
+++ b/test/e2e/scenarios/cross-chassis-fip.sh
@@ -1,0 +1,438 @@
+#!/usr/bin/env bash
+# Cross-chassis FIP-to-FIP scenario for the containerlab E2E harness.
+#
+# Goal (issue #265): with FIP routes in the main table (the lab's default —
+# gwnode-config.yaml sets no route_table_id), traffic between two FIPs whose
+# routers hold their chassisredirect ports on DIFFERENT gateways must be
+# delivered. Before #265 the destination gateway's veth-leak source rule
+# (`from 192.0.2.0/24 lookup 200`) caught the packet arriving on veth-default
+# before the main table was consulted and sent it straight back into
+# vrf-provider, where the FRR static for the /32 pointed at veth-default
+# again: the packet bounced between the veth ends until its TTL expired. The
+# agent's fix is one ingress exception rule, `iif veth-default lookup main`,
+# one priority below the leak rules.
+#
+# Why a separate scenario: every other probe originates outside the provider
+# prefix (client-1) or stays on one chassis (the hairpin scenarios, reflected
+# inside OVS). Neither path ever enters a second gateway's veth pair, so the
+# loop was invisible to CI.
+#
+# Topology used:
+#   * lr0 with FIP_A = 192.0.2.10 → 192.168.10.10 (vm1 on gateway-3) — seeded
+#     by bootstrap.sh, cr-lr0-public on MASTER (gateway-1 in the baseline lab)
+#   * lr1 — added here — on the same provider switch ls-public, with
+#     lr1-public 192.0.2.2/24 pinned to PEER (gateway-2) as its only
+#     candidate, tenant switch ls1 (192.168.20.0/24), and
+#     FIP_C = 192.0.2.20 → 192.168.20.10 (vm3, also on gateway-3)
+#   No default route and no Static_MAC_Binding are seeded for lr1: the agent
+#   on PEER programs both (EnsureGatewayRouting in ovn_gateway.go), exactly
+#   as it does for lr0.
+#
+# Packet path on a green run (vm3 → FIP_A):
+#   vm3 (gateway-3) → geneve → cr-lr1-public on PEER → SNAT to FIP_C →
+#   ls-public localnet → br-ex on PEER → kernel: leak rule → table 200 →
+#   veth-default → vrf-provider → BGP → upstream → MASTER's vrf-provider →
+#   FRR static FIP_A/32 via the veth pair → veth-default on MASTER →
+#   `iif veth-default lookup main` → FIP_A/32 dev br-ex → OVN → DNAT → vm1.
+#   The reply takes the mirror image through both kernels.
+#
+# Assertions:
+#   1. cr-lr1-public is bound to PEER and cr-lr0-public to a different
+#      chassis — otherwise the run would measure the hairpin path.
+#   2. PEER has FIP_C/32 in its kernel table and both gateways carry the
+#      ingress exception rule at INGRESS_RULE_PRIORITY.
+#   3. ping FIP_A from vm3 and FIP_C from vm1: zero loss.
+#   4. PEER's veth-default packet counters grew by at least PING_COUNT across
+#      the probes, which pins that the traffic crossed the kernel path and
+#      did not stay inside OVN.
+#
+# Pre-condition: the lab is up and baseline-green (`make e2e-up`). When
+# SANITY_GATE=1 (default) this scenario runs baseline.sh first.
+#
+# Teardown (EXIT trap, best effort): the NAT, the workload LSP, the router
+# ports and their switch ports, lr1, ls1, the MAC binding the agent
+# programmed for lr1, and the vm3 netns/veth on WORKLOAD_HOST, so a
+# subsequent `make e2e-baseline` passes on the same lab. On a failure the
+# gateways' rule, veth-counter and route state is dumped first.
+#
+# Environment overrides (used by the CI workflow):
+#   LAB                    container-name prefix (default ovn-e2e)
+#   MASTER                 chassis owning cr-lr0-public (default gateway-1)
+#   PEER                   chassis lr1-public is pinned to (default gateway-2)
+#   WORKLOAD_HOST          chassis hosting vm1 and vm3 (default gateway-3)
+#   CENTRAL                OVN central container (default clab-${LAB}-central)
+#   FIP_A                  bootstrap FIP behind lr0 (default 192.0.2.10)
+#   FIP_C                  FIP added here behind lr1 (default 192.0.2.20)
+#   FIP_C_INTERNAL         backing IP for FIP_C (default 192.168.20.10)
+#   INGRESS_RULE_PRIORITY  expected priority of the ingress rule (default 1999,
+#                          the baked veth_leak_rule_priority minus one)
+#   PING_COUNT             packets per direction (default 5)
+#   PING_TIMEOUT           per-packet wait, passed to ping -W (default 2)
+#   RECONCILE_TIMEOUT      seconds to wait for OVN/agent convergence (default 60)
+#   ARTIFACTS_DIR          directory for the failure dumps (default empty = skip)
+#   SANITY_GATE            run baseline.sh first when 1 (default 1)
+
+set -euo pipefail
+
+LAB="${LAB:-ovn-e2e}"
+MASTER="${MASTER:-gateway-1}"
+PEER="${PEER:-gateway-2}"
+WORKLOAD_HOST="${WORKLOAD_HOST:-gateway-3}"
+CENTRAL="${CENTRAL:-clab-${LAB}-central}"
+MASTER_NODE="clab-${LAB}-${MASTER}"
+PEER_NODE="clab-${LAB}-${PEER}"
+WORKLOAD_NODE="clab-${LAB}-${WORKLOAD_HOST}"
+
+LR0_CR_PORT="${LR0_CR_PORT:-cr-lr0-public}"
+FIP_A="${FIP_A:-192.0.2.10}"
+FIP_A_NETNS="${FIP_A_NETNS:-vm1}"
+
+LS1="${LS1:-ls1}"
+LR1="${LR1:-lr1}"
+LRP_TENANT="${LRP_TENANT:-lr1-ls1}"
+LRP_TENANT_MAC="${LRP_TENANT_MAC:-02:00:00:00:14:01}"
+LRP_TENANT_CIDR="${LRP_TENANT_CIDR:-192.168.20.1/24}"
+LRP_PUBLIC="${LRP_PUBLIC:-lr1-public}"
+LRP_PUBLIC_MAC="${LRP_PUBLIC_MAC:-02:00:00:00:14:02}"
+LRP_PUBLIC_CIDR="${LRP_PUBLIC_CIDR:-192.0.2.2/24}"
+LS_PUBLIC="${LS_PUBLIC:-ls-public}"
+# The virtual gateway the agent programs on lr1-public (last usable IP of
+# the provider /24, the same one bootstrap.sh seeds for lr0). Only the
+# teardown needs it, to drop the Static_MAC_Binding the agent created.
+VGW_IP="${VGW_IP:-192.0.2.254}"
+FIP_C="${FIP_C:-192.0.2.20}"
+FIP_C_INTERNAL="${FIP_C_INTERNAL:-192.168.20.10}"
+FIP_C_LSP="${FIP_C_LSP:-ls1-vm3}"
+FIP_C_MAC="${FIP_C_MAC:-02:00:00:00:14:0a}"
+FIP_C_NETNS="${FIP_C_NETNS:-vm3}"
+FIP_C_HOST_VETH="${FIP_C_HOST_VETH:-vm3-host}"
+FIP_C_NS_VETH="${FIP_C_NS_VETH:-vm3-eth0}"
+WORKLOAD_GW="${WORKLOAD_GW:-192.168.20.1}"
+WORKLOAD_CIDR_LEN="${WORKLOAD_CIDR_LEN:-24}"
+INGRESS_RULE_PRIORITY="${INGRESS_RULE_PRIORITY:-1999}"
+
+PING_COUNT="${PING_COUNT:-5}"
+PING_TIMEOUT="${PING_TIMEOUT:-2}"
+RECONCILE_TIMEOUT="${RECONCILE_TIMEOUT:-60}"
+ARTIFACTS_DIR="${ARTIFACTS_DIR:-}"
+SANITY_GATE="${SANITY_GATE:-1}"
+
+SCENARIOS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASELINE="${BASELINE:-${SCENARIOS_DIR}/baseline.sh}"
+
+log() { printf '[cross-chassis-fip] %s\n' "$*" >&2; }
+nbctl() { docker exec "${CENTRAL}" ovn-nbctl "$@"; }
+sbctl() { docker exec "${CENTRAL}" ovn-sbctl "$@"; }
+
+# Write stdin to `path` under ARTIFACTS_DIR when it is set; quietly no-op
+# otherwise. Same shape as the other scenarios.
+write_artifact() {
+    local path="$1"
+    if [ -z "${ARTIFACTS_DIR}" ]; then
+        cat >/dev/null
+        return 0
+    fi
+    mkdir -p "${ARTIFACTS_DIR}"
+    cat >"${ARTIFACTS_DIR}/${path}"
+}
+
+# Parse `N packets transmitted, M received` out of a ping summary block and
+# print the integer loss (transmitted - received). Returns non-zero when the
+# line is missing or the two fields are not integers, which the caller
+# reports as a probe failure. Own copy, like drain-hitless.sh keeps one: the
+# numeric guard matters because BusyBox prints `M packets received,` where
+# iputils prints `M received,`, and a naive field pick would coerce the word
+# to 0 and report a fabricated full loss.
+parse_ping_loss() {
+    local file="$1"
+    awk '
+        /packets transmitted/ {
+            tx = $1
+            for (i = 1; i <= NF; i++) {
+                if ($i == "received,") {
+                    rx = $(i-1)
+                    break
+                }
+            }
+            if (tx !~ /^[0-9]+$/ || rx !~ /^[0-9]+$/) exit 1
+            print tx - rx
+            found = 1
+            exit 0
+        }
+        END { if (!found) exit 1 }
+    ' "${file}"
+}
+
+sanity_gate() {
+    if [ "${SANITY_GATE}" != "1" ]; then
+        log "SANITY_GATE=${SANITY_GATE}: skipping baseline pre-check"
+        return 0
+    fi
+    if [ ! -x "${BASELINE}" ]; then
+        log "baseline script not executable at ${BASELINE} — skipping pre-check"
+        return 0
+    fi
+    log "running baseline.sh as a sanity gate (set SANITY_GATE=0 to skip)"
+    "${BASELINE}"
+}
+
+# Seed the second router on the shared provider switch. Every add is
+# --may-exist and every set replaces its value, so re-running is a no-op.
+ensure_router() {
+    log "ensuring ${LR1} on ${LS_PUBLIC} (${LRP_PUBLIC_CIDR}) with tenant switch ${LS1} (${LRP_TENANT_CIDR})"
+    nbctl --may-exist ls-add "${LS1}"
+    nbctl --may-exist lr-add "${LR1}"
+
+    nbctl --may-exist lrp-add "${LR1}" "${LRP_TENANT}" "${LRP_TENANT_MAC}" "${LRP_TENANT_CIDR}"
+    nbctl --may-exist lsp-add "${LS1}" "${LS1}-${LR1}"
+    nbctl lsp-set-type      "${LS1}-${LR1}" router
+    nbctl lsp-set-addresses "${LS1}-${LR1}" router
+    nbctl lsp-set-options   "${LS1}-${LR1}" router-port="${LRP_TENANT}"
+
+    nbctl --may-exist lrp-add "${LR1}" "${LRP_PUBLIC}" "${LRP_PUBLIC_MAC}" "${LRP_PUBLIC_CIDR}"
+    nbctl --may-exist lsp-add "${LS_PUBLIC}" "${LS_PUBLIC}-${LR1}"
+    nbctl lsp-set-type      "${LS_PUBLIC}-${LR1}" router
+    nbctl lsp-set-addresses "${LS_PUBLIC}-${LR1}" router
+    nbctl lsp-set-options   "${LS_PUBLIC}-${LR1}" router-port="${LRP_PUBLIC}"
+
+    log "pinning ${LRP_PUBLIC} to ${PEER} as its only candidate"
+    nbctl lrp-set-gateway-chassis "${LRP_PUBLIC}" "${PEER}" 30
+
+    log "ensuring FIP ${FIP_C} → ${FIP_C_INTERNAL} on ${LR1}"
+    nbctl --may-exist lr-nat-add "${LR1}" dnat_and_snat "${FIP_C}" "${FIP_C_INTERNAL}"
+
+    log "ensuring workload LSP ${FIP_C_LSP} on ${LS1}"
+    nbctl --may-exist lsp-add "${LS1}" "${FIP_C_LSP}"
+    nbctl lsp-set-addresses "${FIP_C_LSP}" "${FIP_C_MAC} ${FIP_C_INTERNAL}"
+}
+
+# Provision the FIP_C responder on WORKLOAD_HOST: a veth pair with one end
+# attached to br-int (carrying iface-id=ls1-vm3 so ovn-controller binds the
+# LSP to this chassis), the other end in a netns with the workload IP and a
+# default route to lr1. Mirrors ensure_responder in multi-vlan.sh.
+ensure_responder() {
+    log "provisioning ${FIP_C_NETNS} responder on ${WORKLOAD_HOST} (${FIP_C_INTERNAL}/${WORKLOAD_CIDR_LEN})"
+    docker exec -i \
+        --env "FIP_C_NETNS=${FIP_C_NETNS}" \
+        --env "FIP_C_LSP=${FIP_C_LSP}" \
+        --env "FIP_C_MAC=${FIP_C_MAC}" \
+        --env "FIP_C_INTERNAL=${FIP_C_INTERNAL}" \
+        --env "WORKLOAD_GW=${WORKLOAD_GW}" \
+        --env "WORKLOAD_CIDR_LEN=${WORKLOAD_CIDR_LEN}" \
+        --env "FIP_C_HOST_VETH=${FIP_C_HOST_VETH}" \
+        --env "FIP_C_NS_VETH=${FIP_C_NS_VETH}" \
+        "${WORKLOAD_NODE}" sh -eu <<'EOSH'
+if ! ip link show "${FIP_C_HOST_VETH}" >/dev/null 2>&1; then
+    ip link add "${FIP_C_HOST_VETH}" type veth peer name "${FIP_C_NS_VETH}"
+fi
+ovs-vsctl --may-exist add-port br-int "${FIP_C_HOST_VETH}" \
+    -- set Interface "${FIP_C_HOST_VETH}" external_ids:iface-id="${FIP_C_LSP}"
+ip link set "${FIP_C_HOST_VETH}" up
+
+# Enter the namespace rather than asking `ip netns list` whether it exists:
+# a container restart leaves a dead anchor under /run/netns that keeps it
+# listed while every use of it fails. See ensure_workload_netns in
+# bootstrap.sh for the full rationale.
+if ! ip netns exec "${FIP_C_NETNS}" true 2>/dev/null; then
+    ip netns delete "${FIP_C_NETNS}" 2>/dev/null || true
+    ip netns add "${FIP_C_NETNS}"
+fi
+if ! ip -n "${FIP_C_NETNS}" link show "${FIP_C_NS_VETH}" >/dev/null 2>&1; then
+    ip link set "${FIP_C_NS_VETH}" netns "${FIP_C_NETNS}"
+fi
+ip -n "${FIP_C_NETNS}" link set lo up
+ip -n "${FIP_C_NETNS}" link set "${FIP_C_NS_VETH}" address "${FIP_C_MAC}"
+ip -n "${FIP_C_NETNS}" link set "${FIP_C_NS_VETH}" up
+ip -n "${FIP_C_NETNS}" addr replace \
+    "${FIP_C_INTERNAL}/${WORKLOAD_CIDR_LEN}" dev "${FIP_C_NS_VETH}"
+ip -n "${FIP_C_NETNS}" route replace default via "${WORKLOAD_GW}"
+EOSH
+}
+
+# Poll a check up to RECONCILE_TIMEOUT. The check's output is discarded; the
+# description carries the failure message.
+wait_for() {
+    local desc="$1"; shift
+    local deadline
+    deadline=$(( $(date +%s) + RECONCILE_TIMEOUT ))
+    log "waiting up to ${RECONCILE_TIMEOUT}s for ${desc}"
+    while (( $(date +%s) < deadline )); do
+        if "$@" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 2
+    done
+    log "ERROR: ${desc} did not materialise within ${RECONCILE_TIMEOUT}s"
+    return 1
+}
+
+chassis_uuid() {
+    sbctl --bare --columns=_uuid find Chassis "name=$1" | tr -d '[:space:]'
+}
+
+cr_port_chassis() {
+    sbctl --bare --columns=chassis find Port_Binding "logical_port=$1" | tr -d '[:space:]'
+}
+
+# check_cr_port_on <cr-port> <chassis-name>
+check_cr_port_on() {
+    local want got
+    want="$(chassis_uuid "$2")"
+    got="$(cr_port_chassis "$1")"
+    [ -n "${want}" ] && [ "${got}" = "${want}" ]
+}
+
+# The scenario measures the cross-chassis path only while the two routers'
+# chassisredirect ports live on different gateways. A shared chassis would
+# turn every probe into the same-chassis hairpin path, which the hairpin
+# scenarios already cover — fail loudly rather than pass for the wrong reason.
+assert_distinct_chassis() {
+    local lr0 lr1 name
+    lr0="$(cr_port_chassis "${LR0_CR_PORT}")"
+    lr1="$(cr_port_chassis "cr-${LRP_PUBLIC}")"
+    if [ -z "${lr0}" ] || [ -z "${lr1}" ]; then
+        log "ERROR: ${LR0_CR_PORT} (${lr0:-unbound}) or cr-${LRP_PUBLIC} (${lr1:-unbound}) is unbound"
+        return 1
+    fi
+    if [ "${lr0}" = "${lr1}" ]; then
+        name="$(sbctl --bare --columns=name list Chassis "${lr0}" | tr -d '[:space:]')"
+        log "ERROR: ${LR0_CR_PORT} and cr-${LRP_PUBLIC} are both bound to ${name:-${lr0}}: this run would measure the same-chassis hairpin path, not the cross-chassis one"
+        return 1
+    fi
+    log "${LR0_CR_PORT} and cr-${LRP_PUBLIC} are on different chassis"
+}
+
+# check_kernel_route <node> <ip>
+check_kernel_route() {
+    docker exec "$1" ip -4 route show "$2/32" | grep -q "$2"
+}
+
+# check_ingress_rule <node>: the agent's exception rule, as `ip rule show`
+# prints it — "1999:	from all iif veth-default lookup main".
+check_ingress_rule() {
+    docker exec "$1" ip rule show \
+        | grep -E "^${INGRESS_RULE_PRIORITY}:.*iif veth-default.*lookup main"
+}
+
+# check_reply <node> <netns> <target>: one echo reply, used to absorb the
+# agents' convergence (FRR static, BGP propagation) before the strict probe.
+check_reply() {
+    docker exec "$1" ip netns exec "$2" ping -c 1 -W 1 "$3"
+}
+
+# veth_packets <node>: rx + tx packets of veth-default, from the two counter
+# lines `ip -s link show` prints under its RX:/TX: headers.
+veth_packets() {
+    docker exec "$1" ip -s link show veth-default \
+        | awk '/RX:/ { getline; rx = $2 } /TX:/ { getline; tx = $2 } END { print rx + tx }'
+}
+
+# probe <node> <netns> <target> <label>: PING_COUNT packets, zero loss.
+probe() {
+    local node="$1" netns="$2" target="$3" label="$4"
+    local out loss
+    log "${label}: ping -c ${PING_COUNT} -W ${PING_TIMEOUT} ${target} from ${node} netns ${netns}"
+    out="$(mktemp)"
+    docker exec "${node}" ip netns exec "${netns}" \
+        ping -c "${PING_COUNT}" -W "${PING_TIMEOUT}" "${target}" 2>&1 | tee "${out}" >&2 || true
+    if ! loss="$(parse_ping_loss "${out}")"; then
+        rm -f "${out}"
+        log "ERROR: ${label}: could not parse the ping summary"
+        return 1
+    fi
+    rm -f "${out}"
+    if [ "${loss}" -ne 0 ]; then
+        log "ERROR: ${label}: ${loss} of ${PING_COUNT} packets lost"
+        return 1
+    fi
+    log "${label}: ${PING_COUNT}/${PING_COUNT} replies"
+}
+
+# The state a loop or a missing rule shows up in, from both gateways.
+dump_state() {
+    local chassis node
+    for chassis in "${MASTER}" "${PEER}"; do
+        node="clab-${LAB}-${chassis}"
+        {
+            printf '# %s: ip rule show\n\n' "${chassis}"
+            docker exec "${node}" ip rule show 2>&1 || true
+            printf '\n# %s: ip -s link show veth-default\n\n' "${chassis}"
+            docker exec "${node}" ip -s link show veth-default 2>&1 || true
+            printf '\n# %s: ip route show table 200\n\n' "${chassis}"
+            docker exec "${node}" ip route show table 200 2>&1 || true
+            printf '\n# %s: ip route show\n\n' "${chassis}"
+            docker exec "${node}" ip route show 2>&1 || true
+        } | write_artifact "cross-chassis-fip-${chassis}.txt"
+    done
+}
+
+teardown() {
+    log "teardown: removing ${FIP_C_NETNS} responder, FIP ${FIP_C}, ${LR1} and ${LS1}"
+    docker exec -i \
+        --env "FIP_C_NETNS=${FIP_C_NETNS}" \
+        --env "FIP_C_HOST_VETH=${FIP_C_HOST_VETH}" \
+        "${WORKLOAD_NODE}" sh -u <<'EOSH' || true
+ovs-vsctl --if-exists del-port br-int "${FIP_C_HOST_VETH}" || true
+if ip link show "${FIP_C_HOST_VETH}" >/dev/null 2>&1; then
+    ip link delete "${FIP_C_HOST_VETH}" || true
+fi
+if ip netns list | awk '{print $1}' | grep -qx "${FIP_C_NETNS}"; then
+    ip netns delete "${FIP_C_NETNS}" || true
+fi
+EOSH
+    nbctl --if-exists lr-nat-del "${LR1}" dnat_and_snat "${FIP_C}" || true
+    nbctl --if-exists lsp-del "${FIP_C_LSP}" || true
+    nbctl --if-exists lsp-del "${LS_PUBLIC}-${LR1}" || true
+    nbctl --if-exists lsp-del "${LS1}-${LR1}" || true
+    nbctl --if-exists lrp-del "${LRP_PUBLIC}" || true
+    nbctl --if-exists lrp-del "${LRP_TENANT}" || true
+    nbctl --if-exists lr-del "${LR1}" || true
+    nbctl --if-exists ls-del "${LS1}" || true
+    # The agent on PEER programmed this binding for lr1's virtual gateway;
+    # lr-del does not cascade to Static_MAC_Binding.
+    nbctl static-mac-binding-del "${LRP_PUBLIC}" "${VGW_IP}" >/dev/null 2>&1 || true
+}
+
+on_exit() {
+    local rc=$?
+    if [ "${rc}" -ne 0 ]; then
+        log "scenario failed (exit ${rc}); dumping gateway state before teardown"
+        dump_state
+    fi
+    teardown
+    exit "${rc}"
+}
+
+main() {
+    sanity_gate
+
+    trap on_exit EXIT
+    ensure_router
+    ensure_responder
+
+    wait_for "cr-${LRP_PUBLIC} bound to ${PEER}" \
+        check_cr_port_on "cr-${LRP_PUBLIC}" "${PEER}"
+    assert_distinct_chassis
+    wait_for "kernel route ${FIP_C}/32 on ${PEER}" \
+        check_kernel_route "${PEER_NODE}" "${FIP_C}"
+    wait_for "ingress rule at priority ${INGRESS_RULE_PRIORITY} on ${MASTER}" \
+        check_ingress_rule "${MASTER_NODE}"
+    wait_for "ingress rule at priority ${INGRESS_RULE_PRIORITY} on ${PEER}" \
+        check_ingress_rule "${PEER_NODE}"
+    wait_for "a first reply from ${FIP_A} inside ${FIP_C_NETNS}" \
+        check_reply "${WORKLOAD_NODE}" "${FIP_C_NETNS}" "${FIP_A}"
+
+    local before after delta
+    before="$(veth_packets "${PEER_NODE}")"
+    probe "${WORKLOAD_NODE}" "${FIP_C_NETNS}" "${FIP_A}" "${FIP_C_NETNS} → FIP_A"
+    probe "${WORKLOAD_NODE}" "${FIP_A_NETNS}" "${FIP_C}" "${FIP_A_NETNS} → FIP_C"
+    after="$(veth_packets "${PEER_NODE}")"
+    delta=$(( after - before ))
+    if [ "${delta}" -lt "${PING_COUNT}" ]; then
+        log "ERROR: ${PEER}'s veth-default packet counters grew by ${delta} across ${PING_COUNT}-packet probes (want at least ${PING_COUNT}): the traffic did not cross the kernel path"
+        return 1
+    fi
+    log "${PEER}'s veth-default packet counters grew by ${delta} across the probes: the traffic crossed the kernel path on both gateways"
+}
+
+main "$@"

--- a/test/integration/scenario_route_tables_test.go
+++ b/test/integration/scenario_route_tables_test.go
@@ -105,6 +105,9 @@ func TestScenario_FailureInjection_RouteTableCollisions(t *testing.T) {
 	testenv.AssertRouteInTable(t, vethLeakTblStr, "default", testenv.VethDefaultName, 20*time.Second)
 	testenv.AssertIPRuleAtPriorityTable(t, testenv.DefaultVethLeakRulePriority,
 		providerNet, vethLeakTbl, 20*time.Second)
+	// The veth-default ingress exception (#265) is installed regardless of
+	// the table layout and always points at main — never at 200, 201 or 202.
+	testenv.AssertVethIngressRule(t, testenv.VethIngressRulePriority, 10*time.Second)
 
 	// === Negative: no writer encroached on a sibling's table ===========
 

--- a/test/integration/scenario_vethleak_test.go
+++ b/test/integration/scenario_vethleak_test.go
@@ -52,6 +52,9 @@ func TestScenario_VethLeakSetup(t *testing.T) {
 
 	testenv.AssertVethPairPresent(t, 5*time.Second)
 	testenv.AssertVethDefaultRouteInLeakTable(t, 5*time.Second)
+	// The ingress exception (#265) is part of the pair's setup, not of any
+	// network: it must be there before a per-network rule ever is.
+	testenv.AssertVethIngressRule(t, testenv.VethIngressRulePriority, 5*time.Second)
 }
 
 // TestScenario_VethLeakReconcileNetwork (#56 scenario 2):
@@ -207,10 +210,96 @@ func TestScenario_VethLeakTeardownOnSigterm(t *testing.T) {
 		t.Fatalf("agent stop: %v", err)
 	}
 
-	// Veth pair gone, per-network route gone, per-network rule gone.
+	// Veth pair gone, per-network route gone, per-network rule gone, and
+	// the ingress exception rule gone with them.
 	testenv.AssertNoVethPair(t, 5*time.Second)
 	testenv.AssertNoVethRouteInVRF(t, network, 5*time.Second)
 	testenv.AssertNoIPRuleAtPriority(t, testenv.DefaultVethLeakRulePriority, network, 5*time.Second)
+	testenv.AssertNoVethIngressRule(t, 5*time.Second)
+}
+
+// TestScenario_VethLeakIngressRuleDriftRecovery (#265):
+//
+// With a FIP whose /32 lives in the main table (route_table_id unset), the
+// ingress exception rule `iif veth-default lookup main` must be back within
+// a couple of ticks after an out-of-band `ip rule del`, and the repair must
+// not touch the healthy kernel route. The repair path is the
+// ensureVethIngressRule call at the top of ReconcileVethLeakNetworks.
+func TestScenario_VethLeakIngressRuleDriftRecovery(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	const fip = "198.51.100.43"
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "vethingress",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+	testenv.AddFIP(t, ctx, nb, router, fip, "10.0.0.43")
+
+	testenv.WithAgent(t, testenv.FastDefaults())
+
+	testenv.AssertKernelRoute(t, fip, 10*time.Second)
+	testenv.AssertVethIngressRule(t, testenv.VethIngressRulePriority, 10*time.Second)
+
+	// Drift: remove only the rule. Verify the deletion took effect so the
+	// recovery assertion cannot pass trivially.
+	testenv.DeleteVethIngressRule(t, testenv.VethIngressRulePriority)
+	testenv.AssertNoVethIngressRule(t, 1*time.Second)
+
+	// Re-appears within reconcile_interval (2s) + processing slack, and the
+	// route it protects was never replaced.
+	testenv.AssertVethIngressRule(t, testenv.VethIngressRulePriority, 8*time.Second)
+	testenv.AssertKernelRoute(t, fip, 1*time.Second)
+}
+
+// TestScenario_VethLeakIngressNoLoop (#265):
+//
+// The forwarding proof on one host. A packet sourced inside the leaked
+// provider prefix is sent from vrf-provider towards a FIP hosted here; it
+// leaves via veth-provider and enters the default VRF on veth-default, which
+// is exactly what a peer gateway's VRF hands over for cross-chassis
+// FIP-to-FIP traffic. Without the ingress exception the source rule sends it
+// straight back into the VRF and each packet crosses veth-default about 32
+// times before its TTL runs out; with it the packet leaves towards br-ex once
+// and never returns to the veth pair. The veth-default TX counter tells the
+// two apart.
+func TestScenario_VethLeakIngressNoLoop(t *testing.T) {
+	ctx, cancel, nb, sb := startScenario(t)
+	defer cancel()
+
+	const (
+		network = "198.51.100.0/24"
+		fip     = "198.51.100.43"
+		src     = "198.51.100.99"
+		probes  = 3
+	)
+	router := testenv.MakeLocalRouter(t, ctx, nb, sb, testenv.LocalRouterOpts{
+		Name:        "vethnoloop",
+		LRPNetworks: []string{"198.51.100.11/24"},
+	})
+	testenv.AddFIP(t, ctx, nb, router, fip, "10.0.0.43")
+
+	testenv.WithAgent(t, testenv.FastDefaults())
+
+	// Every leg of the path the probe takes must be in place first: the /32
+	// in main, the source rule that would capture the packet, and the FRR
+	// static that steers it out of the VRF through the veth pair.
+	testenv.AssertKernelRoute(t, fip, 10*time.Second)
+	testenv.AssertIPRuleAtPriority(t, testenv.DefaultVethLeakRulePriority, network, 10*time.Second)
+	testenv.AssertFRRRoute(t, fip, 15*time.Second)
+	testenv.AssertVethIngressRule(t, testenv.VethIngressRulePriority, 5*time.Second)
+
+	before := testenv.VethLinkTxPackets(t, testenv.VethDefaultName)
+	testenv.PingFromVRF(t, src, fip, probes)
+	after := testenv.VethLinkTxPackets(t, testenv.VethDefaultName)
+
+	// A looping probe packet would add ~32 transmissions on veth-default;
+	// three of them well over 90. Allow a few packets of unrelated chatter.
+	const maxDelta = 3 * probes
+	if delta := after - before; delta > maxDelta {
+		t.Fatalf("veth-default TX grew by %d packets for %d probes (max %d): provider-sourced ingress is looping through the veth pair",
+			delta, probes, maxDelta)
+	}
 }
 
 // TestScenario_VethLeakDisabledSkip (#56 scenario 6 — negative):
@@ -241,6 +330,8 @@ func TestScenario_VethLeakDisabledSkip(t *testing.T) {
 
 	// The agent reached "agent running" without setting up the pair —
 	// hold for a fraction of a reconcile interval to make sure the
-	// negative still holds across the next tick.
+	// negative still holds across the next tick. The ingress exception
+	// rule belongs to the pair and must be absent with it.
 	testenv.AssertNoVethPair(t, 1*time.Second)
+	testenv.AssertNoVethIngressRule(t, 1*time.Second)
 }

--- a/test/integration/testenv/vethleak.go
+++ b/test/integration/testenv/vethleak.go
@@ -44,6 +44,12 @@ const (
 	// ReconcileVethLeakNetworks live at this priority.
 	DefaultVethLeakRulePriority = 2000
 
+	// VethIngressRulePriority is where the agent installs the veth-default
+	// ingress exception rule (`iif veth-default lookup main`, #265): one
+	// below the per-network leak rules, mirroring vethIngressRulePriority
+	// in routing.go.
+	VethIngressRulePriority = DefaultVethLeakRulePriority - 1
+
 	// VethLeakRouteProtocol mirrors rtProtoOVNNetworkAgent in routing_linux.go
 	// — the custom rtproto the agent tags its per-network VRF routes with so
 	// they can be distinguished from FRR-installed entries.
@@ -79,14 +85,17 @@ type routeInfo struct {
 }
 
 // ruleInfo is the subset of `ip -j rule show` fields relevant to veth-leak
-// per-network rules: priority, source IP + prefix length, and the destination
-// table. iproute2 splits the CIDR across two fields (`src` is the bare IP,
-// `srclen` is the prefix bits) — srcCIDR reassembles them. When there is no
-// source match, iproute2 emits `"src":"all"` and omits srclen.
+// rules: priority, source IP + prefix length, the incoming-interface selector
+// of the ingress exception rule, and the destination table. iproute2 splits
+// the CIDR across two fields (`src` is the bare IP, `srclen` is the prefix
+// bits) — srcCIDR reassembles them. When there is no source match, iproute2
+// emits `"src":"all"` and omits srclen; when there is no iif selector it omits
+// `iif` altogether.
 type ruleInfo struct {
 	Priority int             `json:"priority"`
 	Src      string          `json:"src,omitempty"`
 	Srclen   int             `json:"srclen,omitempty"`
+	Iif      string          `json:"iif,omitempty"`
 	Table    json.RawMessage `json:"table,omitempty"`
 }
 
@@ -374,6 +383,137 @@ func DeleteIPRule(t *testing.T, priority int, src string) {
 	}
 }
 
+// AssertVethIngressRule waits for the agent's veth-default ingress exception
+// rule (#265): `iif veth-default lookup main` at the given priority. Polls up
+// to timeout so a scenario can assert right after readiness or after a
+// reconcile-driven repair.
+func AssertVethIngressRule(t *testing.T, priority int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastOut string
+	for {
+		out, err := exec.Command("ip", "-j", "rule", "show").CombinedOutput()
+		lastOut = string(out)
+		if err == nil {
+			var rules []ruleInfo
+			if err := json.Unmarshal(out, &rules); err == nil {
+				for _, r := range rules {
+					if r.Priority == priority && r.Iif == VethDefaultName && tableMatches(r.Table, 254) {
+						return
+					}
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("ip rule priority %d iif %s lookup main not present after %s (last: %q)",
+				priority, VethDefaultName, timeout, strings.TrimSpace(lastOut))
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+}
+
+// AssertNoVethIngressRule waits until no rule with the veth-default iif
+// selector remains at any priority. The mirror of AssertVethIngressRule for
+// the teardown, the disabled, and the drift-injection checks.
+func AssertNoVethIngressRule(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastOut string
+	for {
+		out, err := exec.Command("ip", "-j", "rule", "show").CombinedOutput()
+		lastOut = string(out)
+		if err == nil {
+			var rules []ruleInfo
+			if err := json.Unmarshal(out, &rules); err == nil {
+				present := false
+				for _, r := range rules {
+					if r.Iif == VethDefaultName {
+						present = true
+						break
+					}
+				}
+				if !present {
+					return
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("ip rule iif %s still present after %s (out: %q)",
+				VethDefaultName, timeout, strings.TrimSpace(lastOut))
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+}
+
+// DeleteVethIngressRule removes the ingress exception rule at priority out
+// of band, the way an operator's `ip rule del` would, so a scenario can
+// watch the next reconcile put it back. Errors surface via t.Fatalf — a
+// drift the test could not inject would make the recovery assertion pass
+// trivially.
+func DeleteVethIngressRule(t *testing.T, priority int) {
+	t.Helper()
+	out, err := exec.Command("ip", "rule", "del",
+		"priority", strconv.Itoa(priority), "iif", VethDefaultName, "lookup", "main").CombinedOutput()
+	if err != nil {
+		t.Fatalf("ip rule del priority %d iif %s lookup main: %v (%s)",
+			priority, VethDefaultName, err, strings.TrimSpace(string(out)))
+	}
+}
+
+// linkStats is the subset of `ip -j -s link show <name>` the loop check
+// reads: the 64-bit transmit packet counter.
+type linkStats struct {
+	Stats64 struct {
+		TX struct {
+			Packets uint64 `json:"packets"`
+		} `json:"tx"`
+	} `json:"stats64"`
+}
+
+// VethLinkTxPackets returns the TX packet counter of the named link. The
+// veth-default counter is how TestScenario_VethLeakIngressNoLoop tells a
+// packet that left the veth pair once from one that bounced between its
+// ends until its TTL ran out.
+func VethLinkTxPackets(t *testing.T, name string) uint64 {
+	t.Helper()
+	out, err := exec.Command("ip", "-j", "-s", "link", "show", name).CombinedOutput()
+	if err != nil {
+		t.Fatalf("ip -j -s link show %s: %v (%s)", name, err, strings.TrimSpace(string(out)))
+	}
+	var links []linkStats
+	if err := json.Unmarshal(out, &links); err != nil || len(links) == 0 {
+		t.Fatalf("ip -j -s link show %s: cannot decode stats64 from %q (err=%v)", name, strings.TrimSpace(string(out)), err)
+	}
+	return links[0].Stats64.TX.Packets
+}
+
+// PingFromVRF sends count ICMP echo requests from inside vrf-provider with
+// the given source address, which it adds to the VRF device for the duration
+// of the call. That is exactly the packet a peer gateway's VRF hands over
+// through the veth pair: it leaves via veth-provider, arrives on veth-default,
+// and its source sits inside the leaked provider prefix (#265). Nothing
+// answers behind br-ex in the harness, so the ping's exit status is ignored;
+// callers read the veth-default TX counter instead.
+//
+// The VRF socket context needs `ip vrf exec` (cgroup v2 + BPF). A harness
+// kernel that cannot provide it skips the caller rather than failing it: the
+// rule lifecycle is asserted elsewhere, only the forwarding proof needs this.
+func PingFromVRF(t *testing.T, src, dst string, count int) {
+	t.Helper()
+	if out, err := exec.Command("ip", "vrf", "exec", DefaultVRFName, "true").CombinedOutput(); err != nil {
+		t.Skipf("ip vrf exec %s is not available on this host: %v (%s)", DefaultVRFName, err, strings.TrimSpace(string(out)))
+	}
+	if out, err := exec.Command("ip", "addr", "add", src+"/32", "dev", DefaultVRFName).CombinedOutput(); err != nil {
+		t.Fatalf("ip addr add %s/32 dev %s: %v (%s)", src, DefaultVRFName, err, strings.TrimSpace(string(out)))
+	}
+	t.Cleanup(func() {
+		_ = exec.Command("ip", "addr", "del", src+"/32", "dev", DefaultVRFName).Run()
+	})
+	out, err := exec.Command("ip", "vrf", "exec", DefaultVRFName,
+		"ping", "-I", src, "-c", strconv.Itoa(count), "-W", "1", dst).CombinedOutput()
+	t.Logf("ping from %s to %s in %s (exit=%v): %s", src, dst, DefaultVRFName, err, strings.TrimSpace(string(out)))
+}
+
 // hasFlag reports whether flag appears in flags. Used to fall back to UP
 // detection when iproute2 omits operstate (rare, but seen on some kernels
 // with veth devices that have no carrier).
@@ -425,11 +565,25 @@ func tableMatches(raw json.RawMessage, want int) bool {
 	}
 	var asStr string
 	if err := json.Unmarshal(raw, &asStr); err == nil {
+		// iproute2 prints the reserved tables by the names in
+		// /etc/iproute2/rt_tables, never by number; the agent's ingress
+		// exception rule points at main.
+		if id, ok := reservedTables[asStr]; ok {
+			return id == want
+		}
 		if n, err := strconv.Atoi(asStr); err == nil && n == want {
 			return true
 		}
 	}
 	return false
+}
+
+// reservedTables maps the routing-table names iproute2 prints for the
+// kernel's reserved tables back to their ids (rt_tables(5)).
+var reservedTables = map[string]int{
+	"local":   255,
+	"main":    254,
+	"default": 253,
 }
 
 // scrubVethLeakState removes any veth-leak residue this test (or a previous
@@ -451,6 +605,16 @@ func scrubVethLeakState(t *testing.T) {
 		var rules []ruleInfo
 		if err := json.Unmarshal(out, &rules); err == nil {
 			for _, r := range rules {
+				// The ingress exception rule (#265) carries the veth-default
+				// iif selector; drop it at whatever priority a previous
+				// scenario's agent left it.
+				if r.Iif == VethDefaultName {
+					_ = exec.Command("ip", "rule", "del",
+						"priority", strconv.Itoa(r.Priority),
+						"iif", VethDefaultName,
+					).Run()
+					continue
+				}
 				if r.Priority != DefaultVethLeakRulePriority {
 					continue
 				}


### PR DESCRIPTION
Closes #265. Supersedes #261.

With FIP routes in the main table (the default), a packet entering the default VRF on `veth-default` with a source inside a leaked provider prefix matched the veth-leak source rule (`from <net> lookup 200`, priority 2000) before the main table was consulted, went back into `vrf-provider`, and looped between the two veth ends until its TTL expired. Cross-chassis FIP-to-FIP traffic on a shared provider network is the trigger; external clients and same-chassis FIP-to-FIP (reflected in OVS) were unaffected, which is why no probe in CI saw it.

The fix is one policy rule, `iif veth-default lookup main`, one priority below the leak rules, owned by the veth-leak lifecycle. Everything that arrives on `veth-default` came out of `vrf-provider`, and for all of it the right next step is the main-table lookup that delivers to the bridge `/32`. One rule covers every hosted IP, so it does not depend on `route_table_id` or on the FIP count, which is why this replaces the per-IP `to <ip> lookup main` rules #261 proposed.

## Commits

1. `fix(routing): exempt veth-default ingress from the veth-leak source rule`: `ensureVethIngressRule` and `removeVethIngressRules` in `routing_linux.go`, called from `SetupVethLeak` (before the first per-network rule can exist), `ReconcileVethLeakNetworks` (every cycle, the standby `nil` call included, removing leftovers at a previous priority) and `TeardownVethLeak`. `veth-leak-rule-priority` gets a floor of 2 with a unit test, and the generated reference docs and sample configs follow.
2. `test(integration): pin the veth-default ingress rule lifecycle and the loop`: setup, teardown, disabled and drift-recovery assertions, plus a single-host forwarding proof (`TestScenario_VethLeakIngressNoLoop`) that counts `veth-default` TX packets for a provider-sourced probe sent from `vrf-provider`; it skips where `ip vrf exec` is unavailable. The three-table scenario also asserts the rule points at main.
3. `test(e2e): add the cross-chassis FIP-to-FIP scenario`: `cross-chassis-fip.sh` seeds a second flat router pinned to gateway-2, asserts the two chassisredirect ports sit on different chassis, pings each FIP from the workload behind the other, and requires gateway-2's `veth-default` counters to grow. Wired as `make e2e-cross-chassis-fip` and the `cross-chassis-fip` workflow job.
4. `test(chaos): layer a cross-chassis router and probe it from vm3`: the same topology as a start-state layer with the `cross-fip` probe in the default set and the four profiles that put the hairpin layer up; wiring tests updated.
5. `docs: describe the veth-default ingress exception rule`: data-plane diagram, VRF route-leaking explanation, troubleshooting rule order and tell, reconcile overview.

## Verification

Run locally on this branch: `gofmt -l .` (clean), `go vet ./...`, `GOOS=linux go build ./...`, `GOOS=linux go vet ./...`, `GOOS=linux go vet -tags=integration ./test/integration/...`, `go test ./...` (unit and chaos-runner packages green), `make docs-gen-check`, `GOOS=linux golangci-lint run` (no findings in changed files), `shellcheck` and `bash -n` on the new scenario. The new config validation test was run before the change (fails) and after (passes).

Not runnable on the development host and left to this PR's checks: the integration job (Linux + root), the E2E jobs including the new `cross-chassis-fip` job, and the nightly chaos run for the new layer.
